### PR TITLE
Derive the WorkOS issuer from the configured client ID

### DIFF
--- a/apps/backend/prisma/migrations/20260805000000_external_auth_sessions/tests/identity-session-constraints.ts
+++ b/apps/backend/prisma/migrations/20260805000000_external_auth_sessions/tests/identity-session-constraints.ts
@@ -109,7 +109,7 @@ export const postMigration = async (sql: Sql, ctx: Awaited<ReturnType<typeof pre
     )
     VALUES (
       ${ctx.tenancyId}::uuid, ${mismatchedUserAuthMethodId}::uuid, ${ctx.secondUserId}::uuid,
-      'workos-integration', 'https://api.workos.com', 'mismatched-user', NOW(), NOW()
+      'workos-integration', 'https://api.workos.com/user_management/client_migration_test', 'mismatched-user', NOW(), NOW()
     )
   `).rejects.toThrow(/ExternalAuthMethod_tenancyId_authMethodId_projectUserId_fkey/);
 

--- a/apps/backend/src/lib/external-auth.tsx
+++ b/apps/backend/src/lib/external-auth.tsx
@@ -1,7 +1,7 @@
 import { Tenancy } from "@/lib/tenancies";
 import { safeOAuthFetch } from "@/lib/ssrf-protection/oauth";
 import { KnownErrors } from "@hexclave/shared";
-import { externalAuthProviderIds, type ExternalAuthProviderId } from "@hexclave/shared/dist/interface/external-auth";
+import { externalAuthProviderIds, getWorkOSVerificationUrls, type ExternalAuthProviderId } from "@hexclave/shared/dist/interface/external-auth";
 import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { createRemoteJWKSet, customFetch, decodeJwt, decodeProtectedHeader, errors as joseErrors, jwtVerify, type JWTPayload } from "jose";
 
@@ -102,10 +102,11 @@ function getProviderVerificationConfig(
     case "workos-integration": {
       const config = tenancy.config["workos-integration"];
       const clientId = requireConfigured(config.clientId);
+      const derivedUrls = getWorkOSVerificationUrls(clientId, config.issuer);
       return {
-        issuer: requireConfigured(config.issuer),
+        issuer: derivedUrls.issuer,
         clientId,
-        jwksUrl: `https://api.workos.com/sso/jwks/${encodeURIComponent(clientId)}`,
+        jwksUrl: derivedUrls.jwksUrl,
       };
     }
   }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/external-auth-integration-page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/external-auth-integration-page.tsx
@@ -139,7 +139,7 @@ export function ExternalAuthIntegrationPage(props: { provider: ExternalAuthInteg
           adminApp,
           configUpdate: {
             "workos-integration.clientId": clientId,
-            "workos-integration.issuer": issuer,
+            "workos-integration.issuer": issuer.length === 0 ? null : issuer,
           },
           pushable: true,
         });

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/external-auth-integration-page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/external-auth-integration-page.tsx
@@ -2,6 +2,7 @@
 
 import { useUpdateConfig } from "@/components/config-update";
 import { DesignAlert, DesignButton, DesignCard, DesignInput } from "@/components/design-components";
+import { getWorkOSVerificationUrls } from "@hexclave/shared/dist/interface/external-auth";
 import { FingerprintSimpleIcon, KeyIcon, LinkSimpleIcon, ShieldCheckIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { AppEnabledGuard } from "./app-enabled-guard";
@@ -90,7 +91,7 @@ export function ExternalAuthIntegrationPage(props: { provider: ExternalAuthInteg
       }
       case "workos": {
         return {
-          issuer: config["workos-integration"].issuer ?? "https://api.workos.com",
+          issuer: config["workos-integration"].issuer ?? "",
           authorizedParties: "",
           audience: "",
           jwksUrl: "",
@@ -104,6 +105,9 @@ export function ExternalAuthIntegrationPage(props: { provider: ExternalAuthInteg
   const [audience, setAudience] = useState(initialValues.audience);
   const [jwksUrl, setJwksUrl] = useState(initialValues.jwksUrl);
   const [clientId, setClientId] = useState(initialValues.clientId);
+  const workosDerivedUrls = props.provider === "workos" && clientId.length > 0
+    ? getWorkOSVerificationUrls(clientId)
+    : null;
 
   const save = async () => {
     switch (props.provider) {
@@ -173,9 +177,13 @@ export function ExternalAuthIntegrationPage(props: { provider: ExternalAuthInteg
                 </label>
               )}
               <label className="flex flex-col gap-2 text-sm font-medium">
-                Issuer
-                <DesignInput value={issuer} onChange={event => setIssuer(event.target.value)} placeholder="https://issuer.example.com" leadingIcon={<LinkSimpleIcon />} />
-                <span className="text-xs font-normal text-muted-foreground">Must exactly match the JWT issuer claim.</span>
+                {props.provider === "workos" ? "Issuer override (advanced, optional)" : "Issuer"}
+                <DesignInput value={issuer} onChange={event => setIssuer(event.target.value)} placeholder={props.provider === "workos" ? "Leave blank to derive from Client ID" : "https://issuer.example.com"} leadingIcon={<LinkSimpleIcon />} />
+                <span className="text-xs font-normal text-muted-foreground">
+                  {props.provider === "workos"
+                    ? "Leave blank to use the issuer derived from the Client ID. Only set this for a WorkOS deployment with a different issuer."
+                    : "Must exactly match the JWT issuer claim."}
+                </span>
               </label>
               {props.provider === "clerk" && (
                 <label className="flex flex-col gap-2 text-sm font-medium">
@@ -197,10 +205,11 @@ export function ExternalAuthIntegrationPage(props: { provider: ExternalAuthInteg
                   </label>
                 </>
               )}
-              {props.provider === "workos" && clientId.length > 0 && (
-                <p className="text-xs text-muted-foreground">
-                  JWKS URL: https://api.workos.com/sso/jwks/{clientId}
-                </p>
+              {workosDerivedUrls != null && (
+                <div className="flex flex-col gap-1 text-xs text-muted-foreground">
+                  <p>Derived issuer: {workosDerivedUrls.issuer}</p>
+                  <p>JWKS URL: {workosDerivedUrls.jwksUrl}</p>
+                </div>
               )}
               <div>
                 <DesignButton onClick={save}>Save configuration</DesignButton>

--- a/packages/shared/src/config/schema-fuzzer.test.ts
+++ b/packages/shared/src/config/schema-fuzzer.test.ts
@@ -233,7 +233,7 @@ const branchSchemaFuzzerConfig = [{
   }],
   "workos-integration": [{
     clientId: [undefined, "client_123"] as (string | undefined)[],
-    issuer: [undefined, "https://api.workos.com"] as (string | undefined)[],
+    issuer: [undefined, "https://api.workos.com/user_management/client_123"] as (string | undefined)[],
   }],
 }] satisfies FuzzerConfig<BranchConfigNormalizedOverride>;
 

--- a/packages/shared/src/interface/external-auth.test.ts
+++ b/packages/shared/src/interface/external-auth.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { getWorkOSVerificationUrls } from "./external-auth";
+
+describe("getWorkOSVerificationUrls", () => {
+  it("derives the issuer and JWKS URL from one encoded client ID", () => {
+    expect(getWorkOSVerificationUrls("client_123")).toMatchInlineSnapshot(`
+      {
+        "issuer": "https://api.workos.com/user_management/client_123",
+        "jwksUrl": "https://api.workos.com/sso/jwks/client_123",
+      }
+    `);
+  });
+
+  it("preserves an explicit issuer override", () => {
+    expect(getWorkOSVerificationUrls("client_123", "https://custom.example.com")).toMatchInlineSnapshot(`
+      {
+        "issuer": "https://custom.example.com",
+        "jwksUrl": "https://api.workos.com/sso/jwks/client_123",
+      }
+    `);
+  });
+});

--- a/packages/shared/src/interface/external-auth.ts
+++ b/packages/shared/src/interface/external-auth.ts
@@ -5,3 +5,25 @@ export const externalAuthProviderIds = [
 ] as const;
 
 export type ExternalAuthProviderId = typeof externalAuthProviderIds[number];
+
+/**
+ * WorkOS User Management access tokens are issued by a per-client issuer
+ * (`https://api.workos.com/user_management/<clientId>`), not by the bare API origin, so both the
+ * issuer and the JWKS endpoint are fully determined by the client ID. They're derived here — in one
+ * place shared by the verifier and the dashboard — because two independent constructions of these
+ * URLs is how the two ended up disagreeing, which rejects every genuine token with nothing pointing
+ * at the issuer as the cause. The override exists only for a WorkOS deployment whose tokens carry a
+ * different issuer.
+ */
+export function getWorkOSVerificationUrls(clientId: string, issuerOverride?: string): {
+  issuer: string,
+  jwksUrl: string,
+} {
+  const encodedClientId = encodeURIComponent(clientId);
+  return {
+    issuer: issuerOverride == null || issuerOverride.length === 0
+      ? `https://api.workos.com/user_management/${encodedClientId}`
+      : issuerOverride,
+    jwksUrl: `https://api.workos.com/sso/jwks/${encodedClientId}`,
+  };
+}


### PR DESCRIPTION
Testing the external auth integrations against a real WorkOS AuthKit environment showed that no genuine WorkOS token could ever verify with the dashboard's suggested configuration: real User Management access tokens are issued by a per-client issuer, while the dashboard prefilled the bare API origin, and the verifier requires an exact match.

```
real token iss:  https://api.workos.com/user_management/<clientId>
prefilled:       https://api.workos.com          -> 401 INVALID_EXTERNAL_AUTH_TOKEN
```

The issuer is as deterministic as the JWKS URL, so both are now derived from the client ID by one shared helper used by the verifier and the dashboard page — the duplicate construction is what let them disagree. `workos-integration.issuer` stays as an optional advanced override (empty by default) rather than being removed, since it isn't verified whether a WorkOS deployment can ever carry a different issuer.

Verified with a real one-shot WorkOS environment end-to-end: with the issuer field cleared, a genuine hosted-AuthKit token exchanges successfully at `/auth/external/token`.

Unrelated findings from the same testing run, left alone here: the Better Auth JWT carries `email`/`name` but the mapped Hexclave user's primary email and display name stay `null`, and external-auth users are indistinguishable in the dashboard Users list.


Link to Devin session: https://app.devin.ai/sessions/9ca1de7e4a9f41feb1e8fbcd61136270
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches external auth token verification for WorkOS; behavior change is intentional but mis-derived URLs would reject valid tokens or affect tenants relying on a custom issuer override.
> 
> **Overview**
> Fixes WorkOS external auth so JWT verification uses the **per-client User Management issuer** (`https://api.workos.com/user_management/<clientId>`) instead of the bare API origin, which caused every real AuthKit token to fail with `INVALID_EXTERNAL_AUTH_TOKEN`.
> 
> Adds shared **`getWorkOSVerificationUrls`** so the backend verifier and dashboard derive issuer and JWKS URL from the same client ID. The backend **`workos-integration`** path now uses that helper (with optional `config.issuer` override); the dashboard stops prefilling `https://api.workos.com`, labels issuer as an advanced optional override, and shows derived issuer/JWKS when a client ID is entered.
> 
> Tests cover the helper and align fuzzer/migration fixtures with the per-client issuer shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0571ef2c0d7bbbf83bc3ab09cfd8b037cab401e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the WorkOS issuer and JWKS URL from the configured client ID and lets you clear the issuer override. Fixes real WorkOS token verification and keeps the dashboard and backend in sync.

- **Bug Fixes**
  - Verifier now uses `getWorkOSVerificationUrls(clientId, issuerOverride)` so tokens validate with issuer `https://api.workos.com/user_management/<clientId>`.
  - Removes the dashboard/backend mismatch that caused 401 INVALID_EXTERNAL_AUTH_TOKEN.

- **New Features**
  - Added shared helper `getWorkOSVerificationUrls` in `packages/shared` with tests.
  - Dashboard derives and shows issuer/JWKS for WorkOS, labels issuer as an optional override, and saving an empty issuer now clears the override.

<sup>Written for commit b24d5029d9a1aab9322b5a9442355c31b8116e6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

