### PR TITLE
Rewrite the CLI docs page as an install guide plus full command reference

### DIFF
--- a/docs-mintlify/guides/going-further/cli.mdx
+++ b/docs-mintlify/guides/going-further/cli.mdx
@@ -49,10 +49,10 @@ The preferred current environment variables are:
 | `HEXCLAVE_DASHBOARD_URL` | Dashboard base URL |
 | `HEXCLAVE_PROJECT_ID` | Default cloud project ID |
 | `HEXCLAVE_SECRET_SERVER_KEY` | Server-key authentication for commands that support it |
-| `STACK_CLI_REFRESH_TOKEN` | Refresh token for CI or other noninteractive login |
-| `STACK_CLI_ANON_REFRESH_TOKEN` | Anonymous session token to link during `login` |
 
-`STACK_API_URL`, `STACK_DASHBOARD_URL`, `STACK_PROJECT_ID`, and `STACK_SECRET_SERVER_KEY` are retained as backwards-compatible aliases for the corresponding `HEXCLAVE_*` variables. The `STACK_CLI_*` credential names are also retained for compatibility. If both names for one setting are set to different values, the CLI reports an error.
+`STACK_API_URL`, `STACK_DASHBOARD_URL`, `STACK_PROJECT_ID`, and `STACK_SECRET_SERVER_KEY` are retained as backwards-compatible aliases for the corresponding `HEXCLAVE_*` variables. If both names for one setting are set to different values, the CLI reports an error.
+
+The CLI credential variables are currently named `STACK_CLI_REFRESH_TOKEN` and `STACK_CLI_ANON_REFRESH_TOKEN`. Use `STACK_CLI_REFRESH_TOKEN` for CI or other noninteractive login, and set `STACK_CLI_ANON_REFRESH_TOKEN` to link an anonymous session during `login`.
 
 The CLI defaults to Hexclave Cloud (`https://api.hexclave.com` and `https://app.hexclave.com`) when endpoint variables are not set.
 
@@ -60,6 +60,90 @@ The root `--json` option enables JSON output for commands that support it. Comma
 
 ## Command reference
 
+### `hexclave init`
+
+**Synopsis**
+
+```text
+hexclave init [options]
+```
+
+**Description**
+
+Initialize Hexclave in a project. The wizard can create a development-environment config, create a cloud project, or link an existing config or cloud project.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--mode <mode>` | Noninteractive mode: `create`, `create-cloud`, `link-config`, or `link-cloud`. |
+| `--apps <apps>` | Comma-separated app IDs to enable in `create` mode. |
+| `--config-file <path>` | Existing config file for `link-config` mode. |
+| `--select-project-id <id>` | Cloud project ID for `link-cloud` mode. |
+| `--output-dir <dir>` | Directory for generated files. Defaults to the current directory. |
+| `--no-agent` | Skip the Claude agent and print setup instructions instead. |
+| `--display-name <name>` | Project display name for `create-cloud` mode. |
+
+**Behavior and authentication**
+
+Without mode or link flags, the command is interactive. Noninteractive environments must provide an explicit mode or link option. Incompatible combinations such as `--config-file` with `--select-project-id` are rejected. The command writes project setup files, registers the Hexclave MCP server, and can run the Claude setup agent unless `--no-agent` is used.
+
+```sh title="Terminal"
+hexclave init --mode create
+```
+### `hexclave doctor`
+
+**Synopsis**
+
+```text
+hexclave doctor [options]
+```
+
+**Description**
+
+Check that Hexclave is correctly wired up in a project.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--output-dir <dir>` | Project root to inspect. Defaults to the current directory. |
+| `--framework <fw>` | Override framework detection: `next`, `react`, or `js`. |
+| `--json` | Emit a machine-readable report. The root `--json` option has the same effect. |
+
+**Behavior and authentication**
+
+The command reads `package.json`, detects or validates the framework, runs integration checks, prints pass/fail/warning results, and exits with status 1 if any check fails.
+
+```sh title="Terminal"
+hexclave doctor --framework next --json
+```
+### `hexclave fix`
+
+**Synopsis**
+
+```text
+hexclave fix [options]
+```
+
+**Description**
+
+Use an AI agent to fix a Hexclave error in the current project.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--error <text>` | Error message to fix. The command also accepts piped stdin. |
+| `-y, --yes` | Skip the confirmation prompt. |
+
+**Behavior and authentication**
+
+If no error is supplied, the CLI reads stdin or prompts interactively. Error input is limited to 8,000 characters. In noninteractive environments, provide `--error`; confirmation is required unless `--yes` is supplied.
+
+```sh title="Terminal"
+printf '%s\n' "$HEXCLAVE_ERROR" | hexclave fix --yes
+```
 ### `hexclave login`
 
 **Synopsis**
@@ -79,7 +163,6 @@ None.
 **Behavior and authentication**
 
 The refresh token is saved as `STACK_CLI_REFRESH_TOKEN` in the CLI credentials file. Set `STACK_CLI_ANON_REFRESH_TOKEN` before logging in to attach the login to an existing anonymous session; the anonymous token is removed after a successful link.
-
 ### `hexclave logout`
 
 **Synopsis**
@@ -99,64 +182,87 @@ None.
 **Behavior and authentication**
 
 This removes the local credential. It does not require an API request.
-
-### `hexclave exec`
+### `hexclave whoami`
 
 **Synopsis**
 
 ```text
-hexclave exec [javascript] [options]
+hexclave whoami
 ```
 
 **Description**
 
-Execute JavaScript as an async function with a preconfigured `HexclaveServerApp` available as `hexclaveServerApp`.
+Show the currently logged-in Hexclave CLI user.
 
 **Options**
 
 | Option | Description |
 | --- | --- |
-| `--cloud-project-id <id>` | Cloud project ID to run against. Use `--config-file` for a development environment. |
-| `--config-file <path>` | Development-environment config file. Use `--cloud-project-id` for the cloud API. |
+| `--json` | Root option; print user and team details as JSON. |
 
 **Behavior and authentication**
 
-Pass exactly one JavaScript argument. Cloud execution requires `hexclave login` and intentionally rejects `HEXCLAVE_SECRET_SERVER_KEY` authentication. Development-environment execution resolves access from the supplied config file. Non-`undefined` return values are printed as formatted JSON; `undefined` prints nothing.
+Requires a login session. Human output includes user identity, email verification, anonymous/restricted status, team count, API URL, and dashboard URL.
+### `hexclave project`
 
-The current built help text still calls the injected object `StackServerApp` and describes the config path as `stack.config.ts`; the runtime object is `hexclaveServerApp`, and current project setup uses `hexclave.config.ts`.
+Manage projects.
 
-```sh title="Terminal"
-hexclave exec --cloud-project-id <project-id> "return await hexclaveServerApp.listUsers()"
-```
-
-### `hexclave deploy`
+#### `hexclave project list`
 
 **Synopsis**
 
 ```text
-hexclave deploy <service> [options]
+hexclave project list [options]
 ```
 
 **Description**
 
-Deploy a service defined under `deployments-alpha.services` in `hexclave.config.ts`. The CLI uploads the service source, waits for Vercel to accept the deployment, and prints the run ID without waiting for the remote build to finish.
+List projects owned by the current user. By default, both cloud and development-environment projects are included.
 
 **Options**
 
 | Option | Description |
 | --- | --- |
-| `--config <path>` | Config file path. If omitted, the CLI auto-discovers `hexclave.config.ts` in the current directory. |
-| `--cloud-project-id <id>` | Cloud project ID. Defaults to `HEXCLAVE_PROJECT_ID` or its `STACK_PROJECT_ID` compatibility alias. |
-| `--secret <KEY=VALUE>` | Secret value for a deployment environment variable. Repeatable. |
+| `--cloud` | Only list cloud projects. |
+| `--local` | Only list development-environment projects. |
+| `--json` | Root option; print project objects as JSON. |
 
 **Behavior and authentication**
 
-Authentication uses `HEXCLAVE_SECRET_SERVER_KEY` when set, which is recommended for CI; otherwise it uses the `hexclave login` session. Every secret referenced by the service must be supplied, and unknown secret keys are rejected. Secret values are sent to the deployment target and are not persisted by Hexclave.
+`--cloud` and `--local` cannot be combined. Listing cloud projects requires a login session; listing local development-environment projects uses local state. Human-readable output contains the project ID, display name, and `[cloud]` or `[local]` target.
 
 ```sh title="Terminal"
-hexclave deploy web --config ./hexclave.config.ts --secret DATABASE_PASSWORD="$DATABASE_PASSWORD"
+hexclave project list --cloud
 ```
 
+#### `hexclave project create`
+
+**Synopsis**
+
+```text
+hexclave project create [options]
+```
+
+**Description**
+
+Create a new cloud project.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--cloud` | Required confirmation that this command creates a cloud project. |
+| `--display-name <name>` | Project display name. |
+| `--team-id <id>` | Team that owns the project. |
+| `--json` | Root option; print the created project as JSON. |
+
+**Behavior and authentication**
+
+The command currently creates cloud projects only, so `--cloud` is required. It requires a login session. Missing display names can be entered interactively; in a noninteractive environment, provide `--display-name`.
+
+```sh title="Terminal"
+hexclave project create --cloud --display-name "My App"
+```
 ### `hexclave config`
 
 Manage project configuration files.
@@ -219,100 +325,6 @@ This command accepts either `hexclave login` or `HEXCLAVE_SECRET_SERVER_KEY` aut
 ```sh title="Terminal"
 hexclave config push --cloud-project-id <project-id> --config-file ./hexclave.config.ts
 ```
-
-### `hexclave init`
-
-**Synopsis**
-
-```text
-hexclave init [options]
-```
-
-**Description**
-
-Initialize Hexclave in a project. The wizard can create a development-environment config, create a cloud project, or link an existing config or cloud project.
-
-**Options**
-
-| Option | Description |
-| --- | --- |
-| `--mode <mode>` | Noninteractive mode: `create`, `create-cloud`, `link-config`, or `link-cloud`. |
-| `--apps <apps>` | Comma-separated app IDs to enable in `create` mode. |
-| `--config-file <path>` | Existing config file for `link-config` mode. |
-| `--select-project-id <id>` | Cloud project ID for `link-cloud` mode. |
-| `--output-dir <dir>` | Directory for generated files. Defaults to the current directory. |
-| `--no-agent` | Skip the Claude agent and print setup instructions instead. |
-| `--display-name <name>` | Project display name for `create-cloud` mode. |
-
-**Behavior and authentication**
-
-Without mode or link flags, the command is interactive. Noninteractive environments must provide an explicit mode or link option. Incompatible combinations such as `--config-file` with `--select-project-id` are rejected. The command writes project setup files, registers the Hexclave MCP server, and can run the Claude setup agent unless `--no-agent` is used.
-
-```sh title="Terminal"
-hexclave init --mode create
-```
-
-### `hexclave project`
-
-Manage projects.
-
-#### `hexclave project list`
-
-**Synopsis**
-
-```text
-hexclave project list [options]
-```
-
-**Description**
-
-List projects owned by the current user. By default, both cloud and development-environment projects are included.
-
-**Options**
-
-| Option | Description |
-| --- | --- |
-| `--cloud` | Only list cloud projects. |
-| `--local` | Only list development-environment projects. |
-| `--json` | Root option; print project objects as JSON. |
-
-**Behavior and authentication**
-
-`--cloud` and `--local` cannot be combined. Listing cloud projects requires a login session; listing local development-environment projects uses local state. Human-readable output contains the project ID, display name, and `[cloud]` or `[local]` target.
-
-```sh title="Terminal"
-hexclave project list --cloud
-```
-
-#### `hexclave project create`
-
-**Synopsis**
-
-```text
-hexclave project create [options]
-```
-
-**Description**
-
-Create a new cloud project.
-
-**Options**
-
-| Option | Description |
-| --- | --- |
-| `--cloud` | Required confirmation that this command creates a cloud project. |
-| `--display-name <name>` | Project display name. |
-| `--team-id <id>` | Team that owns the project. |
-| `--json` | Root option; print the created project as JSON. |
-
-**Behavior and authentication**
-
-The command currently creates cloud projects only, so `--cloud` is required. It requires a login session. Missing display names can be entered interactively; in a noninteractive environment, provide `--display-name`.
-
-```sh title="Terminal"
-hexclave project create --cloud --display-name "My App"
-```
-
 ### `hexclave dev`
 
 **Synopsis**
@@ -334,34 +346,64 @@ Run a command with Hexclave development-environment credentials.
 
 **Behavior and authentication**
 
-The CLI starts or reuses the development dashboard, creates a development-environment session, injects the project’s API URL, dashboard URL, project ID, and related environment variables into the child process, then forwards signals and cleans up when the child exits. The command accepts the config path supplied by the user; current project setup uses `hexclave.config.ts`. The current built help text still labels the option as `Path to stack.config.ts`; this is stale help wording, not a different required filename.
+The CLI starts or reuses the development dashboard, creates a development-environment session, injects the project’s API URL, dashboard URL, project ID, and related environment variables into the child process, then forwards signals and cleans up when the child exits. The command accepts the config path supplied by the user; current project setup uses `hexclave.config.ts`.
 
 ```sh title="Terminal"
 hexclave dev --config-file ./hexclave.config.ts -- npm run dev:inner
 ```
-
-### `hexclave whoami`
+### `hexclave deploy`
 
 **Synopsis**
 
 ```text
-hexclave whoami
+hexclave deploy <service> [options]
 ```
 
 **Description**
 
-Show the currently logged-in Hexclave CLI user.
+Deploy a service defined under `deployments-alpha.services` in `hexclave.config.ts`. The CLI uploads the service source, waits for Vercel to accept the deployment, and prints the run ID without waiting for the remote build to finish.
 
 **Options**
 
 | Option | Description |
 | --- | --- |
-| `--json` | Root option; print user and team details as JSON. |
+| `--config <path>` | Config file path. If omitted, the CLI auto-discovers `hexclave.config.ts` in the current directory. |
+| `--cloud-project-id <id>` | Cloud project ID. Defaults to `HEXCLAVE_PROJECT_ID` or its `STACK_PROJECT_ID` compatibility alias. |
+| `--secret <KEY=VALUE>` | Secret value for a deployment environment variable. Repeatable. |
 
 **Behavior and authentication**
 
-Requires a login session. Human output includes user identity, email verification, anonymous/restricted status, team count, API URL, and dashboard URL.
+Authentication uses `HEXCLAVE_SECRET_SERVER_KEY` when set, which is recommended for CI; otherwise it uses the `hexclave login` session. Every secret referenced by the service must be supplied, and unknown secret keys are rejected. Secret values are sent to the deployment target and are not persisted by Hexclave.
 
+```sh title="Terminal"
+hexclave deploy web --config ./hexclave.config.ts --secret DATABASE_PASSWORD="$DATABASE_PASSWORD"
+```
+### `hexclave exec`
+
+**Synopsis**
+
+```text
+hexclave exec [javascript] [options]
+```
+
+**Description**
+
+Execute JavaScript as an async function with a preconfigured `HexclaveServerApp` available as `hexclaveServerApp`.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--cloud-project-id <id>` | Cloud project ID to run against. Use `--config-file` for a development environment. |
+| `--config-file <path>` | Development-environment config file. Use `--cloud-project-id` for the cloud API. |
+
+**Behavior and authentication**
+
+Pass exactly one JavaScript argument. Cloud execution requires `hexclave login` and intentionally rejects `HEXCLAVE_SECRET_SERVER_KEY` authentication. Development-environment execution resolves access from the supplied config file. Non-`undefined` return values are printed as formatted JSON; `undefined` prints nothing.
+
+```sh title="Terminal"
+hexclave exec --cloud-project-id <project-id> "return await hexclaveServerApp.listUsers()"
+```
 ### `hexclave team`
 
 Manage teams.
@@ -628,58 +670,3 @@ Delete a team.
 **Behavior and authentication**
 
 Deleting a team is destructive. It requires confirmation interactively and requires `--yes` in noninteractive environments.
-
-### `hexclave fix`
-
-**Synopsis**
-
-```text
-hexclave fix [options]
-```
-
-**Description**
-
-Use an AI agent to fix a Hexclave error in the current project.
-
-**Options**
-
-| Option | Description |
-| --- | --- |
-| `--error <text>` | Error message to fix. The command also accepts piped stdin. |
-| `-y, --yes` | Skip the confirmation prompt. |
-
-**Behavior and authentication**
-
-If no error is supplied, the CLI reads stdin or prompts interactively. Error input is limited to 8,000 characters. In noninteractive environments, provide `--error`; confirmation is required unless `--yes` is supplied.
-
-```sh title="Terminal"
-printf '%s\n' "$HEXCLAVE_ERROR" | hexclave fix --yes
-```
-
-### `hexclave doctor`
-
-**Synopsis**
-
-```text
-hexclave doctor [options]
-```
-
-**Description**
-
-Check that Hexclave is correctly wired up in a project.
-
-**Options**
-
-| Option | Description |
-| --- | --- |
-| `--output-dir <dir>` | Project root to inspect. Defaults to the current directory. |
-| `--framework <fw>` | Override framework detection: `next`, `react`, or `js`. |
-| `--json` | Emit a machine-readable report. The root `--json` option has the same effect. |
-
-**Behavior and authentication**
-
-The command reads `package.json`, detects or validates the framework, runs integration checks, prints pass/fail/warning results, and exits with status 1 if any check fails.
-
-```sh title="Terminal"
-hexclave doctor --framework next --json
-```

--- a/docs-mintlify/guides/going-further/cli.mdx
+++ b/docs-mintlify/guides/going-further/cli.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Hexclave CLI"
-description: "Use the Hexclave CLI to manage config and run admin scripts"
+description: "Install and use the Hexclave CLI"
 sidebarTitle: "Hexclave CLI"
 ---
 
@@ -10,114 +10,676 @@ import { hexclaveAgentRemindersText } from "/snippets/hexclave-agent-reminders.j
 {hexclaveAgentRemindersText}
 </Visibility>
 
-The Hexclave CLI is published as `@hexclave/cli` and exposes the `stack` command. Use it for branch config workflows and quick admin scripts.
+The Hexclave CLI is published as `@hexclave/cli` and provides the `hexclave` command for project setup, development environments, configuration, deployments, administration, and team management.
 
-## Install
+## Install and quickstart
 
-Install the CLI globally to use the `stack` command from any project:
+Install the CLI globally if you want to use `hexclave` from any project:
 
 ```sh title="Terminal"
 npm install -g @hexclave/cli@latest
+hexclave --help
 ```
 
-Then check that it is available:
+You can also run it without a global install:
 
 ```sh title="Terminal"
-stack --help
+npx @hexclave/cli@latest --help
+pnpm dlx @hexclave/cli@latest --help
 ```
 
-You can also run any command without installing globally by prefixing it with `npx @hexclave/cli@latest`, for example:
+For a project-local installation, add `@hexclave/cli` as a development dependency and run it with your package manager:
 
 ```sh title="Terminal"
-npx @hexclave/cli@latest project list
+pnpm add -D @hexclave/cli
+pnpm exec hexclave --help
 ```
 
-## Global options
+The CLI stores login credentials locally. For CI and other automation, use the environment variables described below instead of putting secrets in command history.
 
-These options can be used before a subcommand:
+## Authentication and environment
+
+Run `hexclave login` to authenticate in a browser. The CLI stores the resulting refresh token locally. `hexclave logout` removes the stored token.
+
+The preferred current environment variables are:
+
+| Variable | Purpose |
+| --- | --- |
+| `HEXCLAVE_API_URL` | API base URL |
+| `HEXCLAVE_DASHBOARD_URL` | Dashboard base URL |
+| `HEXCLAVE_PROJECT_ID` | Default cloud project ID |
+| `HEXCLAVE_SECRET_SERVER_KEY` | Server-key authentication for commands that support it |
+| `STACK_CLI_REFRESH_TOKEN` | Refresh token for CI or other noninteractive login |
+| `STACK_CLI_ANON_REFRESH_TOKEN` | Anonymous session token to link during `login` |
+
+`STACK_API_URL`, `STACK_DASHBOARD_URL`, `STACK_PROJECT_ID`, and `STACK_SECRET_SERVER_KEY` are retained as backwards-compatible aliases for the corresponding `HEXCLAVE_*` variables. The `STACK_CLI_*` credential names are also retained for compatibility. If both names for one setting are set to different values, the CLI reports an error.
+
+The CLI defaults to Hexclave Cloud (`https://api.hexclave.com` and `https://app.hexclave.com`) when endpoint variables are not set.
+
+The root `--json` option enables JSON output for commands that support it. Commander also provides `-V, --version` and `-h, --help` on every command; the automatically generated help option is omitted from the individual option tables below.
+
+## Command reference
+
+### `hexclave login`
+
+**Synopsis**
+
+```text
+hexclave login
+```
+
+**Description**
+
+Log in to Hexclave through the browser-based CLI authentication flow.
+
+**Options**
+
+None.
+
+**Behavior and authentication**
+
+The refresh token is saved as `STACK_CLI_REFRESH_TOKEN` in the CLI credentials file. Set `STACK_CLI_ANON_REFRESH_TOKEN` before logging in to attach the login to an existing anonymous session; the anonymous token is removed after a successful link.
+
+### `hexclave logout`
+
+**Synopsis**
+
+```text
+hexclave logout
+```
+
+**Description**
+
+Remove the locally stored CLI refresh token.
+
+**Options**
+
+None.
+
+**Behavior and authentication**
+
+This removes the local credential. It does not require an API request.
+
+### `hexclave exec`
+
+**Synopsis**
+
+```text
+hexclave exec [javascript] [options]
+```
+
+**Description**
+
+Execute JavaScript as an async function with a preconfigured `HexclaveServerApp` available as `hexclaveServerApp`.
+
+**Options**
 
 | Option | Description |
 | --- | --- |
-| `--project-id <id>` | Project ID for commands that operate on one project. You can also set `STACK_PROJECT_ID`. |
-| `--json` | Print JSON output for commands that support it, such as `project list` and `project create`. |
-| `--version` | Print the CLI version. |
+| `--cloud-project-id <id>` | Cloud project ID to run against. Use `--config-file` for a development environment. |
+| `--config-file <path>` | Development-environment config file. Use `--cloud-project-id` for the cloud API. |
 
-The CLI reads Hexclave endpoints from `STACK_API_URL` and `STACK_DASHBOARD_URL`. If unset, it uses Hexclave Cloud.
+**Behavior and authentication**
 
-## Authentication
+Pass exactly one JavaScript argument. Cloud execution requires `hexclave login` and intentionally rejects `HEXCLAVE_SECRET_SERVER_KEY` authentication. Development-environment execution resolves access from the supplied config file. Non-`undefined` return values are printed as formatted JSON; `undefined` prints nothing.
 
-Log in with a browser:
-
-```sh title="Terminal"
-stack login
-```
-
-This stores `STACK_CLI_REFRESH_TOKEN` in the CLI credentials file. You can also provide it through the environment, which is useful in CI.
+The current built help text still calls the injected object `StackServerApp` and describes the config path as `stack.config.ts`; the runtime object is `hexclaveServerApp`, and current project setup uses `hexclave.config.ts`.
 
 ```sh title="Terminal"
-STACK_CLI_REFRESH_TOKEN=<refresh-token> stack project list
+hexclave exec --cloud-project-id <project-id> "return await hexclaveServerApp.listUsers()"
 ```
 
-Log out by removing the saved refresh token:
+### `hexclave deploy`
+
+**Synopsis**
+
+```text
+hexclave deploy <service> [options]
+```
+
+**Description**
+
+Deploy a service defined under `deployments-alpha.services` in `hexclave.config.ts`. The CLI uploads the service source, waits for Vercel to accept the deployment, and prints the run ID without waiting for the remote build to finish.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--config <path>` | Config file path. If omitted, the CLI auto-discovers `hexclave.config.ts` in the current directory. |
+| `--cloud-project-id <id>` | Cloud project ID. Defaults to `HEXCLAVE_PROJECT_ID` or its `STACK_PROJECT_ID` compatibility alias. |
+| `--secret <KEY=VALUE>` | Secret value for a deployment environment variable. Repeatable. |
+
+**Behavior and authentication**
+
+Authentication uses `HEXCLAVE_SECRET_SERVER_KEY` when set, which is recommended for CI; otherwise it uses the `hexclave login` session. Every secret referenced by the service must be supplied, and unknown secret keys are rejected. Secret values are sent to the deployment target and are not persisted by Hexclave.
 
 ```sh title="Terminal"
-stack logout
+hexclave deploy web --config ./hexclave.config.ts --secret DATABASE_PASSWORD="$DATABASE_PASSWORD"
 ```
 
-If you have an anonymous CLI session that should be linked during login, set `STACK_CLI_ANON_REFRESH_TOKEN` before running `login`.
+### `hexclave config`
 
-## Project commands
+Manage project configuration files.
 
-List projects owned by the logged-in user:
+#### `hexclave config pull`
+
+**Synopsis**
+
+```text
+hexclave config pull [options]
+```
+
+**Description**
+
+Pull the selected cloud branch configuration into a local TypeScript file.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--cloud-project-id <id>` | Cloud project ID. Defaults to `HEXCLAVE_PROJECT_ID` or its `STACK_PROJECT_ID` compatibility alias. |
+| `--config-file <path>` | Output path. Defaults to `./hexclave.config.ts` in the current directory. |
+| `--overwrite` | Replace the file if it already exists. |
+
+**Behavior and authentication**
+
+This command requires `hexclave login`; secret-server-key-only authentication is rejected. The target must have a `.ts` extension. Existing files are protected unless `--overwrite` is supplied.
 
 ```sh title="Terminal"
-stack project list
+hexclave config pull --cloud-project-id <project-id> --config-file ./hexclave.config.ts
 ```
 
-Create a project:
+#### `hexclave config push`
+
+**Synopsis**
+
+```text
+hexclave config push [options]
+```
+
+**Description**
+
+Push a local JavaScript or TypeScript config file to a cloud branch.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--cloud-project-id <id>` | Cloud project ID. Defaults to `HEXCLAVE_PROJECT_ID` or its `STACK_PROJECT_ID` compatibility alias. |
+| `--config-file <path>` | Required path to a `.js` or `.ts` config file. |
+| `--source <type>` | Explicit source type. Only `github` is supported. |
+| `--source-repo <owner/repo>` | GitHub repository. Only valid with `--source github`. |
+| `--source-path <path>` | Config path inside the source repository. Only valid with `--source github`. |
+| `--source-workflow-path <path>` | Syncing workflow path inside the source repository. Only valid with `--source github`. |
+
+**Behavior and authentication**
+
+This command accepts either `hexclave login` or `HEXCLAVE_SECRET_SERVER_KEY` authentication. GitHub Actions metadata is inferred from `GITHUB_REPOSITORY`, `GITHUB_REF_NAME`, and `GITHUB_SHA` when available. Explicit GitHub source metadata requires all corresponding source options.
 
 ```sh title="Terminal"
-stack project create --display-name "My App"
+hexclave config push --cloud-project-id <project-id> --config-file ./hexclave.config.ts
 ```
 
-Use `--json` when you want machine-readable output:
+### `hexclave init`
+
+**Synopsis**
+
+```text
+hexclave init [options]
+```
+
+**Description**
+
+Initialize Hexclave in a project. The wizard can create a development-environment config, create a cloud project, or link an existing config or cloud project.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--mode <mode>` | Noninteractive mode: `create`, `create-cloud`, `link-config`, or `link-cloud`. |
+| `--apps <apps>` | Comma-separated app IDs to enable in `create` mode. |
+| `--config-file <path>` | Existing config file for `link-config` mode. |
+| `--select-project-id <id>` | Cloud project ID for `link-cloud` mode. |
+| `--output-dir <dir>` | Directory for generated files. Defaults to the current directory. |
+| `--no-agent` | Skip the Claude agent and print setup instructions instead. |
+| `--display-name <name>` | Project display name for `create-cloud` mode. |
+
+**Behavior and authentication**
+
+Without mode or link flags, the command is interactive. Noninteractive environments must provide an explicit mode or link option. Incompatible combinations such as `--config-file` with `--select-project-id` are rejected. The command writes project setup files, registers the Hexclave MCP server, and can run the Claude setup agent unless `--no-agent` is used.
 
 ```sh title="Terminal"
-stack --json project list
+hexclave init --mode create
 ```
 
-## Config commands
+### `hexclave project`
 
-Pull branch config into a local TypeScript config file:
+Manage projects.
+
+#### `hexclave project list`
+
+**Synopsis**
+
+```text
+hexclave project list [options]
+```
+
+**Description**
+
+List projects owned by the current user. By default, both cloud and development-environment projects are included.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--cloud` | Only list cloud projects. |
+| `--local` | Only list development-environment projects. |
+| `--json` | Root option; print project objects as JSON. |
+
+**Behavior and authentication**
+
+`--cloud` and `--local` cannot be combined. Listing cloud projects requires a login session; listing local development-environment projects uses local state. Human-readable output contains the project ID, display name, and `[cloud]` or `[local]` target.
 
 ```sh title="Terminal"
-stack --project-id <project-id> config pull --config-file ./stack.config.ts
+hexclave project list --cloud
 ```
 
-By default, `config pull` refuses to overwrite an existing file. Add `--overwrite` when that is intended.
+#### `hexclave project create`
 
-Push a local config file to branch config:
+**Synopsis**
+
+```text
+hexclave project create [options]
+```
+
+**Description**
+
+Create a new cloud project.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--cloud` | Required confirmation that this command creates a cloud project. |
+| `--display-name <name>` | Project display name. |
+| `--team-id <id>` | Team that owns the project. |
+| `--json` | Root option; print the created project as JSON. |
+
+**Behavior and authentication**
+
+The command currently creates cloud projects only, so `--cloud` is required. It requires a login session. Missing display names can be entered interactively; in a noninteractive environment, provide `--display-name`.
 
 ```sh title="Terminal"
-stack --project-id <project-id> config push --config-file ./stack.config.ts
+hexclave project create --cloud --display-name "My App"
 ```
 
-`config pull` requires `stack login`. `config push` supports either `stack login` or `STACK_SECRET_SERVER_KEY`.
+### `hexclave dev`
 
-Important: Always make sure to pull the latest config before pushing your changes when you're pushing to a Cloud project, as the existing config may not be what you expected it to be.
+**Synopsis**
 
-When running in GitHub Actions, `config push` records `GITHUB_REPOSITORY`, `GITHUB_REF_NAME`, `GITHUB_SHA`, and the config file path as the config source when those environment variables are available.
+```text
+hexclave dev --config-file <path> -- <command> [args...]
+```
 
-## Execute admin JavaScript
+**Description**
 
-`stack exec` runs JavaScript with a preconfigured `HexclaveServerApp` available as `hexclaveServerApp`.
+Run a command with Hexclave development-environment credentials.
+
+**Options and arguments**
+
+| Argument or option | Description |
+| --- | --- |
+| `--config-file <path>` | Required config file path. Use `hexclave.config.ts`. |
+| `<command...>` | Required command and arguments after `--`. |
+
+**Behavior and authentication**
+
+The CLI starts or reuses the development dashboard, creates a development-environment session, injects the project’s API URL, dashboard URL, project ID, and related environment variables into the child process, then forwards signals and cleans up when the child exits. The command accepts the config path supplied by the user; current project setup uses `hexclave.config.ts`. The current built help text still labels the option as `Path to stack.config.ts`; this is stale help wording, not a different required filename.
 
 ```sh title="Terminal"
-stack --project-id <project-id> exec "return await hexclaveServerApp.listUsers()"
+hexclave dev --config-file ./hexclave.config.ts -- npm run dev:inner
 ```
 
-The JavaScript is executed as an async function. Return values are printed as formatted JSON; `undefined` prints nothing.
+### `hexclave whoami`
 
-<Warning>
-  `stack exec` has server-level access to the selected project. It requires `stack login` and intentionally rejects `STACK_SECRET_SERVER_KEY` auth.
-</Warning>
+**Synopsis**
+
+```text
+hexclave whoami
+```
+
+**Description**
+
+Show the currently logged-in Hexclave CLI user.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--json` | Root option; print user and team details as JSON. |
+
+**Behavior and authentication**
+
+Requires a login session. Human output includes user identity, email verification, anonymous/restricted status, team count, API URL, and dashboard URL.
+
+### `hexclave team`
+
+Manage teams.
+
+Team operations require a login session. Where a team ID is optional, the CLI can resolve the team interactively or from the available team context.
+
+#### `hexclave team list`
+
+**Synopsis**
+
+```text
+hexclave team list
+```
+
+**Description**
+
+List the current user’s teams.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--json` | Root option; print teams as JSON. |
+
+#### `hexclave team create`
+
+**Synopsis**
+
+```text
+hexclave team create [options]
+```
+
+**Description**
+
+Create a team.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--display-name <name>` | Team display name. |
+
+**Behavior and authentication**
+
+Missing display names prompt interactively and are required in noninteractive environments.
+
+#### `hexclave team members list`
+
+**Synopsis**
+
+```text
+hexclave team members list [options]
+```
+
+**Description**
+
+List members of a team.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--team-id <id>` | Team ID. |
+| `--json` | Root option; print members as JSON. |
+
+#### `hexclave team members remove`
+
+**Synopsis**
+
+```text
+hexclave team members remove [options]
+```
+
+**Description**
+
+Remove a member from a team.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--team-id <id>` | Team ID. |
+| `--user-id <id>` | Required user ID to remove. |
+| `-y, --yes` | Skip the confirmation prompt. |
+| `--json` | Root option; print the result as JSON. |
+
+**Behavior and authentication**
+
+Destructive actions require confirmation interactively and require `--yes` in noninteractive environments.
+
+#### `hexclave team invite`
+
+**Synopsis**
+
+```text
+hexclave team invite [options]
+```
+
+**Description**
+
+Invite a user to a team.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--team-id <id>` | Team ID. |
+| `--email <email>` | Email address to invite. |
+| `--json` | Root option; print the result as JSON. |
+
+**Behavior and authentication**
+
+Missing email addresses prompt interactively and are required in noninteractive environments.
+
+#### `hexclave team invitations list`
+
+**Synopsis**
+
+```text
+hexclave team invitations list [options]
+```
+
+**Description**
+
+List invitations sent by a team.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--team-id <id>` | Team ID. |
+| `--json` | Root option; print invitations as JSON. |
+
+#### `hexclave team invitations revoke`
+
+**Synopsis**
+
+```text
+hexclave team invitations revoke [options]
+```
+
+**Description**
+
+Revoke a team invitation.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--team-id <id>` | Team ID. |
+| `--invitation-id <id>` | Required invitation ID. |
+| `-y, --yes` | Skip the confirmation prompt. |
+| `--json` | Root option; print the result as JSON. |
+
+**Behavior and authentication**
+
+Destructive actions require confirmation interactively and require `--yes` in noninteractive environments.
+
+#### `hexclave team invitations received`
+
+**Synopsis**
+
+```text
+hexclave team invitations received
+```
+
+**Description**
+
+List invitations received by the current user.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--json` | Root option; print invitations as JSON. |
+
+#### `hexclave team invitations accept`
+
+**Synopsis**
+
+```text
+hexclave team invitations accept [options]
+```
+
+**Description**
+
+Accept an invitation received by the current user.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--invitation-id <id>` | Required invitation ID. |
+| `--json` | Root option; print the result as JSON. |
+
+#### `hexclave team leave`
+
+**Synopsis**
+
+```text
+hexclave team leave [options]
+```
+
+**Description**
+
+Leave a team.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--team-id <id>` | Team ID. |
+| `-y, --yes` | Skip the confirmation prompt. |
+| `--json` | Root option; print the result as JSON. |
+
+**Behavior and authentication**
+
+Leaving a team is destructive. It requires confirmation interactively and requires `--yes` in noninteractive environments.
+
+#### `hexclave team update`
+
+**Synopsis**
+
+```text
+hexclave team update [options]
+```
+
+**Description**
+
+Update a team.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--team-id <id>` | Team ID. |
+| `--display-name <name>` | New team display name. |
+| `--json` | Root option; print the result as JSON. |
+
+**Behavior and authentication**
+
+Missing display names prompt interactively and are required in noninteractive environments.
+
+#### `hexclave team delete`
+
+**Synopsis**
+
+```text
+hexclave team delete [options]
+```
+
+**Description**
+
+Delete a team.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--team-id <id>` | Team ID. |
+| `-y, --yes` | Skip the confirmation prompt. |
+| `--json` | Root option; print the result as JSON. |
+
+**Behavior and authentication**
+
+Deleting a team is destructive. It requires confirmation interactively and requires `--yes` in noninteractive environments.
+
+### `hexclave fix`
+
+**Synopsis**
+
+```text
+hexclave fix [options]
+```
+
+**Description**
+
+Use an AI agent to fix a Hexclave error in the current project.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--error <text>` | Error message to fix. The command also accepts piped stdin. |
+| `-y, --yes` | Skip the confirmation prompt. |
+
+**Behavior and authentication**
+
+If no error is supplied, the CLI reads stdin or prompts interactively. Error input is limited to 8,000 characters. In noninteractive environments, provide `--error`; confirmation is required unless `--yes` is supplied.
+
+```sh title="Terminal"
+printf '%s\n' "$HEXCLAVE_ERROR" | hexclave fix --yes
+```
+
+### `hexclave doctor`
+
+**Synopsis**
+
+```text
+hexclave doctor [options]
+```
+
+**Description**
+
+Check that Hexclave is correctly wired up in a project.
+
+**Options**
+
+| Option | Description |
+| --- | --- |
+| `--output-dir <dir>` | Project root to inspect. Defaults to the current directory. |
+| `--framework <fw>` | Override framework detection: `next`, `react`, or `js`. |
+| `--json` | Emit a machine-readable report. The root `--json` option has the same effect. |
+
+**Behavior and authentication**
+
+The command reads `package.json`, detects or validates the framework, runs integration checks, prints pass/fail/warning results, and exits with status 1 if any check fails.
+
+```sh title="Terminal"
+hexclave doctor --framework next --json
+```

--- a/docs-mintlify/guides/going-further/local-vs-cloud-dashboard.mdx
+++ b/docs-mintlify/guides/going-further/local-vs-cloud-dashboard.mdx
@@ -72,41 +72,41 @@ You can get these values from the cloud dashboard. The project ID appears in the
 To start with a development environment, run the setup wizard and choose the config-file flow:
 
 ```sh title="Terminal"
-stack init --mode create
+hexclave init --mode create
 ```
 
 If you already have a config file, link it instead:
 
 ```sh title="Terminal"
-stack init --mode link-config --config-file ./hexclave.config.ts
+hexclave init --mode link-config --config-file ./hexclave.config.ts
 ```
 
 To start with a cloud project, create one from the CLI:
 
 ```sh title="Terminal"
-stack init --mode create-cloud
+hexclave init --mode create-cloud
 ```
 
 Or link an existing cloud project:
 
 ```sh title="Terminal"
-stack init --mode link-cloud --select-project-id <project-id>
+hexclave init --mode link-cloud --select-project-id <project-id>
 ```
 
 You can also copy config between the two styles. Pull cloud branch config into a local config file:
 
 ```sh title="Terminal"
-stack --project-id <project-id> config pull --config-file ./hexclave.config.ts
+hexclave config pull --cloud-project-id <project-id> --config-file ./hexclave.config.ts
 ```
 
 Push local config-file changes back to a cloud project:
 
 ```sh title="Terminal"
-stack --project-id <project-id> config push --config-file ./hexclave.config.ts
+hexclave config push --cloud-project-id <project-id> --config-file ./hexclave.config.ts
 ```
 
 <Info>
-  `config pull` requires `stack login`. `config push` supports either `stack login` or `HEXCLAVE_SECRET_SERVER_KEY`.
+  `config pull` requires `hexclave login`. `config push` supports either `hexclave login` or `HEXCLAVE_SECRET_SERVER_KEY`.
 </Info>
 
 For the full setup flow by framework, see [Setup](/guides/getting-started/setup).

--- a/docs-mintlify/migration.mdx
+++ b/docs-mintlify/migration.mdx
@@ -46,7 +46,7 @@ All legacy names keep working — rename only if you want your code to match the
 - **Request headers**: `X-Stack-*` → `X-Hexclave-*`.
 - **Environment variables**: `STACK_*` → `HEXCLAVE_*`.
 - **Bearer prefix**: `stackauth_*` tokens remain valid.
-- **CLI binary**: both `stack` and `hexclave` ship with `@hexclave/cli`.
+- **CLI binary**: `hexclave` ships with `@hexclave/cli`. The old `stack` binary is no longer published.
 - **Hosted-handler subdomain**: current SDKs use `.built-with-hexclave.com`. The legacy `.built-with-stack-auth.com` domain remains available for SDK versions that already generated those URLs. Passkeys are scoped to the domain where they were registered and are not transferred between the two domains.
 
 ## Other

--- a/packages/cli/src/commands/config-file.ts
+++ b/packages/cli/src/commands/config-file.ts
@@ -242,7 +242,7 @@ export function registerConfigCommand(program: Command) {
   config
     .command("pull")
     .description("Pull branch config to a local file")
-    .option("--cloud-project-id <id>", "Cloud project ID to pull config from (defaults to the STACK_PROJECT_ID env var)")
+    .option("--cloud-project-id <id>", "Cloud project ID to pull config from (defaults to the HEXCLAVE_PROJECT_ID env var; STACK_PROJECT_ID is also supported)")
     .option("--config-file <path>", "Path to write config file (.ts); defaults to ./hexclave.config.ts in the current directory")
     .option("--overwrite", "Replace the config file if one already exists at the target path")
     .action(async (opts) => {
@@ -273,7 +273,7 @@ export function registerConfigCommand(program: Command) {
   config
     .command("push")
     .description("Push a local config file to branch config")
-    .option("--cloud-project-id <id>", "Cloud project ID to push config to (defaults to the STACK_PROJECT_ID env var)")
+    .option("--cloud-project-id <id>", "Cloud project ID to push config to (defaults to the HEXCLAVE_PROJECT_ID env var; STACK_PROJECT_ID is also supported)")
     .requiredOption("--config-file <path>", "Path to config file (.js or .ts)")
     .option("--source <type>", "Explicit source type for this push. Only 'github' is supported.")
     .option("--source-repo <owner/repo>", "GitHub repository in 'owner/repo' format. Only allowed with --source github.")

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -888,7 +888,7 @@ export function registerDevCommand(program: Command) {
     .command("dev")
     .usage("--config-file <path> -- <command> [args...]")
     .description("Run a command with Hexclave development-environment credentials")
-    .requiredOption("--config-file <path>", "Path to stack.config.ts")
+    .requiredOption("--config-file <path>", "Path to hexclave.config.ts")
     .argument("<command...>", "Command and arguments to run after --")
     .action(async (commandArgs: string[], opts: DevOptions) => {
       if (opts.configFile == null) {

--- a/packages/cli/src/commands/exec.ts
+++ b/packages/cli/src/commands/exec.ts
@@ -49,9 +49,9 @@ export function parseExecTarget(opts: ExecTargetOpts): ExecTarget {
 export function registerExecCommand(program: Command) {
   program
     .command("exec [javascript]")
-    .description("Execute JavaScript with a pre-configured StackServerApp as `hexclaveServerApp`. Pass --cloud-project-id <id> for the cloud API, or --config-file <path> for the development environment.")
+    .description("Execute JavaScript with a pre-configured Hexclave server app as `hexclaveServerApp`. Pass --cloud-project-id <id> for the cloud API, or --config-file <path> for the development environment.")
     .option("--cloud-project-id <id>", "Cloud project ID to run against (use --config-file instead for the development environment)")
-    .option("--config-file <path>", "Path to a development-environment stack.config.ts (use --cloud-project-id instead for the cloud API)")
+    .option("--config-file <path>", "Path to a development-environment hexclave.config.ts (use --cloud-project-id instead for the cloud API)")
     .addHelpText("after", "\nFor available API methods, see: https://docs.hexclave.com/sdk/overview")
     .action(async (javascript: string | undefined, opts: ExecTargetOpts) => {
       if (javascript === undefined) {


### PR DESCRIPTION
The CLI docs page still documented a `stack` binary that is no longer published, a root `--project-id` option that no longer exists, and only 5 of the CLI's commands. It was left behind when the CLI was renamed and expanded.

`guides/going-further/cli.mdx` is now a short install/quickstart section followed by a complete reference: every top-level command (`init`, `doctor`, `fix`, `login`, `logout`, `whoami`, `project`, `config`, `dev`, `deploy`, `exec`, `team`) and every nested subcommand, each with synopsis, options, and auth/behavior notes. `HEXCLAVE_*` env vars are presented as the current names, with `STACK_*` noted as retained aliases. Same nav slug, so no `docs.json` change.

The reference was reconciled against real `--help` output for all 31 commands/subcommands, which surfaced four stale help strings in the CLI itself — those are fixed here rather than documented as quirks (display strings only, no behavior change):

```
exec        "...pre-configured StackServerApp..."          -> "...Hexclave server app..."
exec        --config-file "...stack.config.ts..."          -> hexclave.config.ts
dev         --config-file "Path to stack.config.ts"        -> hexclave.config.ts
config pull/push  --cloud-project-id "...STACK_PROJECT_ID" -> HEXCLAVE_PROJECT_ID (STACK_PROJECT_ID also supported)
```

Also fixed the stale `stack ...` invocations in `local-vs-cloud-dashboard.mdx` and the migration page's claim that both binaries ship with `@hexclave/cli`. Intentional wire-compat identifiers (`STACK_*` env vars, `x-stack-*` headers, `@stackframe/*` packages, `stack.config.ts` filename fallbacks) are untouched.


Link to Devin session: https://app.devin.ai/sessions/400813a198cb40c795ec7c45ac5efe6b
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the CLI docs as a concise install/quickstart plus a complete `hexclave` command reference (all top-level and subcommands). Also updated CLI help strings and removed stale `stack` mentions in related docs; behavior is unchanged, only display text.

- Covers `init`, `doctor`, `fix`, `login`, `logout`, `whoami`, `project`, `config`, `dev`, `deploy`, `exec`, `team`, with synopsis, options, and auth notes.
- Prefers `HEXCLAVE_*` env vars and notes `STACK_*` aliases. `@hexclave/cli` now documents only the `hexclave` binary.

- **Bug Fixes**
  - `exec`: help now says “Hexclave server app” and references `hexclave.config.ts`.
  - `dev`: `--config-file` help updated to “Path to hexclave.config.ts”.
  - `config pull/push`: `--cloud-project-id` help now defaults to `HEXCLAVE_PROJECT_ID` (notes `STACK_PROJECT_ID` also supported).
  - Updated `local-vs-cloud-dashboard.mdx` and `migration.mdx` to remove `stack` invocations and clarify that only `hexclave` ships with `@hexclave/cli`.

<sup>Written for commit 1e01fa5c2b7d82327fc42c670851a5015fe3ac97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Commander help/description text only; no runtime or authentication logic changes.
> 
> **Overview**
> **Replaces outdated `stack` CLI documentation** with an install/quickstart section and a full **`hexclave` command reference** covering every top-level command and nested subcommand (synopsis, options, auth/behavior), including **`HEXCLAVE_*` env vars** with **`STACK_*` aliases** and per-command flags such as **`--cloud-project-id`** instead of the removed root **`--project-id`**.
> 
> **Related docs** now use **`hexclave`** invocations in `local-vs-cloud-dashboard.mdx`, and **`migration.mdx`** states that only the **`hexclave`** binary ships with **`@hexclave/cli`** (the **`stack`** binary is no longer published).
> 
> **CLI help strings only** (no behavior change): **`exec`** and **`dev`** reference **`hexclave.config.ts`** / Hexclave server app naming; **`config pull`/`push`** document **`HEXCLAVE_PROJECT_ID`** as the default project env var with **`STACK_PROJECT_ID`** still supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e01fa5c2b7d82327fc42c670851a5015fe3ac97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Rewrote CLI guidance for the `hexclave` command, including installation, authentication, project setup, development, deployment, diagnostics, administration, and team management.
  - Updated migration instructions to reflect that only the `hexclave` binary is published.
  - Refreshed local and cloud dashboard workflows with current commands and authentication guidance.

- **Improvements**
  - Clarified project ID environment variable support, configuration file names, command descriptions, options, defaults, and confirmation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->