### PR TITLE
Fix bulldozer-related CI test flakiness: readiness gate + bounded entitlement wait

### DIFF
--- a/.github/workflows/setup-tests-with-custom-base-port.yaml
+++ b/.github/workflows/setup-tests-with-custom-base-port.yaml
@@ -66,6 +66,7 @@ jobs:
           run: pnpm run dev &
           wait-on: |
             http://localhost:6902
+            tcp:localhost:6946
           tail: true
           wait-for: 120s
           log-output-if: true

--- a/.github/workflows/setup-tests.yaml
+++ b/.github/workflows/setup-tests.yaml
@@ -69,7 +69,7 @@ jobs:
             pnpm run dev >"$dev_log" 2>&1
             echo "$?" > "$RUNNER_TEMP/hexclave-dev-exit-code.untracked.txt"
           ) &
-          pnpm exec wait-on --timeout 120000 http://localhost:8102
+          pnpm exec wait-on --timeout 120000 http://localhost:8102 tcp:localhost:8146
       - name: Run tests (first attempt)
         id: run-tests-first-attempt
         continue-on-error: ${{ (github.head_ref || github.ref_name) != 'main' && (github.head_ref || github.ref_name) != 'dev' }}

--- a/apps/e2e/tests/backend/backend-helpers.ts
+++ b/apps/e2e/tests/backend/backend-helpers.ts
@@ -1405,12 +1405,13 @@ async function waitForBillingTeamPlanEntitlement(ownerTeamId: string): Promise<v
     } finally {
       clearTimeout(abortTimeout);
     }
+    if (quantity > 0) return;
+
     const remainingAfterPollMs = deadline - performance.now();
     if (remainingAfterPollMs <= 0) {
       warnTimeout();
       return;
     }
-    if (quantity > 0) return;
 
     await wait(Math.min(pollIntervalMs, remainingAfterPollMs));
   }

--- a/apps/e2e/tests/backend/backend-helpers.ts
+++ b/apps/e2e/tests/backend/backend-helpers.ts
@@ -1356,37 +1356,63 @@ export namespace InternalApiKey {
 // The cap is fixed below the 30s minimum timeout declared by any e2e test. This wait runs
 // *inside* Project.create, so keeping it below the suite-wide minimum ensures that slow
 // materialization cannot consume an entire test budget — even for tests that never touch
-// billing (e.g. outbox rendering-state tests).
+// billing (e.g. outbox rendering-state tests). The deadline is enforced before each poll,
+// by aborting the request when its remaining budget expires, and by clamping the sleep
+// between polls to that remaining budget.
 async function waitForBillingTeamPlanEntitlement(ownerTeamId: string): Promise<void> {
   const pollIntervalMs = 200;
   const timeoutMs = 15_000;
   const startedAt = performance.now();
+  const deadline = startedAt + timeoutMs;
+  const warnTimeout = () => {
+    const elapsedMs = performance.now() - startedAt;
+    console.warn(
+      `[billing-entitlement-wait] Timed out waiting for team ${ownerTeamId} after ${elapsedMs.toFixed(0)} ms`,
+    );
+  };
 
   while (true) {
-    const quantity = await withInternalProject(async () => {
-      const response = await niceBackendFetch(
-        `/api/v1/payments/items/team/${encodeURIComponent(ownerTeamId)}/${ITEM_IDS.analyticsTimeoutSeconds}`,
-        { accessType: "server" },
-      );
-      if (response.status !== 200) {
-        throw new HexclaveAssertionError("Failed to read billing-team item quantity while waiting for plan entitlement", { ownerTeamId, response });
-      }
-      const quantity = response.body.quantity;
-      if (typeof quantity !== "number") {
-        throw new HexclaveAssertionError("Expected billing-team item quantity to be a number", { ownerTeamId, quantity });
-      }
-      return quantity;
-    });
-    if (quantity > 0) return;
-
-    const elapsedMs = performance.now() - startedAt;
-    if (elapsedMs > timeoutMs) {
-      console.warn(
-        `[billing-entitlement-wait] Timed out waiting for team ${ownerTeamId} after ${elapsedMs.toFixed(0)} ms`,
-      );
+    const remainingMs = deadline - performance.now();
+    if (remainingMs <= 0) {
+      warnTimeout();
       return;
     }
-    await wait(pollIntervalMs);
+
+    const abortController = new AbortController();
+    const abortTimeout = setTimeout(() => abortController.abort(), remainingMs);
+    let quantity: number;
+    try {
+      quantity = await withInternalProject(async () => {
+        const response = await niceBackendFetch(
+          `/api/v1/payments/items/team/${encodeURIComponent(ownerTeamId)}/${ITEM_IDS.analyticsTimeoutSeconds}`,
+          { accessType: "server", signal: abortController.signal },
+        );
+        if (response.status !== 200) {
+          throw new HexclaveAssertionError("Failed to read billing-team item quantity while waiting for plan entitlement", { ownerTeamId, response });
+        }
+        const quantity = response.body.quantity;
+        if (typeof quantity !== "number") {
+          throw new HexclaveAssertionError("Expected billing-team item quantity to be a number", { ownerTeamId, quantity });
+        }
+        return quantity;
+      });
+    } catch (error) {
+      if (abortController.signal.aborted) {
+        warnTimeout();
+        return;
+      }
+      throw error;
+    } finally {
+      clearTimeout(abortTimeout);
+    }
+    const remainingAfterPollMs = deadline - performance.now();
+    if (remainingAfterPollMs <= 0) {
+      warnTimeout();
+      return;
+    }
+    if (quantity > 0) return;
+
+    await wait(Math.min(pollIntervalMs, remainingAfterPollMs));
   }
 }
 

--- a/apps/e2e/tests/backend/backend-helpers.ts
+++ b/apps/e2e/tests/backend/backend-helpers.ts
@@ -1353,15 +1353,13 @@ export namespace InternalApiKey {
 // appears, the cap adds no latency on the happy path; it only bounds the wait when
 // materialization has genuinely stalled.
 //
-// The cap is half of Vitest's per-test timeout (see apps/e2e/vitest.config.ts: 60s in CI,
-// 30s locally). This wait runs *inside* Project.create, so a cap at or above the test
-// timeout would turn slow materialization into a hard test timeout — even for tests that
-// never touch billing (e.g. outbox rendering-state tests). Bounding it at half the budget
-// guarantees the wait alone can never time a test out and still leaves ample time for the
-// test body, while giving a stalled TimeFold a fair chance to catch up.
+// The cap is fixed below the 30s minimum timeout declared by any e2e test. This wait runs
+// *inside* Project.create, so keeping it below the suite-wide minimum ensures that slow
+// materialization cannot consume an entire test budget — even for tests that never touch
+// billing (e.g. outbox rendering-state tests).
 async function waitForBillingTeamPlanEntitlement(ownerTeamId: string): Promise<void> {
   const pollIntervalMs = 200;
-  const timeoutMs = (process.env.CI ? 60_000 : 30_000) / 2;
+  const timeoutMs = 15_000;
   const startedAt = performance.now();
 
   while (true) {
@@ -1381,7 +1379,13 @@ async function waitForBillingTeamPlanEntitlement(ownerTeamId: string): Promise<v
     });
     if (quantity > 0) return;
 
-    if (performance.now() - startedAt > timeoutMs) return;
+    const elapsedMs = performance.now() - startedAt;
+    if (elapsedMs > timeoutMs) {
+      console.warn(
+        `[billing-entitlement-wait] Timed out waiting for team ${ownerTeamId} after ${elapsedMs.toFixed(0)} ms`,
+      );
+      return;
+    }
     await wait(pollIntervalMs);
   }
 }


### PR DESCRIPTION
The two workflows that background `pnpm run dev` gated only on the backend port before starting the test step, so tests could begin while bulldozer-js was still starting. Backend routes that call it then fail with `ECONNREFUSED`, which is what produced 5 of the 7 failures in the last `setup-tests` run on dev (all of them in the first ~40s, all with the same `fetchBulldozerServerJson` stack, and all in shared test setup rather than the code under test).

Adds the bulldozer port to both readiness gates, matching what `fast-fail-tests.yaml`, `e2e-api-tests.yaml`, `e2e-fallback-tests.yaml` and `db-migration-backwards-compatibility.yaml` already do for the service when they start it themselves.

`setup-tests-with-custom-base-port.yaml` runs with `NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX: "69"`, hence `6946` there — the port is `${prefix}46` per `getBulldozerServerBaseUrl()`.


Link to Devin session: https://app.devin.ai/sessions/ef31465187d04d59a7a86ab763fd0f71
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change to service startup ordering; no application or production behavior is modified.
> 
> **Overview**
> **CI readiness gates** in `setup-tests.yaml` and `setup-tests-with-custom-base-port.yaml` now wait for bulldozer-js (TCP on port `8146`, or `6946` when `NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX` is `69`) in addition to the backend HTTP port before tests run.
> 
> This matches the bulldozer wait already used in other workflows and avoids tests starting while `pnpm run dev` is still bringing up bulldozer, which was causing early `ECONNREFUSED` failures in shared setup via `fetchBulldozerServerJson`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbd7fe26c3a7a44956c843472807c3f4b52580f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure setup-tests workflows wait for the `bulldozer-js` service before running tests (adds `wait-on` on ports 8146/6946) to prevent early ECONNREFUSED failures. Cap the e2e billing entitlement wait to 15s; enforce the deadline by aborting in-flight requests, clamping sleeps, and only treating successful polls as signal (log a warning on timeout).

<sup>Written for commit c0257ad487fb5dc792784c8944a20750cea3334e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test environment readiness checks by verifying required TCP services are available before tests begin.
  * Updated setup workflows to wait for both HTTP and TCP services, reducing failures caused by premature test execution.
  * Standardized billing entitlement polling with a 15-second timeout and clearer diagnostics when checks do not complete.
  * Preserved immediate handling of successful entitlement checks and non-timeout errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->