### PR TITLE
Trigger the backend error-boundary test without the removed artificial delay

### DIFF
--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -420,14 +420,16 @@ import.meta.vitest?.test("uncaught /api/ dispatch errors use the global sanitize
   vi.stubEnv("NODE_ENV", "production");
   const request = new Request("http://localhost/api/v1");
   const originalHeaders = request.headers;
-  let shouldThrow = true;
+  let headersReadCount = 0;
+  let headerReadThrew = false;
   // Simulate an unexpected internal failure escaping dispatch for an /api/ request.
-  // The getter throws once to fail dispatch, then returns the original headers because
-  // response compression reads request headers after the error handler runs.
+  // This depends on runRequestPipeline reading headers first; after the first throw,
+  // return them because response compression reads request headers after the error handler.
   Object.defineProperty(request, "headers", {
     get() {
-      if (shouldThrow) {
-        shouldThrow = false;
+      headersReadCount++;
+      if (headersReadCount === 1) {
+        headerReadThrew = true;
         throw new Error("unexpected request header access");
       }
       return originalHeaders;
@@ -437,6 +439,8 @@ import.meta.vitest?.test("uncaught /api/ dispatch errors use the global sanitize
   try {
     const response = await app.handle(request);
 
+    expect(headerReadThrew).toBe(true);
+    expect(headersReadCount).toBeGreaterThan(1);
     expect({
       status: response.status,
       body: await response.text(),

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -311,142 +311,131 @@ import.meta.vitest?.test("the observability debug page is publicly available", a
 });
 
 import.meta.vitest?.test("dispatcher-generated API errors retain CORS headers", async ({ expect }) => {
-  const { vi } = import.meta.vitest!;
-  vi.stubEnv("HEXCLAVE_ARTIFICIAL_DEVELOPMENT_DELAY_MS", "0");
-  vi.stubEnv("STACK_ARTIFICIAL_DEVELOPMENT_DELAY_MS", "0");
+  const [notFound, methodNotAllowed, unknownMethod] = await Promise.all([
+    app.handle(new Request("http://localhost/api/latest/this-route-does-not-exist")),
+    app.handle(new Request("http://localhost/api/v2beta1/migration-tests/smart-route-handler", {
+      method: "POST",
+    })),
+    app.handle(new Request("http://localhost/api/v2beta1/migration-tests/smart-route-handler", {
+      method: "BREW",
+    })),
+  ]);
 
-  try {
-    const [notFound, methodNotAllowed, unknownMethod] = await Promise.all([
-      app.handle(new Request("http://localhost/api/latest/this-route-does-not-exist")),
-      app.handle(new Request("http://localhost/api/v2beta1/migration-tests/smart-route-handler", {
-        method: "POST",
-      })),
-      app.handle(new Request("http://localhost/api/v2beta1/migration-tests/smart-route-handler", {
-        method: "BREW",
-      })),
-    ]);
-
-    expect([
-      { status: notFound.status, allowOrigin: notFound.headers.get("access-control-allow-origin") },
-      { status: methodNotAllowed.status, allow: methodNotAllowed.headers.get("allow"), allowOrigin: methodNotAllowed.headers.get("access-control-allow-origin") },
-      { status: unknownMethod.status, allow: unknownMethod.headers.get("allow"), allowOrigin: unknownMethod.headers.get("access-control-allow-origin") },
-    ]).toMatchInlineSnapshot(`
-      [
-        {
-          "allowOrigin": "*",
-          "status": 404,
-        },
-        {
-          "allow": "GET, HEAD",
-          "allowOrigin": "*",
-          "status": 405,
-        },
-        {
-          "allow": null,
-          "allowOrigin": "*",
-          "status": 400,
-        },
-      ]
-    `);
-  } finally {
-    vi.unstubAllEnvs();
-  }
+  expect([
+    { status: notFound.status, allowOrigin: notFound.headers.get("access-control-allow-origin") },
+    { status: methodNotAllowed.status, allow: methodNotAllowed.headers.get("allow"), allowOrigin: methodNotAllowed.headers.get("access-control-allow-origin") },
+    { status: unknownMethod.status, allow: unknownMethod.headers.get("allow"), allowOrigin: unknownMethod.headers.get("access-control-allow-origin") },
+  ]).toMatchInlineSnapshot(`
+    [
+      {
+        "allowOrigin": "*",
+        "status": 404,
+      },
+      {
+        "allow": "GET, HEAD",
+        "allowOrigin": "*",
+        "status": 405,
+      },
+      {
+        "allow": null,
+        "allowOrigin": "*",
+        "status": 400,
+      },
+    ]
+  `);
 });
 
 import.meta.vitest?.test("non-API OPTIONS and unknown methods match Next while API OPTIONS keeps its CORS short-circuit", async ({ expect }) => {
-  const { vi } = import.meta.vitest!;
-  vi.stubEnv("HEXCLAVE_ARTIFICIAL_DEVELOPMENT_DELAY_MS", "0");
-  vi.stubEnv("STACK_ARTIFICIAL_DEVELOPMENT_DELAY_MS", "0");
+  const [automaticOptions, unknownMethod, apiOptions] = await Promise.all([
+    app.handle(new Request("http://localhost/health", { method: "OPTIONS" })),
+    app.handle(new Request("http://localhost/health", { method: "BREW" })),
+    app.handle(new Request("http://localhost/api/latest/health-does-not-need-to-exist", { method: "OPTIONS" })),
+  ]);
 
-  try {
-    const [automaticOptions, unknownMethod, apiOptions] = await Promise.all([
-      app.handle(new Request("http://localhost/health", { method: "OPTIONS" })),
-      app.handle(new Request("http://localhost/health", { method: "BREW" })),
-      app.handle(new Request("http://localhost/api/latest/health-does-not-need-to-exist", { method: "OPTIONS" })),
-    ]);
-
-    expect({
-      automaticOptions: {
-        status: automaticOptions.status,
-        allow: automaticOptions.headers.get("allow"),
-        allowOrigin: automaticOptions.headers.get("access-control-allow-origin"),
-        body: await automaticOptions.text(),
+  expect({
+    automaticOptions: {
+      status: automaticOptions.status,
+      allow: automaticOptions.headers.get("allow"),
+      allowOrigin: automaticOptions.headers.get("access-control-allow-origin"),
+      body: await automaticOptions.text(),
+    },
+    unknownMethod: {
+      status: unknownMethod.status,
+      allow: unknownMethod.headers.get("allow"),
+      body: await unknownMethod.text(),
+    },
+    apiOptions: {
+      status: apiOptions.status,
+      allow: apiOptions.headers.get("allow"),
+      allowMethods: apiOptions.headers.get("access-control-allow-methods"),
+      allowOrigin: apiOptions.headers.get("access-control-allow-origin"),
+      body: await apiOptions.text(),
+    },
+  }).toMatchInlineSnapshot(`
+    {
+      "apiOptions": {
+        "allow": null,
+        "allowMethods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+        "allowOrigin": "*",
+        "body": "",
+        "status": 200,
       },
-      unknownMethod: {
-        status: unknownMethod.status,
-        allow: unknownMethod.headers.get("allow"),
-        body: await unknownMethod.text(),
+      "automaticOptions": {
+        "allow": "GET, HEAD, OPTIONS",
+        "allowOrigin": null,
+        "body": "",
+        "status": 204,
       },
-      apiOptions: {
-        status: apiOptions.status,
-        allow: apiOptions.headers.get("allow"),
-        allowMethods: apiOptions.headers.get("access-control-allow-methods"),
-        allowOrigin: apiOptions.headers.get("access-control-allow-origin"),
-        body: await apiOptions.text(),
+      "unknownMethod": {
+        "allow": null,
+        "body": "Bad Request",
+        "status": 400,
       },
-    }).toMatchInlineSnapshot(`
-      {
-        "apiOptions": {
-          "allow": null,
-          "allowMethods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
-          "allowOrigin": "*",
-          "body": "",
-          "status": 200,
-        },
-        "automaticOptions": {
-          "allow": "GET, HEAD, OPTIONS",
-          "allowOrigin": null,
-          "body": "",
-          "status": 204,
-        },
-        "unknownMethod": {
-          "allow": null,
-          "body": "Bad Request",
-          "status": 400,
-        },
-      }
-    `);
-  } finally {
-    vi.unstubAllEnvs();
-  }
+    }
+  `);
 });
 
 import.meta.vitest?.test("global headers add a default cache-control only when the route set none", async ({ expect }) => {
-  const { vi } = import.meta.vitest!;
-  vi.stubEnv("HEXCLAVE_ARTIFICIAL_DEVELOPMENT_DELAY_MS", "0");
-  vi.stubEnv("STACK_ARTIFICIAL_DEVELOPMENT_DELAY_MS", "0");
+  const [homePage, smartResponse] = await Promise.all([
+    // The home page is a raw Response with no cache-control of its own
+    // (unlike /api 404s, which the smart NotFoundHandler catch-all serves),
+    // so it must receive the default.
+    app.handle(new Request("http://localhost/")),
+    // Smart responses set their own cache-control; the default must not
+    // overwrite it.
+    app.handle(new Request("http://localhost/api/v2beta1/migration-tests/smart-route-handler")),
+  ]);
 
-  try {
-    const [homePage, smartResponse] = await Promise.all([
-      // The home page is a raw Response with no cache-control of its own
-      // (unlike /api 404s, which the smart NotFoundHandler catch-all serves),
-      // so it must receive the default.
-      app.handle(new Request("http://localhost/")),
-      // Smart responses set their own cache-control; the default must not
-      // overwrite it.
-      app.handle(new Request("http://localhost/api/v2beta1/migration-tests/smart-route-handler")),
-    ]);
-
-    expect({
-      homePageCacheControl: homePage.headers.get("cache-control"),
-      smartResponseCacheControl: smartResponse.headers.get("cache-control"),
-    }).toEqual({
-      homePageCacheControl: "private, no-store",
-      smartResponseCacheControl: "no-store, max-age=0",
-    });
-  } finally {
-    vi.unstubAllEnvs();
-  }
+  expect({
+    homePageCacheControl: homePage.headers.get("cache-control"),
+    smartResponseCacheControl: smartResponse.headers.get("cache-control"),
+  }).toEqual({
+    homePageCacheControl: "private, no-store",
+    smartResponseCacheControl: "no-store, max-age=0",
+  });
 });
 
-import.meta.vitest?.test("uncaught dispatch errors use the global sanitized error boundary", async ({ expect }) => {
+import.meta.vitest?.test("uncaught /api/ dispatch errors use the global sanitized error boundary", async ({ expect }) => {
   const { vi } = import.meta.vitest!;
   vi.stubEnv("NODE_ENV", "production");
-  vi.stubEnv("HEXCLAVE_ARTIFICIAL_DEVELOPMENT_DELAY_MS", "1");
-  vi.stubEnv("STACK_ARTIFICIAL_DEVELOPMENT_DELAY_MS", "1");
+  const request = new Request("http://localhost/api/v1");
+  const originalHeaders = request.headers;
+  let shouldThrow = true;
+  // Simulate an unexpected internal failure escaping dispatch for an /api/ request.
+  // The getter throws once to fail dispatch, then returns the original headers because
+  // response compression reads request headers after the error handler runs.
+  Object.defineProperty(request, "headers", {
+    get() {
+      if (shouldThrow) {
+        shouldThrow = false;
+        throw new Error("unexpected request header access");
+      }
+      return originalHeaders;
+    },
+  });
 
   try {
-    const response = await app.handle(new Request("http://localhost/api/v1"));
+    const response = await app.handle(request);
 
     expect({
       status: response.status,

--- a/apps/backend/src/server/middleware.ts
+++ b/apps/backend/src/server/middleware.ts
@@ -2,9 +2,6 @@ import apiVersions from "@/generated/api-versions.json";
 import routes from "@/generated/routes.json";
 import { RoutePatternIndex } from "./route-pattern-index";
 
-const DEV_RATE_LIMIT_MAX_REQUESTS = 100;
-const DEV_RATE_LIMIT_WINDOW_MS = 10_000;
-const devRateLimitMarks: number[] = [];
 const migrationRouteIndexes = new Map<string, RoutePatternIndex<(typeof routes)[number]>>();
 for (const version of apiVersions) {
   if (version.migrationFolder == null) {
@@ -87,11 +84,9 @@ export async function runRequestPipeline(request: Request): Promise<PipelineResu
   // the previous contract so signed URLs, caches, and integrations relying on
   // canonicalization behave identically across old and new deployments. Existing e2e
   // tests fetch `/api/v1/` and assert a 200 because their fetch follows redirects — that
-  // held on Next (308→200) and holds again now. This runs before the artificial
-  // development delay and the OPTIONS short-circuit (Next redirected all methods,
-  // including OPTIONS), and redirecting early keeps the dev rate limiter from counting
-  // phantom duplicate paths. 308 (not 301/307) preserves the method and body, exactly
-  // what Next used.
+  // held on Next (308→200) and holds again now. This runs before the OPTIONS short-circuit
+  // (Next redirected all methods, including OPTIONS). A 308 (not 301/307) preserves the
+  // method and body, exactly as Next did.
   const canonicalPathname = getCanonicalPathname(url.pathname);
   if (canonicalPathname !== url.pathname) {
     return {
@@ -181,16 +176,12 @@ function mergeHexclaveHeaderAliases(headers: Headers) {
   return newRequestHeaders;
 }
 
-function isArtificialDevelopmentBehaviorDisabled(headers: Headers) {
-  return Boolean(headers.get("x-stack-disable-artificial-development-delay"));
-}
-
-import.meta.vitest?.test("Hexclave header aliases control artificial development behavior", ({ expect }) => {
+import.meta.vitest?.test("Hexclave header aliases merge into Stack headers", ({ expect }) => {
   const mergedHeaders = mergeHexclaveHeaderAliases(new Headers({
-    "x-hexclave-disable-artificial-development-delay": "true",
+    "x-hexclave-access-token": "test-access-token",
   }));
 
-  expect(isArtificialDevelopmentBehaviorDisabled(mergedHeaders)).toBe(true);
+  expect(mergedHeaders.get("x-stack-access-token")).toBe("test-access-token");
 });
 
 const clientIpForwardingHeaders = ["x-forwarded-for", "x-real-ip", "x-vercel-forwarded-for", "cf-connecting-ip"];


### PR DESCRIPTION
The `uncaught dispatch errors use the global sanitized error boundary` test in `apps/backend/src/server/app.ts` forced its error by setting `STACK_ARTIFICIAL_DEVELOPMENT_DELAY_MS=1` with `NODE_ENV=production`, which used to make `runRequestPipeline` throw. That code was removed, so `/api/v1` now answers 200 and the inline snapshot mismatched.

The test now forces an unexpected failure inside `dispatch` by making the request's `headers` getter throw once (it returns the real headers afterwards, since response compression reads them after the error handler runs), keeping the original coverage: sanitized 500 body, CORS `*` and `nosniff` on an `/api/` path.

Also drops the leftovers of the delay removal: the dead `devRateLimitMarks`/`DEV_RATE_LIMIT_*`/`isArtificialDevelopmentBehaviorDisabled` symbols in `middleware.ts` (the header-aliasing test now asserts on `mergeHexclaveHeaderAliases` directly), the stale comment references, and the no-op delay env stubs in the other `app.ts` tests.


Link to Devin session: https://app.devin.ai/sessions/d5854260eb9f47fc83adc2c9b6e70e8e
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the removed artificial delay with a real dispatch failure in the backend error-boundary test and hardens the assertions to verify header access and post-error behavior. Cleans up delay-era scaffolding in tests and middleware; the header-alias test now verifies `x-hexclave-*` → `x-stack-*` merging.

- **Bug Fixes**
  - In `apps/backend/src/server/app.ts`, the "uncaught `/api/` dispatch errors" test throws once from the `request.headers` getter, then returns real headers so compression runs; adds assertions that the throw happened and headers were read again, and keeps the original checks (500, sanitized body, CORS `*`, `nosniff`).

- **Refactors**
  - Removed no-op delay env stubs from related tests and simplified test setup; no behavior change.
  - In `apps/backend/src/server/middleware.ts`, dropped dead `DEV_RATE_LIMIT_*`, `devRateLimitMarks`, and `isArtificialDevelopmentBehaviorDisabled`; tightened redirect comments; replaced the artificial-delay control test with a `mergeHexclaveHeaderAliases` check (`x-hexclave-access-token` merges into `x-stack-access-token`).

<sup>Written for commit 2f2fef720b7c92b37ae1faee8f3b2bb9e6cd36a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and dead-code removal in middleware; no production request handling logic changes beyond comment edits.
> 
> **Overview**
> Repairs backend server tests and middleware cleanup after **artificial development delay** behavior was removed from the request pipeline.
> 
> The **uncaught dispatch error** test no longer stubs delay env vars to force a throw in production. It now simulates a real dispatch failure by making the request’s `headers` getter throw once (then return the real headers so compression still works), and the test title clarifies it targets **`/api/`** paths. Assertions stay the same: sanitized **500**, CORS `*`, and `nosniff`.
> 
> Several other **`app.ts`** integration tests drop the no-op `HEXCLAVE_ARTIFICIAL_DEVELOPMENT_DELAY_MS` / `STACK_ARTIFICIAL_DEVELOPMENT_DELAY_MS` stubs and the surrounding `try/finally` blocks; behavior is unchanged.
> 
> In **`middleware.ts`**, dead symbols tied to the old delay/rate-limit path are removed (`devRateLimitMarks`, `DEV_RATE_LIMIT_*`, `isArtificialDevelopmentBehaviorDisabled`). Redirect comments no longer mention the artificial delay or dev rate limiter. The header test now asserts **`mergeHexclaveHeaderAliases`** copies `x-hexclave-*` into `x-stack-*` instead of testing delay disable via headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b3399ee8a6e30ae718926015ab309d7c1aaf171. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API error responses now consistently retain CORS headers.
  * Improved handling for non-API `OPTIONS` requests and unknown HTTP methods.
  * Preserved cache-control headers during request processing.
  * Production errors are sanitized when request-header access fails.
  * Access-token aliases now merge correctly into the corresponding request header.
  * Removed inconsistent development-only request delays for more predictable behavior.
  * Improved request processing reliability across supported API and non-API scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->