### PR TITLE
Re-add the email queue auto-trigger in sendEmailToMany

### DIFF
--- a/apps/backend/src/lib/emails.tsx
+++ b/apps/backend/src/lib/emails.tsx
@@ -1,11 +1,12 @@
 import { globalPrismaClient } from '@/prisma-client';
+import { runAsynchronouslyAndWaitUntil } from '@/utils/background-tasks';
 import { EmailOutboxCreatedWith } from '@/generated/prisma/client';
 import { DEFAULT_EMAIL_THEMES, DEFAULT_TEMPLATE_IDS } from '@hexclave/shared/dist/helpers/emails';
 import { UsersCrud } from '@hexclave/shared/dist/interface/crud/users';
-import { getEnvVariable } from '@hexclave/shared/dist/utils/env';
+import { getEnvBoolean, getEnvVariable } from '@hexclave/shared/dist/utils/env';
 import { HexclaveAssertionError } from '@hexclave/shared/dist/utils/errors';
 import { Json } from '@hexclave/shared/dist/utils/json';
-import { serializeRecipient } from './email-queue-step';
+import { runEmailQueueStep, serializeRecipient } from './email-queue-step';
 import { LowLevelEmailConfig, isSecureEmailPort } from './emails-low-level';
 import { Tenancy } from './tenancies';
 
@@ -66,6 +67,12 @@ export async function sendEmailToMany(options: {
       overrideNotificationCategoryId: options.overrideNotificationCategoryId,
     })),
   });
+
+  if (!getEnvBoolean("STACK_EMAIL_BRANCHING_DISABLE_QUEUE_AUTO_TRIGGER")) {
+    // The cron job should run runEmailQueueStep() to process the emails, but we call it here again for those self-hosters
+    // who didn't set up the cron job correctly, and also just in case something happens to the cron job.
+    runAsynchronouslyAndWaitUntil(runEmailQueueStep());
+  }
 }
 
 export async function sendEmailFromDefaultTemplate(options: {


### PR DESCRIPTION
Reverts the `emails.tsx` part of 16ad0ee86 (`Remove sendEmailToMany fan-out`), so enqueueing an email kicks off a queue step immediately instead of waiting for the next cron-driven step:

```ts
if (!getEnvBoolean("STACK_EMAIL_BRANCHING_DISABLE_QUEUE_AUTO_TRIGGER")) {
  runAsynchronouslyAndWaitUntil(runEmailQueueStep());
}
```

`emails.tsx` is now byte-identical to its pre-16ad0ee86 state; the other two files touched by that commit (`emailable.tsx`, `.env.development`) are left alone.

Without the trigger, a newly created row's latency is "wait for the next step boundary" rather than "a step starts now", which matters for the ~12s budget in `waitForOutboxEmailWithStatus`.


Link to Devin session: https://app.devin.ai/sessions/08e0efd24b2d438ca64edde22216c014
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-add immediate email queue triggering in `sendEmailToMany` so enqueued emails are processed right away instead of waiting for the next cron step, helping keep outbox latency within the ~12s budget. This is opt-out via `STACK_EMAIL_BRANCHING_DISABLE_QUEUE_AUTO_TRIGGER`; when not enabled, we call `runEmailQueueStep()` using `runAsynchronouslyAndWaitUntil`.

<sup>Written for commit 431b795ca7665ee30d4a34e2772ffcaad9fae750. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1901?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral change to email dispatch timing with an env opt-out; cron remains the primary path and duplicate queue steps are expected to be safe.
> 
> **Overview**
> **Restores immediate email queue processing** when `sendEmailToMany` creates outbox rows, reversing the removal from commit 16ad0ee86.
> 
> After `createMany`, unless `STACK_EMAIL_BRANCHING_DISABLE_QUEUE_AUTO_TRIGGER` is set, the code calls `runAsynchronouslyAndWaitUntil(runEmailQueueStep())` so delivery does not depend solely on the cron job. That cuts latency for flows with a tight wait budget (e.g. ~12s in `waitForOutboxEmailWithStatus`) and helps self-hosted setups where cron may be missing or flaky.
> 
> Imports are updated to pull in `runAsynchronouslyAndWaitUntil`, `getEnvBoolean`, and `runEmailQueueStep`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 431b795ca7665ee30d4a34e2772ffcaad9fae750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email delivery now automatically begins processing after messages are queued.

* **Bug Fixes**
  * Added a configuration option to disable automatic email queue processing when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->