### PR TITLE
Stop sending incidental verification emails in E2E tests

### DIFF
--- a/apps/e2e/tests/backend/backend-helpers.ts
+++ b/apps/e2e/tests/backend/backend-helpers.ts
@@ -598,7 +598,7 @@ export namespace Auth {
   }
 
   export namespace Password {
-    export async function signUpWithEmail(options: { password?: string, noWaitForEmail?: boolean, turnstileToken?: string } = {}) {
+    export async function signUpWithEmail(options: { password?: string, sendVerificationEmail?: boolean, waitForVerificationEmail?: boolean, turnstileToken?: string } = {}) {
       const mailbox = backendContext.value.mailbox;
       const email = mailbox.emailAddress;
       const password = options.password ?? generateSecureRandomString();
@@ -608,7 +608,7 @@ export namespace Auth {
         body: filterUndefined({
           email,
           password,
-          verification_callback_url: "http://localhost:12345/some-callback-url",
+          verification_callback_url: options.sendVerificationEmail ? "http://localhost:12345/some-callback-url" : undefined,
           bot_challenge_token: options.turnstileToken ?? mockTurnstileTokens.signUpOk,
         }),
       });
@@ -622,8 +622,9 @@ export namespace Auth {
         headers: expect.anything(),
       });
 
-      // Wait for the verification email to arrive (unless explicitly disabled)
-      if (!options.noWaitForEmail) {
+      // Verification emails dominated the baseline outbox and slowed the suite,
+      // so only tests asserting verification behavior opt into sending one.
+      if (options.sendVerificationEmail && options.waitForVerificationEmail !== false) {
         await mailbox.waitForMessagesWithSubject("Verify your email");
       }
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth-flows.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth-flows.test.ts
@@ -68,7 +68,7 @@ it("should not be able to sign in with OTP anymore after signing in with passwor
     }
   });
 
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "some-password" });
+  await Auth.Password.signUpWithEmail({ password: "some-password" });
 
   const response2 = await niceBackendFetch("/api/v1/auth/otp/send-sign-in-code", {
     method: "POST",
@@ -125,7 +125,7 @@ it("signs in with password first, then signs in with oauth should give an accoun
   await InternalApiKey.createAndSetProjectKeys(proj.adminAccessToken);
 
 
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "some-password" });
+  await Auth.Password.signUpWithEmail({ password: "some-password" });
   const cc = await ContactChannels.getTheOnlyContactChannel();
   expect(cc.is_verified).toBe(false);
   expect(cc.used_for_auth).toBe(true);

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/anonymous/anonymous-comprehensive.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/anonymous/anonymous-comprehensive.test.ts
@@ -39,7 +39,7 @@ it("anonymous JWT has different kid and role", async ({ expect }) => {
   expect(header.kid).toBeTruthy();
 
   // The kid should be different from regular users
-  const regularSignUp = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const regularSignUp = await Auth.Password.signUpWithEmail();
   const regularToken = regularSignUp.signUpResponse.body.access_token;
   const [regularHeader] = regularToken.split('.').slice(0, 1).map((part: string) =>
     JSON.parse(Buffer.from(part, 'base64url').toString())
@@ -159,7 +159,7 @@ it("list users excludes anonymous users by default", async ({ expect }) => {
 
   // Create a regular user
   // Email delivery is queue-driven and can take tens of seconds in dev/CI; this test only needs the user record.
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
 
   // List users without include_anonymous
   const listRes = await niceBackendFetch("/api/v1/users", {
@@ -183,7 +183,7 @@ it("list users includes anonymous users when requested", async ({ expect }) => {
   // Create a regular user
   await bumpEmailAddress();
   // Email delivery is queue-driven and can take tens of seconds in dev/CI; this test only needs the user record.
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
 
   // List users with include_anonymous=true
   const listRes = await niceBackendFetch("/api/v1/users?include_anonymous=true", {
@@ -268,7 +268,7 @@ it("search users excludes anonymous users by default", async ({ expect }) => {
 
   // Create a regular user
   await Auth.signOut();
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
 
   // Search for users with query matching anonymous user
   const searchRes = await niceBackendFetch("/api/v1/users?query=Unique", {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/anonymous/anonymous-upgrade.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/anonymous/anonymous-upgrade.test.ts
@@ -49,7 +49,7 @@ it("anonymous user can upgrade to regular user via password sign-up", async ({ e
   `);
 
   // Upgrade the user via password sign-up while logged in as anonymous
-  const { signUpResponse: upgradeRes } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { signUpResponse: upgradeRes } = await Auth.Password.signUpWithEmail();
 
   expect(upgradeRes).toMatchInlineSnapshot(`
     NiceResponse {
@@ -150,7 +150,7 @@ it("non-anonymous user sign-up creates new account (does not upgrade)", async ({
   await Project.createAndSwitch();
 
   // Create a regular user
-  const firstUser = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const firstUser = await Auth.Password.signUpWithEmail();
   const firstUserId = firstUser.userId;
   const firstAccessToken = firstUser.signUpResponse.body.access_token;
 
@@ -227,7 +227,7 @@ it("non-anonymous user sign-up creates new account (does not upgrade)", async ({
 
 it("signing in to an existing account while logged in as anonymous does not upgrade the user", async ({ expect }) => {
   const password = "TestPassword123!";
-  const { userId: existingUserId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password });
+  const { userId: existingUserId } = await Auth.Password.signUpWithEmail({ password });
   await Auth.signOut();
 
   const { accessToken: anonAccessToken, userId: anonUserId } = await Auth.Anonymous.signUp();
@@ -507,7 +507,7 @@ it("cannot upgrade anonymous user to email that already exists", async ({ expect
   // Create a regular user with an email
   await bumpEmailAddress();
   const existingEmail = backendContext.value.mailbox.emailAddress;
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
 
   // Create an anonymous user
   const anonSignUp = await Auth.Anonymous.signUp();

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/cli/complete.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/cli/complete.test.ts
@@ -86,7 +86,7 @@ it("should allow a restricted user's refresh token so clients can choose their o
     "onboarding.requireEmailVerification": true,
   });
 
-  const restrictedUser = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const restrictedUser = await Auth.Password.signUpWithEmail();
   const createResponse = await niceBackendFetch("/api/latest/auth/cli", {
     method: "POST",
     accessType: "server",
@@ -243,7 +243,7 @@ it("should keep the same user when the browser upgrades the CLI anonymous sessio
     },
   });
 
-  const browserUpgradeResponse = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const browserUpgradeResponse = await Auth.Password.signUpWithEmail();
   expect(browserUpgradeResponse.userId).toBe(cliAnonymousUser.userId);
 
   const completeResponse = await niceBackendFetch("/api/latest/auth/cli/complete", {
@@ -591,7 +591,7 @@ it("should handle the full claim → upgrade → complete flow with same user ID
   expect(claimResponse.status).toBe(200);
   expect(claimResponse.body.refresh_token).toBe(cliAnonymousUser.refreshToken);
 
-  const upgradeResponse = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const upgradeResponse = await Auth.Password.signUpWithEmail();
 
   expect(upgradeResponse.userId).toBe(originalUserId);
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/email-normalization.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/email-normalization.test.ts
@@ -32,7 +32,6 @@ it("password sign-in should work with normalized email when account was created 
 
   backendContext.set({ mailbox: createMailbox(uppercaseEmail) });
   const signUpRes = await Auth.Password.signUpWithEmail({
-    noWaitForEmail: true,
     password,
   });
   expect(signUpRes.signUpResponse.status).toBe(200);
@@ -69,7 +68,6 @@ it("password sign-in should work with unnormalized email when account was create
 
   backendContext.set({ mailbox: createMailbox(normalizedEmail) });
   const signUpRes = await Auth.Password.signUpWithEmail({
-    noWaitForEmail: true,
     password,
   });
   expect(signUpRes.signUpResponse.status).toBe(200);
@@ -155,7 +153,6 @@ it("password reset should work with normalized email when account was created wi
 
   backendContext.set({ mailbox: createMailbox(uppercaseEmail) });
   const signUpRes = await Auth.Password.signUpWithEmail({
-    noWaitForEmail: true,
     password,
   });
   expect(signUpRes.signUpResponse.status).toBe(200);
@@ -231,7 +228,6 @@ it("password reset should work with unnormalized email when account was created 
 
   backendContext.set({ mailbox: createMailbox(normalizedEmail) });
   const signUpRes = await Auth.Password.signUpWithEmail({
-    noWaitForEmail: true,
     password,
   });
   expect(signUpRes.signUpResponse.status).toBe(200);
@@ -301,7 +297,6 @@ it("should not allow duplicate accounts with same normalized email", async ({ ex
 
   backendContext.set({ mailbox: createMailbox(email1) });
   const signUpRes1 = await Auth.Password.signUpWithEmail({
-    noWaitForEmail: true,
     password: password1,
   });
   expect(signUpRes1.signUpResponse.status).toBe(200);
@@ -356,7 +351,6 @@ it("case-insensitive email should work for sign in even with mixed case variatio
   // Create account
   backendContext.set({ mailbox: createMailbox(baseEmail) });
   const signUpRes = await Auth.Password.signUpWithEmail({
-    noWaitForEmail: true,
     password,
   });
   expect(signUpRes.signUpResponse.status).toBe(200);

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/mfa/sign-in.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/mfa/sign-in.test.ts
@@ -3,7 +3,7 @@ import { it } from "../../../../../../helpers";
 import { Auth, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
 
 it("should sign in users with MFA enabled", async ({ expect }) => {
-  const passwordRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const passwordRes = await Auth.Password.signUpWithEmail();
   const { totpSecret } = await Auth.Mfa.setupTotpMfa();
   await Auth.signOut();
   const signInRes = await niceBackendFetch("/api/v1/auth/password/sign-in", {
@@ -64,7 +64,7 @@ it("should sign in users with MFA enabled", async ({ expect }) => {
 });
 
 it("should reject invalid attempt codes", async ({ expect }) => {
-  const passwordRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const passwordRes = await Auth.Password.signUpWithEmail();
   const { totpSecret } = await Auth.Mfa.setupTotpMfa();
   await Auth.signOut();
   const totp = generateTOTP(totpSecret, 30, 6);
@@ -94,7 +94,7 @@ it("should reject invalid attempt codes", async ({ expect }) => {
 
 
 it("should reject invalid totp codes", async ({ expect }) => {
-  const passwordRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const passwordRes = await Auth.Password.signUpWithEmail();
   const { totpSecret } = await Auth.Mfa.setupTotpMfa();
   await Auth.signOut();
   const signInRes = await niceBackendFetch("/api/v1/auth/password/sign-in", {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/oauth/cross-domain-authorize.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/oauth/cross-domain-authorize.test.ts
@@ -54,7 +54,7 @@ const exchangeAuthorizationCode = async (options: {
 };
 
 it("creates a one-time cross-domain redirect and exchanges it with PKCE", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   const existingRefreshToken = backendContext.value.userAuth?.refreshToken ?? throwErr("Missing refresh token in backend test context");
   const redirectUri = `${localRedirectUrl}/handler/oauth-callback?stack_cross_domain_auth=1`;
   const afterCallbackRedirectUrl = `${localRedirectUrl}/after-sign-in`;
@@ -88,7 +88,7 @@ it("creates a one-time cross-domain redirect and exchanges it with PKCE", async 
 });
 
 it("rejects reusing the same cross-domain authorization code", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   const redirectUri = `${localRedirectUrl}/handler/oauth-callback?stack_cross_domain_auth=1`;
 
   const authorizeResponse = await createCrossDomainAuthorizeRedirect({ redirectUri });
@@ -114,7 +114,7 @@ it("rejects reusing the same cross-domain authorization code", async ({ expect }
 });
 
 it("rejects exchanging with an invalid PKCE code_verifier", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   const redirectUri = `${localRedirectUrl}/handler/oauth-callback?stack_cross_domain_auth=1`;
 
   const authorizeResponse = await createCrossDomainAuthorizeRedirect({ redirectUri });
@@ -141,7 +141,7 @@ it("rejects exchanging with an invalid PKCE code_verifier", async ({ expect }) =
 });
 
 it("rejects untrusted redirect URLs before issuing a code", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
 
   const response = await createCrossDomainAuthorizeRedirect({
     redirectUri: "https://evil.example.com/oauth/callback",
@@ -163,7 +163,7 @@ it("rejects untrusted redirect URLs before issuing a code", async ({ expect }) =
 });
 
 it("rejects untrusted after-callback redirect URLs before issuing a code", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
 
   const response = await createCrossDomainAuthorizeRedirect({
     afterCallbackRedirectUrl: "https://evil.example.com/post-auth",
@@ -185,7 +185,7 @@ it("rejects untrusted after-callback redirect URLs before issuing a code", async
 });
 
 it("requires a signed-in user to issue a cross-domain code", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   backendContext.set({ userAuth: null });
 
   const response = await createCrossDomainAuthorizeRedirect();
@@ -194,7 +194,7 @@ it("requires a signed-in user to issue a cross-domain code", async ({ expect }) 
 });
 
 it("requires providing the current refresh token to issue a cross-domain code", async ({ expect }) => {
-  const { signUpResponse } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { signUpResponse } = await Auth.Password.signUpWithEmail();
   backendContext.set({
     userAuth: {
       accessToken: signUpResponse.body.access_token,
@@ -208,7 +208,7 @@ it("requires providing the current refresh token to issue a cross-domain code", 
 });
 
 it("rejects refresh tokens that do not match the authenticated session", async ({ expect }) => {
-  const firstSignUp = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const firstSignUp = await Auth.Password.signUpWithEmail();
   const response = await createCrossDomainAuthorizeRedirect({
     userAuth: {
       accessToken: firstSignUp.signUpResponse.body.access_token,
@@ -220,7 +220,7 @@ it("rejects refresh tokens that do not match the authenticated session", async (
 });
 
 it("does not authorize when only a refresh token is present", async ({ expect }) => {
-  const { signUpResponse } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { signUpResponse } = await Auth.Password.signUpWithEmail();
   backendContext.set({
     userAuth: {
       accessToken: undefined,

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/oauth/merge-strategy.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/oauth/merge-strategy.test.ts
@@ -116,7 +116,7 @@ it("should not merge accounts if the merge strategy is set to link_method, but t
   });
   await InternalApiKey.createAndSetProjectKeys(proj.adminAccessToken);
 
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   const cc = await ContactChannels.getTheOnlyContactChannel();
   expect(cc.is_verified).toBe(false);
   expect(cc.used_for_auth).toBe(true);

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/passkey/register.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/passkey/register.test.ts
@@ -6,14 +6,14 @@ import { Auth, niceBackendFetch, Project } from "../../../../../backend-helpers"
 
 it("should allow initiating passkey registration", async ({ expect }) => {
   await Project.createAndSwitch({ config: { passkey_enabled: true } });
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   await Auth.Passkey.initiateRegistration();
 });
 
 
 it("should successfully register a passkey", async ({ expect }) => {
   await Project.createAndSwitch({ config: { passkey_enabled: true } });
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   await Auth.Passkey.register();
 });
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/passkey/sign-in.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/passkey/sign-in.test.ts
@@ -6,7 +6,7 @@ import { Auth, niceBackendFetch, Project } from "../../../../../backend-helpers"
 
 it("should allow initiating passkey authentication", async ({ expect }) => {
   await Project.createAndSwitch({ config: { passkey_enabled: true, magic_link_enabled: true } });
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
   const response = await niceBackendFetch("/api/v1/auth/passkey/initiate-passkey-authentication", {
     method: "POST",
     accessType: "client",
@@ -34,7 +34,7 @@ it("should allow initiating passkey authentication", async ({ expect }) => {
 
 it("should successfully sign in with a passkey", async ({ expect }) => {
   await Project.createAndSwitch({ config: { passkey_enabled: true } });
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
 
   const expectedUserId = res.userId;
   await Auth.Passkey.register();
@@ -87,7 +87,7 @@ it("should successfully sign in with a passkey", async ({ expect }) => {
 
 it("should fail if passkey does not exist", async ({ expect }) => {
   await Project.createAndSwitch({ config: { passkey_enabled: true } });
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
   await Auth.Passkey.register();
   const response_initiation = await niceBackendFetch("/api/v1/auth/passkey/initiate-passkey-authentication", {
     method: "POST",

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/passkey/wildcard-domains.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/passkey/wildcard-domains.test.ts
@@ -89,7 +89,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up a user first
-    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const res = await Auth.Password.signUpWithEmail();
 
     // Configure wildcard domain that matches our test origin
     const configResponse = await niceBackendFetch("/api/v1/internal/config/override/environment", {
@@ -162,7 +162,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up and register passkey with default localhost allowed
-    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const res = await Auth.Password.signUpWithEmail();
     const expectedUserId = res.userId;
     await Auth.Passkey.register(); // This uses http://localhost:8103
     await Auth.signOut();
@@ -227,7 +227,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up a user first
-    await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    await Auth.Password.signUpWithEmail();
 
     // Configure exact domain that doesn't match
     const configResponse = await niceBackendFetch("/api/v1/internal/config/override/environment", {
@@ -303,7 +303,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up and register passkey with default localhost allowed
-    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const res = await Auth.Password.signUpWithEmail();
     await Auth.Passkey.register();
     await Auth.signOut();
 
@@ -375,7 +375,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up and register passkey with default localhost allowed
-    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const res = await Auth.Password.signUpWithEmail();
     await Auth.Passkey.register(); // This uses http://localhost:8103
     await Auth.signOut();
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/password/reset.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/password/reset.test.ts
@@ -33,7 +33,7 @@ async function getResetCode() {
 
 
 it("should reset the password", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   await Auth.signOut();
   const resetCode = await getResetCode();
   const response = await niceBackendFetch("/api/v1/auth/password/reset", {
@@ -81,7 +81,7 @@ it("should set a password if signed up with magic link", async ({ expect }) => {
 });
 
 it("should not reset the password if it's too weak", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   await Auth.signOut();
   const resetCode = await getResetCode();
   const response = await niceBackendFetch("/api/v1/auth/password/reset", {
@@ -109,7 +109,7 @@ it("should not reset the password if it's too weak", async ({ expect }) => {
 });
 
 it("should be able to check the password reset code without using it", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   await Auth.signOut();
   const resetCode = await getResetCode();
   const checkResponse1 = await niceBackendFetch("/api/v1/auth/password/reset/check-code", {
@@ -164,7 +164,7 @@ it("should be able to check the password reset code without using it", async ({ 
 });
 
 it("should return USER_NOT_FOUND if the user was deleted after the reset code was sent", async ({ expect }) => {
-  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { userId } = await Auth.Password.signUpWithEmail();
   await Auth.signOut();
   const resetCode = await getResetCode();
   const deleteResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/password/send-reset-code.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/password/send-reset-code.test.ts
@@ -2,7 +2,7 @@ import { it, localRedirectUrl } from "../../../../../../helpers";
 import { Auth, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
 
 it("should send a password reset code per e-mail", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ sendVerificationEmail: true });
   await Auth.signOut();
   const mailbox = backendContext.value.mailbox;
   const response = await niceBackendFetch("/api/v1/auth/password/send-reset-code", {
@@ -84,7 +84,7 @@ it("should send a password reset code even if the user signed up with magic link
 });
 
 it('should not send a password reset code if the redirect URL is invalid', async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   await Auth.signOut();
   const mailbox = backendContext.value.mailbox;
   const response = await niceBackendFetch("/api/v1/auth/password/send-reset-code", {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/password/set.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/password/set.test.ts
@@ -23,7 +23,7 @@ it("should set password", async ({ expect }) => {
 });
 
 it("is not allowed to set password if user already has a password", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
 
   const response = await niceBackendFetch("/api/v1/auth/password/set", {
     method: "POST",

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/password/sign-in.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/password/sign-in.test.ts
@@ -2,7 +2,7 @@ import { it } from "../../../../../../helpers";
 import { Auth, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
 
 it("should allow signing in to existing accounts", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
   backendContext.set({ userAuth: null });
   await Auth.expectToBeSignedOut();
   const res2 = await Auth.Password.signInWithEmail({ password: res.password });
@@ -81,7 +81,7 @@ it("should not allow signing in with an e-mail that never signed up", async ({ e
 });
 
 it("should not allow signing in with an incorrect password", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
   const response = await niceBackendFetch("/api/v1/auth/password/sign-in", {
     method: "POST",
     accessType: "client",
@@ -106,7 +106,7 @@ it("should not allow signing in with an incorrect password", async ({ expect }) 
 });
 
 it("should not allow signing in when MFA is required", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
   await Auth.Mfa.setupTotpMfa();
   await Auth.signOut();
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/password/sign-up.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/password/sign-up.test.ts
@@ -4,7 +4,7 @@ import { it } from "../../../../../../helpers";
 import { Auth, Project, backendContext, bumpEmailAddress, niceBackendFetch } from "../../../../../backend-helpers";
 
 it("should sign up new users", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ sendVerificationEmail: true });
   expect(res.signUpResponse).toMatchInlineSnapshot(`
     NiceResponse {
       "status": 200,
@@ -126,7 +126,7 @@ it("should not sign up new users if verification callback url is not valid", asy
 });
 
 it("should not allow signing up with an e-mail that already exists", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   const res2 = await niceBackendFetch("/api/v1/auth/password/sign-up", {
     method: "POST",
     accessType: "client",

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/password/sign-up.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/password/sign-up.test.ts
@@ -4,7 +4,10 @@ import { it } from "../../../../../../helpers";
 import { Auth, Project, backendContext, bumpEmailAddress, niceBackendFetch } from "../../../../../backend-helpers";
 
 it("should sign up new users", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail({ sendVerificationEmail: true });
+  const res = await Auth.Password.signUpWithEmail({
+    sendVerificationEmail: true,
+    waitForVerificationEmail: false,
+  });
   expect(res.signUpResponse).toMatchInlineSnapshot(`
     NiceResponse {
       "status": 200,

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/password/update.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/password/update.test.ts
@@ -2,7 +2,7 @@ import { it } from "../../../../../../helpers";
 import { Auth, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
 
 it("should update existing passwords", async ({ expect }) => {
-  const signUpRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const signUpRes = await Auth.Password.signUpWithEmail();
   const oldPassword = signUpRes.password;
   const newPassword = "new-password";
   const response = await niceBackendFetch("/api/v1/auth/password/update", {
@@ -26,7 +26,7 @@ it("should update existing passwords", async ({ expect }) => {
 });
 
 it("should sign out other sessions but not own session when updating password", async ({ expect }) => {
-  const signUpRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const signUpRes = await Auth.Password.signUpWithEmail();
   const oldPassword = signUpRes.password;
   const newPassword = "new-password";
 
@@ -64,7 +64,7 @@ it("should sign out other sessions but not own session when updating password", 
 });
 
 it("should not update passwords to weak passwords", async ({ expect }) => {
-  const signUpRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const signUpRes = await Auth.Password.signUpWithEmail();
   const oldPassword = signUpRes.password;
   const newPassword = "short";
   const response = await niceBackendFetch("/api/v1/auth/password/update", {
@@ -92,7 +92,7 @@ it("should not update passwords to weak passwords", async ({ expect }) => {
 });
 
 it("should not update passwords without old password", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   const newPassword = "new-password";
   const response = await niceBackendFetch("/api/v1/auth/password/update", {
     method: "POST",
@@ -126,7 +126,7 @@ it("should not update passwords without old password", async ({ expect }) => {
 });
 
 it("should not update passwords if the provided old password is wrong", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   const newPassword = "new-password";
   const response = await niceBackendFetch("/api/v1/auth/password/update", {
     method: "POST",

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/current/index.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/current/index.test.ts
@@ -6,7 +6,7 @@ it("should not crash when signing out a session that was already deleted by a bu
   // concurrent password change), then attempt sign-out with the stale access token.
   // Before fix: 500 assertion error in recordExternalDbSyncDeletion.
   // After fix: 401 REFRESH_TOKEN_NOT_FOUND_OR_EXPIRED.
-  const signUpRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const signUpRes = await Auth.Password.signUpWithEmail();
   const savedAuth = backendContext.value.userAuth ?? undefined;
 
   // Admin updates the user's password, which bulk-deletes all refresh tokens
@@ -41,7 +41,7 @@ it("should not crash when signing out a session that was already deleted by a bu
 
 it("should not crash when deleting a session that was already deleted by a bulk operation", async ({ expect }) => {
   // Same race condition but via the sessions CRUD DELETE endpoint
-  const signUpRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const signUpRes = await Auth.Password.signUpWithEmail();
 
   // Create a second session
   const newSessionRes = await niceBackendFetch("/api/v1/auth/sessions", {
@@ -85,7 +85,7 @@ it("should not crash when deleting a session that was already deleted by a bulk 
 });
 
 it("should sign out users", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   await Auth.expectToBeSignedIn();
   const res = await Auth.signOut();
   expect(res.signOutResponse).toMatchInlineSnapshot(`
@@ -116,7 +116,7 @@ it("should sign out users", async ({ expect }) => {
 });
 
 it("should sign out user without refresh token, only using access token", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   const response = await niceBackendFetch("/api/v1/auth/sessions/current", {
     method: "DELETE",
     accessType: "client",

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/current/refresh-race.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/current/refresh-race.test.ts
@@ -49,11 +49,7 @@ it("does not 500 when a refresh races with a sign-out of the same session", { ti
       mailbox: createMailbox(`refresh-race--${randomUUID()}${generatedEmailSuffix}`),
       userAuth: null,
     });
-    // `noWaitForEmail`: the race test only needs a refresh token, which is
-    // returned by the sign-up response itself. Waiting for the verification
-    // email costs 5–10s per iteration on CI and pushes the test past its
-    // 120s timeout.
-    await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    await Auth.Password.signUpWithEmail();
     const rt = backendContext.value.userAuth!.refreshToken!;
 
     const refreshP = niceBackendFetch("/api/v1/auth/sessions/current/refresh", {
@@ -92,8 +88,7 @@ it("does not 500 when an OAuth refresh-token grant races with a sign-out of the 
       mailbox: createMailbox(`oauth-refresh-race--${randomUUID()}${generatedEmailSuffix}`),
       userAuth: null,
     });
-    // See note above on `noWaitForEmail`.
-    await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    await Auth.Password.signUpWithEmail();
     const rt = backendContext.value.userAuth!.refreshToken!;
     const projectKeys = backendContext.value.projectKeys;
     if (projectKeys === "no-project") throw new Error("No project keys found in the backend context");

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/current/refresh.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/current/refresh.test.ts
@@ -2,7 +2,7 @@ import { it } from "../../../../../../../helpers";
 import { Auth, backendContext, niceBackendFetch } from "../../../../../../backend-helpers";
 
 it("should refresh sessions", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   backendContext.set({ userAuth: { ...backendContext.value.userAuth, accessToken: undefined } });
   await Auth.expectSessionToBeValid();
   const refreshSessionResponse = await niceBackendFetch("/api/v1/auth/sessions/current/refresh", {
@@ -22,7 +22,7 @@ it("should refresh sessions", async ({ expect }) => {
 });
 
 it("should not refresh sessions given invalid refresh tokens", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   const refreshSessionResponse = await niceBackendFetch("/api/v1/auth/sessions/current/refresh", {
     method: "POST",
     accessType: "client",
@@ -48,7 +48,7 @@ it("should not refresh sessions given invalid refresh tokens", async ({ expect }
 it.todo("should not refresh sessions of other projects");
 
 it("should not refresh sessions when user has been deleted", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
 
   // delete the user
   const response = await niceBackendFetch("/api/v1/users/me", {
@@ -84,7 +84,7 @@ it("should not refresh sessions when user has been deleted", async ({ expect }) 
 
 it("should not refresh revoked sessions", async ({ expect }) => {
   // Create a user and sign up
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
 
   // Create an additional session for the user
   const additionalSession = await niceBackendFetch("/api/v1/auth/sessions", {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/index.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/index.test.ts
@@ -4,7 +4,7 @@ import { it } from "../../../../../../helpers";
 import { Auth, backendContext, createMailbox, niceBackendFetch } from "../../../../../backend-helpers";
 
 it("cannot create sessions from the client", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
   const res2 = await niceBackendFetch("/api/v1/auth/sessions", {
     accessType: "client",
     method: "POST",
@@ -36,7 +36,7 @@ it("cannot create sessions from the client", async ({ expect }) => {
 });
 
 it("creates sessions for existing users", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
   backendContext.set({ userAuth: null });
   await Auth.expectToBeSignedOut();
   const res2 = await niceBackendFetch("/api/v1/auth/sessions", {
@@ -59,7 +59,7 @@ it("creates sessions for existing users", async ({ expect }) => {
 });
 
 it("creates sessions that expire", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
   await Auth.expectToBeSignedIn();
   const beginDate = new Date();
   const res2 = await niceBackendFetch("/api/v1/auth/sessions", {
@@ -133,7 +133,7 @@ it("creates sessions that expire", async ({ expect }) => {
 });
 
 it("cannot create sessions with an expiry date larger than a year away", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
   const res2 = await niceBackendFetch("/api/v1/auth/sessions", {
     accessType: "server",
     method: "POST",
@@ -168,7 +168,7 @@ it("cannot create sessions with an expiry date larger than a year away", async (
 
 it("can delete sessions as client", async ({ expect }) => {
   // Create a user and sign up
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
   const additionalSession = await niceBackendFetch("/api/v1/auth/sessions", {
     accessType: "server",
     method: "POST",
@@ -217,7 +217,7 @@ it("can delete sessions as client", async ({ expect }) => {
 
 it("cannot delete current session as client", async ({ expect }) => {
   // Create a user and sign up
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
 
   // List sessions to get the current session ID
   const listResponse = await niceBackendFetch("/api/v1/auth/sessions", {
@@ -264,11 +264,11 @@ it("cannot delete current session as client", async ({ expect }) => {
 
 it("cannot read another user's sessions as client", async ({ expect }) => {
   // Create first user and sign up (skip email wait — not needed for this test)
-  const user1 = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const user1 = await Auth.Password.signUpWithEmail();
 
   // Create second user and sign up
   backendContext.set({ userAuth: null, mailbox: createMailbox() }); // Clear first user's auth
-  const user2 = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const user2 = await Auth.Password.signUpWithEmail();
 
   // Try to read user1's sessions while authenticated as user2
   const listResponse = await niceBackendFetch("/api/v1/auth/sessions", {
@@ -323,7 +323,7 @@ it("server cannot list sessions without user_id", async ({ expect }) => {
 
 it("impersonation sessions hidden for non-admin clients and shown for admins", async ({ expect }) => {
   // Create a user and sign up
-  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const res = await Auth.Password.signUpWithEmail();
 
   // Create an impersonation session for the user
   const impersonationSession = await niceBackendFetch("/api/v1/auth/sessions", {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/sign-up-rules.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/sign-up-rules.test.ts
@@ -48,7 +48,7 @@ describe("sign-up rules", () => {
       },
     });
 
-    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const res = await Auth.Password.signUpWithEmail();
     expect(res.signUpResponse.status).toBe(200);
   });
 
@@ -74,7 +74,7 @@ describe("sign-up rules", () => {
     });
 
     // Sign up with a different email should work
-    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const res = await Auth.Password.signUpWithEmail();
     expect(res.signUpResponse.status).toBe(200);
   });
 
@@ -173,7 +173,7 @@ describe("sign-up rules", () => {
       'auth.signUpRulesDefaultAction': 'allow',
     });
 
-    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const res = await Auth.Password.signUpWithEmail();
     expect(res.signUpResponse.status).toBe(200);
   });
 
@@ -815,7 +815,7 @@ describe("sign-up rules", () => {
       'auth.signUpRulesDefaultAction': 'allow',
     });
 
-    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const res = await Auth.Password.signUpWithEmail();
     expect(res.signUpResponse.status).toBe(200);
   });
 
@@ -1159,7 +1159,7 @@ describe("sign-up rules", () => {
     });
 
     // Password signup should work
-    const passwordRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const passwordRes = await Auth.Password.signUpWithEmail();
     expect(passwordRes.signUpResponse.status).toBe(200);
   });
 
@@ -1186,7 +1186,7 @@ describe("sign-up rules", () => {
     });
 
     // Password signup should work
-    const passwordRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const passwordRes = await Auth.Password.signUpWithEmail();
     expect(passwordRes.signUpResponse.status).toBe(200);
   });
 
@@ -2000,7 +2000,7 @@ describe("sign-up rules", () => {
     });
 
     // Should be allowed since rule never matches
-    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const res = await Auth.Password.signUpWithEmail();
     expect(res.signUpResponse.status).toBe(200);
   });
 
@@ -2434,7 +2434,7 @@ describe("sign-up rules", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     // User should not be restricted initially
     const beforeResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {
@@ -2475,7 +2475,7 @@ describe("sign-up rules", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     // Restrict without reason or details - should succeed (both are optional)
     const restrictResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {
@@ -2505,7 +2505,7 @@ describe("sign-up rules", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     // Try to set unrestricted with a reason - should fail
     const restrictResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {
@@ -2527,7 +2527,7 @@ describe("sign-up rules", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     // Try to set unrestricted with private details - should fail
     const restrictResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {
@@ -2611,7 +2611,7 @@ describe("sign-up rules", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     // Restrict with reason + details
     const restrictResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {

--- a/apps/e2e/tests/backend/endpoints/api/v1/connected-accounts.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/connected-accounts.test.ts
@@ -535,7 +535,7 @@ it("should return 400 when trying to get access token for non-existent provider_
 
 it("should return empty list when user has no connected accounts", async ({ expect }) => {
   // Sign in without OAuth (using password)
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
 
   const response = await niceBackendFetch("/api/v1/connected-accounts/me", {
     accessType: "client",
@@ -706,7 +706,7 @@ it("should forbid client access to other users' connected accounts", async ({ ex
 
   // User 2 signs in
   backendContext.set({ mailbox: createMailbox() });
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
 
   // Try to access user 1's connected accounts as user 2
   const response = await niceBackendFetch(`/api/v1/connected-accounts/${user1Id}`, {
@@ -952,7 +952,7 @@ it("should allow server access to list any user's connected accounts", async ({ 
 
   // User 2 signs in
   backendContext.set({ mailbox: createMailbox() });
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
 
   // Server can access user 1's connected accounts
   const response = await niceBackendFetch(`/api/v1/connected-accounts/${user1Id}`, {

--- a/apps/e2e/tests/backend/endpoints/api/v1/contact-channels/legacy-send-verification-code.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/contact-channels/legacy-send-verification-code.test.ts
@@ -2,7 +2,7 @@ import { it } from "../../../../../helpers";
 import { Auth, backendContext, niceBackendFetch } from "../../../../backend-helpers";
 
 it("doesn't send a verification code if logged out", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   backendContext.set({ userAuth: null });
   const response = await niceBackendFetch("/api/v1/contact-channels/send-verification-code", {
     method: "POST",
@@ -38,7 +38,7 @@ it("doesn't send a verification code if logged out", async ({ expect }) => {
 
 
 it("should send a verification code per e-mail", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ sendVerificationEmail: true });
   const mailbox = backendContext.value.mailbox;
   await niceBackendFetch(`/api/v1/contact-channels/send-verification-code`, {
     method: "POST",

--- a/apps/e2e/tests/backend/endpoints/api/v1/contact-channels/send-verification-code.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/contact-channels/send-verification-code.test.ts
@@ -2,7 +2,7 @@ import { it } from "../../../../../helpers";
 import { Auth, ContactChannels, backendContext, niceBackendFetch } from "../../../../backend-helpers";
 
 it("can't send a verification code while logged out", async ({ expect }) => {
-  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { userId } = await Auth.Password.signUpWithEmail();
   const ccResponse = await niceBackendFetch("/api/v1/contact-channels?user_id=me", {
     method: "GET",
     accessType: "client",
@@ -33,7 +33,7 @@ it("can't send a verification code while logged out", async ({ expect }) => {
 
 
 it("should send a verification code per e-mail", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ sendVerificationEmail: true });
   await ContactChannels.sendVerificationCode();
   // expect two emails; one from the signup, and one from the send-verification-code
   const messages = await backendContext.value.mailbox.waitForMessagesWithSubjectCount("Verify your email", 2, { noBody: true });

--- a/apps/e2e/tests/backend/endpoints/api/v1/contact-channels/verify.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/contact-channels/verify.test.ts
@@ -3,7 +3,7 @@ import { it } from "../../../../../helpers";
 import { Auth, ContactChannels, backendContext, niceBackendFetch } from "../../../../backend-helpers";
 
 it("should verify user's email", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ sendVerificationEmail: true });
   const userResponse1 = await niceBackendFetch("/api/v1/users/me", { accessType: "client" });
   expect(userResponse1.body.primary_email_verified).toBe(false);
   await ContactChannels.verify();
@@ -14,10 +14,8 @@ it("should verify user's email", async ({ expect }) => {
 it("each verification code that was already requested can be used exactly once", async ({ expect }) => {
   // note: send-verification-code checks that you didn't already verify the email when you send the verification code, but if you request multiple at the same time you should be able to use them all
 
-  // Skip the per-email wait in signUpWithEmail — we'll batch-wait for all 3
-  // emails at the end. This avoids 3 sequential email waits (each 5–20s under
-  // CI load), which together can exceed the 60s test timeout.
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  // Batch-wait for the signup code and the two explicit verification codes.
+  await Auth.Password.signUpWithEmail({ sendVerificationEmail: true, waitForVerificationEmail: false });
 
   // Fire both send-verification-code requests without waiting for delivery
   const contactChannelId = (await ContactChannels.getTheOnlyContactChannel()).id;
@@ -34,8 +32,6 @@ it("each verification code that was already requested can be used exactly once",
   });
   expect(sendRes2).toMatchObject({ status: 200 });
 
-  // Single batch wait for all 3 verification emails (1 from signup + 2 from
-  // send-verification-code) instead of 3 sequential waits.
   const mailbox = backendContext.value.mailbox;
   const verifyMessages = await mailbox.waitForMessagesWithSubjectCount("Verify your email", 3);
   const verificationCodes = verifyMessages.map((message) => message.body?.text.match(/http:\/\/localhost:12345\/some-callback-url\?code=([a-zA-Z0-9]+)/)?.[1] ?? throwErr("Verification code not found"));
@@ -80,7 +76,7 @@ it("each verification code that was already requested can be used exactly once",
 });
 
 it("should not allow verify a code that doesn't exist", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   const response = await niceBackendFetch("/api/v1/contact-channels/verify", {
     method: "POST",
     accessType: "client",

--- a/apps/e2e/tests/backend/endpoints/api/v1/emails/email-queue.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/emails/email-queue.test.ts
@@ -119,7 +119,7 @@ describe("email queue edge cases", () => {
     });
 
     const mailbox = await bumpEmailAddress();
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     // Get the contact channel ID
     const contactChannelsResponse = await niceBackendFetch(`/api/v1/contact-channels?user_id=${userId}`, {
@@ -185,7 +185,7 @@ describe("email queue edge cases", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     const createDraftResponse = await niceBackendFetch("/api/v1/internal/email-drafts", {
       method: "POST",
@@ -249,7 +249,7 @@ describe("email queue edge cases", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     // Unsubscribe from Marketing first
     await niceBackendFetch(
@@ -333,7 +333,7 @@ describe("email queue edge cases", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
     const sendResponse = await niceBackendFetch("/api/v1/emails/send-email", {
       method: "POST",
       accessType: "server",
@@ -512,7 +512,7 @@ describe("template rendering edge cases", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     // Create a draft with a subject in the template
     const templateWithSubject = `import { Container } from "@react-email/components";
@@ -569,7 +569,7 @@ export function EmailTemplate({ user, project }: Props) {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     // Create a draft with a subject in the template
     const templateWithSubject = `import { Container } from "@react-email/components";
@@ -627,7 +627,7 @@ export function EmailTemplate({ user, project }: Props) {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     // Create a draft without NotificationCategory export
     const templateWithoutCategory = `import { Container } from "@react-email/components";
@@ -956,7 +956,7 @@ describe("template variables", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     // Create a simple template
     const simpleTemplate = deindent`
@@ -1065,7 +1065,7 @@ describe("template variables", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
 
     // Create a simple template
     const simpleTemplate = deindent`

--- a/apps/e2e/tests/backend/endpoints/api/v1/integrations/credential-scanning/revoke.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/integrations/credential-scanning/revoke.test.ts
@@ -12,7 +12,7 @@ it("should send email notification to user when revoking an API key through cred
   await Project.createAndSwitch({ config: { magic_link_enabled: true, allow_team_api_keys: true, allow_user_api_keys: true } });
 
   const mailbox2 = await bumpEmailAddress();
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
   await Auth.signOut();
   const mailbox1 = await bumpEmailAddress();
   const user1 = await Auth.fastSignUp({ primary_email: mailbox1.emailAddress, primary_email_verified: true });
@@ -134,13 +134,13 @@ it("should send email notification to team members when revoking a team API key 
   await InternalApiKey.createAndSetProjectKeys();
 
   const mailbox2 = await bumpEmailAddress();
-  const user2 = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const user2 = await Auth.Password.signUpWithEmail();
   await Auth.signOut();
   const mailbox3 = await bumpEmailAddress();
-  const user3 = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const user3 = await Auth.Password.signUpWithEmail();
   await Auth.signOut();
   const mailbox1 = await bumpEmailAddress();
-  const user1 = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const user1 = await Auth.Password.signUpWithEmail();
 
   // Create a team and add all users
   const { teamId } = await Team.create();

--- a/apps/e2e/tests/backend/endpoints/api/v1/integrations/neon/projects/provision.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/integrations/neon/projects/provision.test.ts
@@ -104,7 +104,7 @@ it("should be able to provision a new project if neon client details are correct
   `);
 
   // ensure we can create a user in the new project (make sure it's writable)
-  const signInResponse = await Auth.Password.signUpWithEmail({ password: "test1234", noWaitForEmail: true });
+  const signInResponse = await Auth.Password.signUpWithEmail({ password: "test1234" });
   expect(signInResponse).toMatchInlineSnapshot(`
     {
       "email": "default-mailbox--<stripped UUID>@stack-generated.example.com",

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal-metrics.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal-metrics.test.ts
@@ -372,7 +372,7 @@ it("should handle mixed auth methods excluding anonymous users", async ({ expect
   // Regular user with password
   const passwordMailbox = createMailbox();
   backendContext.set({ mailbox: passwordMailbox });
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "test1234" });
+  await Auth.Password.signUpWithEmail({ password: "test1234" });
 
   // Anonymous users (should not be counted)
   for (let i = 0; i < 5; i++) {

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/compliance-security-events.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/compliance-security-events.test.ts
@@ -7,7 +7,7 @@ import { Auth, Project, niceBackendFetch } from "../../../../backend-helpers";
 describe("Compliance Center security events", () => {
   it("records failed and successful password sign-in attempts", async ({ expect }) => {
     await Project.createAndSwitch({ config: {} });
-    const { email, password, userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { email, password, userId } = await Auth.Password.signUpWithEmail();
 
     const failedResponse = await niceBackendFetch("/api/v1/auth/password/sign-in", {
       method: "POST",
@@ -68,7 +68,7 @@ describe("Compliance Center security events", () => {
 
   it("records successful password sign-ins completed through MFA", async ({ expect }) => {
     await Project.createAndSwitch({ config: {} });
-    const { email, password } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { email, password } = await Auth.Password.signUpWithEmail();
     const { totpSecret } = await Auth.Mfa.setupTotpMfa();
     await Auth.signOut();
 
@@ -182,7 +182,7 @@ describe("Compliance Center security events", () => {
     });
     const anonymousUser = await Auth.Anonymous.signUp();
     await Auth.signOut();
-    const registeredUser = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const registeredUser = await Auth.Password.signUpWithEmail();
 
     const response = await niceBackendFetch("/api/v1/internal/compliance/restricted-users", {
       accessType: "admin",

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/failed-emails-digest.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/failed-emails-digest.test.ts
@@ -146,8 +146,9 @@ describe("with valid credentials", () => {
         },
       },
     }, true);
-    // Don't wait for verification email since the SMTP is intentionally broken
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    // The project intentionally has a broken SMTP host, so preserve the
+    // verification outbox row without waiting for delivery.
+    const { userId } = await Auth.Password.signUpWithEmail({ sendVerificationEmail: true, waitForVerificationEmail: false });
     await Auth.signOut();
 
     const testEmailResponse = await niceBackendFetch("/api/v1/emails/send-email", {

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/sign-up-rules-stats.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/sign-up-rules-stats.test.ts
@@ -190,7 +190,7 @@ describe("with admin access", () => {
       },
     });
 
-    await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    await Auth.Password.signUpWithEmail();
 
     // Wait for the ClickHouse event to appear and verify via a raw COALESCE query
     let chResult: any;

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/sign-up-rules-stats.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/sign-up-rules-stats.test.ts
@@ -131,13 +131,23 @@ describe("with admin access", () => {
       await wait(1_000 + 10_000 - (now.getTime() - lastSecondOfHour.getTime()));
     }
 
-    // Sign up a user to trigger the rule. Keep the (otherwise unnecessary) verification email wait:
-    // it doubles as the delay that lets the rule-trigger event land in ClickHouse before we query
-    // the stats endpoint below, which snapshots exact trigger counts.
+    // ClickHouse receives the rule-trigger event asynchronously, so wait for it before querying stats.
     const { userId } = await Auth.Password.signUpWithEmail();
 
-    const response = await niceBackendFetch("/api/v1/internal/sign-up-rules-stats", { accessType: "admin" });
-    expect(response.status).toBe(200);
+    const getStats = () => niceBackendFetch("/api/v1/internal/sign-up-rules-stats", { accessType: "admin" });
+    let response = await getStats();
+    for (let attempt = 0; attempt < 15; attempt++) {
+      const testRule = response.status === 200
+        ? response.body.rule_triggers.find((rule: { rule_id: string }) => rule.rule_id === "test-rule")
+        : undefined;
+      if (testRule?.total_count > 0) break;
+      await wait(500);
+      response = await getStats();
+    }
+
+    expect(response.status, "Timed out waiting for sign-up rule stats").toBe(200);
+    const testRule = response.body.rule_triggers.find((rule: { rule_id: string }) => rule.rule_id === "test-rule");
+    expect(testRule?.total_count, "Timed out waiting for test-rule event in ClickHouse").toBeGreaterThan(0);
     expect(Array.isArray(response.body.rule_triggers)).toBe(true);
     expect(typeof response.body.total_triggers).toBe('number');
     expect(response).toMatchInlineSnapshot(`

--- a/apps/e2e/tests/backend/endpoints/api/v1/project-permissions.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/project-permissions.test.ts
@@ -119,7 +119,7 @@ it("can create a new permission and grant it to a user on the server", async ({ 
 
   await InternalApiKey.createAndSetProjectKeys(adminAccessToken);
 
-  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: 'test1234' });
+  const { userId } = await Auth.Password.signUpWithEmail({ password: 'test1234' });
 
   // list current permissions
   const response1 = await niceBackendFetch(`/api/v1/project-permissions?user_id=me`, {
@@ -254,7 +254,7 @@ it("can customize default user permissions", async ({ expect }) => {
   `);
 
   // sign up a new user
-  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: 'test1234' });
+  const { userId } = await Auth.Password.signUpWithEmail({ password: 'test1234' });
   // list permissions for the new user
   const response3 = await niceBackendFetch(`/api/v1/project-permissions?user_id=${userId}`, {
     accessType: "client",

--- a/apps/e2e/tests/backend/endpoints/api/v1/projects.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/projects.test.ts
@@ -1614,7 +1614,7 @@ it("should increment and decrement userCount when a user is added to a project",
 
 
   // Create a new user in the project
-  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  await Auth.Password.signUpWithEmail();
 
   // The metrics endpoint reads from ClickHouse (eventual consistency).
   // Poll until the new user is visible.

--- a/apps/e2e/tests/backend/endpoints/api/v1/risk-scores.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/risk-scores.test.ts
@@ -141,7 +141,7 @@ describe("risk scores", () => {
   it("server responses include risk_scores while client responses omit them", async ({ expect }) => {
     await Project.createAndSwitch({ config: { credential_enabled: true } });
 
-    const signUpResult = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const signUpResult = await Auth.Password.signUpWithEmail();
 
     const serverUser = await readServerUser(signUpResult.userId);
     expectDerivedRiskScores(expect, serverUser.risk_scores.sign_up);
@@ -154,7 +154,7 @@ describe("risk scores", () => {
   it("client cannot update risk_scores", async ({ expect }) => {
     await Project.createAndSwitch({ config: { credential_enabled: true } });
 
-    const signUpResult = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const signUpResult = await Auth.Password.signUpWithEmail();
     const beforeUpdate = (await readServerUser(signUpResult.userId)).risk_scores.sign_up;
     const updateResponse = await niceBackendFetch("/api/v1/users/me", {
       method: "PATCH",

--- a/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
@@ -213,7 +213,7 @@ it("should return 200 and send email successfully", async ({ expect }) => {
       email_config: testEmailConfig,
     },
   });
-  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { userId } = await Auth.Password.signUpWithEmail();
   const response = await niceBackendFetch(
     "/api/v1/emails/send-email",
     {
@@ -418,7 +418,7 @@ it("should send email using a draft_id and mark draft as sent", async ({ expect 
       },
     },
   });
-  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { userId } = await Auth.Password.signUpWithEmail();
 
   const tsxSource = `import { Container } from "@react-email/components";
 import { Subject, NotificationCategory, Props } from "@stackframe/emails";
@@ -750,7 +750,7 @@ describe("notification categories", () => {
         email_config: testEmailConfig,
       },
     });
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
     const response = await niceBackendFetch(
       "/api/v1/emails/send-email",
       {
@@ -783,7 +783,7 @@ describe("notification categories", () => {
         email_config: testEmailConfig,
       },
     });
-    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+    const { userId } = await Auth.Password.signUpWithEmail();
     const response = await niceBackendFetch(
       "/api/v1/emails/send-email",
       {

--- a/apps/e2e/tests/backend/endpoints/api/v1/team-memberships.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/team-memberships.test.ts
@@ -503,9 +503,9 @@ it("should give team creator default permissions", async ({ expect }) => {
   const { adminAccessToken } = await Project.createAndGetAdminToken({ config: { magic_link_enabled: true } });
   await InternalApiKey.createAndSetProjectKeys(adminAccessToken);
 
-  const { userId: userId1 } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: 'test1234' });
+  const { userId: userId1 } = await Auth.Password.signUpWithEmail({ password: 'test1234' });
   await bumpEmailAddress();
-  const { userId: userId2 } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: 'test1234' });
+  const { userId: userId2 } = await Auth.Password.signUpWithEmail({ password: 'test1234' });
   const { teamId } = await Team.createWithCurrentAsCreator();
 
   await niceBackendFetch(`/api/v1/team-memberships/${teamId}/${userId1}`, {

--- a/apps/e2e/tests/backend/endpoints/api/v1/team-permissions.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/team-permissions.test.ts
@@ -123,7 +123,7 @@ it("can create a new permission and grant it to a user on the server", async ({ 
 
   await InternalApiKey.createAndSetProjectKeys(adminAccessToken);
 
-  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: 'test1234' });
+  const { userId } = await Auth.Password.signUpWithEmail({ password: 'test1234' });
   const { teamId } = await Team.createWithCurrentAsCreator();
 
   // list current permissions

--- a/apps/e2e/tests/backend/endpoints/api/v1/token-refresh-events.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/token-refresh-events.test.ts
@@ -148,7 +148,7 @@ it("password signup creates exactly one $token-refresh event", async ({ expect }
     config: { credential_enabled: true },
   });
   await InternalApiKey.createAndSetProjectKeys();
-  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { userId } = await Auth.Password.signUpWithEmail();
 
   const events = await expectExactlyNTokenRefreshEvents(userId, 1, { projectId });
   expect(events[0]).toMatchObject({
@@ -230,7 +230,7 @@ it("password signin (existing user) creates exactly one additional $token-refres
   await InternalApiKey.createAndSetProjectKeys();
 
   // First, sign up
-  const { userId, password } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { userId, password } = await Auth.Password.signUpWithEmail();
 
   // Wait for the signup event to be recorded
   await expectExactlyNTokenRefreshEvents(userId, 1, { projectId });

--- a/apps/e2e/tests/backend/endpoints/api/v1/unsubscribe-link.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/unsubscribe-link.test.ts
@@ -17,7 +17,7 @@ it("unsubscribe link should be sent and update notification preference", async (
       },
     },
   });
-  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { userId } = await Auth.Password.signUpWithEmail();
   const response = await niceBackendFetch(
     "/api/v1/emails/send-email",
     {
@@ -105,7 +105,7 @@ it("unsubscribe link should not be sent for emails with transactional notificati
       },
     },
   });
-  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { userId } = await Auth.Password.signUpWithEmail();
   const response = await niceBackendFetch(
     "/api/v1/emails/send-email",
     {
@@ -150,7 +150,7 @@ it("unsubscribe link should be included when template exports Marketing notifica
       },
     },
   });
-  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { userId } = await Auth.Password.signUpWithEmail();
 
   // Create a draft with a template that exports Marketing notification category
   const marketingTemplate = `import { Container } from "@react-email/components";
@@ -222,7 +222,7 @@ it("unsubscribe link should NOT be included when template exports Transactional 
       },
     },
   });
-  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const { userId } = await Auth.Password.signUpWithEmail();
 
   // Create a draft with a template that exports Transactional notification category
   // Using default theme so we can verify the theme doesn't add unsubscribe link for Transactional

--- a/apps/e2e/tests/backend/endpoints/api/v1/users.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/users.test.ts
@@ -2385,7 +2385,7 @@ describe("with server access", () => {
   });
 
   it("should be able to update primary email and sign-in with the new email", async ({ expect }) => {
-    await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "password123" });
+    await Auth.Password.signUpWithEmail({ password: "password123" });
     const mailbox = createMailbox();
     const response = await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
@@ -2467,7 +2467,7 @@ describe("with server access", () => {
     const primaryEmail = backendContext.value.mailbox.emailAddress;
     await Auth.signOut();
     await bumpEmailAddress();
-    await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "password123" });
+    await Auth.Password.signUpWithEmail({ password: "password123" });
     const response = await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
       method: "PATCH",
@@ -2529,7 +2529,7 @@ describe("with server access", () => {
   });
 
   it("should not be able to sign up with an email already in use for auth", async ({ expect }) => {
-    await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "password123" });
+    await Auth.Password.signUpWithEmail({ password: "password123" });
     const response = await niceBackendFetch("/api/v1/auth/password/sign-up", {
       method: "POST",
       accessType: "client",
@@ -2560,7 +2560,7 @@ describe("with server access", () => {
   });
 
   it("should be able to sign up with an email already in use for auth in a different project", async ({ expect }) => {
-    await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "password123" });
+    await Auth.Password.signUpWithEmail({ password: "password123" });
     await Project.createAndSwitch({});
     const response = await niceBackendFetch("/api/v1/auth/password/sign-up", {
       method: "POST",

--- a/apps/e2e/tests/general/cli.test.ts
+++ b/apps/e2e/tests/general/cli.test.ts
@@ -68,7 +68,7 @@ describe("Stack CLI", () => {
     Result.orThrow(await internalApp.signUpWithCredential({
       email: fakeEmail,
       password: "test-password-123",
-      verificationCallbackUrl: "http://localhost:3000",
+      noVerificationCallback: true,
     }));
 
     const user = await internalApp.getUser({ or: "throw" });

--- a/apps/e2e/tests/js/access-token-refresh.test.ts
+++ b/apps/e2e/tests/js/access-token-refresh.test.ts
@@ -19,7 +19,7 @@ describe("access token refresh on user property changes", () => {
       await clientApp.signUpWithCredential({
         email: "test@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       const user = await clientApp.getUser({ or: "throw" });
@@ -59,7 +59,7 @@ describe("access token refresh on user property changes", () => {
       await clientApp.signUpWithCredential({
         email: "test@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       const user = await clientApp.getUser({ or: "throw" });
@@ -92,7 +92,7 @@ describe("access token refresh on user property changes", () => {
       await clientApp.signUpWithCredential({
         email: "test@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       const user = await clientApp.getUser({ or: "throw" });
@@ -134,7 +134,7 @@ describe("access token refresh on user property changes", () => {
       await clientApp.signUpWithCredential({
         email: "test@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       const user = await clientApp.getUser({ or: "throw" });
@@ -173,7 +173,7 @@ describe("access token refresh on user property changes", () => {
       await clientApp.signUpWithCredential({
         email: "test@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       // Get restricted user
@@ -232,7 +232,7 @@ describe("access token refresh on user property changes", () => {
       await clientApp.signUpWithCredential({
         email: "upgraded@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       // Get a fresh access token
@@ -263,7 +263,7 @@ describe("access token refresh on user property changes", () => {
       await clientApp.signUpWithCredential({
         email: "test@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       const user = await clientApp.getUser({ or: "throw" });
@@ -284,7 +284,7 @@ describe("access token refresh on user property changes", () => {
       await clientApp.signUpWithCredential({
         email: "test@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       const user = await clientApp.getUser({ or: "throw" });
@@ -313,7 +313,7 @@ describe("access token refresh on user property changes", () => {
       await clientApp.signUpWithCredential({
         email: "test@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       const user = await clientApp.getUser({ or: "throw" });
@@ -345,7 +345,7 @@ describe("access token refresh on user property changes", () => {
       await clientApp.signUpWithCredential({
         email: "test@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       const user = await clientApp.getUser({ or: "throw" });
@@ -377,7 +377,7 @@ describe("access token refresh on user property changes", () => {
       await clientApp.signUpWithCredential({
         email: "test@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       const user = await clientApp.getUser({ or: "throw" });
@@ -410,7 +410,7 @@ describe("access token refresh on user property changes", () => {
       await clientApp.signUpWithCredential({
         email: "test@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       const user = await clientApp.getUser({ or: "throw" });

--- a/apps/e2e/tests/js/api-keys.test.ts
+++ b/apps/e2e/tests/js/api-keys.test.ts
@@ -14,7 +14,7 @@ it("should be able to create and update user api keys", async ({ expect }) => {
   await clientApp.signUpWithCredential({
     email: "test@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
 
   await clientApp.signInWithCredential({
@@ -118,7 +118,7 @@ it("should be able to get user by api key from server app", async ({ expect }) =
   await clientApp.signUpWithCredential({
     email: "test@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
 
   await clientApp.signInWithCredential({
@@ -162,7 +162,7 @@ it("should be able to revoke an API key from the client and server should not be
   await clientApp.signUpWithCredential({
     email: "test@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
 
   await clientApp.signInWithCredential({
@@ -211,7 +211,7 @@ it("should be able to revoke an API key from the server", async ({ expect }) => 
   await clientApp.signUpWithCredential({
     email: "test@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
 
   await clientApp.signInWithCredential({
@@ -276,7 +276,7 @@ it("should be able to create a team, add an API key, and get the team from the A
   await clientApp.signUpWithCredential({
     email: "test@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
 
   await clientApp.signInWithCredential({
@@ -336,7 +336,7 @@ it("should not be able to get a user with a team API key", async ({ expect }) =>
   await clientApp.signUpWithCredential({
     email: "test@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
 
   await clientApp.signInWithCredential({
@@ -390,7 +390,7 @@ it("should not allow team members without manage API key permission to manage te
   await clientApp.signUpWithCredential({
     email: "owner@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
 
   await clientApp.signInWithCredential({
@@ -424,7 +424,7 @@ it("should not allow team members without manage API key permission to manage te
   await clientApp.signUpWithCredential({
     email: "member@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
 
   await clientApp.signInWithCredential({

--- a/apps/e2e/tests/js/app.test.ts
+++ b/apps/e2e/tests/js/app.test.ts
@@ -14,7 +14,7 @@ it("should sign up with credential", async ({ expect }) => {
   const result1 = await clientApp.signUpWithCredential({
     email: "test@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
 
   expect(result1).toMatchInlineSnapshot(`
@@ -177,7 +177,7 @@ it("should throw a helpful error when destructuring user", async ({ expect }) =>
   const signUpResult = await clientApp.signUpWithCredential({
     email,
     password,
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   expect(signUpResult.status).toBe("ok");
 

--- a/apps/e2e/tests/js/auth-like.test.ts
+++ b/apps/e2e/tests/js/auth-like.test.ts
@@ -5,7 +5,7 @@ const signIn = async (clientApp: any) => {
   await clientApp.signUpWithCredential({
     email: "test@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "test@test.com",
@@ -510,7 +510,7 @@ it("getUser should work with request-like tokenStore containing auth cookies", a
   await clientApp.signUpWithCredential({
     email: userAEmail,
     password,
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({ email: userAEmail, password });
   const userA = await clientApp.getUser({ or: "throw" });
@@ -521,7 +521,7 @@ it("getUser should work with request-like tokenStore containing auth cookies", a
   await clientApp.signUpWithCredential({
     email: userBEmail,
     password,
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({ email: userBEmail, password });
   const userB = await clientApp.getUser({ or: "throw" });

--- a/apps/e2e/tests/js/convex.test.ts
+++ b/apps/e2e/tests/js/convex.test.ts
@@ -37,7 +37,7 @@ const signIn = async (clientApp: any) => {
   await clientApp.signUpWithCredential({
     email: "test@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "test@test.com",

--- a/apps/e2e/tests/js/cookies.test.ts
+++ b/apps/e2e/tests/js/cookies.test.ts
@@ -160,7 +160,7 @@ it("should set refresh token cookies for trusted parent domains", async ({ expec
   const signUpResult = await clientApp.signUpWithCredential({
     email,
     password,
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
     noRedirect: true,
   });
   expect(signUpResult.status).toBe("ok");
@@ -226,7 +226,7 @@ it("should avoid setting custom refresh cookies when no trusted parent domain is
   const signUpResult = await clientApp.signUpWithCredential({
     email,
     password,
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
     noRedirect: true,
   });
   expect(signUpResult.status).toBe("ok");
@@ -278,7 +278,7 @@ it("should omit secure-only defaults when running on http origins", async ({ exp
   const signUpResult = await clientApp.signUpWithCredential({
     email,
     password,
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
     noRedirect: true,
   });
   expect(signUpResult.status).toBe("ok");
@@ -381,7 +381,7 @@ it("should eagerly create cross-subdomain cookie on construction when session ex
   // Sign in to get a valid session
   const email = `${crypto.randomUUID()}@eager-cookie.test`;
   const password = "password";
-  await clientApp.signUpWithCredential({ email, password, verificationCallbackUrl: "http://localhost:3000", noRedirect: true });
+  await clientApp.signUpWithCredential({ email, password, noVerificationCallback: true, noRedirect: true });
   await clientApp.signInWithCredential({ email, password, noRedirect: true });
 
   const defaultCookieName = getDefaultRefreshCookieName(clientApp.projectId, true);

--- a/apps/e2e/tests/js/js-helpers.ts
+++ b/apps/e2e/tests/js/js-helpers.ts
@@ -27,7 +27,7 @@ export async function scaffoldProject(body?: Omit<AdminProjectCreateOptions, 'di
   Result.orThrow(await internalApp.signUpWithCredential({
     email: fakeEmail,
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   }));
   const adminUser = await internalApp.getUser({
     or: 'throw',

--- a/apps/e2e/tests/js/payments.test.ts
+++ b/apps/e2e/tests/js/payments.test.ts
@@ -17,7 +17,7 @@ it("createCheckoutUrl supports optional returnUrl and embeds it", async ({ expec
     },
   });
 
-  await clientApp.signUpWithCredential({ email: "checkout-return@test.com", password: "password", verificationCallbackUrl: "http://localhost:3000" });
+  await clientApp.signUpWithCredential({ email: "checkout-return@test.com", password: "password", noVerificationCallback: true });
   await clientApp.signInWithCredential({ email: "checkout-return@test.com", password: "password" });
   const user = await clientApp.getUser();
   if (!user) throw new Error("User not found");
@@ -48,7 +48,7 @@ it("returns default item quantity for a team", async ({ expect }) => {
   await clientApp.signUpWithCredential({
     email: "test@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
 
   await clientApp.signInWithCredential({
@@ -84,7 +84,7 @@ it("root-level getItem works for user and team", async ({ expect }) => {
     },
   });
 
-  await clientApp.signUpWithCredential({ email: "rl@test.com", password: "password", verificationCallbackUrl: "http://localhost:3000" });
+  await clientApp.signUpWithCredential({ email: "rl@test.com", password: "password", noVerificationCallback: true });
   await clientApp.signInWithCredential({ email: "rl@test.com", password: "password" });
   const user = await clientApp.getUser();
   if (!user) throw new Error("User not found");
@@ -144,7 +144,7 @@ it("admin can increase team item quantity and client sees updated value", async 
   await clientApp.signUpWithCredential({
     email: "inc@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({ email: "inc@test.com", password: "password" });
 
@@ -185,7 +185,7 @@ it("cannot decrease team item quantity below zero", async ({ expect }) => {
   await clientApp.signUpWithCredential({
     email: "dec@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({ email: "dec@test.com", password: "password" });
 
@@ -221,7 +221,7 @@ it("client can cancel their own subscription", async ({ expect }) => {
     },
   });
 
-  await clientApp.signUpWithCredential({ email: "cancel-sub@test.com", password: "password", verificationCallbackUrl: "http://localhost:3000" });
+  await clientApp.signUpWithCredential({ email: "cancel-sub@test.com", password: "password", noVerificationCallback: true });
   await clientApp.signInWithCredential({ email: "cancel-sub@test.com", password: "password" });
   const user = await clientApp.getUser({ or: "throw" });
 
@@ -251,7 +251,7 @@ it("team admin can cancel a team's subscription", async ({ expect }) => {
     },
   });
 
-  await clientApp.signUpWithCredential({ email: "cancel-team-sub@test.com", password: "password", verificationCallbackUrl: "http://localhost:3000" });
+  await clientApp.signUpWithCredential({ email: "cancel-team-sub@test.com", password: "password", noVerificationCallback: true });
   await clientApp.signInWithCredential({ email: "cancel-team-sub@test.com", password: "password" });
   const user = await clientApp.getUser({ or: "throw" });
 
@@ -332,7 +332,7 @@ it("supports granting and listing customer products", { timeout: 60_000 }, async
   await clientApp.signUpWithCredential({
     email: "products@example.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "products@example.com",

--- a/apps/e2e/tests/js/restricted-users.test.ts
+++ b/apps/e2e/tests/js/restricted-users.test.ts
@@ -22,7 +22,7 @@ describe("restricted user SDK filtering", () => {
       await clientApp.signUpWithCredential({
         email: "test-restricted@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       // By default, getUser should return null for restricted users
@@ -47,7 +47,7 @@ describe("restricted user SDK filtering", () => {
       await clientApp.signUpWithCredential({
         email: "test-restricted@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       // With includeRestricted: true, should return the restricted user
@@ -74,7 +74,7 @@ describe("restricted user SDK filtering", () => {
       await clientApp.signUpWithCredential({
         email: "test-verified@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       // User should be restricted at first
@@ -125,7 +125,7 @@ describe("restricted user SDK filtering", () => {
       await clientApp.signUpWithCredential({
         email: "test-restricted@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       // Get the restricted user with includeRestricted to capture its ID
@@ -161,7 +161,7 @@ describe("restricted user SDK filtering", () => {
       await clientApp.signUpWithCredential({
         email: "test-restricted@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       // Get the tokens from the restricted user (must use includeRestricted to get the user first)
@@ -191,7 +191,7 @@ describe("restricted user SDK filtering", () => {
       await clientApp.signUpWithCredential({
         email: "test-restricted@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       // Get the tokens from the restricted user (must use includeRestricted to get the user first)
@@ -222,7 +222,7 @@ describe("restricted user SDK filtering", () => {
       await clientApp.signUpWithCredential({
         email: "test-restricted@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       // Get the tokens from the restricted user
@@ -266,7 +266,7 @@ describe("restricted user SDK filtering", () => {
       await clientApp.signUpWithCredential({
         email: "test-restricted@example.com",
         password: "password123",
-        verificationCallbackUrl: "http://localhost:3000",
+        noVerificationCallback: true,
       });
 
       // By default, getUser should return null for restricted users

--- a/apps/e2e/tests/js/team-invitations.test.ts
+++ b/apps/e2e/tests/js/team-invitations.test.ts
@@ -9,7 +9,7 @@ it("should list team invitations for the current user via the client SDK", { tim
   await clientApp.signUpWithCredential({
     email: "team-owner@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "team-owner@test.com",
@@ -30,7 +30,7 @@ it("should list team invitations for the current user via the client SDK", { tim
   await clientApp.signUpWithCredential({
     email: "invited-user@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "invited-user@test.com",
@@ -63,7 +63,7 @@ it("should return empty invitations when user has no matching invitations", asyn
   await clientApp.signUpWithCredential({
     email: "no-invites@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "no-invites@test.com",
@@ -83,7 +83,7 @@ it("should list team invitations for a server user", async ({ expect }) => {
   await clientApp.signUpWithCredential({
     email: "server-owner@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "server-owner@test.com",
@@ -123,7 +123,7 @@ it("should not return invitations for unverified emails", async ({ expect }) => 
   await clientApp.signUpWithCredential({
     email: "unverified-owner@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "unverified-owner@test.com",
@@ -158,7 +158,7 @@ it("should list invitations from multiple teams", async ({ expect }) => {
   await clientApp.signUpWithCredential({
     email: "multi-owner@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "multi-owner@test.com",
@@ -205,7 +205,7 @@ it("should accept a team invitation via the client SDK", { timeout: 120_000 }, a
   await clientApp.signUpWithCredential({
     email: "accept-owner@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "accept-owner@test.com",
@@ -226,7 +226,7 @@ it("should accept a team invitation via the client SDK", { timeout: 120_000 }, a
   await clientApp.signUpWithCredential({
     email: "accept-user@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "accept-user@test.com",
@@ -263,7 +263,7 @@ it("should accept a team invitation via the server SDK", async ({ expect }) => {
   await clientApp.signUpWithCredential({
     email: "server-accept-owner@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "server-accept-owner@test.com",

--- a/apps/e2e/tests/js/team-memberships.test.ts
+++ b/apps/e2e/tests/js/team-memberships.test.ts
@@ -8,7 +8,7 @@ it("allows a client team member with permission to remove another member", { tim
   await clientApp.signUpWithCredential({
     email: "membership-owner@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "membership-owner@test.com",
@@ -20,7 +20,7 @@ it("allows a client team member with permission to remove another member", { tim
   await clientApp.signUpWithCredential({
     email: "membership-member@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   const member = await clientApp.getUser({ or: "throw" });
   const serverTeam = await serverApp.getTeam(team.id);
@@ -47,7 +47,7 @@ it("rejects client team member removal without the remove-members permission", {
   await clientApp.signUpWithCredential({
     email: "membership-owner-no-permission@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   await clientApp.signInWithCredential({
     email: "membership-owner-no-permission@test.com",
@@ -59,7 +59,7 @@ it("rejects client team member removal without the remove-members permission", {
   await clientApp.signUpWithCredential({
     email: "membership-member-no-permission@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   const member = await clientApp.getUser({ or: "throw" });
   const serverTeam = await serverApp.getTeam(team.id);
@@ -79,7 +79,7 @@ it("refreshes the current user after removing themselves from a team", { timeout
   await clientApp.signUpWithCredential({
     email: "membership-leave@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   const user = await clientApp.getUser({ or: "throw" });
   const team = await user.createTeam({ displayName: "Leave Team" });
@@ -103,7 +103,7 @@ it("refreshes the current user after leaving a team", { timeout: 60_000 }, async
   await clientApp.signUpWithCredential({
     email: "membership-leave-team@test.com",
     password: "password",
-    verificationCallbackUrl: "http://localhost:3000",
+    noVerificationCallback: true,
   });
   const user = await clientApp.getUser({ or: "throw" });
   const team = await user.createTeam({ displayName: "Leave Team" });


### PR DESCRIPTION
Most E2E tests sign up a user just to get an authenticated session, but every signup also queued a verification email that no assertion ever looked at. Those made up the large majority of all emails a full E2E run produces.

No endpoint or SDK change was needed: `verification_callback_url` is already optional on `/auth/password/sign-up` (the send is gated on it), and the JS SDK already supports `noVerificationCallback: true`.

- `Auth.Password.signUpWithEmail()` no longer passes a verification callback URL by default. The old `noWaitForEmail` option — which only skipped the mailbox wait, not the send — is replaced by `sendVerificationEmail: true` (opt in to the previous behavior) plus `waitForVerificationEmail: false` for tests that batch-wait for several emails at once.
- `scaffoldProject()` and the other JS/CLI signups use `noVerificationCallback: true`.
- Tests that actually assert on the signup verification email (password sign-up, send-reset-code, contact-channel verification/count, failed-emails digest) opt in explicitly, so their assertions and snapshots are unchanged.

Intentional email traffic (magic links, password resets, team invitations, payment receipts, `/emails/send-email`) is untouched.


Link to Devin session: https://app.devin.ai/sessions/692d35f1ffc2452d83e4ddc07fa10738
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make E2E password sign-ups opt-in to verification so we stop sending incidental verification emails. This removes most outbox traffic and speeds up CI runs.

- **Refactors**
  - `Auth.Password.signUpWithEmail()` no longer sets `verification_callback_url` by default; new options: `sendVerificationEmail` and `waitForVerificationEmail` (replaces `noWaitForEmail`).
  - JS/CLI signups (e.g., `scaffoldProject()`) now use `noVerificationCallback: true`.
  - Tests that assert on verification emails opt in explicitly; other intentional emails (magic links, resets, invites, receipts, `/emails/send-email`) are unchanged.

- **Bug Fixes**
  - Stabilized sign-up rule stats test by polling ClickHouse for the rule-trigger event instead of relying on verification email timing.

<sup>Written for commit b95d07108b742dd376f1dba033ac77bbaac53b24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Authentication**
  - Sign-up verification email delivery and waiting behavior are now more explicit and configurable.
  - Verification emails are sent only when requested, with delivery waiting enabled by default when applicable.
  - Verification callback handling is more consistent across sign-up flows.

- **Testing**
  - Updated authentication, password recovery, MFA, passkey, OAuth, session, and email verification coverage to reflect the improved behavior.
  - Improved validation of asynchronous event processing and email delivery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->