### PR TITLE
Fix top loading indicator staying visible forever

### DIFF
--- a/apps/dashboard/src/app/globals.css
+++ b/apps/dashboard/src/app/globals.css
@@ -368,7 +368,11 @@
   opacity: 0;
   transition: opacity 0.2s ease-in-out;
 }
-body:has(.show-site-loading-indicator) .site-loading-indicator {
+body:has(.show-site-loading-indicator) .site-loading-indicator:not([data-site-loading-indicator]) {
+  opacity: 1;
+  transition: none;
+}
+.site-loading-indicator[data-site-loading-indicator="active"] {
   opacity: 1;
   transition: none;
 }

--- a/apps/dashboard/src/components/site-loading-indicator.tsx
+++ b/apps/dashboard/src/components/site-loading-indicator.tsx
@@ -2,14 +2,21 @@
 
 import { useEffect, useSyncExternalStore } from "react";
 
-// The marker alone is not enough: React/Next can keep a previous route mounted in a
-// hidden subtree, leaving its Suspense fallback marker behind indefinitely.
+// Once hydrated, the indicator is driven by the number of mounted SiteLoadingIndicator
+// components instead of by the mere presence of their marker element in the DOM. React/Next
+// keeps the previous route mounted in a hidden subtree (inline `display: none !important`)
+// after a navigation, and if that route was still showing its Suspense fallback, the
+// fallback's marker lingers there forever — which used to keep the indicator visible
+// forever, too. Effects of hidden subtrees are cleaned up, so the count doesn't have that
+// problem. The marker element remains for the pre-hydration/no-JS path (see globals.css).
 const subscribers = new Set<() => void>();
 let indicatorCount = 0;
 
 function subscribe(callback: () => void) {
   subscribers.add(callback);
-  return () => subscribers.delete(callback);
+  return () => {
+    subscribers.delete(callback);
+  };
 }
 
 function getSnapshot() {
@@ -41,7 +48,7 @@ export function SiteLoadingIndicatorDisplay() {
   return <span>
     <span
       className="site-loading-indicator"
-      {...(count === null ? {} : { "data-site-loading-indicator": count > 0 ? "active" : "inactive" })}
+      data-site-loading-indicator={count === null ? undefined : (count > 0 ? "active" : "inactive")}
     >
       <span className="site-loading-indicator-inner">
         <span className="site-loading-indicator-inner-glow" />

--- a/apps/dashboard/src/components/site-loading-indicator.tsx
+++ b/apps/dashboard/src/components/site-loading-indicator.tsx
@@ -1,8 +1,48 @@
+"use client";
+
+import { useEffect, useSyncExternalStore } from "react";
+
+// The marker alone is not enough: React/Next can keep a previous route mounted in a
+// hidden subtree, leaving its Suspense fallback marker behind indefinitely.
+const subscribers = new Set<() => void>();
+let indicatorCount = 0;
+
+function subscribe(callback: () => void) {
+  subscribers.add(callback);
+  return () => subscribers.delete(callback);
+}
+
+function getSnapshot() {
+  return indicatorCount;
+}
+
+function getServerSnapshot() {
+  return null;
+}
+
+function registerIndicator() {
+  indicatorCount += 1;
+  for (const subscriber of subscribers) {
+    subscriber();
+  }
+  return () => {
+    indicatorCount -= 1;
+    for (const subscriber of subscribers) {
+      subscriber();
+    }
+  };
+}
+
 export function SiteLoadingIndicatorDisplay() {
+  const count = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
   // Next.js doesn't like a sticky or fixed position element at the root, so wrap it in a span
   // https://github.com/shadcn-ui/ui/issues/1355
   return <span>
-    <span className="site-loading-indicator">
+    <span
+      className="site-loading-indicator"
+      {...(count === null ? {} : { "data-site-loading-indicator": count > 0 ? "active" : "inactive" })}
+    >
       <span className="site-loading-indicator-inner">
         <span className="site-loading-indicator-inner-glow" />
       </span>
@@ -11,5 +51,7 @@ export function SiteLoadingIndicatorDisplay() {
 }
 
 export function SiteLoadingIndicator() {
+  useEffect(() => registerIndicator(), []);
+
   return <div className="show-site-loading-indicator" />;
 }


### PR DESCRIPTION
The top loading bar could stay visible indefinitely after a navigation.

Visibility was decided purely by DOM presence of the marker element that `loading.tsx` renders:

```css
body:has(.show-site-loading-indicator) .site-loading-indicator { opacity: 1 }
```

After a client navigation, React/Next keeps the previous route mounted in a hidden subtree (inline `display: none !important`). If that route was still showing its Suspense fallback when you navigated away, the fallback's marker lingers in that hidden subtree forever, and `:has()` keeps matching it — so the bar animates forever even though nothing is loading.

Once hydrated, visibility is now driven by how many `SiteLoadingIndicator` components are actually mounted (effects of hidden subtrees are cleaned up, so stale ones don't count) and reflected as `data-site-loading-indicator="active" | "inactive"`. The marker element and the `:has()` rule remain for the pre-hydration/no-JS window, scoped to when that attribute is absent, so a cold load still shows the bar while HTML streams. No visual change to the bar itself.


Link to Devin session: https://app.devin.ai/sessions/e0a7ffc882c54316a761d7c153f1df0b
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the top loading bar getting stuck after navigation. Visibility is now driven by a hydrated counter of mounted indicators, not lingering DOM markers, with no visual changes.

- **Bug Fixes**
  - Root cause: `:has(.show-site-loading-indicator)` matched markers left in hidden subtrees after navigation.
  - Solution: Track mounted `SiteLoadingIndicator` instances via `useSyncExternalStore`; set `data-site-loading-indicator="active|inactive"` on the bar.
  - CSS: Limit the `:has()` rule to pre-hydration (`.site-loading-indicator:not([data-site-loading-indicator])`) and add an attribute-based selector for active state.

<sup>Written for commit 729ad50364b6d64ccfdbb085bb049df565b06b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI loading-indicator logic and CSS only; no auth, data, or API changes.
> 
> **Overview**
> Fixes the **top loading bar** staying visible indefinitely after client navigation when a previous route’s Suspense fallback left a `.show-site-loading-indicator` marker in Next’s hidden, `display: none` route subtree—`:has()` kept matching that stale DOM node.
> 
> After hydration, visibility is driven by a **ref-count** of mounted `SiteLoadingIndicator` instances (`useSyncExternalStore` + `useEffect` register/unregister), and `SiteLoadingIndicatorDisplay` sets `data-site-loading-indicator="active"` or `"inactive"` on the bar. **CSS** limits the old `:has(.show-site-loading-indicator)` rule to pre-hydration only (`.site-loading-indicator:not([data-site-loading-indicator])`) and shows the bar when `data-site-loading-indicator="active"`. Marker divs remain for streaming/no-JS; bar appearance is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 729ad50364b6d64ccfdbb085bb049df565b06b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading indicator behavior during page loads and hydration.
  * Loading indicators now display immediately and accurately reflect active loading states.
  * Preserved loading feedback before the app becomes interactive and when JavaScript is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->