### PR TITLE
Harden the backend -> bulldozer hop against transient socket resets

### DIFF
--- a/apps/backend/src/lib/bulldozer-server-client.test.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.test.ts
@@ -1,0 +1,66 @@
+import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchBulldozerServerJson } from "./bulldozer-server-client";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function socketResetError() {
+  return Object.assign(new Error("socket reset"), { code: "ECONNRESET" });
+}
+
+describe("fetchBulldozerServerJson", () => {
+  it("retries a transient GET transport error", async () => {
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(socketResetError())
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchBulldozerServerJson<{ ok: boolean }>({ method: "GET", path: "/v1/test" })).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws with the attempt count after exhausting transient GET retries", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(socketResetError());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchBulldozerServerJson({ method: "GET", path: "/v1/test" })).rejects.toMatchObject({
+      name: "HexclaveAssertionError",
+      extraData: {
+        attempts: 3,
+        path: "/v1/test",
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("does not retry POST transport errors", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(socketResetError());
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchBulldozerServerJson({ method: "POST", path: "/v1/test", body: {} })).rejects.toBeInstanceOf(HexclaveAssertionError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry HTTP error responses", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("server error", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchBulldozerServerJson({ method: "GET", path: "/v1/test" })).rejects.toMatchObject({
+      extraData: {
+        status: 500,
+        path: "/v1/test",
+      },
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry JSON parse failures", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("not json", { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchBulldozerServerJson({ method: "GET", path: "/v1/test" })).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/lib/bulldozer-server-client.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.ts
@@ -1,5 +1,29 @@
 import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+import { wait } from "@hexclave/shared/dist/utils/promises";
+
+const BULLDOZER_GET_MAX_ATTEMPTS = 3;
+const BULLDOZER_GET_RETRY_DELAYS_MS = [25, 50];
+
+function isTransientBulldozerTransportError(error: unknown): boolean {
+  const transportErrorCodes = new Set([
+    "ECONNRESET",
+    "EPIPE",
+    "ETIMEDOUT",
+    "UND_ERR_BODY_TIMEOUT",
+    "UND_ERR_CONNECT_TIMEOUT",
+    "UND_ERR_HEADERS_TIMEOUT",
+    "UND_ERR_SOCKET",
+  ]);
+  let current: unknown = error;
+  for (let depth = 0; depth < 4 && current instanceof Error; depth++) {
+    const code = Reflect.get(current, "code");
+    if (typeof code === "string" && transportErrorCodes.has(code)) return true;
+    if (current.name === "SocketError" || current.name.endsWith("TimeoutError")) return true;
+    current = current.cause;
+  }
+  return false;
+}
 
 function getBulldozerServerBaseUrl(): string {
   const configuredUrl = getEnvVariable("HEXCLAVE_BULLDOZER_SERVER_URL", "");
@@ -27,14 +51,43 @@ export async function fetchBulldozerServerJson<T>(options: {
   path: string,
   body?: unknown,
 }): Promise<T> {
-  const response = await fetch(`${getBulldozerServerBaseUrl()}${options.path}`, {
-    method: options.method,
-    headers: {
-      "content-type": "application/json",
-      "authorization": `Bearer ${getEnvVariable("HEXCLAVE_BULLDOZER_SERVER_SECRET")}`,
-    },
-    ...options.body === undefined ? {} : { body: JSON.stringify(options.body) },
-  });
+  const maxAttempts = options.method === "GET" ? BULLDOZER_GET_MAX_ATTEMPTS : 1;
+  let response: Response | undefined;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      response = await fetch(`${getBulldozerServerBaseUrl()}${options.path}`, {
+        method: options.method,
+        headers: {
+          "content-type": "application/json",
+          "authorization": `Bearer ${getEnvVariable("HEXCLAVE_BULLDOZER_SERVER_SECRET")}`,
+        },
+        ...options.body === undefined ? {} : { body: JSON.stringify(options.body) },
+      });
+      break;
+    } catch (error) {
+      if (!isTransientBulldozerTransportError(error) || attempt === maxAttempts - 1) {
+        throw new HexclaveAssertionError(`Bulldozer server request failed after ${attempt + 1} attempt(s) for ${options.method} ${options.path}`, {
+          method: options.method,
+          path: options.path,
+          attempts: attempt + 1,
+          cause: error,
+        });
+      }
+      // The GET failures seen in CI are consistent with a transient localhost
+      // keep-alive reset while the bulldozer event loop is busy with LMDB/GC
+      // work. Replay only GETs: a reset after a POST may mean the write already
+      // reached the server, so retrying it could duplicate a side effect.
+      await wait(BULLDOZER_GET_RETRY_DELAYS_MS[attempt]);
+    }
+  }
+
+  if (response === undefined) {
+    throw new HexclaveAssertionError(`Bulldozer server request failed without a response for ${options.method} ${options.path}`, {
+      method: options.method,
+      path: options.path,
+      attempts: maxAttempts,
+    });
+  }
 
   if (!response.ok) {
     const responseText = await response.text();

--- a/apps/bulldozer-js/src/index.ts
+++ b/apps/bulldozer-js/src/index.ts
@@ -1041,6 +1041,14 @@ const app = new Elysia({ adapter: node() })
   .listen(port, (server) => {
     // @elysia/node 1.4.6 does not assign the server to app.server, so
     // Elysia.stop() throws even though the callback's server is running.
+    const node = Reflect.get(server, "node");
+    const nodeHttpServer = isRecord(node) ? Reflect.get(node, "server") : undefined;
+    if (!isRecord(nodeHttpServer)) throw new Error("Bulldozer HTTP server did not expose its underlying Node server");
+    // Keep idle connections alive longer than the client's idle timeout (Node's
+    // default is 5s) so a busy event loop cannot race undici while it reuses a
+    // keep-alive connection. Node requires headersTimeout > keepAliveTimeout,
+    // which its 60s default still satisfies.
+    Reflect.set(nodeHttpServer, "keepAliveTimeout", 30_000);
     stopHttpServer = () => server.stop();
   });
 


### PR DESCRIPTION
E2E runs intermittently fail with a 500 from `GET /api/v1/payments/items/team/<id>/<item>`, caused by `fetch failed` / `read ECONNRESET` in `fetchBulldozerServerJson`. The bulldozer process is still serving requests for minutes afterwards in those runs, so these look like transient resets on the localhost hop rather than the server going away.

Two changes:

- `fetchBulldozerServerJson` retries transport-level failures (`ECONNRESET`, `EPIPE`, socket/timeout undici codes, including nested `cause`) up to 3 attempts with 25ms/50ms backoff — GET only, since a reset after a POST may mean the write already landed. HTTP error statuses and JSON parse failures are not retried; the exhausted error carries method/path/attempts and the original `cause`.
- bulldozer-js sets the underlying Node server's `keepAliveTimeout` to 30s (Node's default is 5s), so the server no longer initiates the idle close before the client does.

Note the second change is a mitigation for a plausible mechanism (idle-close race, amplified when the bulldozer event loop is busy), not a confirmed root cause — no bulldozer-side logs are captured in CI around the failures. Runs where bulldozer becomes genuinely unreachable (`ECONNREFUSED`) are a separate issue and out of scope here.

New unit test covers: retry-then-succeed, retries exhausted, POST not retried, HTTP 500 not retried, JSON parse failure not retried.


Link to Devin session: https://app.devin.ai/sessions/c2f00827b5b447ffa8b7a5cc04bd7ce9
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the backend bulldozer hop to reduce flaky 500s from transient `ECONNRESET`/socket resets on GET requests. We now retry safe GETs and keep idle connections alive longer on the bulldozer server.

- **Bug Fixes**
  - Retries transient transport errors on GETs (e.g., `ECONNRESET`, `EPIPE`, undici timeouts; including nested causes) up to 3 attempts with 25ms/50ms backoff. No retries for POSTs, HTTP errors, or JSON parse failures; exhausted errors include method, path, attempts, and cause.
  - In `bulldozer-js`, sets the underlying Node server `keepAliveTimeout` to 30s (was 5s) to avoid server-initiated idle closes racing the client; `headersTimeout` remains higher.

<sup>Written for commit b3303c8267a9e81efe2170d2ad561a44a2babc45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

