### PR TITLE
Map external auth profile claims onto the created user

### DIFF
--- a/apps/backend/src/lib/external-auth-users.tsx
+++ b/apps/backend/src/lib/external-auth-users.tsx
@@ -42,7 +42,12 @@ export async function getOrCreateExternalAuthSession(options: {
     const user = await createOrUpgradeAnonymousUserWithRules(
       options.tenancy,
       options.currentUser?.is_anonymous === true ? options.currentUser : null,
-      {},
+      {
+        display_name: options.identity.name,
+        primary_email: options.identity.email,
+        primary_email_verified: options.identity.emailVerified,
+        primary_email_auth_enabled: false,
+      },
       [],
       buildSignUpRuleOptions({
         // External identity providers follow the existing federated sign-up rule path.

--- a/apps/backend/src/lib/external-auth-users.tsx
+++ b/apps/backend/src/lib/external-auth-users.tsx
@@ -39,6 +39,8 @@ export async function getOrCreateExternalAuthSession(options: {
     // already-committed user creation and produces duplicate users). Instead, we create the user
     // first and resolve the (rare) concurrent-first-exchange race below via the identity's unique
     // constraint, cleaning up our user if we lost.
+    // Provider authentication owns this address, so it must not become a Hexclave password or OTP identity.
+    // Apply provider claims only while creating the user; a returning exchange must not overwrite later profile edits.
     const user = await createOrUpgradeAnonymousUserWithRules(
       options.tenancy,
       options.currentUser?.is_anonymous === true ? options.currentUser : null,

--- a/apps/backend/src/lib/external-auth-users.tsx
+++ b/apps/backend/src/lib/external-auth-users.tsx
@@ -39,8 +39,8 @@ export async function getOrCreateExternalAuthSession(options: {
     // already-committed user creation and produces duplicate users). Instead, we create the user
     // first and resolve the (rare) concurrent-first-exchange race below via the identity's unique
     // constraint, cleaning up our user if we lost.
-    // Provider authentication owns this address, so it must not become a Hexclave password or OTP identity.
-    // Apply provider claims only while creating the user; a returning exchange must not overwrite later profile edits.
+    // Provider claims are mapped only here, while creating the user: a returning exchange must not
+    // overwrite a profile the end user or an admin edited in the meantime.
     const user = await createOrUpgradeAnonymousUserWithRules(
       options.tenancy,
       options.currentUser?.is_anonymous === true ? options.currentUser : null,
@@ -48,6 +48,8 @@ export async function getOrCreateExternalAuthSession(options: {
         display_name: options.identity.name,
         primary_email: options.identity.email,
         primary_email_verified: options.identity.emailVerified,
+        // The provider owns authentication for this identity, so its address must never become a
+        // Hexclave password or OTP login identity of its own.
         primary_email_auth_enabled: false,
       },
       [],

--- a/apps/backend/src/lib/external-auth-users.tsx
+++ b/apps/backend/src/lib/external-auth-users.tsx
@@ -41,17 +41,27 @@ export async function getOrCreateExternalAuthSession(options: {
     // constraint, cleaning up our user if we lost.
     // Provider claims are mapped only here, while creating the user: a returning exchange must not
     // overwrite a profile the end user or an admin edited in the meantime.
-    const user = await createOrUpgradeAnonymousUserWithRules(
-      options.tenancy,
-      options.currentUser?.is_anonymous === true ? options.currentUser : null,
-      {
+    const profile = options.currentUser?.is_anonymous === true
+      ? {
+        ...(options.identity.name == null ? {} : { display_name: options.identity.name }),
+        ...(options.identity.email == null ? {} : {
+          primary_email: options.identity.email,
+          primary_email_verified: options.identity.emailVerified,
+          primary_email_auth_enabled: false,
+        }),
+      }
+      : {
         display_name: options.identity.name,
         primary_email: options.identity.email,
         primary_email_verified: options.identity.emailVerified,
         // The provider owns authentication for this identity, so its address must never become a
         // Hexclave password or OTP login identity of its own.
         primary_email_auth_enabled: false,
-      },
+      };
+    const user = await createOrUpgradeAnonymousUserWithRules(
+      options.tenancy,
+      options.currentUser?.is_anonymous === true ? options.currentUser : null,
+      profile,
       [],
       buildSignUpRuleOptions({
         // External identity providers follow the existing federated sign-up rule path.

--- a/apps/backend/src/lib/external-auth.tsx
+++ b/apps/backend/src/lib/external-auth.tsx
@@ -2,6 +2,7 @@ import { Tenancy } from "@/lib/tenancies";
 import { safeOAuthFetch } from "@/lib/ssrf-protection/oauth";
 import { KnownErrors } from "@hexclave/shared";
 import { externalAuthProviderIds, getWorkOSVerificationUrls, type ExternalAuthProviderId } from "@hexclave/shared/dist/interface/external-auth";
+import { emailSchema } from "@hexclave/shared/dist/schema-fields";
 import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { createRemoteJWKSet, customFetch, decodeJwt, decodeProtectedHeader, errors as joseErrors, jwtVerify, type JWTPayload } from "jose";
 
@@ -129,7 +130,13 @@ function getOptionalProfileClaim(payload: JWTPayload, claim: "email" | "name"): 
     return null;
   }
   const trimmed = value.trim();
-  return trimmed.length > 0 && trimmed.length <= 256 ? trimmed : null;
+  if (trimmed.length === 0 || trimmed.length > 256) {
+    return null;
+  }
+  if (claim === "email" && !emailSchema.isValidSync(trimmed)) {
+    return null;
+  }
+  return trimmed;
 }
 
 function validateTokenEncoding(token: string): void {
@@ -197,13 +204,14 @@ export async function verifyExternalAuthToken(options: {
     throw new KnownErrors.InvalidExternalAuthToken();
   }
 
+  const email = getOptionalProfileClaim(payload, "email");
   return {
     issuer: config.issuer,
     subject,
     providerSessionId,
     expiresAt: new Date(payload.exp * 1000),
-    email: getOptionalProfileClaim(payload, "email"),
+    email,
     name: getOptionalProfileClaim(payload, "name"),
-    emailVerified: payload.email_verified === true,
+    emailVerified: email != null && payload.email_verified === true,
   };
 }

--- a/apps/backend/src/lib/external-auth.tsx
+++ b/apps/backend/src/lib/external-auth.tsx
@@ -13,6 +13,9 @@ export type VerifiedExternalIdentity = {
   subject: string,
   providerSessionId: string,
   expiresAt: Date,
+  email: string | null,
+  name: string | null,
+  emailVerified: boolean,
 };
 
 type ProviderVerificationConfig = {
@@ -120,6 +123,15 @@ function getRequiredClaim(payload: JWTPayload, claim: "sub" | "sid"): string {
   return value;
 }
 
+function getOptionalProfileClaim(payload: JWTPayload, claim: "email" | "name"): string | null {
+  const value = payload[claim];
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 && trimmed.length <= 256 ? trimmed : null;
+}
+
 function validateTokenEncoding(token: string): void {
   if (token.length > 16_384 || token.split(".").length !== 3) {
     throw new KnownErrors.InvalidExternalAuthToken();
@@ -190,5 +202,8 @@ export async function verifyExternalAuthToken(options: {
     subject,
     providerSessionId,
     expiresAt: new Date(payload.exp * 1000),
+    email: getOptionalProfileClaim(payload, "email"),
+    name: getOptionalProfileClaim(payload, "name"),
+    emailVerified: payload.email_verified === true,
   };
 }

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/external/token.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/external/token.test.ts
@@ -63,10 +63,16 @@ async function createProviderToken(options: {
   audience?: string,
   expirationTime?: string,
   authorizedParty?: string,
+  email?: unknown,
+  name?: unknown,
+  emailVerified?: unknown,
 } = {}) {
   return await new SignJWT({
     sid: options.sessionId ?? "provider-session-1",
     ...options.authorizedParty == null ? {} : { azp: options.authorizedParty },
+    ...options.email === undefined ? {} : { email: options.email },
+    ...options.name === undefined ? {} : { name: options.name },
+    ...options.emailVerified === undefined ? {} : { email_verified: options.emailVerified },
   })
     .setProtectedHeader({ alg: "ES256", kid: publicJwk.kid ?? throwErr("Test JWK has no kid") })
     .setIssuer(options.issuer ?? issuer)
@@ -91,7 +97,11 @@ async function exchange(token: string, providerId = "better-auth-integration") {
 describe("external authentication token exchange", () => {
   it("creates one user and reuses provider sessions idempotently", async ({ expect }) => {
     await configureProject();
-    const firstToken = await createProviderToken();
+    const firstToken = await createProviderToken({
+      email: "provider-user@example.com",
+      name: "Provider User",
+      emailVerified: false,
+    });
     const first = await exchange(firstToken);
     expect(first.status).toBe(200);
     expect(first.body).toMatchObject({
@@ -99,6 +109,17 @@ describe("external authentication token exchange", () => {
     });
     expect(first.body.user_id).toMatch(/^[0-9a-f-]{36}$/);
     expect(first.body.session_id).toMatch(/^[0-9a-f-]{36}$/);
+
+    const createdUser = await niceBackendFetch(`/api/v1/users/${first.body.user_id}`, {
+      accessType: "server",
+    });
+    expect(createdUser.status).toBe(200);
+    expect(createdUser.body).toMatchObject({
+      primary_email: "provider-user@example.com",
+      primary_email_verified: false,
+      primary_email_auth_enabled: false,
+      display_name: "Provider User",
+    });
 
     const repeated = await exchange(firstToken);
     expect(repeated.status).toBe(200);
@@ -124,6 +145,84 @@ describe("external authentication token exchange", () => {
     expect(sessions.status).toBe(200);
     expect(sessions.body.items).toHaveLength(2);
     expect(sessions.body.items.filter((session: { is_current_session: boolean }) => session.is_current_session)).toHaveLength(1);
+  });
+
+  it("does not overwrite a profile edited after the first exchange", async ({ expect }) => {
+    await configureProject();
+    const first = await exchange(await createProviderToken({
+      email: "original@example.com",
+      name: "Original Name",
+      emailVerified: true,
+    }));
+    expect(first.status).toBe(200);
+
+    const updated = await niceBackendFetch(`/api/v1/users/${first.body.user_id}`, {
+      method: "PATCH",
+      accessType: "server",
+      body: {
+        primary_email: "edited@example.com",
+        display_name: "Edited Name",
+        primary_email_verified: true,
+        primary_email_auth_enabled: false,
+      },
+    });
+    expect(updated.status).toBe(200);
+
+    const repeated = await exchange(await createProviderToken({
+      email: "provider-update@example.com",
+      name: "Provider Update",
+      emailVerified: false,
+    }));
+    expect(repeated.status).toBe(200);
+    expect(repeated.body.user_id).toBe(first.body.user_id);
+
+    const user = await niceBackendFetch(`/api/v1/users/${first.body.user_id}`, {
+      accessType: "server",
+    });
+    expect(user.body).toMatchObject({
+      primary_email: "edited@example.com",
+      display_name: "Edited Name",
+    });
+  });
+
+  it("ignores malformed or absent profile claims", async ({ expect }) => {
+    await configureProject();
+    const response = await exchange(await createProviderToken({
+      email: "   ",
+      name: "n".repeat(257),
+      emailVerified: "true",
+    }));
+    expect(response.status).toBe(200);
+
+    const user = await niceBackendFetch(`/api/v1/users/${response.body.user_id}`, {
+      accessType: "server",
+    });
+    expect(user.body).toMatchObject({
+      primary_email: null,
+      display_name: null,
+      primary_email_verified: false,
+      primary_email_auth_enabled: false,
+    });
+  });
+
+  it("allows a provider email to collide with another user", async ({ expect }) => {
+    await configureProject();
+    const first = await exchange(await createProviderToken({
+      subject: "provider-user-1",
+      sessionId: "provider-session-1",
+      email: "same@example.com",
+      name: "First Provider User",
+    }));
+    const second = await exchange(await createProviderToken({
+      subject: "provider-user-2",
+      sessionId: "provider-session-2",
+      email: "same@example.com",
+      name: "Second Provider User",
+    }));
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body.user_id).not.toBe(first.body.user_id);
   });
 
   it("projects a new external identity once under concurrent exchanges", async ({ expect }) => {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/external/token.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/external/token.test.ts
@@ -3,7 +3,7 @@ import { exportJWK, generateKeyPair, SignJWT, type JWK } from "jose";
 import * as http from "node:http";
 import { afterAll, beforeAll, describe } from "vitest";
 import { it } from "../../../../../../helpers";
-import { Project, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
+import { Auth, Project, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
 
 let jwksServer: http.Server;
 let issuer: string;
@@ -182,6 +182,56 @@ describe("external authentication token exchange", () => {
     expect(user.body).toMatchObject({
       primary_email: "edited@example.com",
       display_name: "Edited Name",
+    });
+  });
+
+  it("preserves an anonymous profile when provider claims are absent", async ({ expect }) => {
+    await configureProject();
+    const anonymous = await Auth.Anonymous.signUp();
+    const updated = await niceBackendFetch("/api/v1/users/me", {
+      method: "PATCH",
+      accessType: "client",
+      body: {
+        display_name: "Anonymous Name",
+        primary_email: "anonymous@example.com",
+        primary_email_auth_enabled: false,
+      },
+    });
+    expect(updated.status).toBe(200);
+
+    const response = await exchange(await createProviderToken(), "better-auth-integration");
+    expect(response.status).toBe(200);
+    expect(response.body.user_id).toBe(anonymous.userId);
+
+    const user = await niceBackendFetch(`/api/v1/users/${anonymous.userId}`, {
+      accessType: "server",
+    });
+    expect(user.body).toMatchObject({
+      display_name: "Anonymous Name",
+      primary_email: "anonymous@example.com",
+      primary_email_auth_enabled: false,
+    });
+  });
+
+  it("maps provider claims when upgrading an anonymous user", async ({ expect }) => {
+    await configureProject();
+    const anonymous = await Auth.Anonymous.signUp();
+    const response = await exchange(await createProviderToken({
+      email: "upgraded@example.com",
+      name: "Upgraded Provider User",
+      emailVerified: true,
+    }));
+    expect(response.status).toBe(200);
+    expect(response.body.user_id).toBe(anonymous.userId);
+
+    const user = await niceBackendFetch(`/api/v1/users/${anonymous.userId}`, {
+      accessType: "server",
+    });
+    expect(user.body).toMatchObject({
+      display_name: "Upgraded Provider User",
+      primary_email: "upgraded@example.com",
+      primary_email_verified: true,
+      primary_email_auth_enabled: false,
     });
   });
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/external/token.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/external/token.test.ts
@@ -205,6 +205,54 @@ describe("external authentication token exchange", () => {
     });
   });
 
+  it("ignores syntactically invalid email claims", async ({ expect }) => {
+    await configureProject();
+    const response = await exchange(await createProviderToken({
+      email: "not-an-email",
+      name: "Valid Name",
+      emailVerified: true,
+    }));
+    expect(response.status).toBe(200);
+
+    const user = await niceBackendFetch(`/api/v1/users/${response.body.user_id}`, {
+      accessType: "server",
+    });
+    expect(user.body).toMatchObject({
+      primary_email: null,
+      display_name: "Valid Name",
+      primary_email_verified: false,
+    });
+  });
+
+  it("ignores email_verified when the email claim is absent or invalid", async ({ expect }) => {
+    await configureProject();
+    const absentEmail = await exchange(await createProviderToken({
+      emailVerified: true,
+    }));
+    const invalidEmail = await exchange(await createProviderToken({
+      subject: "invalid-email-user",
+      sessionId: "invalid-email-session",
+      email: "not-an-email",
+      emailVerified: true,
+    }));
+
+    expect(absentEmail.status).toBe(200);
+    expect(invalidEmail.status).toBe(200);
+
+    const users = await Promise.all([
+      niceBackendFetch(`/api/v1/users/${absentEmail.body.user_id}`, { accessType: "server" }),
+      niceBackendFetch(`/api/v1/users/${invalidEmail.body.user_id}`, { accessType: "server" }),
+    ]);
+    expect(users[0].body).toMatchObject({
+      primary_email: null,
+      primary_email_verified: false,
+    });
+    expect(users[1].body).toMatchObject({
+      primary_email: null,
+      primary_email_verified: false,
+    });
+  });
+
   it("allows a provider email to collide with another user", async ({ expect }) => {
     await configureProject();
     const first = await exchange(await createProviderToken({


### PR DESCRIPTION
Every user created through an external auth token exchange landed with a null email and display name, even when the provider's JWT carried both — `getOrCreateExternalAuthSession` passed `{}` as the create payload, and `verifyExternalAuthToken` dropped every claim except `iss`/`sub`/`sid`/`exp`. Verified against a real Better Auth token, whose payload carries `email` and `name`.

`VerifiedExternalIdentity` now carries the profile claims through to user creation, mirroring the payload shape the sibling OAuth path (`createOAuthUserAndAccount`) already uses:

```ts
{ display_name, primary_email, primary_email_verified, primary_email_auth_enabled: false }
```

Decisions worth flagging:

- `primary_email_auth_enabled: false` — the provider owns authentication for this identity, so its address must not also become a Hexclave password/OTP login identity.
- Claims are applied only when the user is created, never on a returning exchange, so a profile edited later by the end user or an admin is not clobbered.
- `email_verified` is trusted only when it is literally `true`; absent or non-boolean means unverified. A provider address is never marked verified on faith.
- Claims are treated as untrusted input despite the valid signature: non-empty strings up to 256 characters, otherwise treated as absent.
- A provider email colliding with an existing user's email cannot break the exchange, because the email-auth collision check only applies when `primary_email_auth_enabled` is true. Covered by a test asserting both exchanges succeed with distinct users.

WorkOS access tokens carry neither claim, so WorkOS users still have no name or email — that's the provider's token shape, not this path.


Link to Devin session: https://app.devin.ai/sessions/9ca1de7e4a9f41feb1e8fbcd61136270
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sign-up user creation and email-related fields in the auth path; behavior is constrained to create-only with explicit validation and tests, but incorrect claim handling could affect account identity or collisions.
> 
> **Overview**
> External auth token exchange now seeds **display name**, **primary email**, and **email verified** from provider JWT claims on **first-time user creation**, instead of always creating users with empty profile fields.
> 
> `verifyExternalAuthToken` parses optional `email`/`name` (trimmed, max 256 chars; otherwise ignored) and treats `email_verified` as verified only when it is literally `true`. Those fields flow through `VerifiedExternalIdentity` into `createOrUpgradeAnonymousUserWithRules` with **`primary_email_auth_enabled: false`** so the provider-owned address does not become a separate Hexclave password/OTP login identity.
> 
> **Returning exchanges do not re-apply claims**, so later user or admin profile edits are not overwritten. E2E coverage adds assertions for initial mapping, no clobber on repeat exchange, malformed claims, and duplicate provider emails across distinct external subjects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfe8907ea801354122569351698a40d4502eb9d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps external auth profile claims (email, name, email_verified) onto newly created users during token exchange. Also preserves existing anonymous profiles when claims are absent, and keeps provider emails out of password/OTP identities.

- **Bug Fixes**
  - Carry `email`, `name`, and `email_verified` via `VerifiedExternalIdentity`; set `primary_email_auth_enabled: false` on user creation.
  - Apply claims only on first creation; never overwrite edited profiles on later exchanges.
  - When upgrading an anonymous user, map only provided claims; keep existing anonymous profile fields if claims are absent.
  - Validate claims: trim, max 256; ignore non-strings; reject invalid email syntax; trust `email_verified` only when a valid email is present and it’s literally `true`.
  - E2E: idempotent session reuse; preserve anonymous profiles without claims; map claims on anonymous upgrade; no profile clobber after edits; malformed/invalid email handling; ignore `email_verified` without a valid email; same-email across distinct providers create distinct users.

<sup>Written for commit d8037dad2bcc8ad4744f5bba1fc9f3de43e50f78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

