### PR TITLE
Capture bulldozer-js logs in CI test jobs

### DIFF
--- a/.github/workflows/db-migration-backwards-compatibility.yaml
+++ b/.github/workflows/db-migration-backwards-compatibility.yaml
@@ -169,8 +169,9 @@ jobs:
             bulldozer_log="$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
             (
               set +e
-              pnpm run start:bulldozer >"$bulldozer_log" 2>&1
-              echo "$?" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
+              # Keep service output correlatable with the surrounding GitHub Actions logs.
+              pnpm run start:bulldozer 2>&1 | TZ=UTC awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' >"$bulldozer_log"
+              echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
             ) &
           wait-on: |
             tcp:localhost:8146
@@ -415,8 +416,9 @@ jobs:
             bulldozer_log="$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
             (
               set +e
-              pnpm run start:bulldozer >"$bulldozer_log" 2>&1
-              echo "$?" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
+              # Keep service output correlatable with the surrounding GitHub Actions logs.
+              pnpm run start:bulldozer 2>&1 | TZ=UTC awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' >"$bulldozer_log"
+              echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
             ) &
           wait-on: |
             tcp:localhost:8146

--- a/.github/workflows/db-migration-backwards-compatibility.yaml
+++ b/.github/workflows/db-migration-backwards-compatibility.yaml
@@ -165,7 +165,13 @@ jobs:
         env:
           HEXCLAVE_BULLDOZER_JS_USE_TMP_LMDB: "1"
         with:
-          run: pnpm run start:bulldozer &
+          run: |
+            bulldozer_log="$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
+            (
+              set +e
+              pnpm run start:bulldozer >"$bulldozer_log" 2>&1
+              echo "$?" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
+            ) &
           wait-on: |
             tcp:localhost:8146
           tail: true
@@ -262,6 +268,24 @@ jobs:
 
       - name: Verify data integrity
         run: pnpm run verify-data-integrity --no-bail
+
+      - name: Print bulldozer-js diagnostics
+        if: ${{ failure() }}
+        run: |
+          if [[ -f "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt" ]]; then
+            echo "Bulldozer-js command exited with code $(<"$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt")"
+          else
+            echo "Bulldozer-js command is still running; a child process may have exited"
+          fi
+          tail -n 2000 "$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
+
+      - name: Upload bulldozer-js logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: db-migration-backwards-bulldozer
+          path: ${{ runner.temp }}/hexclave-bulldozer.untracked.log
+          if-no-files-found: error
 
       - name: Print Docker Compose logs
         if: always()
@@ -387,7 +411,13 @@ jobs:
         env:
           HEXCLAVE_BULLDOZER_JS_USE_TMP_LMDB: "1"
         with:
-          run: pnpm run start:bulldozer &
+          run: |
+            bulldozer_log="$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
+            (
+              set +e
+              pnpm run start:bulldozer >"$bulldozer_log" 2>&1
+              echo "$?" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
+            ) &
           wait-on: |
             tcp:localhost:8146
           tail: true
@@ -469,6 +499,24 @@ jobs:
 
       - name: Verify data integrity
         run: pnpm run verify-data-integrity --no-bail
+
+      - name: Print bulldozer-js diagnostics
+        if: ${{ failure() }}
+        run: |
+          if [[ -f "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt" ]]; then
+            echo "Bulldozer-js command exited with code $(<"$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt")"
+          else
+            echo "Bulldozer-js command is still running; a child process may have exited"
+          fi
+          tail -n 2000 "$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
+
+      - name: Upload bulldozer-js logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: db-migration-forward-bulldozer
+          path: ${{ runner.temp }}/hexclave-bulldozer.untracked.log
+          if-no-files-found: error
 
       - name: Print Docker Compose logs
         if: always()

--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -133,7 +133,13 @@ jobs:
         env:
           HEXCLAVE_BULLDOZER_JS_USE_TMP_LMDB: "1"
         with:
-          run: pnpm run start:bulldozer &
+          run: |
+            bulldozer_log="$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
+            (
+              set +e
+              pnpm run start:bulldozer >"$bulldozer_log" 2>&1
+              echo "$?" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
+            ) &
           wait-on: |
             tcp:localhost:8146
           tail: true
@@ -219,6 +225,24 @@ jobs:
 
       - name: Verify data integrity
         run: pnpm run verify-data-integrity --no-bail
+
+      - name: Print bulldozer-js diagnostics
+        if: ${{ failure() }}
+        run: |
+          if [[ -f "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt" ]]; then
+            echo "Bulldozer-js command exited with code $(<"$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt")"
+          else
+            echo "Bulldozer-js command is still running; a child process may have exited"
+          fi
+          tail -n 2000 "$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
+
+      - name: Upload bulldozer-js logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-api-bulldozer-${{ matrix.freestyle-mode }}
+          path: ${{ runner.temp }}/hexclave-bulldozer.untracked.log
+          if-no-files-found: error
 
       - name: Print Docker Compose logs
         if: always()

--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -137,8 +137,9 @@ jobs:
             bulldozer_log="$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
             (
               set +e
-              pnpm run start:bulldozer >"$bulldozer_log" 2>&1
-              echo "$?" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
+              # Keep service output correlatable with the surrounding GitHub Actions logs.
+              pnpm run start:bulldozer 2>&1 | TZ=UTC awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' >"$bulldozer_log"
+              echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
             ) &
           wait-on: |
             tcp:localhost:8146

--- a/.github/workflows/e2e-fallback-tests.yaml
+++ b/.github/workflows/e2e-fallback-tests.yaml
@@ -115,8 +115,9 @@ jobs:
             bulldozer_log="$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
             (
               set +e
-              pnpm run start:bulldozer >"$bulldozer_log" 2>&1
-              echo "$?" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
+              # Keep service output correlatable with the surrounding GitHub Actions logs.
+              pnpm run start:bulldozer 2>&1 | TZ=UTC awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' >"$bulldozer_log"
+              echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
             ) &
           wait-on: |
             tcp:localhost:8146

--- a/.github/workflows/e2e-fallback-tests.yaml
+++ b/.github/workflows/e2e-fallback-tests.yaml
@@ -111,7 +111,13 @@ jobs:
         env:
           HEXCLAVE_BULLDOZER_JS_USE_TMP_LMDB: "1"
         with:
-          run: pnpm run start:bulldozer &
+          run: |
+            bulldozer_log="$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
+            (
+              set +e
+              pnpm run start:bulldozer >"$bulldozer_log" 2>&1
+              echo "$?" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
+            ) &
           wait-on: |
             tcp:localhost:8146
           tail: true
@@ -195,6 +201,24 @@ jobs:
       # Exclude cross-domain-auth which hardcodes the primary URL.
       - name: Run SDK fallback tests
         run: pnpm -w run pre && cd apps/e2e && npx vitest run tests/js/ --exclude '**/{cross-domain-auth,oauth,email-template-existing-project}*'
+
+      - name: Print bulldozer-js diagnostics
+        if: ${{ failure() }}
+        run: |
+          if [[ -f "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt" ]]; then
+            echo "Bulldozer-js command exited with code $(<"$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt")"
+          else
+            echo "Bulldozer-js command is still running; a child process may have exited"
+          fi
+          tail -n 2000 "$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
+
+      - name: Upload bulldozer-js logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-fallback-bulldozer
+          path: ${{ runner.temp }}/hexclave-bulldozer.untracked.log
+          if-no-files-found: error
 
       - name: Print Docker Compose logs
         if: always()

--- a/.github/workflows/fast-fail-tests.yaml
+++ b/.github/workflows/fast-fail-tests.yaml
@@ -268,8 +268,9 @@ jobs:
             bulldozer_log="$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
             (
               set +e
-              pnpm run start:bulldozer >"$bulldozer_log" 2>&1
-              echo "$?" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
+              # Keep service output correlatable with the surrounding GitHub Actions logs.
+              pnpm run start:bulldozer 2>&1 | TZ=UTC awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' >"$bulldozer_log"
+              echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
             ) &
           wait-on: |
             tcp:localhost:8146

--- a/.github/workflows/fast-fail-tests.yaml
+++ b/.github/workflows/fast-fail-tests.yaml
@@ -264,7 +264,13 @@ jobs:
         env:
           HEXCLAVE_BULLDOZER_JS_USE_TMP_LMDB: "1"
         with:
-          run: pnpm run start:bulldozer &
+          run: |
+            bulldozer_log="$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
+            (
+              set +e
+              pnpm run start:bulldozer >"$bulldozer_log" 2>&1
+              echo "$?" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
+            ) &
           wait-on: |
             tcp:localhost:8146
           tail: true
@@ -342,6 +348,24 @@ jobs:
           set -euo pipefail
           echo "Running fast-fail subset: $SELECTED_TEST_FILES"
           pnpm test run $SELECTED_TEST_FILES --reporter=verbose
+
+      - name: Print bulldozer-js diagnostics
+        if: ${{ failure() }}
+        run: |
+          if [[ -f "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt" ]]; then
+            echo "Bulldozer-js command exited with code $(<"$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt")"
+          else
+            echo "Bulldozer-js command is still running; a child process may have exited"
+          fi
+          tail -n 2000 "$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
+
+      - name: Upload bulldozer-js logs
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: fast-fail-bulldozer
+          path: ${{ runner.temp }}/hexclave-bulldozer.untracked.log
+          if-no-files-found: error
 
       - name: Print Docker Compose logs
         if: always()


### PR DESCRIPTION
When an E2E test fails with a bulldozer socket error, the job log currently contains no bulldozer-side output at all — `background-action` preserves the startup command but not the service's ongoing stdout — so a crash/restart is indistinguishable from a transient socket race.

Each CI job that starts a dedicated bulldozer process (`e2e-api-tests`, `e2e-fallback-tests`, `fast-fail-tests`, `db-migration-backwards-compatibility`) now captures its merged stdout+stderr to a runner-temp log, tails it and reports the process exit code on failure, and uploads the full log as an artifact. Mirrors the existing `hexclave-dev.untracked.log` pattern used for the combined dev services.

Output is piped through `awk`+`strftime` to prefix every line with an ISO-8601 UTC timestamp, since redirecting to a file drops the Actions per-line timestamps and bulldozer's own log records carry no time field — without that the log can't be correlated with the failure time. Exit code is taken from `PIPESTATUS[0]` so the pipeline doesn't mask it.


Link to Devin session: https://app.devin.ai/sessions/c2f00827b5b447ffa8b7a5cc04bd7ce9
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture and timestamp `bulldozer-js` logs in CI test jobs to make E2E failures debuggable and distinguish crashes from socket races. Jobs now write merged stdout/stderr to a temp log, report the process exit code on failure, and upload the full log as an artifact.

- **New Features**
  - Pipe `pnpm run start:bulldozer` output to `$RUNNER_TEMP/hexclave-bulldozer.untracked.log` with ISO-8601 UTC prefixes via `awk`.
  - Save exit status to `$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt`, print it on failure, and tail the last 2000 lines.
  - Enabled for `e2e-api-tests`, `e2e-fallback-tests`, `fast-fail-tests`, and `db-migration-backwards-compatibility`; logs uploaded using `actions/upload-artifact`.

<sup>Written for commit 270408461ce5ced2922053e8117a936dabd174f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions workflow steps for observability; no application runtime or test logic is modified.
> 
> **Overview**
> CI jobs that start **bulldozer-js** in the background no longer rely on `background-action` alone for service output. **`pnpm run start:bulldozer`** stdout/stderr is redirected to `$RUNNER_TEMP/hexclave-bulldozer.untracked.log`, with each line prefixed in UTC via `awk`/`strftime` so logs line up with the rest of the job when Actions timestamps are lost on redirect.
> 
> The wrapper records **`pnpm`**’s exit code in a temp file using **`PIPESTATUS[0]`** so a pipe does not hide crashes. On **failure**, jobs tail the last 2000 lines, print whether bulldozer exited, and upload the log as an artifact. The same pattern is applied in **`e2e-api-tests`**, **`e2e-fallback-tests`**, **`fast-fail-tests`**, and both compat jobs in **`db-migration-backwards-compatibility`** (backwards and forward).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 270408461ce5ced2922053e8117a936dabd174f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated test and compatibility workflows with timestamped service logs and preserved startup status.
  * Failed jobs now display recent diagnostic output and upload detailed logs as downloadable artifacts.
  * These improvements make automated test failures easier to investigate and help maintain reliable validation across test modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->