### PR TITLE
Replace incidental OTP sign-in setup with fastSignUp in E2E tests

### DIFF
--- a/apps/e2e/tests/backend/backend-helpers.ts
+++ b/apps/e2e/tests/backend/backend-helpers.ts
@@ -337,6 +337,13 @@ export namespace Auth {
     };
   }
 
+  export async function fastSignUpWithEmail(email = backendContext.value.mailbox.emailAddress) {
+    return await fastSignUp({
+      primary_email: email,
+      primary_email_verified: true,
+    });
+  }
+
   export async function ensureParsableAccessToken() {
     const accessToken = backendContext.value.userAuth?.accessToken;
     if (accessToken) {

--- a/apps/e2e/tests/backend/endpoints/api/v1/analytics-events-batch.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/analytics-events-batch.test.ts
@@ -64,7 +64,7 @@ it("requires a user token", async ({ expect }) => {
 it("throws error when analytics is not enabled", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   // Analytics is disabled by default - do NOT call Project.updateConfig
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await uploadEventBatch({
     sessionReplaySegmentId: randomUUID(),
@@ -80,7 +80,7 @@ it("throws error when analytics is not enabled", async ({ expect }) => {
 it("accepts valid $page-view events", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const now = Date.now();
   const res = await uploadEventBatch({
@@ -133,7 +133,7 @@ it("accepts valid $page-view events", async ({ expect }) => {
 it("accepts valid $click events", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const now = Date.now();
   const res = await uploadEventBatch({
@@ -172,7 +172,7 @@ it("accepts valid $click events", async ({ expect }) => {
 it("accepts a gzipped binary body (adblocker-evasion encoding)", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const now = Date.now();
   const payload = {
@@ -214,7 +214,7 @@ it("accepts a gzipped binary body (adblocker-evasion encoding)", async ({ expect
 it("rejects a binary body that isn't valid gzip", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await niceBackendFetch("/api/v1/analytics/events/batch", {
     method: "POST",
@@ -234,7 +234,7 @@ it("rejects a binary body that isn't valid gzip", async ({ expect }) => {
 it("rejects a binary body larger than the compressed size cap", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   // Random bytes don't compress, so even before gunzip the byteLength check
   // fires. 1.1 MB > the 1 MB MAX_COMPRESSED_BYTES cap.
@@ -258,7 +258,7 @@ it("rejects a binary body larger than the compressed size cap", async ({ expect 
 it("rejects a gzipped body that decompresses past the server size cap", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   // 9 MB of zeros gzips to ~9 KB but decompresses past the 8 MB server cap.
   const bomb = gzipSync(Buffer.alloc(9 * 1024 * 1024));
@@ -281,7 +281,7 @@ it("rejects a gzipped body that decompresses past the server size cap", async ({
 it("handles click event data containing a truncated surrogate pair (lone high surrogate)", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   // Simulate what the client-side event tracker does: .substring(0, 200) can
   // cut a string in the middle of a surrogate pair when emoji characters are
@@ -326,7 +326,7 @@ it("handles click event data containing a truncated surrogate pair (lone high su
 it("rejects empty events array", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await uploadEventBatch({
     sessionReplaySegmentId: randomUUID(),
@@ -362,7 +362,7 @@ it("rejects empty events array", async ({ expect }) => {
 it("rejects too many events (>500)", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const tooManyEvents = Array.from({ length: 501 }, (_, i) => ({
     event_type: "$page-view",
@@ -404,7 +404,7 @@ it("rejects too many events (>500)", async ({ expect }) => {
 it("rejects invalid session_replay_segment_id", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await niceBackendFetch("/api/v1/analytics/events/batch", {
     method: "POST",
@@ -444,7 +444,7 @@ it("rejects invalid session_replay_segment_id", async ({ expect }) => {
 it("rejects invalid batch_id", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await niceBackendFetch("/api/v1/analytics/events/batch", {
     method: "POST",
@@ -484,7 +484,7 @@ it("rejects invalid batch_id", async ({ expect }) => {
 it("rejects invalid event_type", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await niceBackendFetch("/api/v1/analytics/events/batch", {
     method: "POST",
@@ -524,7 +524,7 @@ it("rejects invalid event_type", async ({ expect }) => {
 it("inserted events are queryable via analytics query endpoint", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const sessionReplaySegmentId = randomUUID();
   const now = Date.now();

--- a/apps/e2e/tests/backend/endpoints/api/v1/emails/delivery-info.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/emails/delivery-info.test.ts
@@ -6,7 +6,7 @@ import { Auth, niceBackendFetch, Project, User } from "../../../../backend-helpe
 
 describe("capacity-boost", () => {
   it("should activate capacity boost and increase rate", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     await Project.createAndSwitch({
       display_name: "Test Boost Project",
     }, true);
@@ -42,7 +42,7 @@ describe("capacity-boost", () => {
   });
 
   it("should reject double activation while boost is active", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     await Project.createAndSwitch({
       display_name: "Test Double Boost Project",
     }, true);
@@ -66,7 +66,7 @@ describe("capacity-boost", () => {
   });
 
   it("should require server access type", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     await Project.createAndSwitch({
       display_name: "Test Auth Project",
     }, true);
@@ -82,7 +82,7 @@ describe("capacity-boost", () => {
 
 describe("with valid credentials", () => {
   it("should return zero stats for a new project", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     await Project.createAndSwitch({
       display_name: "Test Stats Project",
     }, true);

--- a/apps/e2e/tests/backend/endpoints/api/v1/emails/rewrite-template-source.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/emails/rewrite-template-source.test.ts
@@ -4,7 +4,7 @@ import { Auth, niceBackendFetch, Project } from "../../../../backend-helpers";
 
 describe("rewrite-template-source", () => {
   it("rewrites a regular template with variables", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     await Project.createAndSwitch({ display_name: "Rewrite Happy Path Project" }, true);
 
     const response = await niceBackendFetch("/api/v1/internal/rewrite-template-source", {
@@ -29,7 +29,7 @@ describe("rewrite-template-source", () => {
   });
 
   it("rewrites templates even when schema symbol is renamed", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     await Project.createAndSwitch({ display_name: "Rewrite Renamed Schema Project" }, true);
 
     const response = await niceBackendFetch("/api/v1/internal/rewrite-template-source", {
@@ -54,7 +54,7 @@ describe("rewrite-template-source", () => {
   });
 
   it("passes through templates without variables schema", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     await Project.createAndSwitch({ display_name: "Rewrite Pass Through Project" }, true);
 
     const source = `

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/failed-emails-digest.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/failed-emails-digest.test.ts
@@ -129,10 +129,7 @@ describe("with valid credentials", () => {
       projectKeys: InternalProjectKeys,
       userAuth: null,
     });
-    await Auth.fastSignUp({
-      primary_email: backendContext.value.mailbox.emailAddress,
-      primary_email_verified: true,
-    });
+    await Auth.fastSignUpWithEmail();
     const projectOwnerMailbox = backendContext.value.mailbox;
     const { projectId } = await Project.createAndSwitch({
       display_name: "Test Failed Emails Project",
@@ -228,20 +225,14 @@ describe("with valid credentials", () => {
   });
 
   it("should return 200 and not send digest email when all emails are successful and dry run is enabled", async ({ expect }) => {
-    await Auth.fastSignUp({
-      primary_email: backendContext.value.mailbox.emailAddress,
-      primary_email_verified: true,
-    });
+    await Auth.fastSignUpWithEmail();
     await Project.createAndSwitch({
       display_name: "Test Successful Emails Project",
       config: {
         magic_link_enabled: true,
       },
     }, true);
-    await Auth.fastSignUp({
-      primary_email: backendContext.value.mailbox.emailAddress,
-      primary_email_verified: true,
-    });
+    await Auth.fastSignUpWithEmail();
 
     const response = await niceBackendFetch("/api/v1/internal/failed-emails-digest", {
       method: "POST",
@@ -265,20 +256,14 @@ describe("with valid credentials", () => {
 
   // TODO: fix this when we re-enable failed emails digest
   it.todo("should return 200 and not send digest email when all emails are successful", async ({ expect }) => {
-    await Auth.fastSignUp({
-      primary_email: backendContext.value.mailbox.emailAddress,
-      primary_email_verified: true,
-    });
+    await Auth.fastSignUpWithEmail();
     await Project.createAndSwitch({
       display_name: "Test Successful Emails Project",
       config: {
         magic_link_enabled: true,
       },
     }, true);
-    await Auth.fastSignUp({
-      primary_email: backendContext.value.mailbox.emailAddress,
-      primary_email_verified: true,
-    });
+    await Auth.fastSignUpWithEmail();
 
     const response = await niceBackendFetch("/api/v1/internal/failed-emails-digest", {
       method: "POST",
@@ -303,10 +288,7 @@ describe("with valid credentials", () => {
       projectKeys: InternalProjectKeys,
       userAuth: null,
     });
-    const { userId } = await Auth.fastSignUp({
-      primary_email: backendContext.value.mailbox.emailAddress,
-      primary_email_verified: true,
-    });
+    const { userId } = await Auth.fastSignUpWithEmail();
 
     // Remove primary email from the user
     const updateEmailResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {
@@ -345,10 +327,7 @@ describe("with valid credentials", () => {
 
   // TODO: fix this when we re-enable failed emails digest
   it.todo("should not send digest email when project has no owner (account deleted)", async ({ expect }) => {
-    const { userId } = await Auth.fastSignUp({
-      primary_email: backendContext.value.mailbox.emailAddress,
-      primary_email_verified: true,
-    });
+    const { userId } = await Auth.fastSignUpWithEmail();
     await Project.createAndSwitch({
       display_name: "Test Project Deleted Owner",
     }, true);
@@ -387,10 +366,7 @@ describe("with valid credentials", () => {
 
   // TODO: fix this when we re-enable failed emails digest
   it.todo("should not send digest email when project is deleted after email delivery failed", async ({ expect }) => {
-    await Auth.fastSignUp({
-      primary_email: backendContext.value.mailbox.emailAddress,
-      primary_email_verified: true,
-    });
+    await Auth.fastSignUpWithEmail();
     await Project.createAndSwitch({
       display_name: "Test Project To Be Deleted",
     }, true);
@@ -430,10 +406,7 @@ describe("with valid credentials", () => {
     backendContext.set({
       projectKeys: InternalProjectKeys,
     });
-    const { userId: user1Id } = await Auth.fastSignUp({
-      primary_email: firstOwnerMailbox.emailAddress,
-      primary_email_verified: true,
-    });
+    const { userId: user1Id } = await Auth.fastSignUpWithEmail(firstOwnerMailbox.emailAddress);
     const { projectId } = await Project.createAndSwitch({
       display_name: "Test Project Multiple Owners",
     }, true);
@@ -443,10 +416,7 @@ describe("with valid credentials", () => {
     backendContext.set({
       projectKeys: InternalProjectKeys,
     });
-    const { userId: user2Id } = await Auth.fastSignUp({
-      primary_email: secondOwnerMailbox.emailAddress,
-      primary_email_verified: true,
-    });
+    const { userId: user2Id } = await Auth.fastSignUpWithEmail(secondOwnerMailbox.emailAddress);
 
     const user1Response = await niceBackendFetch(`/api/v1/users/${user1Id}`, {
       method: "GET",

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/failed-emails-digest.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/failed-emails-digest.test.ts
@@ -129,7 +129,10 @@ describe("with valid credentials", () => {
       projectKeys: InternalProjectKeys,
       userAuth: null,
     });
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp({
+      primary_email: backendContext.value.mailbox.emailAddress,
+      primary_email_verified: true,
+    });
     const projectOwnerMailbox = backendContext.value.mailbox;
     const { projectId } = await Project.createAndSwitch({
       display_name: "Test Failed Emails Project",
@@ -225,14 +228,20 @@ describe("with valid credentials", () => {
   });
 
   it("should return 200 and not send digest email when all emails are successful and dry run is enabled", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp({
+      primary_email: backendContext.value.mailbox.emailAddress,
+      primary_email_verified: true,
+    });
     await Project.createAndSwitch({
       display_name: "Test Successful Emails Project",
       config: {
         magic_link_enabled: true,
       },
     }, true);
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp({
+      primary_email: backendContext.value.mailbox.emailAddress,
+      primary_email_verified: true,
+    });
 
     const response = await niceBackendFetch("/api/v1/internal/failed-emails-digest", {
       method: "POST",
@@ -256,14 +265,20 @@ describe("with valid credentials", () => {
 
   // TODO: fix this when we re-enable failed emails digest
   it.todo("should return 200 and not send digest email when all emails are successful", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp({
+      primary_email: backendContext.value.mailbox.emailAddress,
+      primary_email_verified: true,
+    });
     await Project.createAndSwitch({
       display_name: "Test Successful Emails Project",
       config: {
         magic_link_enabled: true,
       },
     }, true);
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp({
+      primary_email: backendContext.value.mailbox.emailAddress,
+      primary_email_verified: true,
+    });
 
     const response = await niceBackendFetch("/api/v1/internal/failed-emails-digest", {
       method: "POST",
@@ -288,7 +303,10 @@ describe("with valid credentials", () => {
       projectKeys: InternalProjectKeys,
       userAuth: null,
     });
-    const { userId } = await Auth.Otp.signIn();
+    const { userId } = await Auth.fastSignUp({
+      primary_email: backendContext.value.mailbox.emailAddress,
+      primary_email_verified: true,
+    });
 
     // Remove primary email from the user
     const updateEmailResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {
@@ -327,7 +345,10 @@ describe("with valid credentials", () => {
 
   // TODO: fix this when we re-enable failed emails digest
   it.todo("should not send digest email when project has no owner (account deleted)", async ({ expect }) => {
-    const { userId } = await Auth.Otp.signIn();
+    const { userId } = await Auth.fastSignUp({
+      primary_email: backendContext.value.mailbox.emailAddress,
+      primary_email_verified: true,
+    });
     await Project.createAndSwitch({
       display_name: "Test Project Deleted Owner",
     }, true);
@@ -366,7 +387,10 @@ describe("with valid credentials", () => {
 
   // TODO: fix this when we re-enable failed emails digest
   it.todo("should not send digest email when project is deleted after email delivery failed", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp({
+      primary_email: backendContext.value.mailbox.emailAddress,
+      primary_email_verified: true,
+    });
     await Project.createAndSwitch({
       display_name: "Test Project To Be Deleted",
     }, true);
@@ -406,7 +430,10 @@ describe("with valid credentials", () => {
     backendContext.set({
       projectKeys: InternalProjectKeys,
     });
-    const { userId: user1Id } = await Auth.Otp.signIn();
+    const { userId: user1Id } = await Auth.fastSignUp({
+      primary_email: firstOwnerMailbox.emailAddress,
+      primary_email_verified: true,
+    });
     const { projectId } = await Project.createAndSwitch({
       display_name: "Test Project Multiple Owners",
     }, true);
@@ -416,7 +443,10 @@ describe("with valid credentials", () => {
     backendContext.set({
       projectKeys: InternalProjectKeys,
     });
-    const { userId: user2Id } = await Auth.Otp.signIn();
+    const { userId: user2Id } = await Auth.fastSignUp({
+      primary_email: secondOwnerMailbox.emailAddress,
+      primary_email_verified: true,
+    });
 
     const user1Response = await niceBackendFetch(`/api/v1/users/${user1Id}`, {
       method: "GET",

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/feedback.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/feedback.test.ts
@@ -8,7 +8,10 @@ const supportConversationsPath = "/api/v1/internal/dogfood/support/conversations
 describe("POST /api/v1/internal/feedback", () => {
   it("should send feedback from an authenticated user", async ({ expect }) => {
     const senderEmail = backendContext.value.mailbox.emailAddress;
-    const signInResult = await Auth.Otp.signIn();
+    const signInResult = await Auth.fastSignUp({
+      primary_email: senderEmail,
+      primary_email_verified: true,
+    });
     const recipientMailbox = createMailbox("team@hexclave.com");
     const subject = `[Support] ${senderEmail}`;
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/feedback.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/feedback.test.ts
@@ -8,10 +8,7 @@ const supportConversationsPath = "/api/v1/internal/dogfood/support/conversations
 describe("POST /api/v1/internal/feedback", () => {
   it("should send feedback from an authenticated user", async ({ expect }) => {
     const senderEmail = backendContext.value.mailbox.emailAddress;
-    const signInResult = await Auth.fastSignUp({
-      primary_email: senderEmail,
-      primary_email_verified: true,
-    });
+    const signInResult = await Auth.fastSignUpWithEmail();
     const recipientMailbox = createMailbox("team@hexclave.com");
     const subject = `[Support] ${senderEmail}`;
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/session-replays.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/session-replays.test.ts
@@ -72,7 +72,7 @@ it("requires a user token", async ({ expect }) => {
 it("throws error when analytics is not enabled", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   // Analytics is disabled by default - do NOT call Project.updateConfig
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await niceBackendFetch("/api/v1/session-replays/batch", {
     method: "POST",
@@ -105,7 +105,7 @@ it("throws error when analytics is not enabled", async ({ expect }) => {
 it("stores session replay batch metadata and dedupes by (session_replay_id, batch_id)", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const now = Date.now();
   const browserSessionId = randomUUID();
@@ -175,7 +175,7 @@ it("stores session replay batch metadata and dedupes by (session_replay_id, batc
 it("accepts a gzipped binary body (compressed large-payload encoding)", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const now = Date.now();
   const payload = {
@@ -214,7 +214,7 @@ it("accepts a gzipped binary body (compressed large-payload encoding)", async ({
 it("rejects a binary body that isn't valid gzip", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await niceBackendFetch("/api/v1/session-replays/batch", {
     method: "POST",
@@ -234,7 +234,7 @@ it("rejects a binary body that isn't valid gzip", async ({ expect }) => {
 it("rejects a binary body larger than the compressed size cap", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   // Random bytes don't compress, so the byteLength check fires before gunzip.
   // 1.1 MB > the 1 MB MAX_BODY_BYTES cap.
@@ -258,7 +258,7 @@ it("rejects a binary body larger than the compressed size cap", async ({ expect 
 it("rejects a gzipped body that decompresses past the server size cap", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   // 9 MB of zeros gzips to ~9 KB but decompresses past the 8 MB server cap.
   const bomb = gzipSync(Buffer.alloc(9 * 1024 * 1024));
@@ -281,7 +281,7 @@ it("rejects a gzipped body that decompresses past the server size cap", async ({
 it("rejects empty events", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await niceBackendFetch("/api/v1/session-replays/batch", {
     method: "POST",
@@ -308,7 +308,7 @@ it("rejects empty events", async ({ expect }) => {
 it("rejects too many events", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const tooManyEvents = Array.from({ length: 5001 }, (_, i) => ({ timestamp: 1_700_000_000_000 + i }));
 
@@ -337,7 +337,7 @@ it("rejects too many events", async ({ expect }) => {
 it("rejects invalid browser_session_id", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await niceBackendFetch("/api/v1/session-replays/batch", {
     method: "POST",
@@ -379,7 +379,7 @@ it("rejects invalid browser_session_id", async ({ expect }) => {
 it("rejects invalid batch_id", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await niceBackendFetch("/api/v1/session-replays/batch", {
     method: "POST",
@@ -421,7 +421,7 @@ it("rejects invalid batch_id", async ({ expect }) => {
 it("rejects invalid session_replay_segment_id", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await niceBackendFetch("/api/v1/session-replays/batch", {
     method: "POST",
@@ -463,7 +463,7 @@ it("rejects invalid session_replay_segment_id", async ({ expect }) => {
 it("accepts events without timestamps (falls back to sent_at_ms)", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const browserSessionId = randomUUID();
   const batchId = randomUUID();
@@ -499,7 +499,7 @@ it("accepts events without timestamps (falls back to sent_at_ms)", async ({ expe
 it("rejects non-integer started_at_ms", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const res = await niceBackendFetch("/api/v1/session-replays/batch", {
     method: "POST",
@@ -541,7 +541,7 @@ it("rejects non-integer started_at_ms", async ({ expect }) => {
 it("rejects oversized payloads", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   // Backend limit is 1_000_000 bytes; a single large string is sufficient to exceed it.
   const hugeString = "a".repeat(1_100_000);
@@ -571,7 +571,7 @@ it("rejects oversized payloads", async ({ expect }) => {
 it("admin can list session replays, list chunks, and fetch events", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const browserSessionId = randomUUID();
   const batchId = randomUUID();
@@ -622,7 +622,7 @@ it("admin list session replays paginates without skipping items", async ({ expec
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
 
   // Use separate sign-ins to get different refresh tokens → different session replays.
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   const uploadA = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -633,7 +633,7 @@ it("admin list session replays paginates without skipping items", async ({ expec
   expect(uploadA.status).toBe(200);
   const recordingA = uploadA.body?.session_replay_id;
 
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   const uploadB = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -683,7 +683,7 @@ it("admin list session replays paginates without skipping items", async ({ expec
 it("admin can fetch a single session replay by id", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const upload = await uploadBatch({
     browserSessionId: randomUUID(),
@@ -718,7 +718,7 @@ it("admin can fetch a single session replay by id", async ({ expect }) => {
         "project_user": {
           "display_name": null,
           "id": "<stripped UUID>",
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
+          "primary_email": null,
         },
         "refresh_token_id": <stripped field 'refresh_token_id'>,
         "started_at_millis": 1700000000100,
@@ -731,7 +731,7 @@ it("admin can fetch a single session replay by id", async ({ expect }) => {
 it("admin session replay endpoints expose the recording session's refresh token", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ "apps.installed.analytics.enabled": true });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const upload = await uploadBatch({
     browserSessionId: randomUUID(),
@@ -776,7 +776,7 @@ it("admin session replay endpoints expose the recording session's refresh token"
 
 it("admin get session replay returns 404 for nonexistent id", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const fakeId = randomUUID();
   const res = await niceBackendFetch(`/api/v1/internal/session-replays/${fakeId}`, {
@@ -803,7 +803,7 @@ it("admin get session replay returns 404 for nonexistent id", async ({ expect })
 it("non-admin access cannot call single session replay endpoint", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const upload = await uploadBatch({
     browserSessionId: randomUUID(),
@@ -863,7 +863,7 @@ it("non-admin access cannot call single session replay endpoint", async ({ expec
 
 it("admin list session replays rejects unknown cursor", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const cursor = randomUUID();
   const res = await niceBackendFetch(`/api/v1/internal/session-replays?cursor=${encodeURIComponent(cursor)}`, {
@@ -894,7 +894,7 @@ it("admin list chunks paginates and rejects a cursor from another session", asyn
   const now = Date.now();
 
   // session1: two batches under first refresh token
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   const upload1a = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -914,7 +914,7 @@ it("admin list chunks paginates and rejects a cursor from another session", asyn
   });
 
   // session2: one batch under a different refresh token
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   const upload2 = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -1046,7 +1046,7 @@ it("admin events endpoint does not allow fetching a chunk via the wrong session 
 
 it("non-admin access cannot call internal session replays endpoints", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const clientRes = await niceBackendFetch("/api/v1/internal/session-replays", {
     method: "GET",
@@ -1096,7 +1096,7 @@ it("non-admin access cannot call internal session replays endpoints", async ({ e
 it("groups batches from same refresh token into one session replay", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const now = Date.now();
 
@@ -1229,7 +1229,7 @@ it("admin list session replays filters by team_ids", async ({ expect }) => {
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
 
   // User A — member of a team
-  const userA = await Auth.Otp.signIn();
+  const userA = await Auth.fastSignUp();
   const uploadA = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -1243,7 +1243,7 @@ it("admin list session replays filters by team_ids", async ({ expect }) => {
 
   // User B — not in any team
   await bumpEmailAddress();
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   const uploadB = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -1275,7 +1275,7 @@ it("admin list session replays filters by duration range", async ({ expect }) =>
   const baseTime = 1_700_000_000_000;
 
   // Short replay: 5 seconds (first event → last event = 5000ms)
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   const uploadShort = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -1291,7 +1291,7 @@ it("admin list session replays filters by duration range", async ({ expect }) =>
 
   // Long replay: 30 seconds (first event → last event = 30000ms)
   await bumpEmailAddress();
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   const uploadLong = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -1345,7 +1345,7 @@ it("admin list session replays filters by last_event_at time range", async ({ ex
   const lateTime = 1_700_000_100_000; // 100 seconds later
 
   // Early replay
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   const uploadEarly = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -1358,7 +1358,7 @@ it("admin list session replays filters by last_event_at time range", async ({ ex
 
   // Late replay
   await bumpEmailAddress();
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   const uploadLate = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -1486,7 +1486,7 @@ it("admin list session replays filters by click_count_min", async ({ expect }) =
 
 it("admin list session replays rejects invalid UUID values in user_ids and team_ids", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const invalidUserIds = await listReplays({ user_ids: "not-a-uuid" });
   expect(invalidUserIds).toMatchInlineSnapshot(`
@@ -1513,7 +1513,7 @@ it("admin list session replays paginates correctly when last_event_at timestamps
 
   const baseTime = 1_700_000_000_000;
 
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   const uploadA = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -1525,7 +1525,7 @@ it("admin list session replays paginates correctly when last_event_at timestamps
   const replayIdA = uploadA.body?.session_replay_id;
 
   await bumpEmailAddress();
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   const uploadB = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -1570,7 +1570,7 @@ it("admin list session replays combines filters with AND semantics", async ({ ex
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
 
-  const userA = await Auth.Otp.signIn();
+  const userA = await Auth.fastSignUp();
   const uploadA = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -1582,7 +1582,7 @@ it("admin list session replays combines filters with AND semantics", async ({ ex
   const { teamId } = await Team.create({ accessType: "server", creatorUserId: userA.userId });
 
   await bumpEmailAddress();
-  const userB = await Auth.Otp.signIn();
+  const userB = await Auth.fastSignUp();
   const uploadB = await uploadBatch({
     browserSessionId: randomUUID(),
     batchId: randomUUID(),
@@ -1611,7 +1611,7 @@ it("admin list session replays returns empty page with null next_cursor when cli
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
 
   const now = Date.now();
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   const segmentId = randomUUID();
 
   const upload = await uploadBatch({
@@ -1668,7 +1668,7 @@ it("admin list session replays returns empty page with null next_cursor when cli
 
 it("admin list session replays rejects invalid filter parameters", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   // Non-integer duration_ms_min
   const res1 = await listReplays({ duration_ms_min: "abc" });
@@ -1796,7 +1796,7 @@ it("rejects new session replay when quota is exhausted", async ({ expect }) => {
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
   const ownerTeamId = createProjectResponse.body.owner_team_id;
 
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
   await setSessionReplayItemQuantity(ownerTeamId, 0);
 
   const now = Date.now();
@@ -1817,7 +1817,7 @@ it("accepts new session replay and debits quota by 1", async ({ expect }) => {
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
   const ownerTeamId = createProjectResponse.body.owner_team_id;
 
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const quantityBefore = await getSessionReplayItemQuantity(ownerTeamId);
 
@@ -1842,7 +1842,7 @@ it("does not debit quota when appending chunks to an existing session replay, ev
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
   const ownerTeamId = createProjectResponse.body.owner_team_id;
 
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const now = Date.now();
   const firstBatch = await uploadBatch({

--- a/apps/e2e/tests/backend/endpoints/api/v1/support.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/support.test.ts
@@ -4,10 +4,7 @@ import { Auth, InternalProjectKeys, Project, backendContext, bumpEmailAddress, n
 const supportConversationsPath = "/api/v1/internal/dogfood/support/conversations";
 
 it("current user can create and reply to a conversation", async ({ expect }) => {
-  await Auth.fastSignUp({
-    primary_email: backendContext.value.mailbox.emailAddress,
-    primary_email_verified: true,
-  });
+  await Auth.fastSignUpWithEmail();
 
   const createResponse = await niceBackendFetch(supportConversationsPath, {
     accessType: "client",
@@ -224,10 +221,7 @@ it("current user can create and reply to a conversation", async ({ expect }) => 
 });
 
 it("users cannot access conversations owned by another user", async ({ expect }) => {
-  await Auth.fastSignUp({
-    primary_email: backendContext.value.mailbox.emailAddress,
-    primary_email_verified: true,
-  });
+  await Auth.fastSignUpWithEmail();
 
   const createResponse = await niceBackendFetch(supportConversationsPath, {
     accessType: "client",
@@ -239,10 +233,7 @@ it("users cannot access conversations owned by another user", async ({ expect })
   });
 
   await bumpEmailAddress();
-  await Auth.fastSignUp({
-    primary_email: backendContext.value.mailbox.emailAddress,
-    primary_email_verified: true,
-  });
+  await Auth.fastSignUpWithEmail();
 
   const listResponse = await niceBackendFetch(supportConversationsPath, {
     accessType: "client",
@@ -276,10 +267,7 @@ it("deleting a user preserves their conversations with historical user IDs", asy
       magic_link_enabled: true,
     },
   });
-  await Auth.fastSignUp({
-    primary_email: backendContext.value.mailbox.emailAddress,
-    primary_email_verified: true,
-  });
+  await Auth.fastSignUpWithEmail();
 
   const userResponse = await niceBackendFetch("/api/v1/users/me", {
     accessType: "server",

--- a/apps/e2e/tests/backend/endpoints/api/v1/support.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/support.test.ts
@@ -4,7 +4,10 @@ import { Auth, InternalProjectKeys, Project, backendContext, bumpEmailAddress, n
 const supportConversationsPath = "/api/v1/internal/dogfood/support/conversations";
 
 it("current user can create and reply to a conversation", async ({ expect }) => {
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp({
+    primary_email: backendContext.value.mailbox.emailAddress,
+    primary_email_verified: true,
+  });
 
   const createResponse = await niceBackendFetch(supportConversationsPath, {
     accessType: "client",
@@ -221,7 +224,10 @@ it("current user can create and reply to a conversation", async ({ expect }) => 
 });
 
 it("users cannot access conversations owned by another user", async ({ expect }) => {
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp({
+    primary_email: backendContext.value.mailbox.emailAddress,
+    primary_email_verified: true,
+  });
 
   const createResponse = await niceBackendFetch(supportConversationsPath, {
     accessType: "client",
@@ -233,7 +239,10 @@ it("users cannot access conversations owned by another user", async ({ expect })
   });
 
   await bumpEmailAddress();
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp({
+    primary_email: backendContext.value.mailbox.emailAddress,
+    primary_email_verified: true,
+  });
 
   const listResponse = await niceBackendFetch(supportConversationsPath, {
     accessType: "client",
@@ -267,7 +276,10 @@ it("deleting a user preserves their conversations with historical user IDs", asy
       magic_link_enabled: true,
     },
   });
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp({
+    primary_email: backendContext.value.mailbox.emailAddress,
+    primary_email_verified: true,
+  });
 
   const userResponse = await niceBackendFetch("/api/v1/users/me", {
     accessType: "server",

--- a/apps/e2e/tests/backend/endpoints/api/v1/team-invitations.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/team-invitations.test.ts
@@ -639,7 +639,7 @@ it("should not allow restricted users (unverified email) to accept team invitati
   });
 
   // Create a verified user to send the invitation
-  const { userId: inviterId } = await Auth.Otp.signIn();
+  const { userId: inviterId } = await Auth.fastSignUp();
   const { teamId } = await createAndAddCurrentUserWithoutMemberPermission();
 
   // Grant invite permission to the inviter
@@ -725,7 +725,7 @@ it("should not allow anonymous users to accept team invitations", async ({ expec
   });
 
   // Create a verified user to send the invitation
-  const { userId: inviterId } = await Auth.Otp.signIn();
+  const { userId: inviterId } = await Auth.fastSignUp();
   const { teamId } = await createAndAddCurrentUserWithoutMemberPermission();
 
   // Grant invite permission to the inviter
@@ -812,7 +812,7 @@ it("should not allow restricted users to get team invitation details", async ({ 
   });
 
   // Create a verified user to send the invitation
-  const { userId: inviterId } = await Auth.Otp.signIn();
+  const { userId: inviterId } = await Auth.fastSignUp();
   const { teamId } = await createAndAddCurrentUserWithoutMemberPermission();
 
   // Grant invite permission to the inviter

--- a/apps/e2e/tests/backend/endpoints/api/v1/teams.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/teams.test.ts
@@ -757,7 +757,7 @@ it("enables create team on sign up", async ({ expect }) => {
   await InternalApiKey.createAndSetProjectKeys(adminAccessToken);
 
   await bumpEmailAddress();
-  await Auth.Otp.signIn();
+  await Auth.fastSignUp();
 
   const response2 = await niceBackendFetch("/api/v1/teams?user_id=me", { accessType: "server" });
   expect(response2).toMatchInlineSnapshot(`
@@ -770,7 +770,7 @@ it("enables create team on sign up", async ({ expect }) => {
             "client_metadata": null,
             "client_read_only_metadata": null,
             "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "mailbox-1--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
             "server_metadata": null,

--- a/apps/e2e/tests/backend/endpoints/api/v1/token-refresh-events.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/token-refresh-events.test.ts
@@ -164,7 +164,7 @@ it("OTP signin (new user) creates exactly one $token-refresh event", async ({ ex
     config: { magic_link_enabled: true },
   });
   await InternalApiKey.createAndSetProjectKeys();
-  const { userId } = await Auth.Otp.signIn();
+  const { userId } = await Auth.fastSignUp();
 
   const events = await expectExactlyNTokenRefreshEvents(userId, 1, { projectId });
   expect(events[0]).toMatchObject({
@@ -305,7 +305,7 @@ it("session refresh endpoint creates exactly one additional $token-refresh event
   });
   await InternalApiKey.createAndSetProjectKeys();
 
-  const { userId } = await Auth.Otp.signIn();
+  const { userId } = await Auth.fastSignUp();
   await expectExactlyNTokenRefreshEvents(userId, 1, { projectId });
 
   // Refresh the session

--- a/apps/e2e/tests/backend/endpoints/api/v1/users.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/users.test.ts
@@ -127,7 +127,7 @@ describe("with client access", () => {
   });
 
   it("should be able to read own user if signed in", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     const response = await niceBackendFetch("/api/v1/users/me", {
       accessType: "client",
     });
@@ -135,7 +135,7 @@ describe("with client access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": null,
           "client_read_only_metadata": null,
           "display_name": null,
@@ -144,10 +144,10 @@ describe("with client access", () => {
           "is_anonymous": false,
           "is_restricted": false,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_verified": true,
+          "primary_email": null,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -156,7 +156,7 @@ describe("with client access", () => {
           "selected_team": {
             "client_metadata": null,
             "client_read_only_metadata": null,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
           },
@@ -169,7 +169,7 @@ describe("with client access", () => {
   });
 
   it("should be able to read own user if signed in even without refresh token", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     backendContext.set({ userAuth: { ...backendContext.value.userAuth, refreshToken: undefined } });
     const response = await niceBackendFetch("/api/v1/users/me", {
       accessType: "client",
@@ -178,7 +178,7 @@ describe("with client access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": null,
           "client_read_only_metadata": null,
           "display_name": null,
@@ -187,10 +187,10 @@ describe("with client access", () => {
           "is_anonymous": false,
           "is_restricted": false,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_verified": true,
+          "primary_email": null,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -199,7 +199,7 @@ describe("with client access", () => {
           "selected_team": {
             "client_metadata": null,
             "client_read_only_metadata": null,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
           },
@@ -254,7 +254,7 @@ describe("with client access", () => {
   });
 
   it("should be able to update own user", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     const response1 = await niceBackendFetch("/api/v1/users/me", {
       accessType: "client",
       method: "PATCH",
@@ -266,7 +266,7 @@ describe("with client access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": null,
           "client_read_only_metadata": null,
           "display_name": "John Doe",
@@ -275,10 +275,10 @@ describe("with client access", () => {
           "is_anonymous": false,
           "is_restricted": false,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_verified": true,
+          "primary_email": null,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -287,7 +287,7 @@ describe("with client access", () => {
           "selected_team": {
             "client_metadata": null,
             "client_read_only_metadata": null,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
           },
@@ -308,7 +308,7 @@ describe("with client access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": { "key": "value" },
           "client_read_only_metadata": null,
           "display_name": "John Doe",
@@ -317,10 +317,10 @@ describe("with client access", () => {
           "is_anonymous": false,
           "is_restricted": false,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_verified": true,
+          "primary_email": null,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -329,7 +329,7 @@ describe("with client access", () => {
           "selected_team": {
             "client_metadata": null,
             "client_read_only_metadata": null,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
           },
@@ -454,7 +454,7 @@ describe("with client access", () => {
   });
 
   it("should set own display name to null when set to the empty string", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     const response1 = await niceBackendFetch("/api/v1/users/me", {
       accessType: "client",
       method: "PATCH",
@@ -466,7 +466,7 @@ describe("with client access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": null,
           "client_read_only_metadata": null,
           "display_name": "John Doe",
@@ -475,10 +475,10 @@ describe("with client access", () => {
           "is_anonymous": false,
           "is_restricted": false,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_verified": true,
+          "primary_email": null,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -487,7 +487,7 @@ describe("with client access", () => {
           "selected_team": {
             "client_metadata": null,
             "client_read_only_metadata": null,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
           },
@@ -508,7 +508,7 @@ describe("with client access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": null,
           "client_read_only_metadata": null,
           "display_name": null,
@@ -517,10 +517,10 @@ describe("with client access", () => {
           "is_anonymous": false,
           "is_restricted": false,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_verified": true,
+          "primary_email": null,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -529,7 +529,7 @@ describe("with client access", () => {
           "selected_team": {
             "client_metadata": null,
             "client_read_only_metadata": null,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
           },
@@ -645,7 +645,7 @@ describe("with client access", () => {
   });
 
   it("should be able to update own client metadata", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     const response = await niceBackendFetch("/api/v1/users/me", {
       accessType: "client",
       method: "PATCH",
@@ -657,7 +657,7 @@ describe("with client access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": { "key": "value" },
           "client_read_only_metadata": null,
           "display_name": null,
@@ -666,10 +666,10 @@ describe("with client access", () => {
           "is_anonymous": false,
           "is_restricted": false,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_verified": true,
+          "primary_email": null,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -678,7 +678,7 @@ describe("with client access", () => {
           "selected_team": {
             "client_metadata": null,
             "client_read_only_metadata": null,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
           },
@@ -809,7 +809,7 @@ describe("with client access", () => {
 
 describe("with server access", () => {
   it("should be able to read own user", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     const response = await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
     });
@@ -817,7 +817,7 @@ describe("with server access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": null,
           "client_read_only_metadata": null,
           "country_code": null,
@@ -828,11 +828,11 @@ describe("with server access", () => {
           "is_restricted": false,
           "last_active_at_millis": <stripped field 'last_active_at_millis'>,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_auth_enabled": true,
-          "primary_email_verified": true,
+          "primary_email": null,
+          "primary_email_auth_enabled": false,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -849,7 +849,7 @@ describe("with server access", () => {
             "client_metadata": null,
             "client_read_only_metadata": null,
             "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
             "server_metadata": null,
@@ -864,7 +864,7 @@ describe("with server access", () => {
   });
 
   it("should be able to update own user", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     const response = await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
       method: "PATCH",
@@ -876,7 +876,7 @@ describe("with server access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": null,
           "client_read_only_metadata": null,
           "country_code": null,
@@ -887,11 +887,11 @@ describe("with server access", () => {
           "is_restricted": false,
           "last_active_at_millis": <stripped field 'last_active_at_millis'>,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_auth_enabled": true,
-          "primary_email_verified": true,
+          "primary_email": null,
+          "primary_email_auth_enabled": false,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -908,7 +908,7 @@ describe("with server access", () => {
             "client_metadata": null,
             "client_read_only_metadata": null,
             "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
             "server_metadata": null,
@@ -939,57 +939,57 @@ describe("with server access", () => {
 
   it("should be able to list users", async ({ expect }) => {
     await Project.createAndSwitch({ config: { magic_link_enabled: true } });
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
 
     const response = await niceBackendFetch("/api/v1/users", {
       accessType: "server",
     });
     expect(response).toMatchInlineSnapshot(`
-          NiceResponse {
-            "status": 200,
-            "body": {
-              "is_paginated": true,
-              "items": [
-                {
-                  "auth_with_email": true,
-                  "client_metadata": null,
-                  "client_read_only_metadata": null,
-                  "country_code": null,
-                  "display_name": null,
-                  "has_password": false,
-                  "id": "<stripped UUID>",
-                  "is_anonymous": false,
-                  "is_restricted": false,
-                  "last_active_at_millis": <stripped field 'last_active_at_millis'>,
-                  "oauth_providers": [],
-                  "otp_auth_enabled": true,
-                  "passkey_auth_enabled": false,
-                  "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-                  "primary_email_auth_enabled": true,
-                  "primary_email_verified": true,
-                  "profile_image_url": null,
-                  "requires_totp_mfa": false,
-                  "restricted_by_admin": false,
-                  "restricted_by_admin_private_details": null,
-                  "restricted_by_admin_reason": null,
-                  "restricted_reason": null,
-                  "risk_scores": {
-                    "sign_up": {
-                      "bot": 0,
-                      "free_trial_abuse": 0,
-                    },
-                  },
-                  "selected_team": null,
-                  "selected_team_id": null,
-                  "server_metadata": null,
-                  "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
+      NiceResponse {
+        "status": 200,
+        "body": {
+          "is_paginated": true,
+          "items": [
+            {
+              "auth_with_email": false,
+              "client_metadata": null,
+              "client_read_only_metadata": null,
+              "country_code": null,
+              "display_name": null,
+              "has_password": false,
+              "id": "<stripped UUID>",
+              "is_anonymous": false,
+              "is_restricted": false,
+              "last_active_at_millis": <stripped field 'last_active_at_millis'>,
+              "oauth_providers": [],
+              "otp_auth_enabled": false,
+              "passkey_auth_enabled": false,
+              "primary_email": null,
+              "primary_email_auth_enabled": false,
+              "primary_email_verified": false,
+              "profile_image_url": null,
+              "requires_totp_mfa": false,
+              "restricted_by_admin": false,
+              "restricted_by_admin_private_details": null,
+              "restricted_by_admin_reason": null,
+              "restricted_reason": null,
+              "risk_scores": {
+                "sign_up": {
+                  "bot": 0,
+                  "free_trial_abuse": 0,
                 },
-              ],
-              "pagination": { "next_cursor": null },
+              },
+              "selected_team": null,
+              "selected_team_id": null,
+              "server_metadata": null,
+              "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
             },
-            "headers": Headers { <some fields may have been hidden> },
-          }
-        `);
+          ],
+          "pagination": { "next_cursor": null },
+        },
+        "headers": Headers { <some fields may have been hidden> },
+      }
+    `);
   });
 
   it("should require include_anonymous=true when only_anonymous=true", async ({ expect }) => {
@@ -1114,7 +1114,10 @@ describe("with server access", () => {
   });
 
   it("should be able to read a user", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp({
+      primary_email: backendContext.value.mailbox.emailAddress,
+      primary_email_verified: true,
+    });
     const signedInResponse = (await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
     }));
@@ -1129,7 +1132,7 @@ describe("with server access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": null,
           "client_read_only_metadata": null,
           "country_code": null,
@@ -1140,10 +1143,10 @@ describe("with server access", () => {
           "is_restricted": false,
           "last_active_at_millis": <stripped field 'last_active_at_millis'>,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
           "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_auth_enabled": true,
+          "primary_email_auth_enabled": false,
           "primary_email_verified": true,
           "profile_image_url": null,
           "requires_totp_mfa": false,
@@ -1966,7 +1969,7 @@ describe("with server access", () => {
   });
 
   it("should be able to update a user", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     const signedInResponse = (await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
     }));
@@ -1986,7 +1989,7 @@ describe("with server access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": null,
           "client_read_only_metadata": null,
           "country_code": null,
@@ -1997,11 +2000,11 @@ describe("with server access", () => {
           "is_restricted": false,
           "last_active_at_millis": <stripped field 'last_active_at_millis'>,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_auth_enabled": true,
-          "primary_email_verified": true,
+          "primary_email": null,
+          "primary_email_auth_enabled": false,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -2018,7 +2021,7 @@ describe("with server access", () => {
             "client_metadata": null,
             "client_read_only_metadata": null,
             "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
             "server_metadata": null,
@@ -2037,7 +2040,7 @@ describe("with server access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": null,
           "client_read_only_metadata": null,
           "country_code": null,
@@ -2048,11 +2051,11 @@ describe("with server access", () => {
           "is_restricted": false,
           "last_active_at_millis": <stripped field 'last_active_at_millis'>,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_auth_enabled": true,
-          "primary_email_verified": true,
+          "primary_email": null,
+          "primary_email_auth_enabled": false,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -2069,7 +2072,7 @@ describe("with server access", () => {
             "client_metadata": null,
             "client_read_only_metadata": null,
             "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
             "server_metadata": null,
@@ -2084,7 +2087,7 @@ describe("with server access", () => {
   });
 
   it("should be able to update own user", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     const response1 = await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
       method: "PATCH",
@@ -2097,7 +2100,7 @@ describe("with server access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": null,
           "client_read_only_metadata": null,
           "country_code": null,
@@ -2108,11 +2111,11 @@ describe("with server access", () => {
           "is_restricted": false,
           "last_active_at_millis": <stripped field 'last_active_at_millis'>,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_auth_enabled": true,
-          "primary_email_verified": true,
+          "primary_email": null,
+          "primary_email_auth_enabled": false,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -2129,7 +2132,7 @@ describe("with server access", () => {
             "client_metadata": null,
             "client_read_only_metadata": null,
             "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
             "server_metadata": null,
@@ -2145,7 +2148,7 @@ describe("with server access", () => {
 
   it("should be able to update a user's password, signing them out, and sign in with it again", async ({ expect }) => {
     const password = "this-is-some-password";
-    await Auth.Otp.signIn();
+    await Auth.Password.signUpWithEmail();
     const response1 = await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
       method: "PATCH",
@@ -2168,11 +2171,11 @@ describe("with server access", () => {
           "is_restricted": false,
           "last_active_at_millis": <stripped field 'last_active_at_millis'>,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
           "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
           "primary_email_auth_enabled": true,
-          "primary_email_verified": true,
+          "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -2181,8 +2184,8 @@ describe("with server access", () => {
           "restricted_reason": null,
           "risk_scores": {
             "sign_up": {
-              "bot": 0,
-              "free_trial_abuse": 0,
+              "bot": 38,
+              "free_trial_abuse": 38,
             },
           },
           "selected_team": {
@@ -2213,7 +2216,7 @@ describe("with server access", () => {
   });
 
   it("should be able to delete a user", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     const signedInResponse = (await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
     }));
@@ -2251,7 +2254,7 @@ describe("with server access", () => {
   });
 
   it("should be able to update all metadata fields", async ({ expect }) => {
-    await Auth.Otp.signIn();
+    await Auth.fastSignUp();
     const response = await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
       method: "PATCH",
@@ -2266,7 +2269,7 @@ describe("with server access", () => {
       NiceResponse {
         "status": 200,
         "body": {
-          "auth_with_email": true,
+          "auth_with_email": false,
           "client_metadata": { "key": "client value" },
           "client_read_only_metadata": { "key": "client read only value" },
           "country_code": null,
@@ -2277,82 +2280,10 @@ describe("with server access", () => {
           "is_restricted": false,
           "last_active_at_millis": <stripped field 'last_active_at_millis'>,
           "oauth_providers": [],
-          "otp_auth_enabled": true,
+          "otp_auth_enabled": false,
           "passkey_auth_enabled": false,
-          "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-          "primary_email_auth_enabled": true,
-          "primary_email_verified": true,
-          "profile_image_url": null,
-          "requires_totp_mfa": false,
-          "restricted_by_admin": false,
-          "restricted_by_admin_private_details": null,
-          "restricted_by_admin_reason": null,
-          "restricted_reason": null,
-          "risk_scores": {
-            "sign_up": {
-              "bot": 0,
-              "free_trial_abuse": 0,
-            },
-          },
-          "selected_team": {
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
-            "id": "<stripped UUID>",
-            "profile_image_url": null,
-            "server_metadata": null,
-          },
-          "selected_team_id": "<stripped UUID>",
-          "server_metadata": { "key": "server value" },
-          "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
-        },
-        "headers": Headers { <some fields may have been hidden> },
-      }
-    `);
-  });
-
-  it("should be able to update profile image url", async ({ expect }) => {
-    await Auth.Otp.signIn();
-    const response = await niceBackendFetch("/api/v1/users/me", {
-      accessType: "server",
-      method: "PATCH",
-      body: {
-        profile_image_url: localhostUrl("01", "/open-graph-image.png"),
-      },
-    });
-    expect(response.body.profile_image_url).toMatchInlineSnapshot(`"http://localhost:<$NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX>01/open-graph-image.png"`);
-  });
-
-  it("should be able to update primary email", async ({ expect }) => {
-    await Auth.Otp.signIn();
-    const mailbox = createMailbox();
-    const response = await niceBackendFetch("/api/v1/users/me", {
-      accessType: "server",
-      method: "PATCH",
-      body: {
-        primary_email: mailbox.emailAddress,
-      },
-    });
-    expect(response).toMatchInlineSnapshot(`
-      NiceResponse {
-        "status": 200,
-        "body": {
-          "auth_with_email": true,
-          "client_metadata": null,
-          "client_read_only_metadata": null,
-          "country_code": null,
-          "display_name": null,
-          "has_password": false,
-          "id": "<stripped UUID>",
-          "is_anonymous": false,
-          "is_restricted": false,
-          "last_active_at_millis": <stripped field 'last_active_at_millis'>,
-          "oauth_providers": [],
-          "otp_auth_enabled": true,
-          "passkey_auth_enabled": false,
-          "primary_email": "mailbox-1--<stripped UUID>@stack-generated.example.com",
-          "primary_email_auth_enabled": true,
+          "primary_email": null,
+          "primary_email_auth_enabled": false,
           "primary_email_verified": false,
           "profile_image_url": null,
           "requires_totp_mfa": false,
@@ -2370,7 +2301,79 @@ describe("with server access", () => {
             "client_metadata": null,
             "client_read_only_metadata": null,
             "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "default-mailbox--<stripped UUID>@stack-generated.example.com's Team",
+            "display_name": "Personal Team",
+            "id": "<stripped UUID>",
+            "profile_image_url": null,
+            "server_metadata": null,
+          },
+          "selected_team_id": "<stripped UUID>",
+          "server_metadata": { "key": "server value" },
+          "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
+        },
+        "headers": Headers { <some fields may have been hidden> },
+      }
+    `);
+  });
+
+  it("should be able to update profile image url", async ({ expect }) => {
+    await Auth.fastSignUp();
+    const response = await niceBackendFetch("/api/v1/users/me", {
+      accessType: "server",
+      method: "PATCH",
+      body: {
+        profile_image_url: localhostUrl("01", "/open-graph-image.png"),
+      },
+    });
+    expect(response.body.profile_image_url).toMatchInlineSnapshot(`"http://localhost:<$NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX>01/open-graph-image.png"`);
+  });
+
+  it("should be able to update primary email", async ({ expect }) => {
+    await Auth.fastSignUp();
+    const mailbox = createMailbox();
+    const response = await niceBackendFetch("/api/v1/users/me", {
+      accessType: "server",
+      method: "PATCH",
+      body: {
+        primary_email: mailbox.emailAddress,
+      },
+    });
+    expect(response).toMatchInlineSnapshot(`
+      NiceResponse {
+        "status": 200,
+        "body": {
+          "auth_with_email": false,
+          "client_metadata": null,
+          "client_read_only_metadata": null,
+          "country_code": null,
+          "display_name": null,
+          "has_password": false,
+          "id": "<stripped UUID>",
+          "is_anonymous": false,
+          "is_restricted": false,
+          "last_active_at_millis": <stripped field 'last_active_at_millis'>,
+          "oauth_providers": [],
+          "otp_auth_enabled": false,
+          "passkey_auth_enabled": false,
+          "primary_email": "mailbox-1--<stripped UUID>@stack-generated.example.com",
+          "primary_email_auth_enabled": false,
+          "primary_email_verified": false,
+          "profile_image_url": null,
+          "requires_totp_mfa": false,
+          "restricted_by_admin": false,
+          "restricted_by_admin_private_details": null,
+          "restricted_by_admin_reason": null,
+          "restricted_reason": null,
+          "risk_scores": {
+            "sign_up": {
+              "bot": 0,
+              "free_trial_abuse": 0,
+            },
+          },
+          "selected_team": {
+            "client_metadata": null,
+            "client_read_only_metadata": null,
+            "created_at_millis": <stripped field 'created_at_millis'>,
+            "display_name": "Personal Team",
             "id": "<stripped UUID>",
             "profile_image_url": null,
             "server_metadata": null,
@@ -2440,8 +2443,8 @@ describe("with server access", () => {
           "restricted_reason": null,
           "risk_scores": {
             "sign_up": {
-              "bot": 0,
-              "free_trial_abuse": 0,
+              "bot": 38,
+              "free_trial_abuse": 38,
             },
           },
           "selected_team": {

--- a/apps/e2e/tests/backend/endpoints/api/v1/users.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/users.test.ts
@@ -1114,10 +1114,7 @@ describe("with server access", () => {
   });
 
   it("should be able to read a user", async ({ expect }) => {
-    await Auth.fastSignUp({
-      primary_email: backendContext.value.mailbox.emailAddress,
-      primary_email_verified: true,
-    });
+    await Auth.fastSignUpWithEmail();
     const signedInResponse = (await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
     }));
@@ -2148,7 +2145,7 @@ describe("with server access", () => {
 
   it("should be able to update a user's password, signing them out, and sign in with it again", async ({ expect }) => {
     const password = "this-is-some-password";
-    await Auth.Password.signUpWithEmail();
+    await Auth.Otp.signIn();
     const response1 = await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
       method: "PATCH",
@@ -2171,11 +2168,11 @@ describe("with server access", () => {
           "is_restricted": false,
           "last_active_at_millis": <stripped field 'last_active_at_millis'>,
           "oauth_providers": [],
-          "otp_auth_enabled": false,
+          "otp_auth_enabled": true,
           "passkey_auth_enabled": false,
           "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
           "primary_email_auth_enabled": true,
-          "primary_email_verified": false,
+          "primary_email_verified": true,
           "profile_image_url": null,
           "requires_totp_mfa": false,
           "restricted_by_admin": false,
@@ -2184,8 +2181,8 @@ describe("with server access", () => {
           "restricted_reason": null,
           "risk_scores": {
             "sign_up": {
-              "bot": 38,
-              "free_trial_abuse": 38,
+              "bot": 0,
+              "free_trial_abuse": 0,
             },
           },
           "selected_team": {
@@ -2443,8 +2440,8 @@ describe("with server access", () => {
           "restricted_reason": null,
           "risk_scores": {
             "sign_up": {
-              "bot": 38,
-              "free_trial_abuse": 38,
+              "bot": 0,
+              "free_trial_abuse": 0,
             },
           },
           "selected_team": {


### PR DESCRIPTION
Follow-up to #1892. That PR removed incidental verification emails; the largest remaining bucket in a full E2E run was ~209 magic-link emails, most of which come from `Auth.Otp.signIn()` being used purely as a "give me a signed-in user" shortcut. `Auth.fastSignUp()` already does that without any email (server users API + `/auth/sessions`), and is already the dominant idiom in several of these files.

Audited all 221 `Auth.Otp.signIn()` / `Auth.Otp.sendSignInCode()` call sites and swapped only the ~100 that are pure setup. Left untouched: sites where the test is about OTP/magic-link behavior, asserts on the mailbox or the sign-in code, or depends on the user's auth method / contact-channel state (`used_for_auth`, verified, `otp_auth_enabled`), plus everything ambiguous — notably the OTP suites, `auth-flows`, `users-primary-email`, contact-channel, password, passkey, `internal-metrics`, and the analytics/quota tests that consume events emitted by the sign-in path.

Where a test needs the user to actually have an email (support/feedback mail, failed-emails digest), the swap creates the user with the mailbox address as a verified primary email instead, so those assertions are unchanged.

Snapshot churn is the visible part of the diff: a setup user created via the users API has no auth method, so `auth_with_email`, `otp_auth_enabled`, `primary_email*` and the auto-created team's display name differ. Each changed snapshot value was reviewed individually; call sites where the changed value was part of what the test asserts were reverted to OTP rather than re-baselined.


Link to Devin session: https://app.devin.ai/sessions/692d35f1ffc2452d83e4ddc07fa10738
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced incidental OTP sign-in in E2E tests with `Auth.fastSignUp()` to eliminate magic-link emails and speed up runs. Added `Auth.fastSignUpWithEmail()` for tests that need a real mailbox.

- **Refactors**
  - Swapped setup-only `Auth.Otp.signIn()` / `Auth.Otp.sendSignInCode()` for `Auth.fastSignUp()` across affected suites (e.g., analytics, session replays).
  - Introduced `Auth.fastSignUpWithEmail(email?)` and used where an actual email is required (support/feedback, failed-emails digest, multi-owner cases).
  - Left OTP/magic-link suites and tests asserting mailbox/sign-in code or auth-method state unchanged.
  - Updated snapshots/expectations for differing defaults (no email auth, `otp_auth_enabled: false`, `primary_email: null`, team display name "Personal Team"); reverted to OTP where those fields are part of the assertions.

<sup>Written for commit 2123cf248e8d20a4c7a91f3e0af5ee0b3cbc05e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactors with no production code changes; snapshot churn reflects intentional fixture differences, with OTP retained where behavior is under test.
> 
> **Overview**
> E2E tests that only needed a signed-in user no longer go through magic-link OTP. They use **`Auth.fastSignUp()`** (server user create + session) or **`Auth.fastSignUpWithEmail()`** when the mailbox address must be a verified primary email (support, failed-emails digest, multi-owner cases).
> 
> A new **`fastSignUpWithEmail`** wrapper was added in `backend-helpers.ts`. Roughly ~100 setup-only `Auth.Otp.signIn()` call sites were swapped across analytics batch, session replays, emails, users, teams, support, and related suites. OTP flows stay where the test is about magic links, mailbox content, or sign-in–driven side effects (e.g. analytics quota tests still use **`Auth.Otp.signIn()`** for async `$token-refresh` debits).
> 
> Inline snapshots were updated where setup users differ: no primary email / OTP auth flags, **"Personal Team"** display name, and session-replay user email **`null`** when appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2123cf248e8d20a4c7a91f3e0af5ee0b3cbc05e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated automated coverage across analytics, email delivery, support, invitations, teams, sessions, users, and related API workflows.
  - Added streamlined test setup for verified email accounts, including scenarios involving multiple email addresses.
  - Refreshed expected results for personal team names, authentication settings, email details, and session replay data.
  - Existing endpoint behavior and validation coverage remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->