### PR TITLE
Add WorkOS and Better Auth external auth example apps

### DIFF
--- a/examples/better-auth-integration-demo/.env.local.example
+++ b/examples/better-auth-integration-demo/.env.local.example
@@ -1,0 +1,6 @@
+NEXT_PUBLIC_HEXCLAVE_API_URL=http://localhost:8102
+NEXT_PUBLIC_HEXCLAVE_PROJECT_ID=internal
+NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY=this-publishable-client-key-is-for-local-development-only
+HEXCLAVE_SECRET_SERVER_KEY=this-secret-server-key-is-for-local-development-only
+BETTER_AUTH_SECRET=local-only-better-auth-secret
+BETTER_AUTH_URL=http://localhost:8111

--- a/examples/better-auth-integration-demo/.env.local.example
+++ b/examples/better-auth-integration-demo/.env.local.example
@@ -1,3 +1,4 @@
+# Set NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX to use the repository's alternate port prefix.
 NEXT_PUBLIC_HEXCLAVE_API_URL=http://localhost:8102
 NEXT_PUBLIC_HEXCLAVE_PROJECT_ID=internal
 NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY=this-publishable-client-key-is-for-local-development-only

--- a/examples/better-auth-integration-demo/.eslintrc.js
+++ b/examples/better-auth-integration-demo/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  extends: [
+    "../../configs/eslint/defaults.js",
+    "../../configs/eslint/next.js",
+  ],
+  ignorePatterns: ["/*", "!/src"],
+  rules: {
+    "@typescript-eslint/no-misused-promises": [0],
+    "@typescript-eslint/no-unnecessary-condition": [0],
+  },
+};

--- a/examples/better-auth-integration-demo/.gitignore
+++ b/examples/better-auth-integration-demo/.gitignore
@@ -1,0 +1,6 @@
+.next
+node_modules
+*.db
+*.db-*
+.env.local
+*.untracked

--- a/examples/better-auth-integration-demo/README.md
+++ b/examples/better-auth-integration-demo/README.md
@@ -1,0 +1,17 @@
+# Better Auth → Hexclave example
+
+This example signs in with a local Better Auth instance, exchanges its provider
+JWT with the local Hexclave backend, and displays the resulting session
+metadata.
+
+## Local setup
+
+1. Copy `.env.local.example` to `.env.local`.
+2. Set a local `BETTER_AUTH_SECRET` and the local Hexclave client and server
+   keys and API URL.
+3. Run `pnpm dev` from this directory.
+4. Create a Better Auth user through the form, then sign in and exchange its
+   token with Hexclave.
+
+The example intentionally does not include provider credentials, access tokens,
+or user credentials. The local SQLite database is created at runtime.

--- a/examples/better-auth-integration-demo/README.md
+++ b/examples/better-auth-integration-demo/README.md
@@ -9,7 +9,8 @@ metadata.
 1. Copy `.env.local.example` to `.env.local`.
 2. Set a local `BETTER_AUTH_SECRET` and the local Hexclave client and server
    keys and API URL.
-3. Run `pnpm dev` from this directory.
+3. Run `pnpm dev` from this directory. The script follows the repository's
+   `NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX` convention (`81` defaults to port `8111`).
 4. Create a Better Auth user through the form, then sign in and exchange its
    token with Hexclave.
 

--- a/examples/better-auth-integration-demo/next.config.ts
+++ b/examples/better-auth-integration-demo/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/examples/better-auth-integration-demo/package.json
+++ b/examples/better-auth-integration-demo/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack --port 8111",
+    "dev": "next dev --turbopack --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}11",
     "build": "next build",
-    "start": "next start --port 8111",
+    "start": "next start --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}11",
     "typecheck": "tsc --noEmit",
     "lint": "eslint ."
   },

--- a/examples/better-auth-integration-demo/package.json
+++ b/examples/better-auth-integration-demo/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@hexclave/example-better-auth-integration-demo",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --turbopack --port 8111",
+    "build": "next build",
+    "start": "next start --port 8111",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@hexclave/next": "workspace:*",
+    "@hexclave/shared": "workspace:*",
+    "better-auth": "^1.6.25",
+    "better-sqlite3": "^11.10.0",
+    "next": "15.5.19",
+    "react": "19.0.1",
+    "react-dom": "19.0.1"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^22.15.0",
+    "@types/react": "19.0.12",
+    "@types/react-dom": "19.0.4",
+    "typescript": "^5.8.3"
+  }
+}

--- a/examples/better-auth-integration-demo/src/app/api/auth/[...all]/route.ts
+++ b/examples/better-auth-integration-demo/src/app/api/auth/[...all]/route.ts
@@ -1,0 +1,7 @@
+import { toNextJsHandler } from "better-auth/next-js";
+import { auth } from "@/lib/auth";
+
+const handler = toNextJsHandler(auth);
+
+export const GET = handler.GET;
+export const POST = handler.POST;

--- a/examples/better-auth-integration-demo/src/app/api/auth/[...all]/route.ts
+++ b/examples/better-auth-integration-demo/src/app/api/auth/[...all]/route.ts
@@ -1,7 +1,10 @@
 import { toNextJsHandler } from "better-auth/next-js";
-import { auth } from "@/lib/auth";
+import { getAuth } from "@/lib/auth";
 
-const handler = toNextJsHandler(auth);
+export async function GET(request: Request) {
+  return await toNextJsHandler(getAuth()).GET(request);
+}
 
-export const GET = handler.GET;
-export const POST = handler.POST;
+export async function POST(request: Request) {
+  return await toNextJsHandler(getAuth()).POST(request);
+}

--- a/examples/better-auth-integration-demo/src/app/api/auth/exchange/route.ts
+++ b/examples/better-auth-integration-demo/src/app/api/auth/exchange/route.ts
@@ -19,6 +19,12 @@ export async function GET(request: Request) {
     },
     body: JSON.stringify({ provider_id: "better-auth-integration", token: token.token }),
   });
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!response.ok || !contentType.includes("application/json")) {
+    return NextResponse.json({
+      error: "Hexclave rejected the Better Auth token exchange",
+    }, { status: response.ok ? 502 : response.status });
+  }
   const result = await response.json() as { access_token?: string, session_id?: string, user_id?: string, is_new_user?: boolean, code?: string, error?: string };
   let profile: { primary_email?: string | null, display_name?: string | null } = {};
   if (result.access_token != null) {
@@ -29,7 +35,10 @@ export async function GET(request: Request) {
         "x-hexclave-project-id": projectId,
       },
     });
-    if (profileResponse.ok) profile = await profileResponse.json() as typeof profile;
+    if (!profileResponse.ok || !(profileResponse.headers.get("content-type") ?? "").includes("application/json")) {
+      return NextResponse.json({ error: "Hexclave user lookup failed after token exchange" }, { status: 502 });
+    }
+    profile = await profileResponse.json() as typeof profile;
   }
   return NextResponse.json({
     sessionId: result.session_id,

--- a/examples/better-auth-integration-demo/src/app/api/auth/exchange/route.ts
+++ b/examples/better-auth-integration-demo/src/app/api/auth/exchange/route.ts
@@ -5,23 +5,27 @@ export async function GET(request: Request) {
   const session = await auth.api.getSession({ headers: request.headers });
   if (session == null) return NextResponse.json({ error: "Not signed in" }, { status: 401 });
   const token = await auth.api.getToken({ headers: request.headers });
-  const response = await fetch(`${process.env.NEXT_PUBLIC_HEXCLAVE_API_URL}/api/latest/auth/external/token`, {
+  const apiUrl = process.env.NEXT_PUBLIC_HEXCLAVE_API_URL;
+  const projectId = process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID;
+  if (apiUrl == null || apiUrl.length === 0) throw new Error("Missing required environment variable: NEXT_PUBLIC_HEXCLAVE_API_URL");
+  if (projectId == null || projectId.length === 0) throw new Error("Missing required environment variable: NEXT_PUBLIC_HEXCLAVE_PROJECT_ID");
+  const response = await fetch(`${apiUrl}/api/latest/auth/external/token`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-hexclave-access-type": "client",
-      "x-hexclave-project-id": process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID ?? "internal",
+      "x-hexclave-project-id": projectId,
     },
     body: JSON.stringify({ provider_id: "better-auth-integration", token: token.token }),
   });
   const result = await response.json() as { access_token?: string, session_id?: string, user_id?: string, is_new_user?: boolean, code?: string, error?: string };
   let profile: { primary_email?: string | null, display_name?: string | null } = {};
   if (result.access_token != null) {
-    const profileResponse = await fetch(`${process.env.NEXT_PUBLIC_HEXCLAVE_API_URL}/api/v1/users/me`, {
+    const profileResponse = await fetch(`${apiUrl}/api/v1/users/me`, {
       headers: {
         "x-hexclave-access-token": result.access_token,
         "x-hexclave-access-type": "client",
-        "x-hexclave-project-id": process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID ?? "internal",
+        "x-hexclave-project-id": projectId,
       },
     });
     if (profileResponse.ok) profile = await profileResponse.json() as typeof profile;

--- a/examples/better-auth-integration-demo/src/app/api/auth/exchange/route.ts
+++ b/examples/better-auth-integration-demo/src/app/api/auth/exchange/route.ts
@@ -1,7 +1,8 @@
-import { auth } from "@/lib/auth";
+import { getAuth } from "@/lib/auth";
 import { NextResponse } from "next/server";
 
 export async function GET(request: Request) {
+  const auth = getAuth();
   const session = await auth.api.getSession({ headers: request.headers });
   if (session == null) return NextResponse.json({ error: "Not signed in" }, { status: 401 });
   const token = await auth.api.getToken({ headers: request.headers });

--- a/examples/better-auth-integration-demo/src/app/api/auth/exchange/route.ts
+++ b/examples/better-auth-integration-demo/src/app/api/auth/exchange/route.ts
@@ -1,0 +1,37 @@
+import { auth } from "@/lib/auth";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (session == null) return NextResponse.json({ error: "Not signed in" }, { status: 401 });
+  const token = await auth.api.getToken({ headers: request.headers });
+  const response = await fetch(`${process.env.NEXT_PUBLIC_HEXCLAVE_API_URL}/api/latest/auth/external/token`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-hexclave-access-type": "client",
+      "x-hexclave-project-id": process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID ?? "internal",
+    },
+    body: JSON.stringify({ provider_id: "better-auth-integration", token: token.token }),
+  });
+  const result = await response.json() as { access_token?: string, session_id?: string, user_id?: string, is_new_user?: boolean, code?: string, error?: string };
+  let profile: { primary_email?: string | null, display_name?: string | null } = {};
+  if (result.access_token != null) {
+    const profileResponse = await fetch(`${process.env.NEXT_PUBLIC_HEXCLAVE_API_URL}/api/v1/users/me`, {
+      headers: {
+        "x-hexclave-access-token": result.access_token,
+        "x-hexclave-access-type": "client",
+        "x-hexclave-project-id": process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID ?? "internal",
+      },
+    });
+    if (profileResponse.ok) profile = await profileResponse.json() as typeof profile;
+  }
+  return NextResponse.json({
+    sessionId: result.session_id,
+    userId: result.user_id,
+    isNewUser: result.is_new_user,
+    primaryEmail: profile.primary_email ?? null,
+    displayName: profile.display_name ?? null,
+    error: result.error ?? result.code,
+  }, { status: response.status });
+}

--- a/examples/better-auth-integration-demo/src/app/api/auth/sign-out/route.ts
+++ b/examples/better-auth-integration-demo/src/app/api/auth/sign-out/route.ts
@@ -1,7 +1,7 @@
-import { auth } from "@/lib/auth";
+import { getAuth } from "@/lib/auth";
 import { NextResponse } from "next/server";
 
 export async function POST(request: Request) {
-  await auth.api.signOut({ headers: request.headers });
+  await getAuth().api.signOut({ headers: request.headers });
   return new NextResponse(null, { status: 204 });
 }

--- a/examples/better-auth-integration-demo/src/app/api/auth/sign-out/route.ts
+++ b/examples/better-auth-integration-demo/src/app/api/auth/sign-out/route.ts
@@ -1,0 +1,7 @@
+import { auth } from "@/lib/auth";
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  await auth.api.signOut({ headers: request.headers });
+  return new NextResponse(null, { status: 204 });
+}

--- a/examples/better-auth-integration-demo/src/app/api/auth/sign-out/route.ts
+++ b/examples/better-auth-integration-demo/src/app/api/auth/sign-out/route.ts
@@ -1,7 +1,7 @@
 import { getAuth } from "@/lib/auth";
-import { NextResponse } from "next/server";
-
 export async function POST(request: Request) {
-  await getAuth().api.signOut({ headers: request.headers });
-  return new NextResponse(null, { status: 204 });
+  return await getAuth().api.signOut({
+    headers: request.headers,
+    asResponse: true,
+  });
 }

--- a/examples/better-auth-integration-demo/src/app/api/auth/token/route.ts
+++ b/examples/better-auth-integration-demo/src/app/api/auth/token/route.ts
@@ -1,7 +1,8 @@
-import { auth } from "@/lib/auth";
+import { getAuth } from "@/lib/auth";
 import { NextResponse } from "next/server";
 
 export async function GET(request: Request) {
+  const auth = getAuth();
   const session = await auth.api.getSession({ headers: request.headers });
   if (session == null) return NextResponse.json({ error: "Not signed in" }, { status: 401 });
   const token = await auth.api.getToken({ headers: request.headers });

--- a/examples/better-auth-integration-demo/src/app/api/auth/token/route.ts
+++ b/examples/better-auth-integration-demo/src/app/api/auth/token/route.ts
@@ -6,5 +6,8 @@ export async function GET(request: Request) {
   const session = await auth.api.getSession({ headers: request.headers });
   if (session == null) return NextResponse.json({ error: "Not signed in" }, { status: 401 });
   const token = await auth.api.getToken({ headers: request.headers });
+  if (token == null || typeof token.token !== "string") {
+    return NextResponse.json({ error: "Better Auth token unavailable" }, { status: 502 });
+  }
   return NextResponse.json({ token: token.token });
 }

--- a/examples/better-auth-integration-demo/src/app/api/auth/token/route.ts
+++ b/examples/better-auth-integration-demo/src/app/api/auth/token/route.ts
@@ -1,0 +1,9 @@
+import { auth } from "@/lib/auth";
+import { NextResponse } from "next/server";
+
+export async function GET(request: Request) {
+  const session = await auth.api.getSession({ headers: request.headers });
+  if (session == null) return NextResponse.json({ error: "Not signed in" }, { status: 401 });
+  const token = await auth.api.getToken({ headers: request.headers });
+  return NextResponse.json({ token: token.token });
+}

--- a/examples/better-auth-integration-demo/src/app/better-auth-demo.tsx
+++ b/examples/better-auth-integration-demo/src/app/better-auth-demo.tsx
@@ -3,20 +3,53 @@
 import { HexclaveClientApp, betterAuthTokenStore } from "@hexclave/next";
 import { useEffect, useMemo, useState } from "react";
 
-type Claims = { iss?: string, sub?: string, sid?: string, aud?: string | string[], exp?: number };
-type ProviderUser = { email: string, name: string };
-type HexclaveUser = { id: string, primaryEmail: string | null, displayName: string | null };
-type Exchange = { sessionId?: string, userId?: string, isNewUser?: boolean, primaryEmail?: string | null, displayName?: string | null, error?: string };
+type Claims = {
+  iss?: string;
+  sub?: string;
+  sid?: string;
+  aud?: string | string[];
+  exp?: number;
+};
+type ProviderUser = { email: string; name: string };
+type HexclaveUser = {
+  id: string;
+  primaryEmail: string | null;
+  displayName: string | null;
+};
+type Exchange = {
+  sessionId?: string;
+  userId?: string;
+  isNewUser?: boolean;
+  primaryEmail?: string | null;
+  displayName?: string | null;
+  error?: string;
+};
 type Status = "idle" | "exchanging" | "exchanged" | "error";
 
 function decodeClaims(token: string): Claims {
   const payload = token.split(".")[1];
-  if (payload == null) throw new Error("The Better Auth token did not contain a JWT payload");
-  return JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/"))) as Claims;
+  if (payload == null)
+    throw new Error("The Better Auth token did not contain a JWT payload");
+  return JSON.parse(
+    atob(payload.replace(/-/g, "+").replace(/_/g, "/")),
+  ) as Claims;
 }
 
-function Claim({ label, value }: { label: string, value: string | number | undefined }) {
-  return <><dt>{label}</dt><dd><code>{value == null ? "Not present" : String(value)}</code></dd></>;
+function Claim({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number | undefined;
+}) {
+  return (
+    <>
+      <dt>{label}</dt>
+      <dd>
+        <code>{value == null ? "Not present" : String(value)}</code>
+      </dd>
+    </>
+  );
 }
 
 export function BetterAuthDemo() {
@@ -30,41 +63,67 @@ export function BetterAuthDemo() {
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [status, setStatus] = useState<Status>("idle");
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const tokenStore = useMemo(() => betterAuthTokenStore({
-    getSessionId: () => sessionId,
-    getToken: async () => {
-      const response = await fetch("/api/auth/token");
-      if (!response.ok) return null;
-      return (await response.json() as { token: string }).token;
-    },
-    subscribe: callback => {
-      window.addEventListener("better-auth-session-change", callback);
-      return () => window.removeEventListener("better-auth-session-change", callback);
-    },
-    signOut: async () => {
-      setIsSubmitting(true);
-      await fetch("/api/auth/sign-out", { method: "POST" });
-      setSessionId(null); setProviderUser(null); setClaims(null); setExchange(null); setUser(null); setStatus("idle");
-      window.dispatchEvent(new Event("better-auth-session-change"));
-      setIsSubmitting(false);
-    },
-  }), [sessionId]);
-  const app = useMemo(() => new HexclaveClientApp({
-    baseUrl: process.env.NEXT_PUBLIC_HEXCLAVE_API_URL,
-    projectId: process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID,
-    publishableClientKey: process.env.NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY,
-    tokenStore,
-    automaticSideEffects: false,
-  }), [tokenStore]);
+  const tokenStore = useMemo(
+    () =>
+      betterAuthTokenStore({
+        getSessionId: () => sessionId,
+        getToken: async () => {
+          const response = await fetch("/api/auth/token");
+          if (!response.ok) return null;
+          return ((await response.json()) as { token: string }).token;
+        },
+        subscribe: (callback) => {
+          window.addEventListener("better-auth-session-change", callback);
+          return () =>
+            window.removeEventListener("better-auth-session-change", callback);
+        },
+        signOut: async () => {
+          setIsSubmitting(true);
+          await fetch("/api/auth/sign-out", { method: "POST" });
+          setSessionId(null);
+          setProviderUser(null);
+          setClaims(null);
+          setExchange(null);
+          setUser(null);
+          setStatus("idle");
+          window.dispatchEvent(new Event("better-auth-session-change"));
+          setIsSubmitting(false);
+        },
+      }),
+    [sessionId],
+  );
+  const app = useMemo(
+    () =>
+      new HexclaveClientApp({
+        baseUrl: process.env.NEXT_PUBLIC_HEXCLAVE_API_URL,
+        projectId: process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID,
+        publishableClientKey:
+          process.env.NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY,
+        tokenStore,
+        automaticSideEffects: false,
+      }),
+    [tokenStore],
+  );
 
   const authenticate = async (path: "sign-up" | "sign-in") => {
-    setError(null); setIsSubmitting(true);
-    const response = await fetch(`/api/auth/${path}/email`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ email, password, name: email.split("@")[0] }) });
+    setError(null);
+    setIsSubmitting(true);
+    const response = await fetch(`/api/auth/${path}/email`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, password, name: email.split("@")[0] }),
+    });
     if (!response.ok) {
-      setError(await response.text()); setIsSubmitting(false); setStatus("error"); return;
+      setError(await response.text());
+      setIsSubmitting(false);
+      setStatus("error");
+      return;
     }
     const sessionResponse = await fetch("/api/auth/get-session");
-    const session = await sessionResponse.json() as { session?: { id: string }, user?: ProviderUser };
+    const session = (await sessionResponse.json()) as {
+      session?: { id: string };
+      user?: ProviderUser;
+    };
     setProviderUser(session.user ?? { email, name: email.split("@")[0] });
     setSessionId(session.session?.id ?? null);
     window.dispatchEvent(new Event("better-auth-session-change"));
@@ -76,31 +135,183 @@ export function BetterAuthDemo() {
     let active = true;
     setStatus("exchanging");
     Promise.all([
-      fetch("/api/auth/token").then(async response => {
-        if (!response.ok) throw new Error(`Better Auth token endpoint returned ${response.status}`);
-        return (await response.json() as { token: string }).token;
+      fetch("/api/auth/token").then(async (response) => {
+        if (!response.ok)
+          throw new Error(
+            `Better Auth token endpoint returned ${response.status}`,
+          );
+        return ((await response.json()) as { token: string }).token;
       }),
-      fetch("/api/auth/exchange").then(async response => {
-        const result = await response.json() as Exchange;
-        if (!response.ok) throw new Error(result.error ?? `Better Auth exchange returned ${response.status}`);
+      fetch("/api/auth/exchange").then(async (response) => {
+        const result = (await response.json()) as Exchange;
+        if (!response.ok)
+          throw new Error(
+            result.error ?? `Better Auth exchange returned ${response.status}`,
+          );
         return result;
       }),
-    ]).then(async ([token, result]) => {
-      if (!active) return;
-      setClaims(decodeClaims(token)); setExchange(result);
-      setUser(result.userId == null ? null : { id: result.userId, primaryEmail: result.primaryEmail ?? null, displayName: result.displayName ?? null });
-      setStatus("exchanged");
-    }).catch(reason => {
-      if (!active) return;
-      setStatus("error"); setError(reason instanceof Error ? reason.message : "Better Auth exchange failed");
-    });
-    return () => { active = false; };
+    ])
+      .then(async ([token, result]) => {
+        if (!active) return;
+        setClaims(decodeClaims(token));
+        setExchange(result);
+        setUser(
+          result.userId == null
+            ? null
+            : {
+              id: result.userId,
+              primaryEmail: result.primaryEmail ?? null,
+              displayName: result.displayName ?? null,
+            },
+        );
+        setStatus("exchanged");
+      })
+      .catch((reason) => {
+        if (!active) return;
+        setStatus("error");
+        setError(
+          reason instanceof Error
+            ? reason.message
+            : "Better Auth exchange failed",
+        );
+      });
+    return () => {
+      active = false;
+    };
   }, [app, sessionId]);
 
-  if (sessionId == null) return <main><p className="eyebrow">External authentication demo</p><h1>Better Auth <span>→</span> Hexclave</h1><p className="lede">Sign in to the local Better Auth provider, then watch its JWT become a Hexclave session.</p><p className="status">Exchange status: <strong>{status}</strong></p>{error != null && <p className="error" role="alert">Authentication error: {error}</p>}<section className="panel auth-form"><label>Email<input type="email" value={email} onChange={event => setEmail(event.target.value)} /></label><label>Password<input type="password" value={password} onChange={event => setPassword(event.target.value)} /></label><div className="actions"><button type="button" disabled={isSubmitting} onClick={() => authenticate("sign-in")}>{isSubmitting ? "Signing in…" : "Sign in to Better Auth"}</button><button className="secondary" type="button" disabled={isSubmitting} onClick={() => authenticate("sign-up")}>Create Better Auth user</button></div></section></main>;
+  if (sessionId == null)
+    return (
+      <main>
+        <p className="eyebrow">External authentication demo</p>
+        <h1>
+          Better Auth <span>→</span> Hexclave
+        </h1>
+        <p className="lede">
+          Sign in to the local Better Auth provider, then watch its JWT become a
+          Hexclave session.
+        </p>
+        <p className="status">
+          Exchange status: <strong>{status}</strong>
+        </p>
+        {error != null && (
+          <p className="error" role="alert">
+            Authentication error: {error}
+          </p>
+        )}
+        <section className="panel auth-form">
+          <label>
+            Email
+            <input
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+            />
+          </label>
+          <label>
+            Password
+            <input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+            />
+          </label>
+          <div className="actions">
+            <button
+              type="button"
+              disabled={isSubmitting}
+              onClick={() => authenticate("sign-in")}
+            >
+              {isSubmitting ? "Signing in…" : "Sign in to Better Auth"}
+            </button>
+            <button
+              className="secondary"
+              type="button"
+              disabled={isSubmitting}
+              onClick={() => authenticate("sign-up")}
+            >
+              Create Better Auth user
+            </button>
+          </div>
+        </section>
+      </main>
+    );
 
-  return <main><p className="eyebrow">External authentication demo</p><h1>Better Auth <span>→</span> Hexclave</h1><p className="lede">A locally issued Better Auth JWT, including its session ID, is exchanged for a Hexclave session.</p><p className="status">Exchange status: <strong>{status}</strong></p>{error != null && <p className="error" role="alert">Exchange error: {error}</p>}<div className="panels">
-    <section className="panel"><p className="panel-kicker">Provider session</p><h2>Better Auth</h2><dl><Claim label="User" value={providerUser?.name} /><Claim label="Email" value={providerUser?.email} /><Claim label="Session ID" value={sessionId} /></dl><div className="claims"><p className="panel-kicker">Decoded token claims</p><dl><Claim label="iss" value={claims?.iss} /><Claim label="sub" value={claims?.sub} /><Claim label="sid" value={claims?.sid} /><Claim label="aud" value={Array.isArray(claims?.aud) ? claims.aud.join(", ") : claims?.aud} /><Claim label="exp" value={claims?.exp} /></dl></div></section>
-    <section className="panel"><p className="panel-kicker">Hexclave session</p><h2>Project user</h2><dl><Claim label="User ID" value={user?.id} /><Claim label="Primary email" value={user?.primaryEmail ?? "null"} /><Claim label="Display name" value={user?.displayName ?? "null"} /><Claim label="New user on this exchange" value={exchange?.isNewUser == null ? undefined : exchange.isNewUser ? "yes" : "no"} /><Claim label="Session ID" value={exchange?.sessionId} /></dl><div className="actions"><button type="button" disabled={isSubmitting || status === "exchanging"} onClick={() => tokenStore.signOut?.()}>{isSubmitting ? "Signing out…" : "Sign out of Better Auth"}</button></div></section>
-  </div></main>;
+  return (
+    <main>
+      <p className="eyebrow">External authentication demo</p>
+      <h1>
+        Better Auth <span>→</span> Hexclave
+      </h1>
+      <p className="lede">
+        A locally issued Better Auth JWT, including its session ID, is exchanged
+        for a Hexclave session.
+      </p>
+      <p className="status">
+        Exchange status: <strong>{status}</strong>
+      </p>
+      {error != null && (
+        <p className="error" role="alert">
+          Exchange error: {error}
+        </p>
+      )}
+      <div className="panels">
+        <section className="panel">
+          <p className="panel-kicker">Provider session</p>
+          <h2>Better Auth</h2>
+          <dl>
+            <Claim label="User" value={providerUser?.name} />
+            <Claim label="Email" value={providerUser?.email} />
+            <Claim label="Session ID" value={sessionId} />
+          </dl>
+          <div className="claims">
+            <p className="panel-kicker">Decoded token claims</p>
+            <dl>
+              <Claim label="iss" value={claims?.iss} />
+              <Claim label="sub" value={claims?.sub} />
+              <Claim label="sid" value={claims?.sid} />
+              <Claim
+                label="aud"
+                value={
+                  Array.isArray(claims?.aud)
+                    ? claims.aud.join(", ")
+                    : claims?.aud
+                }
+              />
+              <Claim label="exp" value={claims?.exp} />
+            </dl>
+          </div>
+        </section>
+        <section className="panel">
+          <p className="panel-kicker">Hexclave session</p>
+          <h2>Project user</h2>
+          <dl>
+            <Claim label="User ID" value={user?.id} />
+            <Claim label="Primary email" value={user?.primaryEmail ?? "null"} />
+            <Claim label="Display name" value={user?.displayName ?? "null"} />
+            <Claim
+              label="New user on this exchange"
+              value={
+                exchange?.isNewUser == null
+                  ? undefined
+                  : exchange.isNewUser
+                    ? "yes"
+                    : "no"
+              }
+            />
+            <Claim label="Session ID" value={exchange?.sessionId} />
+          </dl>
+          <div className="actions">
+            <button
+              type="button"
+              disabled={isSubmitting || status === "exchanging"}
+              onClick={() => tokenStore.signOut?.()}
+            >
+              {isSubmitting ? "Signing out…" : "Sign out of Better Auth"}
+            </button>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
 }

--- a/examples/better-auth-integration-demo/src/app/better-auth-demo.tsx
+++ b/examples/better-auth-integration-demo/src/app/better-auth-demo.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { HexclaveClientApp, betterAuthTokenStore } from "@hexclave/next";
+import { useEffect, useMemo, useState } from "react";
+
+type Claims = { iss?: string, sub?: string, sid?: string, aud?: string | string[], exp?: number };
+type ProviderUser = { email: string, name: string };
+type HexclaveUser = { id: string, primaryEmail: string | null, displayName: string | null };
+type Exchange = { sessionId?: string, userId?: string, isNewUser?: boolean, primaryEmail?: string | null, displayName?: string | null, error?: string };
+type Status = "idle" | "exchanging" | "exchanged" | "error";
+
+function decodeClaims(token: string): Claims {
+  const payload = token.split(".")[1];
+  if (payload == null) throw new Error("The Better Auth token did not contain a JWT payload");
+  return JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/"))) as Claims;
+}
+
+function Claim({ label, value }: { label: string, value: string | number | undefined }) {
+  return <><dt>{label}</dt><dd><code>{value == null ? "Not present" : String(value)}</code></dd></>;
+}
+
+export function BetterAuthDemo() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [providerUser, setProviderUser] = useState<ProviderUser | null>(null);
+  const [claims, setClaims] = useState<Claims | null>(null);
+  const [user, setUser] = useState<HexclaveUser | null>(null);
+  const [exchange, setExchange] = useState<Exchange | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [status, setStatus] = useState<Status>("idle");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const tokenStore = useMemo(() => betterAuthTokenStore({
+    getSessionId: () => sessionId,
+    getToken: async () => {
+      const response = await fetch("/api/auth/token");
+      if (!response.ok) return null;
+      return (await response.json() as { token: string }).token;
+    },
+    subscribe: callback => {
+      window.addEventListener("better-auth-session-change", callback);
+      return () => window.removeEventListener("better-auth-session-change", callback);
+    },
+    signOut: async () => {
+      setIsSubmitting(true);
+      await fetch("/api/auth/sign-out", { method: "POST" });
+      setSessionId(null); setProviderUser(null); setClaims(null); setExchange(null); setUser(null); setStatus("idle");
+      window.dispatchEvent(new Event("better-auth-session-change"));
+      setIsSubmitting(false);
+    },
+  }), [sessionId]);
+  const app = useMemo(() => new HexclaveClientApp({
+    baseUrl: process.env.NEXT_PUBLIC_HEXCLAVE_API_URL,
+    projectId: process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID,
+    publishableClientKey: process.env.NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY,
+    tokenStore,
+    automaticSideEffects: false,
+  }), [tokenStore]);
+
+  const authenticate = async (path: "sign-up" | "sign-in") => {
+    setError(null); setIsSubmitting(true);
+    const response = await fetch(`/api/auth/${path}/email`, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ email, password, name: email.split("@")[0] }) });
+    if (!response.ok) {
+      setError(await response.text()); setIsSubmitting(false); setStatus("error"); return;
+    }
+    const sessionResponse = await fetch("/api/auth/get-session");
+    const session = await sessionResponse.json() as { session?: { id: string }, user?: ProviderUser };
+    setProviderUser(session.user ?? { email, name: email.split("@")[0] });
+    setSessionId(session.session?.id ?? null);
+    window.dispatchEvent(new Event("better-auth-session-change"));
+    setIsSubmitting(false);
+  };
+
+  useEffect(() => {
+    if (sessionId == null) return;
+    let active = true;
+    setStatus("exchanging");
+    Promise.all([
+      fetch("/api/auth/token").then(async response => {
+        if (!response.ok) throw new Error(`Better Auth token endpoint returned ${response.status}`);
+        return (await response.json() as { token: string }).token;
+      }),
+      fetch("/api/auth/exchange").then(async response => {
+        const result = await response.json() as Exchange;
+        if (!response.ok) throw new Error(result.error ?? `Better Auth exchange returned ${response.status}`);
+        return result;
+      }),
+    ]).then(async ([token, result]) => {
+      if (!active) return;
+      setClaims(decodeClaims(token)); setExchange(result);
+      setUser(result.userId == null ? null : { id: result.userId, primaryEmail: result.primaryEmail ?? null, displayName: result.displayName ?? null });
+      setStatus("exchanged");
+    }).catch(reason => {
+      if (!active) return;
+      setStatus("error"); setError(reason instanceof Error ? reason.message : "Better Auth exchange failed");
+    });
+    return () => { active = false; };
+  }, [app, sessionId]);
+
+  if (sessionId == null) return <main><p className="eyebrow">External authentication demo</p><h1>Better Auth <span>→</span> Hexclave</h1><p className="lede">Sign in to the local Better Auth provider, then watch its JWT become a Hexclave session.</p><p className="status">Exchange status: <strong>{status}</strong></p>{error != null && <p className="error" role="alert">Authentication error: {error}</p>}<section className="panel auth-form"><label>Email<input type="email" value={email} onChange={event => setEmail(event.target.value)} /></label><label>Password<input type="password" value={password} onChange={event => setPassword(event.target.value)} /></label><div className="actions"><button type="button" disabled={isSubmitting} onClick={() => authenticate("sign-in")}>{isSubmitting ? "Signing in…" : "Sign in to Better Auth"}</button><button className="secondary" type="button" disabled={isSubmitting} onClick={() => authenticate("sign-up")}>Create Better Auth user</button></div></section></main>;
+
+  return <main><p className="eyebrow">External authentication demo</p><h1>Better Auth <span>→</span> Hexclave</h1><p className="lede">A locally issued Better Auth JWT, including its session ID, is exchanged for a Hexclave session.</p><p className="status">Exchange status: <strong>{status}</strong></p>{error != null && <p className="error" role="alert">Exchange error: {error}</p>}<div className="panels">
+    <section className="panel"><p className="panel-kicker">Provider session</p><h2>Better Auth</h2><dl><Claim label="User" value={providerUser?.name} /><Claim label="Email" value={providerUser?.email} /><Claim label="Session ID" value={sessionId} /></dl><div className="claims"><p className="panel-kicker">Decoded token claims</p><dl><Claim label="iss" value={claims?.iss} /><Claim label="sub" value={claims?.sub} /><Claim label="sid" value={claims?.sid} /><Claim label="aud" value={Array.isArray(claims?.aud) ? claims.aud.join(", ") : claims?.aud} /><Claim label="exp" value={claims?.exp} /></dl></div></section>
+    <section className="panel"><p className="panel-kicker">Hexclave session</p><h2>Project user</h2><dl><Claim label="User ID" value={user?.id} /><Claim label="Primary email" value={user?.primaryEmail ?? "null"} /><Claim label="Display name" value={user?.displayName ?? "null"} /><Claim label="New user on this exchange" value={exchange?.isNewUser == null ? undefined : exchange.isNewUser ? "yes" : "no"} /><Claim label="Session ID" value={exchange?.sessionId} /></dl><div className="actions"><button type="button" disabled={isSubmitting || status === "exchanging"} onClick={() => tokenStore.signOut?.()}>{isSubmitting ? "Signing out…" : "Sign out of Better Auth"}</button></div></section>
+  </div></main>;
+}

--- a/examples/better-auth-integration-demo/src/app/better-auth-demo.tsx
+++ b/examples/better-auth-integration-demo/src/app/better-auth-demo.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { HexclaveClientApp, betterAuthTokenStore } from "@hexclave/next";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type Claims = {
   iss?: string;
@@ -53,6 +53,7 @@ function Claim({
 }
 
 export function BetterAuthDemo() {
+  const sessionLookupController = useRef<AbortController | null>(null);
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [providerUser, setProviderUser] = useState<ProviderUser | null>(null);
@@ -117,6 +118,8 @@ export function BetterAuthDemo() {
   );
 
   const authenticate = async (path: "sign-up" | "sign-in") => {
+    sessionLookupController.current?.abort();
+    sessionLookupController.current = null;
     setError(null);
     setIsSubmitting(true);
     try {
@@ -158,7 +161,9 @@ export function BetterAuthDemo() {
 
   useEffect(() => {
     let active = true;
-    fetch("/api/auth/get-session")
+    const controller = new AbortController();
+    sessionLookupController.current = controller;
+    fetch("/api/auth/get-session", { signal: controller.signal })
       .then(async (response) => {
         if (!response.ok) return null;
         return await response.json() as { session?: { id: string }; user?: ProviderUser };
@@ -169,10 +174,16 @@ export function BetterAuthDemo() {
         setSessionId(session.session.id);
       })
       .catch(() => {
-        if (active) setError("Better Auth session lookup failed");
+        if (active && !controller.signal.aborted) {
+          setError("Better Auth session lookup failed");
+        }
       });
     return () => {
       active = false;
+      controller.abort();
+      if (sessionLookupController.current === controller) {
+        sessionLookupController.current = null;
+      }
     };
   }, []);
 
@@ -204,6 +215,7 @@ export function BetterAuthDemo() {
         setClaims(decodeClaims(token));
         setExchange(result);
         const sdkUser = await app.getUser();
+        if (!active) return;
         setUser(sdkUser == null ? null : {
           id: sdkUser.id,
           primaryEmail: sdkUser.primaryEmail,

--- a/examples/better-auth-integration-demo/src/app/better-auth-demo.tsx
+++ b/examples/better-auth-integration-demo/src/app/better-auth-demo.tsx
@@ -30,9 +30,9 @@ function decodeClaims(token: string): Claims {
   const payload = token.split(".")[1];
   if (payload == null)
     throw new Error("The Better Auth token did not contain a JWT payload");
-  return JSON.parse(
-    atob(payload.replace(/-/g, "+").replace(/_/g, "/")),
-  ) as Claims;
+  const padded = payload.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(payload.length / 4) * 4, "=");
+  const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+  return JSON.parse(new TextDecoder().decode(bytes)) as Claims;
 }
 
 function Claim({
@@ -69,7 +69,7 @@ export function BetterAuthDemo() {
         getSessionId: () => sessionId,
         getToken: async () => {
           const response = await fetch("/api/auth/token");
-          if (!response.ok) return null;
+          if (!response.ok || !(response.headers.get("content-type") ?? "").includes("application/json")) return null;
           return ((await response.json()) as { token: string }).token;
         },
         subscribe: (callback) => {
@@ -79,15 +79,26 @@ export function BetterAuthDemo() {
         },
         signOut: async () => {
           setIsSubmitting(true);
-          await fetch("/api/auth/sign-out", { method: "POST" });
-          setSessionId(null);
-          setProviderUser(null);
-          setClaims(null);
-          setExchange(null);
-          setUser(null);
-          setStatus("idle");
-          window.dispatchEvent(new Event("better-auth-session-change"));
-          setIsSubmitting(false);
+          try {
+            const response = await fetch("/api/auth/sign-out", { method: "POST" });
+            if (!response.ok) {
+              setError(`Better Auth sign-out returned ${response.status}`);
+              setStatus("error");
+              return;
+            }
+            setSessionId(null);
+            setProviderUser(null);
+            setClaims(null);
+            setExchange(null);
+            setUser(null);
+            setStatus("idle");
+            window.dispatchEvent(new Event("better-auth-session-change"));
+          } catch {
+            setError("Better Auth sign-out failed");
+            setStatus("error");
+          } finally {
+            setIsSubmitting(false);
+          }
         },
       }),
     [sessionId],
@@ -108,41 +119,62 @@ export function BetterAuthDemo() {
   const authenticate = async (path: "sign-up" | "sign-in") => {
     setError(null);
     setIsSubmitting(true);
-    const response = await fetch(`/api/auth/${path}/email`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ email, password, name: email.split("@")[0] }),
-    });
-    if (!response.ok) {
-      setError(await response.text());
-      setIsSubmitting(false);
+    try {
+      const response = await fetch(`/api/auth/${path}/email`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email, password, name: email.split("@")[0] }),
+      });
+      if (!response.ok) {
+        setError("Better Auth authentication request failed");
+        setStatus("error");
+        return;
+      }
+      const sessionResponse = await fetch("/api/auth/get-session");
+      if (!sessionResponse.ok) {
+        setError(`Better Auth session endpoint returned ${sessionResponse.status}`);
+        setStatus("error");
+        return;
+      }
+      const session = (await sessionResponse.json()) as {
+        session?: { id: string };
+        user?: ProviderUser;
+      };
+      if (session.session == null) {
+        setError("Better Auth sign-in succeeded but no session was returned");
+        setStatus("error");
+        return;
+      }
+      setProviderUser(session.user ?? { email, name: email.split("@")[0] });
+      setSessionId(session.session.id);
+      window.dispatchEvent(new Event("better-auth-session-change"));
+    } catch {
+      setError("Better Auth authentication request failed");
       setStatus("error");
-      return;
-    }
-    const sessionResponse = await fetch("/api/auth/get-session");
-    if (!sessionResponse.ok) {
-      setError(
-        `Better Auth session endpoint returned ${sessionResponse.status}`,
-      );
+    } finally {
       setIsSubmitting(false);
-      setStatus("error");
-      return;
     }
-    const session = (await sessionResponse.json()) as {
-      session?: { id: string };
-      user?: ProviderUser;
-    };
-    if (session.session == null) {
-      setError("Better Auth sign-in succeeded but no session was returned");
-      setIsSubmitting(false);
-      setStatus("error");
-      return;
-    }
-    setProviderUser(session.user ?? { email, name: email.split("@")[0] });
-    setSessionId(session.session.id);
-    window.dispatchEvent(new Event("better-auth-session-change"));
-    setIsSubmitting(false);
   };
+
+  useEffect(() => {
+    let active = true;
+    fetch("/api/auth/get-session")
+      .then(async (response) => {
+        if (!response.ok) return null;
+        return await response.json() as { session?: { id: string }; user?: ProviderUser };
+      })
+      .then((session) => {
+        if (!active || session?.session == null) return;
+        setProviderUser(session.user ?? null);
+        setSessionId(session.session.id);
+      })
+      .catch(() => {
+        if (active) setError("Better Auth session lookup failed");
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (sessionId == null) return;
@@ -157,7 +189,9 @@ export function BetterAuthDemo() {
         return ((await response.json()) as { token: string }).token;
       }),
       fetch("/api/auth/exchange").then(async (response) => {
-        const result = (await response.json()) as Exchange;
+        const result = response.ok && (response.headers.get("content-type") ?? "").includes("application/json")
+          ? await response.json() as Exchange
+          : {};
         if (!response.ok)
           throw new Error(
             result.error ?? `Better Auth exchange returned ${response.status}`,
@@ -169,15 +203,12 @@ export function BetterAuthDemo() {
         if (!active) return;
         setClaims(decodeClaims(token));
         setExchange(result);
-        setUser(
-          result.userId == null
-            ? null
-            : {
-              id: result.userId,
-              primaryEmail: result.primaryEmail ?? null,
-              displayName: result.displayName ?? null,
-            },
-        );
+        const sdkUser = await app.getUser();
+        setUser(sdkUser == null ? null : {
+          id: sdkUser.id,
+          primaryEmail: sdkUser.primaryEmail,
+          displayName: sdkUser.displayName,
+        });
         setStatus("exchanged");
       })
       .catch((reason) => {

--- a/examples/better-auth-integration-demo/src/app/better-auth-demo.tsx
+++ b/examples/better-auth-integration-demo/src/app/better-auth-demo.tsx
@@ -120,12 +120,26 @@ export function BetterAuthDemo() {
       return;
     }
     const sessionResponse = await fetch("/api/auth/get-session");
+    if (!sessionResponse.ok) {
+      setError(
+        `Better Auth session endpoint returned ${sessionResponse.status}`,
+      );
+      setIsSubmitting(false);
+      setStatus("error");
+      return;
+    }
     const session = (await sessionResponse.json()) as {
       session?: { id: string };
       user?: ProviderUser;
     };
+    if (session.session == null) {
+      setError("Better Auth sign-in succeeded but no session was returned");
+      setIsSubmitting(false);
+      setStatus("error");
+      return;
+    }
     setProviderUser(session.user ?? { email, name: email.split("@")[0] });
-    setSessionId(session.session?.id ?? null);
+    setSessionId(session.session.id);
     window.dispatchEvent(new Event("better-auth-session-change"));
     setIsSubmitting(false);
   };

--- a/examples/better-auth-integration-demo/src/app/globals.css
+++ b/examples/better-auth-integration-demo/src/app/globals.css
@@ -1,0 +1,34 @@
+:root {
+  color-scheme: dark;
+  background: #08111f;
+  color: #e6edf7;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+}
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; }
+a { color: #7dd3fc; }
+button, input { font: inherit; }
+button { border: 0; border-radius: 10px; background: #38bdf8; color: #042033; cursor: pointer; font-weight: 700; padding: 0.7rem 1rem; }
+button:disabled { cursor: wait; opacity: 0.55; }
+main { margin: 0 auto; max-width: 1120px; padding: 3rem 1.25rem; }
+.eyebrow { color: #7dd3fc; font-size: 0.75rem; font-weight: 800; letter-spacing: 0.14em; text-transform: uppercase; }
+h1 { font-size: clamp(2rem, 5vw, 3.6rem); line-height: 1; margin: 0.5rem 0 1rem; }
+.lede { color: #a9bad0; max-width: 720px; }
+.status { border: 1px solid #29405b; border-radius: 999px; display: inline-flex; gap: 0.5rem; margin: 1rem 0; padding: 0.45rem 0.8rem; }
+.status strong { color: #7dd3fc; }
+.error { background: #451a26; border: 1px solid #fb7185; border-radius: 10px; color: #fecdd3; padding: 0.8rem 1rem; }
+.panels { display: grid; gap: 1rem; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-top: 1rem; }
+.panel { background: linear-gradient(145deg, #102239, #0c1829); border: 1px solid #29405b; border-radius: 18px; padding: 1.25rem; }
+.panel h2 { margin: 0 0 0.25rem; }
+.panel-kicker { color: #8ea6c1; font-size: 0.85rem; margin: 0 0 1rem; }
+dl { display: grid; gap: 0.7rem; margin: 0; }
+dt { color: #8ea6c1; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.06em; }
+dd { margin: -0.4rem 0 0; overflow-wrap: anywhere; }
+.claims { border-top: 1px solid #29405b; margin-top: 1rem; padding-top: 1rem; }
+.claims code { color: #bae6fd; font-size: 0.82rem; overflow-wrap: anywhere; }
+.actions { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 1.25rem; }
+.secondary { background: #1e3652; color: #dbeafe; }
+.auth-form { display: grid; gap: 0.8rem; max-width: 460px; }
+label { color: #a9bad0; display: grid; gap: 0.35rem; }
+input { background: #08111f; border: 1px solid #395573; border-radius: 9px; color: #e6edf7; padding: 0.7rem; }
+@media (max-width: 720px) { .panels { grid-template-columns: 1fr; } main { padding-top: 2rem; } }

--- a/examples/better-auth-integration-demo/src/app/layout.tsx
+++ b/examples/better-auth-integration-demo/src/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Better Auth + Hexclave",
+  description: "Self-hosted Better Auth JWT exchange demo",
+};
+
+export default function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/better-auth-integration-demo/src/app/page.tsx
+++ b/examples/better-auth-integration-demo/src/app/page.tsx
@@ -1,0 +1,5 @@
+import { BetterAuthDemo } from "./better-auth-demo";
+
+export default function Page() {
+  return <BetterAuthDemo />;
+}

--- a/examples/better-auth-integration-demo/src/app/page.tsx
+++ b/examples/better-auth-integration-demo/src/app/page.tsx
@@ -1,5 +1,7 @@
 import { BetterAuthDemo } from "./better-auth-demo";
 
+export const dynamic = "force-dynamic";
+
 export default function Page() {
   return <BetterAuthDemo />;
 }

--- a/examples/better-auth-integration-demo/src/lib/auth.ts
+++ b/examples/better-auth-integration-demo/src/lib/auth.ts
@@ -2,6 +2,14 @@ import { betterAuth } from "better-auth";
 import { jwt } from "better-auth/plugins";
 import Database from "better-sqlite3";
 
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (value == null || value.length === 0) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
 const database = new Database("./better-auth.db");
 database.exec(`
   create table if not exists "user" ("id" text not null primary key, "name" text not null, "email" text not null unique, "emailVerified" integer not null, "image" text, "createdAt" date not null, "updatedAt" date not null);
@@ -14,15 +22,17 @@ database.exec(`
   create index if not exists "verification_identifier_idx" on "verification" ("identifier");
 `);
 
+const betterAuthUrl = requireEnv("BETTER_AUTH_URL");
+
 export const auth = betterAuth({
   database,
-  baseURL: process.env.BETTER_AUTH_URL ?? "http://localhost:8111",
-  secret: process.env.BETTER_AUTH_SECRET ?? "local-only-better-auth-secret",
+  baseURL: betterAuthUrl,
+  secret: requireEnv("BETTER_AUTH_SECRET"),
   emailAndPassword: { enabled: true },
   plugins: [
     jwt({
       jwt: {
-        issuer: process.env.BETTER_AUTH_URL ?? "http://localhost:8111",
+        issuer: betterAuthUrl,
         audience: "better-auth-integration-demo",
         definePayload: ({ user, session }) => ({
           sub: user.id,

--- a/examples/better-auth-integration-demo/src/lib/auth.ts
+++ b/examples/better-auth-integration-demo/src/lib/auth.ts
@@ -10,8 +10,7 @@ function requireEnv(name: string): string {
   return value;
 }
 
-const database = new Database("./better-auth.db");
-database.exec(`
+const databaseSchema = `
   create table if not exists "user" ("id" text not null primary key, "name" text not null, "email" text not null unique, "emailVerified" integer not null, "image" text, "createdAt" date not null, "updatedAt" date not null);
   create table if not exists "session" ("id" text not null primary key, "expiresAt" date not null, "token" text not null unique, "createdAt" date not null, "updatedAt" date not null, "ipAddress" text, "userAgent" text, "userId" text not null references "user" ("id") on delete cascade);
   create table if not exists "account" ("id" text not null primary key, "accountId" text not null, "providerId" text not null, "userId" text not null references "user" ("id") on delete cascade, "accessToken" text, "refreshToken" text, "idToken" text, "accessTokenExpiresAt" date, "refreshTokenExpiresAt" date, "scope" text, "password" text, "createdAt" date not null, "updatedAt" date not null);
@@ -20,27 +19,38 @@ database.exec(`
   create index if not exists "session_userId_idx" on "session" ("userId");
   create index if not exists "account_userId_idx" on "account" ("userId");
   create index if not exists "verification_identifier_idx" on "verification" ("identifier");
-`);
+`;
 
-const betterAuthUrl = requireEnv("BETTER_AUTH_URL");
+function createAuth() {
+  const database = new Database("./better-auth.db");
+  database.exec(databaseSchema);
+  const betterAuthUrl = requireEnv("BETTER_AUTH_URL");
+  return betterAuth({
+    database,
+    baseURL: betterAuthUrl,
+    secret: requireEnv("BETTER_AUTH_SECRET"),
+    emailAndPassword: { enabled: true },
+    plugins: [
+      jwt({
+        jwt: {
+          issuer: betterAuthUrl,
+          audience: "better-auth-integration-demo",
+          definePayload: ({ user, session }) => ({
+            sub: user.id,
+            email: user.email,
+            name: user.name,
+            sid: session.id,
+          }),
+        },
+      }),
+    ],
+  });
+}
 
-export const auth = betterAuth({
-  database,
-  baseURL: betterAuthUrl,
-  secret: requireEnv("BETTER_AUTH_SECRET"),
-  emailAndPassword: { enabled: true },
-  plugins: [
-    jwt({
-      jwt: {
-        issuer: betterAuthUrl,
-        audience: "better-auth-integration-demo",
-        definePayload: ({ user, session }) => ({
-          sub: user.id,
-          email: user.email,
-          name: user.name,
-          sid: session.id,
-        }),
-      },
-    }),
-  ],
-});
+let auth: ReturnType<typeof createAuth> | null = null;
+
+export function getAuth(): ReturnType<typeof createAuth> {
+  if (auth != null) return auth;
+  auth = createAuth();
+  return auth;
+}

--- a/examples/better-auth-integration-demo/src/lib/auth.ts
+++ b/examples/better-auth-integration-demo/src/lib/auth.ts
@@ -1,0 +1,36 @@
+import { betterAuth } from "better-auth";
+import { jwt } from "better-auth/plugins";
+import Database from "better-sqlite3";
+
+const database = new Database("./better-auth.db");
+database.exec(`
+  create table if not exists "user" ("id" text not null primary key, "name" text not null, "email" text not null unique, "emailVerified" integer not null, "image" text, "createdAt" date not null, "updatedAt" date not null);
+  create table if not exists "session" ("id" text not null primary key, "expiresAt" date not null, "token" text not null unique, "createdAt" date not null, "updatedAt" date not null, "ipAddress" text, "userAgent" text, "userId" text not null references "user" ("id") on delete cascade);
+  create table if not exists "account" ("id" text not null primary key, "accountId" text not null, "providerId" text not null, "userId" text not null references "user" ("id") on delete cascade, "accessToken" text, "refreshToken" text, "idToken" text, "accessTokenExpiresAt" date, "refreshTokenExpiresAt" date, "scope" text, "password" text, "createdAt" date not null, "updatedAt" date not null);
+  create table if not exists "verification" ("id" text not null primary key, "identifier" text not null, "value" text not null, "expiresAt" date not null, "createdAt" date not null, "updatedAt" date not null);
+  create table if not exists "jwks" ("id" text not null primary key, "publicKey" text not null, "privateKey" text not null, "createdAt" date not null, "expiresAt" date);
+  create index if not exists "session_userId_idx" on "session" ("userId");
+  create index if not exists "account_userId_idx" on "account" ("userId");
+  create index if not exists "verification_identifier_idx" on "verification" ("identifier");
+`);
+
+export const auth = betterAuth({
+  database,
+  baseURL: process.env.BETTER_AUTH_URL ?? "http://localhost:8111",
+  secret: process.env.BETTER_AUTH_SECRET ?? "local-only-better-auth-secret",
+  emailAndPassword: { enabled: true },
+  plugins: [
+    jwt({
+      jwt: {
+        issuer: process.env.BETTER_AUTH_URL ?? "http://localhost:8111",
+        audience: "better-auth-integration-demo",
+        definePayload: ({ user, session }) => ({
+          sub: user.id,
+          email: user.email,
+          name: user.name,
+          sid: session.id,
+        }),
+      },
+    }),
+  ],
+});

--- a/examples/better-auth-integration-demo/tsconfig.json
+++ b/examples/better-auth-integration-demo/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "allowJs": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/examples/workos-integration-demo/.env.local.example
+++ b/examples/workos-integration-demo/.env.local.example
@@ -1,0 +1,9 @@
+NEXT_PUBLIC_HEXCLAVE_API_URL=http://localhost:8102
+NEXT_PUBLIC_HEXCLAVE_PROJECT_ID=internal
+NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY=this-publishable-client-key-is-for-local-development-only
+HEXCLAVE_SECRET_SERVER_KEY=this-secret-server-key-is-for-local-development-only
+WORKOS_CLIENT_ID=
+WORKOS_API_KEY=
+WORKOS_AUTHKIT_DOMAIN=
+WORKOS_REDIRECT_URI=http://localhost:8110/auth/callback
+WORKOS_COOKIE_PASSWORD=replace-with-a-32-character-local-secret

--- a/examples/workos-integration-demo/.env.local.example
+++ b/examples/workos-integration-demo/.env.local.example
@@ -1,3 +1,4 @@
+# Set NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX to use the repository's alternate port prefix.
 NEXT_PUBLIC_HEXCLAVE_API_URL=http://localhost:8102
 NEXT_PUBLIC_HEXCLAVE_PROJECT_ID=internal
 NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY=this-publishable-client-key-is-for-local-development-only

--- a/examples/workos-integration-demo/.eslintrc.js
+++ b/examples/workos-integration-demo/.eslintrc.js
@@ -1,0 +1,11 @@
+module.exports = {
+  extends: [
+    "../../configs/eslint/defaults.js",
+    "../../configs/eslint/next.js",
+  ],
+  ignorePatterns: ["/*", "!/src"],
+  rules: {
+    "@typescript-eslint/no-misused-promises": [0],
+    "@typescript-eslint/no-unnecessary-condition": [0],
+  },
+};

--- a/examples/workos-integration-demo/.gitignore
+++ b/examples/workos-integration-demo/.gitignore
@@ -1,0 +1,4 @@
+.next
+node_modules
+.env.local
+*.untracked

--- a/examples/workos-integration-demo/README.md
+++ b/examples/workos-integration-demo/README.md
@@ -13,7 +13,9 @@ with the local Hexclave backend, and displays the resulting session metadata.
    - `WORKOS_COOKIE_PASSWORD` (use a local value at least 32 characters long)
 3. Set the local Hexclave client and server keys and API URL.
 4. Configure `http://localhost:8110/auth/callback` as an allowed WorkOS redirect
-   URI.
+   URI. If `NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX` is set, use the matching
+   `${prefix}10` port instead; `.env` files use the working default because they
+   do not expand shell variables.
 5. Run `pnpm dev` from this directory.
 
 The example intentionally does not include provider credentials, access tokens,

--- a/examples/workos-integration-demo/README.md
+++ b/examples/workos-integration-demo/README.md
@@ -1,0 +1,21 @@
+# WorkOS AuthKit → Hexclave example
+
+This example signs in with WorkOS AuthKit, exchanges the provider access token
+with the local Hexclave backend, and displays the resulting session metadata.
+
+## Local setup
+
+1. Copy `.env.local.example` to `.env.local`.
+2. Fill in the WorkOS AuthKit values for your own development tenant:
+   - `WORKOS_CLIENT_ID`
+   - `WORKOS_API_KEY`
+   - `WORKOS_AUTHKIT_DOMAIN`
+   - `WORKOS_COOKIE_PASSWORD` (use a local value at least 32 characters long)
+3. Set the local Hexclave client and server keys and API URL.
+4. Configure `http://localhost:8110/auth/callback` as an allowed WorkOS redirect
+   URI.
+5. Run `pnpm dev` from this directory.
+
+The example intentionally does not include provider credentials, access tokens,
+or user credentials. The WorkOS issuer is derived from the configured client ID
+by the Hexclave dashboard unless an explicit override is required.

--- a/examples/workos-integration-demo/next.config.ts
+++ b/examples/workos-integration-demo/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/examples/workos-integration-demo/package.json
+++ b/examples/workos-integration-demo/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack --port 8110",
+    "dev": "next dev --turbopack --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}10",
     "build": "next build",
-    "start": "next start --port 8110",
+    "start": "next start --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}10",
     "typecheck": "tsc --noEmit",
     "lint": "eslint ."
   },

--- a/examples/workos-integration-demo/package.json
+++ b/examples/workos-integration-demo/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@hexclave/example-workos-integration-demo",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev --turbopack --port 8110",
+    "build": "next build",
+    "start": "next start --port 8110",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@hexclave/next": "workspace:*",
+    "@hexclave/shared": "workspace:*",
+    "@workos-inc/authkit-nextjs": "^4.3.1",
+    "next": "15.5.19",
+    "react": "19.0.1",
+    "react-dom": "19.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.0",
+    "@types/react": "19.0.12",
+    "@types/react-dom": "19.0.4",
+    "typescript": "^5.8.3"
+  }
+}

--- a/examples/workos-integration-demo/src/app/api/auth/[...authkit]/route.ts
+++ b/examples/workos-integration-demo/src/app/api/auth/[...authkit]/route.ts
@@ -1,0 +1,3 @@
+import { handleAuth } from "@workos-inc/authkit-nextjs";
+
+export const GET = handleAuth();

--- a/examples/workos-integration-demo/src/app/api/auth/exchange/route.ts
+++ b/examples/workos-integration-demo/src/app/api/auth/exchange/route.ts
@@ -4,23 +4,27 @@ import { NextResponse } from "next/server";
 export async function GET() {
   const { accessToken } = await withAuth();
   if (accessToken == null) return NextResponse.json({ error: "Not signed in" }, { status: 401 });
-  const response = await fetch(`${process.env.NEXT_PUBLIC_HEXCLAVE_API_URL}/api/latest/auth/external/token`, {
+  const apiUrl = process.env.NEXT_PUBLIC_HEXCLAVE_API_URL;
+  const projectId = process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID;
+  if (apiUrl == null || apiUrl.length === 0) throw new Error("Missing required environment variable: NEXT_PUBLIC_HEXCLAVE_API_URL");
+  if (projectId == null || projectId.length === 0) throw new Error("Missing required environment variable: NEXT_PUBLIC_HEXCLAVE_PROJECT_ID");
+  const response = await fetch(`${apiUrl}/api/latest/auth/external/token`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
       "x-hexclave-access-type": "client",
-      "x-hexclave-project-id": process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID ?? "internal",
+      "x-hexclave-project-id": projectId,
     },
     body: JSON.stringify({ provider_id: "workos-integration", token: accessToken }),
   });
   const result = await response.json() as { access_token?: string, session_id?: string, user_id?: string, is_new_user?: boolean, code?: string, error?: string };
   let profile: { primary_email?: string | null, display_name?: string | null } = {};
   if (result.access_token != null) {
-    const profileResponse = await fetch(`${process.env.NEXT_PUBLIC_HEXCLAVE_API_URL}/api/v1/users/me`, {
+    const profileResponse = await fetch(`${apiUrl}/api/v1/users/me`, {
       headers: {
         "x-hexclave-access-token": result.access_token,
         "x-hexclave-access-type": "client",
-        "x-hexclave-project-id": process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID ?? "internal",
+        "x-hexclave-project-id": projectId,
       },
     });
     if (profileResponse.ok) profile = await profileResponse.json() as typeof profile;

--- a/examples/workos-integration-demo/src/app/api/auth/exchange/route.ts
+++ b/examples/workos-integration-demo/src/app/api/auth/exchange/route.ts
@@ -1,0 +1,36 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const { accessToken } = await withAuth();
+  if (accessToken == null) return NextResponse.json({ error: "Not signed in" }, { status: 401 });
+  const response = await fetch(`${process.env.NEXT_PUBLIC_HEXCLAVE_API_URL}/api/latest/auth/external/token`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-hexclave-access-type": "client",
+      "x-hexclave-project-id": process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID ?? "internal",
+    },
+    body: JSON.stringify({ provider_id: "workos-integration", token: accessToken }),
+  });
+  const result = await response.json() as { access_token?: string, session_id?: string, user_id?: string, is_new_user?: boolean, code?: string, error?: string };
+  let profile: { primary_email?: string | null, display_name?: string | null } = {};
+  if (result.access_token != null) {
+    const profileResponse = await fetch(`${process.env.NEXT_PUBLIC_HEXCLAVE_API_URL}/api/v1/users/me`, {
+      headers: {
+        "x-hexclave-access-token": result.access_token,
+        "x-hexclave-access-type": "client",
+        "x-hexclave-project-id": process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID ?? "internal",
+      },
+    });
+    if (profileResponse.ok) profile = await profileResponse.json() as typeof profile;
+  }
+  return NextResponse.json({
+    sessionId: result.session_id,
+    userId: result.user_id,
+    isNewUser: result.is_new_user,
+    primaryEmail: profile.primary_email ?? null,
+    displayName: profile.display_name ?? null,
+    error: result.error ?? result.code,
+  }, { status: response.status });
+}

--- a/examples/workos-integration-demo/src/app/api/auth/exchange/route.ts
+++ b/examples/workos-integration-demo/src/app/api/auth/exchange/route.ts
@@ -1,7 +1,7 @@
 import { withAuth } from "@workos-inc/authkit-nextjs";
 import { NextResponse } from "next/server";
 
-export async function GET() {
+export async function GET(request: Request) {
   const { accessToken } = await withAuth();
   if (accessToken == null) return NextResponse.json({ error: "Not signed in" }, { status: 401 });
   const apiUrl = process.env.NEXT_PUBLIC_HEXCLAVE_API_URL;
@@ -16,7 +16,14 @@ export async function GET() {
       "x-hexclave-project-id": projectId,
     },
     body: JSON.stringify({ provider_id: "workos-integration", token: accessToken }),
+    signal: request.signal,
   });
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!response.ok || !contentType.includes("application/json")) {
+    return NextResponse.json({
+      error: "Hexclave rejected the WorkOS token exchange",
+    }, { status: response.ok ? 502 : response.status });
+  }
   const result = await response.json() as { access_token?: string, session_id?: string, user_id?: string, is_new_user?: boolean, code?: string, error?: string };
   let profile: { primary_email?: string | null, display_name?: string | null } = {};
   if (result.access_token != null) {
@@ -26,8 +33,12 @@ export async function GET() {
         "x-hexclave-access-type": "client",
         "x-hexclave-project-id": projectId,
       },
+      signal: request.signal,
     });
-    if (profileResponse.ok) profile = await profileResponse.json() as typeof profile;
+    if (!profileResponse.ok || !(profileResponse.headers.get("content-type") ?? "").includes("application/json")) {
+      return NextResponse.json({ error: "Hexclave user lookup failed after token exchange" }, { status: 502 });
+    }
+    profile = await profileResponse.json() as typeof profile;
   }
   return NextResponse.json({
     sessionId: result.session_id,

--- a/examples/workos-integration-demo/src/app/api/auth/provider-session/route.ts
+++ b/examples/workos-integration-demo/src/app/api/auth/provider-session/route.ts
@@ -1,0 +1,16 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const { accessToken, sessionId, user } = await withAuth();
+  if (accessToken == null || sessionId == null) return NextResponse.json({ error: "Not signed in" }, { status: 401 });
+  return NextResponse.json({
+    accessToken,
+    sessionId,
+    user: user == null ? null : {
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName,
+    },
+  });
+}

--- a/examples/workos-integration-demo/src/app/api/auth/signout/route.ts
+++ b/examples/workos-integration-demo/src/app/api/auth/signout/route.ts
@@ -1,0 +1,9 @@
+import { signOut } from "@workos-inc/authkit-nextjs";
+
+async function handleSignOut() {
+  await signOut();
+  return new Response(null, { status: 204 });
+}
+
+export const GET = handleSignOut;
+export const POST = handleSignOut;

--- a/examples/workos-integration-demo/src/app/api/auth/signout/route.ts
+++ b/examples/workos-integration-demo/src/app/api/auth/signout/route.ts
@@ -2,7 +2,6 @@ import { signOut } from "@workos-inc/authkit-nextjs";
 
 async function handleSignOut() {
   await signOut();
-  return new Response(null, { status: 200 });
 }
 
 export const GET = handleSignOut;

--- a/examples/workos-integration-demo/src/app/api/auth/signout/route.ts
+++ b/examples/workos-integration-demo/src/app/api/auth/signout/route.ts
@@ -2,7 +2,7 @@ import { signOut } from "@workos-inc/authkit-nextjs";
 
 async function handleSignOut() {
   await signOut();
-  return new Response(null, { status: 204 });
+  return new Response(null, { status: 200 });
 }
 
 export const GET = handleSignOut;

--- a/examples/workos-integration-demo/src/app/auth/callback/route.ts
+++ b/examples/workos-integration-demo/src/app/auth/callback/route.ts
@@ -1,5 +1,6 @@
 import { handleAuth } from "@workos-inc/authkit-nextjs";
+import { getWorkOSBaseUrl } from "../../../lib/workos";
 
 export const GET = handleAuth({
-  baseURL: "http://localhost:8110",
+  baseURL: getWorkOSBaseUrl(),
 });

--- a/examples/workos-integration-demo/src/app/auth/callback/route.ts
+++ b/examples/workos-integration-demo/src/app/auth/callback/route.ts
@@ -1,6 +1,9 @@
 import { handleAuth } from "@workos-inc/authkit-nextjs";
+import { NextRequest } from "next/server";
 import { getWorkOSBaseUrl } from "../../../lib/workos";
 
-export const GET = handleAuth({
-  baseURL: getWorkOSBaseUrl(),
-});
+export async function GET(request: NextRequest) {
+  return await handleAuth({
+    baseURL: getWorkOSBaseUrl(),
+  })(request);
+}

--- a/examples/workos-integration-demo/src/app/auth/callback/route.ts
+++ b/examples/workos-integration-demo/src/app/auth/callback/route.ts
@@ -1,0 +1,5 @@
+import { handleAuth } from "@workos-inc/authkit-nextjs";
+
+export const GET = handleAuth({
+  baseURL: "http://localhost:8110",
+});

--- a/examples/workos-integration-demo/src/app/auth/sign-in/route.ts
+++ b/examples/workos-integration-demo/src/app/auth/sign-in/route.ts
@@ -1,6 +1,7 @@
 import { getSignInUrl } from "@workos-inc/authkit-nextjs";
 import { redirect } from "next/navigation";
+import { getWorkOSRedirectUri } from "../../../lib/workos";
 
 export async function GET() {
-  redirect(await getSignInUrl({ redirectUri: "http://localhost:8110/auth/callback" }));
+  redirect(await getSignInUrl({ redirectUri: getWorkOSRedirectUri() }));
 }

--- a/examples/workos-integration-demo/src/app/auth/sign-in/route.ts
+++ b/examples/workos-integration-demo/src/app/auth/sign-in/route.ts
@@ -1,0 +1,6 @@
+import { getSignInUrl } from "@workos-inc/authkit-nextjs";
+import { redirect } from "next/navigation";
+
+export async function GET() {
+  redirect(await getSignInUrl({ redirectUri: "http://localhost:8110/auth/callback" }));
+}

--- a/examples/workos-integration-demo/src/app/globals.css
+++ b/examples/workos-integration-demo/src/app/globals.css
@@ -1,0 +1,43 @@
+:root {
+  color-scheme: dark;
+  background: #08111f;
+  color: #e6edf7;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; min-width: 320px; }
+a { color: #7dd3fc; }
+button, input { font: inherit; }
+button {
+  border: 0;
+  border-radius: 10px;
+  background: #38bdf8;
+  color: #042033;
+  cursor: pointer;
+  font-weight: 700;
+  padding: 0.7rem 1rem;
+}
+button:disabled { cursor: wait; opacity: 0.55; }
+main { margin: 0 auto; max-width: 1120px; padding: 3rem 1.25rem; }
+.eyebrow { color: #7dd3fc; font-size: 0.75rem; font-weight: 800; letter-spacing: 0.14em; text-transform: uppercase; }
+h1 { font-size: clamp(2rem, 5vw, 3.6rem); line-height: 1; margin: 0.5rem 0 1rem; }
+.lede { color: #a9bad0; max-width: 720px; }
+.status { border: 1px solid #29405b; border-radius: 999px; display: inline-flex; gap: 0.5rem; margin: 1rem 0; padding: 0.45rem 0.8rem; }
+.status strong { color: #7dd3fc; }
+.error { background: #451a26; border: 1px solid #fb7185; border-radius: 10px; color: #fecdd3; padding: 0.8rem 1rem; }
+.panels { display: grid; gap: 1rem; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-top: 1rem; }
+.panel { background: linear-gradient(145deg, #102239, #0c1829); border: 1px solid #29405b; border-radius: 18px; padding: 1.25rem; }
+.panel h2 { margin: 0 0 0.25rem; }
+.panel-kicker { color: #8ea6c1; font-size: 0.85rem; margin: 0 0 1rem; }
+dl { display: grid; gap: 0.7rem; margin: 0; }
+dt { color: #8ea6c1; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.06em; }
+dd { margin: -0.4rem 0 0; overflow-wrap: anywhere; }
+.claims { border-top: 1px solid #29405b; margin-top: 1rem; padding-top: 1rem; }
+.claims code { color: #bae6fd; font-size: 0.82rem; overflow-wrap: anywhere; }
+.actions { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-top: 1.25rem; }
+.secondary { background: #1e3652; color: #dbeafe; }
+.auth-form { display: grid; gap: 0.8rem; max-width: 460px; }
+label { color: #a9bad0; display: grid; gap: 0.35rem; }
+input { background: #08111f; border: 1px solid #395573; border-radius: 9px; color: #e6edf7; padding: 0.7rem; }
+@media (max-width: 720px) { .panels { grid-template-columns: 1fr; } main { padding-top: 2rem; } }

--- a/examples/workos-integration-demo/src/app/layout.tsx
+++ b/examples/workos-integration-demo/src/app/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "WorkOS + Hexclave",
+  description: "External WorkOS AuthKit session exchange demo",
+};
+
+export default function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/workos-integration-demo/src/app/page.tsx
+++ b/examples/workos-integration-demo/src/app/page.tsx
@@ -1,0 +1,11 @@
+import { withAuth } from "@workos-inc/authkit-nextjs";
+import { WorkosDemo } from "./workos-demo";
+
+export default async function Page() {
+  const { user, sessionId, accessToken } = await withAuth();
+
+  if (user == null || accessToken == null || sessionId == null) {
+    return <main><p className="eyebrow">External authentication demo</p><h1>WorkOS AuthKit <span>→</span> Hexclave</h1><p className="lede">Sign in through hosted WorkOS AuthKit to exchange a genuine provider token for a Hexclave session.</p><a href="/auth/sign-in">Sign in with WorkOS AuthKit</a></main>;
+  }
+  return <WorkosDemo />;
+}

--- a/examples/workos-integration-demo/src/app/workos-demo.tsx
+++ b/examples/workos-integration-demo/src/app/workos-demo.tsx
@@ -3,24 +3,63 @@
 import { HexclaveClientApp, workosTokenStore } from "@hexclave/next";
 import { useEffect, useMemo, useState } from "react";
 
-type Claims = { iss?: string, sub?: string, sid?: string, client_id?: string, aud?: string | string[], exp?: number };
-type ProviderSession = { accessToken: string, sessionId: string, user: { email?: string, firstName?: string, lastName?: string } | null };
-type HexclaveUser = { id: string, primaryEmail: string | null, displayName: string | null };
-type Exchange = { sessionId?: string, userId?: string, isNewUser?: boolean, primaryEmail?: string | null, displayName?: string | null, error?: string };
+type Claims = {
+  iss?: string;
+  sub?: string;
+  sid?: string;
+  client_id?: string;
+  aud?: string | string[];
+  exp?: number;
+};
+type ProviderSession = {
+  accessToken: string;
+  sessionId: string;
+  user: { email?: string; firstName?: string; lastName?: string } | null;
+};
+type HexclaveUser = {
+  id: string;
+  primaryEmail: string | null;
+  displayName: string | null;
+};
+type Exchange = {
+  sessionId?: string;
+  userId?: string;
+  isNewUser?: boolean;
+  primaryEmail?: string | null;
+  displayName?: string | null;
+  error?: string;
+};
 type Status = "idle" | "exchanging" | "exchanged" | "error";
 
 function decodeClaims(token: string): Claims {
   const payload = token.split(".")[1];
-  if (payload == null) throw new Error("The WorkOS token did not contain a JWT payload");
-  return JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/"))) as Claims;
+  if (payload == null)
+    throw new Error("The WorkOS token did not contain a JWT payload");
+  return JSON.parse(
+    atob(payload.replace(/-/g, "+").replace(/_/g, "/")),
+  ) as Claims;
 }
 
-function Claim({ label, value }: { label: string, value: string | number | undefined }) {
-  return <><dt>{label}</dt><dd><code>{value == null ? "Not present" : String(value)}</code></dd></>;
+function Claim({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | number | undefined;
+}) {
+  return (
+    <>
+      <dt>{label}</dt>
+      <dd>
+        <code>{value == null ? "Not present" : String(value)}</code>
+      </dd>
+    </>
+  );
 }
 
 export function WorkosDemo() {
-  const [providerSession, setProviderSession] = useState<ProviderSession | null>(null);
+  const [providerSession, setProviderSession] =
+    useState<ProviderSession | null>(null);
   const [claims, setClaims] = useState<Claims | null>(null);
   const [user, setUser] = useState<HexclaveUser | null>(null);
   const [exchange, setExchange] = useState<Exchange | null>(null);
@@ -28,74 +67,185 @@ export function WorkosDemo() {
   const [error, setError] = useState<string | null>(null);
   const [signedOut, setSignedOut] = useState(false);
   const [isSigningOut, setIsSigningOut] = useState(false);
-  const tokenStore = useMemo(() => workosTokenStore({
-    getSessionId: () => providerSession?.sessionId ?? null,
-    getToken: async () => providerSession?.accessToken ?? null,
-    signOut: async () => {
-      setIsSigningOut(true);
-      setSignedOut(true);
-      setProviderSession(null);
-      setUser(null);
-      window.location.assign("/api/auth/signout");
-    },
-  }), [providerSession]);
-  const app = useMemo(() => new HexclaveClientApp({
-    baseUrl: process.env.NEXT_PUBLIC_HEXCLAVE_API_URL,
-    projectId: process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID,
-    publishableClientKey: process.env.NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY,
-    tokenStore,
-    automaticSideEffects: false,
-  }), [tokenStore]);
+  const tokenStore = useMemo(
+    () =>
+      workosTokenStore({
+        getSessionId: () => providerSession?.sessionId ?? null,
+        getToken: async () => providerSession?.accessToken ?? null,
+        signOut: async () => {
+          setIsSigningOut(true);
+          setSignedOut(true);
+          setProviderSession(null);
+          setUser(null);
+          window.location.assign("/api/auth/signout");
+        },
+      }),
+    [providerSession],
+  );
+  const app = useMemo(
+    () =>
+      new HexclaveClientApp({
+        baseUrl: process.env.NEXT_PUBLIC_HEXCLAVE_API_URL,
+        projectId: process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID,
+        publishableClientKey:
+          process.env.NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY,
+        tokenStore,
+        automaticSideEffects: false,
+      }),
+    [tokenStore],
+  );
 
   useEffect(() => {
     if (signedOut) return;
     let active = true;
     setStatus("exchanging");
     Promise.all([
-      fetch("/api/auth/provider-session").then(async response => {
-        if (!response.ok) throw new Error(`WorkOS session endpoint returned ${response.status}`);
-        return await response.json() as ProviderSession;
+      fetch("/api/auth/provider-session").then(async (response) => {
+        if (!response.ok)
+          throw new Error(
+            `WorkOS session endpoint returned ${response.status}`,
+          );
+        return (await response.json()) as ProviderSession;
       }),
-      fetch("/api/auth/exchange").then(async response => {
-        const result = await response.json() as Exchange;
-        if (!response.ok) throw new Error(result.error ?? `WorkOS exchange returned ${response.status}`);
+      fetch("/api/auth/exchange").then(async (response) => {
+        const result = (await response.json()) as Exchange;
+        if (!response.ok)
+          throw new Error(
+            result.error ?? `WorkOS exchange returned ${response.status}`,
+          );
         return result;
       }),
-    ]).then(([session, result]) => {
-      if (!active) return;
-      setProviderSession(session);
-      setClaims(decodeClaims(session.accessToken));
-      setExchange(result);
-      setUser(result.userId == null ? null : { id: result.userId, primaryEmail: result.primaryEmail ?? null, displayName: result.displayName ?? null });
-      setStatus("exchanged");
-    }).catch(reason => {
-      if (!active) return;
-      setStatus("error");
-      setError(reason instanceof Error ? reason.message : "WorkOS exchange failed");
-    });
-    return () => { active = false; };
+    ])
+      .then(([session, result]) => {
+        if (!active) return;
+        setProviderSession(session);
+        setClaims(decodeClaims(session.accessToken));
+        setExchange(result);
+        setUser(
+          result.userId == null
+            ? null
+            : {
+              id: result.userId,
+              primaryEmail: result.primaryEmail ?? null,
+              displayName: result.displayName ?? null,
+            },
+        );
+        setStatus("exchanged");
+      })
+      .catch((reason) => {
+        if (!active) return;
+        setStatus("error");
+        setError(
+          reason instanceof Error ? reason.message : "WorkOS exchange failed",
+        );
+      });
+    return () => {
+      active = false;
+    };
   }, [signedOut]);
 
   if (signedOut) {
-    return <main><p className="eyebrow">WorkOS AuthKit</p><h1>Signed out</h1><p className="lede">The WorkOS provider session and local Hexclave view are cleared.</p><a href="/auth/sign-in">Sign in with WorkOS AuthKit</a></main>;
+    return (
+      <main>
+        <p className="eyebrow">WorkOS AuthKit</p>
+        <h1>Signed out</h1>
+        <p className="lede">
+          The WorkOS provider session and local Hexclave view are cleared.
+        </p>
+        <a href="/auth/sign-in">Sign in with WorkOS AuthKit</a>
+      </main>
+    );
   }
 
-  const providerName = [providerSession?.user?.firstName, providerSession?.user?.lastName].filter(Boolean).join(" ");
-  return <main>
-    <p className="eyebrow">External authentication demo</p>
-    <h1>WorkOS AuthKit <span>→</span> Hexclave</h1>
-    <p className="lede">A genuine WorkOS access token is exchanged for a Hexclave session. The raw token never appears here.</p>
-    <p className="status">Exchange status: <strong>{status}</strong></p>
-    {error != null && <p className="error" role="alert">Exchange error: {error}</p>}
-    <div className="panels">
-      <section className="panel"><p className="panel-kicker">Provider session</p><h2>WorkOS AuthKit</h2>
-        <dl><Claim label="User" value={providerName || providerSession?.user?.email || "Provider profile did not expose a name"} /><Claim label="Email" value={providerSession?.user?.email} /><Claim label="Session ID" value={providerSession?.sessionId} /></dl>
-        <div className="claims"><p className="panel-kicker">Decoded token claims</p><dl><Claim label="iss" value={claims?.iss} /><Claim label="sub" value={claims?.sub} /><Claim label="sid" value={claims?.sid} /><Claim label="client_id" value={claims?.client_id} /><Claim label="aud" value={Array.isArray(claims?.aud) ? claims.aud.join(", ") : claims?.aud} /><Claim label="exp" value={claims?.exp} /></dl></div>
-      </section>
-      <section className="panel"><p className="panel-kicker">Hexclave session</p><h2>Project user</h2>
-        <dl><Claim label="User ID" value={user?.id} /><Claim label="Primary email" value={user?.primaryEmail ?? "null"} /><Claim label="Display name" value={user?.displayName ?? "null"} /><Claim label="New user on this exchange" value={exchange?.isNewUser == null ? undefined : exchange.isNewUser ? "yes" : "no"} /><Claim label="Session ID" value={exchange?.sessionId} /></dl>
-        <div className="actions"><button type="button" disabled={isSigningOut || status === "exchanging"} onClick={() => tokenStore.signOut?.()}>{isSigningOut ? "Signing out…" : "Sign out of WorkOS"}</button></div>
-      </section>
-    </div>
-  </main>;
+  const providerName = [
+    providerSession?.user?.firstName,
+    providerSession?.user?.lastName,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <main>
+      <p className="eyebrow">External authentication demo</p>
+      <h1>
+        WorkOS AuthKit <span>→</span> Hexclave
+      </h1>
+      <p className="lede">
+        A genuine WorkOS access token is exchanged for a Hexclave session. The
+        raw token never appears here.
+      </p>
+      <p className="status">
+        Exchange status: <strong>{status}</strong>
+      </p>
+      {error != null && (
+        <p className="error" role="alert">
+          Exchange error: {error}
+        </p>
+      )}
+      <div className="panels">
+        <section className="panel">
+          <p className="panel-kicker">Provider session</p>
+          <h2>WorkOS AuthKit</h2>
+          <dl>
+            <Claim
+              label="User"
+              value={
+                providerName ||
+                providerSession?.user?.email ||
+                "Provider profile did not expose a name"
+              }
+            />
+            <Claim label="Email" value={providerSession?.user?.email} />
+            <Claim label="Session ID" value={providerSession?.sessionId} />
+          </dl>
+          <div className="claims">
+            <p className="panel-kicker">Decoded token claims</p>
+            <dl>
+              <Claim label="iss" value={claims?.iss} />
+              <Claim label="sub" value={claims?.sub} />
+              <Claim label="sid" value={claims?.sid} />
+              <Claim label="client_id" value={claims?.client_id} />
+              <Claim
+                label="aud"
+                value={
+                  Array.isArray(claims?.aud)
+                    ? claims.aud.join(", ")
+                    : claims?.aud
+                }
+              />
+              <Claim label="exp" value={claims?.exp} />
+            </dl>
+          </div>
+        </section>
+        <section className="panel">
+          <p className="panel-kicker">Hexclave session</p>
+          <h2>Project user</h2>
+          <dl>
+            <Claim label="User ID" value={user?.id} />
+            <Claim label="Primary email" value={user?.primaryEmail ?? "null"} />
+            <Claim label="Display name" value={user?.displayName ?? "null"} />
+            <Claim
+              label="New user on this exchange"
+              value={
+                exchange?.isNewUser == null
+                  ? undefined
+                  : exchange.isNewUser
+                    ? "yes"
+                    : "no"
+              }
+            />
+            <Claim label="Session ID" value={exchange?.sessionId} />
+          </dl>
+          <div className="actions">
+            <button
+              type="button"
+              disabled={isSigningOut || status === "exchanging"}
+              onClick={() => tokenStore.signOut?.()}
+            >
+              {isSigningOut ? "Signing out…" : "Sign out of WorkOS"}
+            </button>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
 }

--- a/examples/workos-integration-demo/src/app/workos-demo.tsx
+++ b/examples/workos-integration-demo/src/app/workos-demo.tsx
@@ -35,9 +35,9 @@ function decodeClaims(token: string): Claims {
   const payload = token.split(".")[1];
   if (payload == null)
     throw new Error("The WorkOS token did not contain a JWT payload");
-  return JSON.parse(
-    atob(payload.replace(/-/g, "+").replace(/_/g, "/")),
-  ) as Claims;
+  const padded = payload.replace(/-/g, "+").replace(/_/g, "/").padEnd(Math.ceil(payload.length / 4) * 4, "=");
+  const bytes = Uint8Array.from(atob(padded), (character) => character.charCodeAt(0));
+  return JSON.parse(new TextDecoder().decode(bytes)) as Claims;
 }
 
 function Claim({
@@ -108,7 +108,9 @@ export function WorkosDemo() {
         return (await response.json()) as ProviderSession;
       }),
       fetch("/api/auth/exchange").then(async (response) => {
-        const result = (await response.json()) as Exchange;
+        const result = response.headers.get("content-type")?.includes("application/json")
+          ? await response.json() as Exchange
+          : {};
         if (!response.ok)
           throw new Error(
             result.error ?? `WorkOS exchange returned ${response.status}`,
@@ -143,6 +145,25 @@ export function WorkosDemo() {
       active = false;
     };
   }, [signedOut]);
+
+  useEffect(() => {
+    if (providerSession == null) return;
+    let active = true;
+    app.getUser().then((sdkUser) => {
+      if (active) {
+        setUser(sdkUser == null ? null : {
+          id: sdkUser.id,
+          primaryEmail: sdkUser.primaryEmail,
+          displayName: sdkUser.displayName,
+        });
+      }
+    }).catch(() => {
+      if (active) setError("Hexclave SDK user lookup failed");
+    });
+    return () => {
+      active = false;
+    };
+  }, [app, providerSession]);
 
   if (signedOut) {
     return (

--- a/examples/workos-integration-demo/src/app/workos-demo.tsx
+++ b/examples/workos-integration-demo/src/app/workos-demo.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { HexclaveClientApp, workosTokenStore } from "@hexclave/next";
+import { useEffect, useMemo, useState } from "react";
+
+type Claims = { iss?: string, sub?: string, sid?: string, client_id?: string, aud?: string | string[], exp?: number };
+type ProviderSession = { accessToken: string, sessionId: string, user: { email?: string, firstName?: string, lastName?: string } | null };
+type HexclaveUser = { id: string, primaryEmail: string | null, displayName: string | null };
+type Exchange = { sessionId?: string, userId?: string, isNewUser?: boolean, primaryEmail?: string | null, displayName?: string | null, error?: string };
+type Status = "idle" | "exchanging" | "exchanged" | "error";
+
+function decodeClaims(token: string): Claims {
+  const payload = token.split(".")[1];
+  if (payload == null) throw new Error("The WorkOS token did not contain a JWT payload");
+  return JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/"))) as Claims;
+}
+
+function Claim({ label, value }: { label: string, value: string | number | undefined }) {
+  return <><dt>{label}</dt><dd><code>{value == null ? "Not present" : String(value)}</code></dd></>;
+}
+
+export function WorkosDemo() {
+  const [providerSession, setProviderSession] = useState<ProviderSession | null>(null);
+  const [claims, setClaims] = useState<Claims | null>(null);
+  const [user, setUser] = useState<HexclaveUser | null>(null);
+  const [exchange, setExchange] = useState<Exchange | null>(null);
+  const [status, setStatus] = useState<Status>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const [signedOut, setSignedOut] = useState(false);
+  const [isSigningOut, setIsSigningOut] = useState(false);
+  const tokenStore = useMemo(() => workosTokenStore({
+    getSessionId: () => providerSession?.sessionId ?? null,
+    getToken: async () => providerSession?.accessToken ?? null,
+    signOut: async () => {
+      setIsSigningOut(true);
+      setSignedOut(true);
+      setProviderSession(null);
+      setUser(null);
+      window.location.assign("/api/auth/signout");
+    },
+  }), [providerSession]);
+  const app = useMemo(() => new HexclaveClientApp({
+    baseUrl: process.env.NEXT_PUBLIC_HEXCLAVE_API_URL,
+    projectId: process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID,
+    publishableClientKey: process.env.NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY,
+    tokenStore,
+    automaticSideEffects: false,
+  }), [tokenStore]);
+
+  useEffect(() => {
+    if (signedOut) return;
+    let active = true;
+    setStatus("exchanging");
+    Promise.all([
+      fetch("/api/auth/provider-session").then(async response => {
+        if (!response.ok) throw new Error(`WorkOS session endpoint returned ${response.status}`);
+        return await response.json() as ProviderSession;
+      }),
+      fetch("/api/auth/exchange").then(async response => {
+        const result = await response.json() as Exchange;
+        if (!response.ok) throw new Error(result.error ?? `WorkOS exchange returned ${response.status}`);
+        return result;
+      }),
+    ]).then(([session, result]) => {
+      if (!active) return;
+      setProviderSession(session);
+      setClaims(decodeClaims(session.accessToken));
+      setExchange(result);
+      setUser(result.userId == null ? null : { id: result.userId, primaryEmail: result.primaryEmail ?? null, displayName: result.displayName ?? null });
+      setStatus("exchanged");
+    }).catch(reason => {
+      if (!active) return;
+      setStatus("error");
+      setError(reason instanceof Error ? reason.message : "WorkOS exchange failed");
+    });
+    return () => { active = false; };
+  }, [signedOut]);
+
+  if (signedOut) {
+    return <main><p className="eyebrow">WorkOS AuthKit</p><h1>Signed out</h1><p className="lede">The WorkOS provider session and local Hexclave view are cleared.</p><a href="/auth/sign-in">Sign in with WorkOS AuthKit</a></main>;
+  }
+
+  const providerName = [providerSession?.user?.firstName, providerSession?.user?.lastName].filter(Boolean).join(" ");
+  return <main>
+    <p className="eyebrow">External authentication demo</p>
+    <h1>WorkOS AuthKit <span>→</span> Hexclave</h1>
+    <p className="lede">A genuine WorkOS access token is exchanged for a Hexclave session. The raw token never appears here.</p>
+    <p className="status">Exchange status: <strong>{status}</strong></p>
+    {error != null && <p className="error" role="alert">Exchange error: {error}</p>}
+    <div className="panels">
+      <section className="panel"><p className="panel-kicker">Provider session</p><h2>WorkOS AuthKit</h2>
+        <dl><Claim label="User" value={providerName || providerSession?.user?.email || "Provider profile did not expose a name"} /><Claim label="Email" value={providerSession?.user?.email} /><Claim label="Session ID" value={providerSession?.sessionId} /></dl>
+        <div className="claims"><p className="panel-kicker">Decoded token claims</p><dl><Claim label="iss" value={claims?.iss} /><Claim label="sub" value={claims?.sub} /><Claim label="sid" value={claims?.sid} /><Claim label="client_id" value={claims?.client_id} /><Claim label="aud" value={Array.isArray(claims?.aud) ? claims.aud.join(", ") : claims?.aud} /><Claim label="exp" value={claims?.exp} /></dl></div>
+      </section>
+      <section className="panel"><p className="panel-kicker">Hexclave session</p><h2>Project user</h2>
+        <dl><Claim label="User ID" value={user?.id} /><Claim label="Primary email" value={user?.primaryEmail ?? "null"} /><Claim label="Display name" value={user?.displayName ?? "null"} /><Claim label="New user on this exchange" value={exchange?.isNewUser == null ? undefined : exchange.isNewUser ? "yes" : "no"} /><Claim label="Session ID" value={exchange?.sessionId} /></dl>
+        <div className="actions"><button type="button" disabled={isSigningOut || status === "exchanging"} onClick={() => tokenStore.signOut?.()}>{isSigningOut ? "Signing out…" : "Sign out of WorkOS"}</button></div>
+      </section>
+    </div>
+  </main>;
+}

--- a/examples/workos-integration-demo/src/lib/workos.ts
+++ b/examples/workos-integration-demo/src/lib/workos.ts
@@ -4,7 +4,10 @@ export function getWorkOSRedirectUri(): string {
     throw new Error("Missing required environment variable: WORKOS_REDIRECT_URI");
   }
   try {
-    new URL(redirectUri);
+    const parsed = new URL(redirectUri);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("unsupported protocol");
+    }
   } catch {
     throw new Error("WORKOS_REDIRECT_URI must be a valid URL");
   }

--- a/examples/workos-integration-demo/src/lib/workos.ts
+++ b/examples/workos-integration-demo/src/lib/workos.ts
@@ -1,0 +1,16 @@
+export function getWorkOSRedirectUri(): string {
+  const redirectUri = process.env.WORKOS_REDIRECT_URI;
+  if (redirectUri == null || redirectUri.length === 0) {
+    throw new Error("Missing required environment variable: WORKOS_REDIRECT_URI");
+  }
+  try {
+    new URL(redirectUri);
+  } catch {
+    throw new Error("WORKOS_REDIRECT_URI must be a valid URL");
+  }
+  return redirectUri;
+}
+
+export function getWorkOSBaseUrl(): string {
+  return new URL(getWorkOSRedirectUri()).origin;
+}

--- a/examples/workos-integration-demo/src/middleware.ts
+++ b/examples/workos-integration-demo/src/middleware.ts
@@ -1,8 +1,9 @@
 import { authkitMiddleware } from "@workos-inc/authkit-nextjs";
+import { getWorkOSRedirectUri } from "./lib/workos";
 
 export default authkitMiddleware({
   debug: true,
-  redirectUri: "http://localhost:8110/auth/callback",
+  redirectUri: getWorkOSRedirectUri(),
 });
 
 export const config = {

--- a/examples/workos-integration-demo/src/middleware.ts
+++ b/examples/workos-integration-demo/src/middleware.ts
@@ -1,0 +1,10 @@
+import { authkitMiddleware } from "@workos-inc/authkit-nextjs";
+
+export default authkitMiddleware({
+  debug: true,
+  redirectUri: "http://localhost:8110/auth/callback",
+});
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],
+};

--- a/examples/workos-integration-demo/src/middleware.ts
+++ b/examples/workos-integration-demo/src/middleware.ts
@@ -1,10 +1,13 @@
 import { authkitMiddleware } from "@workos-inc/authkit-nextjs";
+import { NextFetchEvent, NextRequest } from "next/server";
 import { getWorkOSRedirectUri } from "./lib/workos";
 
-export default authkitMiddleware({
-  debug: true,
-  redirectUri: getWorkOSRedirectUri(),
-});
+export default function middleware(request: NextRequest, event: NextFetchEvent) {
+  return authkitMiddleware({
+    debug: true,
+    redirectUri: getWorkOSRedirectUri(),
+  })(request, event);
+}
 
 export const config = {
   matcher: ["/((?!_next/static|_next/image|favicon.ico).*)"],

--- a/examples/workos-integration-demo/tsconfig.json
+++ b/examples/workos-integration-demo/tsconfig.json
@@ -1,0 +1,38 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "allowJs": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,10 +181,10 @@ importers:
         version: 7.1.0
       '@prisma/client':
         specifier: ^7.0.0
-        version: 7.1.0(prisma@7.1.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3))(typescript@6.0.3)
+        version: 7.1.0(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3))(typescript@6.0.3)
       '@prisma/extension-read-replicas':
         specifier: ^0.5.0
-        version: 0.5.0(@prisma/client@7.1.0(prisma@7.1.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3))(typescript@6.0.3))
+        version: 0.5.0(@prisma/client@7.1.0(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3))(typescript@6.0.3))
       '@prisma/instrumentation':
         specifier: ^7.0.0
         version: 7.1.0(@opentelemetry/api@1.9.0)
@@ -332,7 +332,7 @@ importers:
         version: 1.14.2
       prisma:
         specifier: ^7.0.0
-        version: 7.1.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+        version: 7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       require-in-the-middle:
         specifier: ^7.4.0
         version: 7.4.0
@@ -836,7 +836,7 @@ importers:
         version: 0.468.0(react@19.2.1)
       nitro:
         specifier: ^3.0.0
-        version: 3.0.0(@electric-sql/pglite@0.3.2)(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(chokidar@4.0.3)(lru-cache@11.2.2)(mysql2@3.15.3)(rolldown@1.1.2)(vite@7.3.1(@types/node@22.19.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(xml2js@0.6.2)
+        version: 3.0.0(@electric-sql/pglite@0.3.2)(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(better-sqlite3@11.10.0)(chokidar@4.0.3)(lru-cache@11.2.2)(mysql2@3.15.3)(rolldown@1.1.2)(vite@7.3.1(@types/node@22.19.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(xml2js@0.6.2)
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -1057,6 +1057,46 @@ importers:
       mint:
         specifier: ^4.2.487
         version: 4.2.487(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@20.17.6)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
+
+  examples/better-auth-integration-demo:
+    dependencies:
+      '@hexclave/next':
+        specifier: workspace:*
+        version: link:../../packages/next
+      '@hexclave/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      better-auth:
+        specifier: ^1.6.25
+        version: 1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.1.0(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3))(typescript@5.9.3))(@tanstack/react-start@1.167.58(crossws@0.4.10(srvx@0.11.22))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.24.2)(lightningcss@1.32.0)))(better-sqlite3@11.10.0)(mysql2@3.15.3)(next@15.5.19(@babel/core@7.26.0)(@opentelemetry/api@1.9.1)(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(pg@8.16.3)(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(vitest@1.6.0(@types/node@20.17.6)(jsdom@24.1.3)(lightningcss@1.32.0)(terser@5.49.0))
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      next:
+        specifier: 15.5.19
+        version: 15.5.19(@babel/core@7.26.0)(@opentelemetry/api@1.9.1)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      react:
+        specifier: 19.0.1
+        version: 19.0.1
+      react-dom:
+        specifier: 19.0.1
+        version: 19.0.1(react@19.0.1)
+    devDependencies:
+      '@types/better-sqlite3':
+        specifier: ^7.6.13
+        version: 7.6.13
+      '@types/node':
+        specifier: ^22.15.0
+        version: 22.19.0
+      '@types/react':
+        specifier: 19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
 
   examples/cjs-test:
     dependencies:
@@ -1596,7 +1636,7 @@ importers:
         version: 1.167.58(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.24.2)(lightningcss@1.32.0)(postcss@8.5.6))
       nitro:
         specifier: ^3.0.0
-        version: 3.0.0(@electric-sql/pglite@0.3.2)(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(chokidar@4.0.3)(lru-cache@11.2.2)(mysql2@3.15.3)(rolldown@1.1.2)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(xml2js@0.6.2)
+        version: 3.0.0(@electric-sql/pglite@0.3.2)(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(better-sqlite3@11.10.0)(chokidar@4.0.3)(lru-cache@11.2.2)(mysql2@3.15.3)(rolldown@1.1.2)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(xml2js@0.6.2)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -1637,6 +1677,40 @@ importers:
       vite-tsconfig-paths:
         specifier: ^4.3.2
         version: 4.3.2(typescript@6.0.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))
+
+  examples/workos-integration-demo:
+    dependencies:
+      '@hexclave/next':
+        specifier: workspace:*
+        version: link:../../packages/next
+      '@hexclave/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@workos-inc/authkit-nextjs':
+        specifier: ^4.3.1
+        version: 4.3.1(@workos-inc/node@10.9.0)(next@15.5.19(@babel/core@7.26.0)(@opentelemetry/api@1.9.1)(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3)
+      next:
+        specifier: 15.5.19
+        version: 15.5.19(@babel/core@7.26.0)(@opentelemetry/api@1.9.1)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      react:
+        specifier: 19.0.1
+        version: 19.0.1
+      react-dom:
+        specifier: 19.0.1
+        version: 19.0.1(react@19.0.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.0
+        version: 22.19.0
+      '@types/react':
+        specifier: 19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: 19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
 
   packages/cli:
     dependencies:
@@ -3311,6 +3385,85 @@ packages:
     resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@better-auth/core@1.6.25':
+    resolution: {integrity: sha512-lMTlhtwyK4NpY9kPF+2rQCRKYpg136d3gM2xl8esxT1PjJx5Nh5YwZvxcYCIjDuO759sx6TCloJTuwcZGG6ZBw==}
+    peerDependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.7
+      jose: ^6.1.0
+      kysely: ^0.28.5 || ^0.29.0
+      nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@better-auth/drizzle-adapter@1.6.25':
+    resolution: {integrity: sha512-ru/DeKjFPQUVeKkxF/ScazmPqIY7lwfkAV5Yt4j24wmn1Y8vFwoiPRnHgXUeZqBs10+nubaRwEqLF39CP6EhRw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.25
+      '@better-auth/utils': 0.4.2
+      drizzle-orm: ^0.45.2
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
+
+  '@better-auth/kysely-adapter@1.6.25':
+    resolution: {integrity: sha512-zxiePhtN1YClS1irKYPVwWfN6kYp+QoYlz1hdQUOj8hXyo2aE/ny4RNAb6v332b0+U6Vu88EhYITRPdmvCo6uA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.25
+      '@better-auth/utils': 0.4.2
+      kysely: ^0.28.17 || ^0.29.0
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  '@better-auth/memory-adapter@1.6.25':
+    resolution: {integrity: sha512-GhEzTumc8yfTz+OZ6pMg06BA49xob49x1bX+1mEl/FStDJoSF+6mTfI5M2ytFxaiN89336/aUjkW8u+qRyLexw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.25
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.25':
+    resolution: {integrity: sha512-ZtMmjcOdXR2Ziqx5y8ptTOaNpe0snNfALbBUPXJsgeyeRkDJDYzyLZ8MpuvNBTNllNeIFDbiXWAK5k+pEBZrUQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.25
+      '@better-auth/utils': 0.4.2
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/prisma-adapter@1.6.25':
+    resolution: {integrity: sha512-ym7B6Iqcry+/4aQnYpFwqP/GBIiXvjrm/5B6+0qmx8mkTY/apHFTpHuGzUYYNf4vPTtzF3eYY2+s2GOsomKaRg==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.25
+      '@better-auth/utils': 0.4.2
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/telemetry@1.6.25':
+    resolution: {integrity: sha512-2ZfC9lp7tU6Jw/q2Lz/bKfQqGMdMwc/IQDTYdBhvtGi24qInYVnhp2ZCW57hHM9j+fq1ULOtxgg6M3T1LEaihw==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.25
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
+
+  '@better-fetch/fetch@1.3.1':
+    resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
+
   '@borewit/text-codec@0.2.2':
     resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
@@ -3471,9 +3624,6 @@ packages:
 
   '@emnapi/runtime@1.11.3':
     resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
-
-  '@emnapi/runtime@1.8.1':
-    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
@@ -4782,10 +4932,6 @@ packages:
     resolution: {integrity: sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==}
     deprecated: Use @eslint/object-schema instead
 
-  '@img/colour@1.0.0':
-    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
-    engines: {node: '>=18'}
-
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -5767,6 +5913,14 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
 
   '@node-oauth/formats@1.0.0':
     resolution: {integrity: sha512-DwSbLtdC8zC5B5gTJkFzJj5s9vr9SGzOgQvV9nH7tUVuMSScg0EswAczhjIapOmH3Y8AyP7C4Jv7b8+QJObWZA==}
@@ -8914,6 +9068,10 @@ packages:
   '@sinclair/typebox@0.34.49':
     resolution: {integrity: sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==}
 
+  '@sindresorhus/fnv1a@3.1.0':
+    resolution: {integrity: sha512-KV321z5m/0nuAg83W1dPLy85HpHDk7Sdi4fJbwvacWsEhAh+rZUW4ZfGcXmUIvjZg4ss2bcwNlRhJ7GBEUG08w==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   '@sindresorhus/is@5.6.0':
     resolution: {integrity: sha512-TV7t8GKYaJWsn00tFDqBw8+Uqmr8A0fRU1tvTQhyZzGv0sJCGRQL3JGMI3ucuKo3XIZdUP+Lx7/gh2t3lewy7g==}
     engines: {node: '>=14.16'}
@@ -9700,6 +9858,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/better-sqlite3@7.6.13':
+    resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
+
   '@types/bn.js@5.1.5':
     resolution: {integrity: sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==}
 
@@ -10246,6 +10407,19 @@ packages:
 
   '@webgpu/types@0.1.66':
     resolution: {integrity: sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==}
+
+  '@workos-inc/authkit-nextjs@4.3.1':
+    resolution: {integrity: sha512-4UwtzGGDZV3qWx+hpqvgYIp81d/jvvvuW3q/7d29xsA3b11IUfFaHOWs1CsWQnyhPzAKzoq3dNVpsA8ip8iR/w==}
+    engines: {node: '>=22.11.0'}
+    peerDependencies:
+      '@workos-inc/node': ^9.0.0 || ^10.0.0
+      next: ^13.5.9 || ^14.2.26 || ^15.2.3 || ^16
+      react: ^18.0 || ^19.0.0
+      react-dom: ^18.0 || ^19.0.0
+
+  '@workos-inc/node@10.9.0':
+    resolution: {integrity: sha512-Voxhxocg7Q9lpi1gJ6qyPCjgcjh7fZmxU0gR7BQRnv+ozCJ9Xj4jZulVt38tGMukniDI1uwTiXm+G2vdogpD4Q==}
+    engines: {node: '>=22.11.0'}
 
   '@xstate/fsm@1.6.5':
     resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
@@ -10849,6 +11023,76 @@ packages:
     resolution: {integrity: sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==}
     hasBin: true
 
+  better-auth@1.6.25:
+    resolution: {integrity: sha512-fvoq+oCO+FF5fpP3XfU7znRyGFpHB77UG2EyxsKNy+Cak7Q5pELu+auvvDveQbWQxcoKugZ7jYQQPFQLpUTGOw==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/kit': ^2.0.0
+      '@tanstack/react-start': ^1.0.0
+      '@tanstack/solid-start': ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: '>=0.31.4'
+      drizzle-orm: ^0.45.2
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      '@tanstack/react-start':
+        optional: true
+      '@tanstack/solid-start':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
+  better-call@1.3.7:
+    resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   better-opn@3.0.2:
     resolution: {integrity: sha512-aVNobHnJqLiUelTaHat9DZ1qM2w0C0Eym4LPI/3JxOnSokGVdsl1T1kN7TFvsEAD8G47A6VKQ0TVHqbBnYMJlQ==}
     engines: {node: '>=12.0.0'}
@@ -10857,12 +11101,18 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
   bignumber.js@9.3.1:
     resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
   birpc@4.0.0:
     resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
@@ -11536,6 +11786,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
@@ -12655,6 +12906,9 @@ packages:
     resolution: {integrity: sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==}
     engines: {node: '>=22'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -13443,6 +13697,12 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
+  iron-session@8.0.4:
+    resolution: {integrity: sha512-9ivNnaKOd08osD0lJ3i6If23GFS2LsxyMU8Gf/uBUEgm8/8CC1hrrCHFDpMo3IFbpBgwoo/eairRsaD3c5itxA==}
+
+  iron-webcrypto@1.2.1:
+    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
+
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
 
@@ -13915,6 +14175,10 @@ packages:
   koa@2.15.3:
     resolution: {integrity: sha512-j/8tY9j5t+GVMLeioLaxweJiKUayFhlGqNTzf2ZGwL0ZCQijd2RLHK0SLW5Tsko8YyyqCZC2cojIb0/s62qTAg==}
     engines: {node: ^4.8.4 || ^6.10.1 || ^7.10.1 || >= 8.1.4}
+
+  kysely@0.29.4:
+    resolution: {integrity: sha512-y5mVgQNkMbs1eK9Xyc0pmNdabN2wHhRYY/5r4W5HrUT1rYCEPeVNSj1RUJeSDKT3U0p+mXCvLgkrFuIafYI6BA==}
+    engines: {node: '>=22.0.0'}
 
   language-subtag-registry@0.3.23:
     resolution: {integrity: sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==}
@@ -14724,6 +14988,10 @@ packages:
     engines: {node: ^18 || >=20}
     hasBin: true
 
+  nanostores@1.4.2:
+    resolution: {integrity: sha512-Wxv8Roefr2nqtiRG0bnaFlpYqpIVtOEeJZHaH+4nGgOK1/7n6OHOuHCb/bhqrNQgZM8fyd0s1PqhdrJc9Ib44g==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -15281,6 +15549,9 @@ packages:
 
   path-to-regexp@6.2.2:
     resolution: {integrity: sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -16556,6 +16827,9 @@ packages:
   set-cookie-parser@2.7.1:
     resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
+  set-cookie-parser@3.1.2:
+    resolution: {integrity: sha512-5/r/lTwbJ3zQ+qwdUFZYeRNqda7P5HD8zQKqlSjdGt1/S0cjLAphHusj4Y58ahDtWn/g32xrIS58/ikOvwl0Lw==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -17598,6 +17872,9 @@ packages:
 
   unconfig-core@7.5.0:
     resolution: {integrity: sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w==}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
   underscore.string@3.3.6:
     resolution: {integrity: sha512-VoC83HWXmCrF6rgkyxS9GHv8W9Q5nhMKho+OadDJGzL2oDYbYEppBaCMH6pFlwLeqj2QS+hhkw2kpXkSdD1JxQ==}
@@ -19834,6 +20111,62 @@ snapshots:
       '@babel/helper-string-parser': 8.0.0
       '@babel/helper-validator-identifier': 8.0.2
 
+  '@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2)':
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.7(zod@4.3.6)
+      jose: 6.1.3
+      kysely: 0.29.4
+      nanostores: 1.4.2
+      zod: 4.3.6
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/kysely-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.4)':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      kysely: 0.29.4
+
+  '@better-auth/memory-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/prisma-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.1.0(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3))':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      '@prisma/client': 7.1.0(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3))(typescript@5.9.3)
+      prisma: 7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3)
+
+  '@better-auth/telemetry@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@better-fetch/fetch@1.3.1': {}
+
   '@borewit/text-codec@0.2.2': {}
 
   '@canvas/image-data@1.1.0': {}
@@ -20088,11 +20421,6 @@ snapshots:
     optional: true
 
   '@emnapi/runtime@1.11.3':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -20846,8 +21174,6 @@ snapshots:
 
   '@humanwhocodes/object-schema@2.0.3': {}
 
-  '@img/colour@1.0.0': {}
-
   '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.33.5':
@@ -21086,7 +21412,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.8.1
+      '@emnapi/runtime': 1.11.3
     optional: true
 
   '@img/sharp-wasm32@0.35.3':
@@ -21542,9 +21868,9 @@ snapshots:
     dependencies:
       '@inquirer/prompts': 7.9.0(@types/node@20.17.6)
       '@mintlify/common': 1.0.835(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
-      '@mintlify/link-rot': 3.0.1010(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
-      '@mintlify/prebuild': 1.0.977(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
-      '@mintlify/previewing': 4.0.1038(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
+      '@mintlify/link-rot': 3.0.1010(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@20.17.6)(@types/react@19.2.7)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
+      '@mintlify/prebuild': 1.0.977(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@20.17.6)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
+      '@mintlify/previewing': 4.0.1038(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@20.17.6)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
       '@mintlify/validation': 0.1.653(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       adm-zip: 0.5.16
       chalk: 5.2.0
@@ -21772,11 +22098,11 @@ snapshots:
       - typescript
       - yaml
 
-  '@mintlify/link-rot@3.0.1010(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)':
+  '@mintlify/link-rot@3.0.1010(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@20.17.6)(@types/react@19.2.7)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)':
     dependencies:
       '@mintlify/common': 1.0.835(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@18.3.1)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
-      '@mintlify/prebuild': 1.0.977(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@18.3.1)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
-      '@mintlify/previewing': 4.0.1038(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
+      '@mintlify/prebuild': 1.0.977(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@20.17.6)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@18.3.1)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
+      '@mintlify/previewing': 4.0.1038(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@20.17.6)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
       '@mintlify/scraping': 4.0.522(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@18.3.1)(typescript@6.0.3)
       '@mintlify/validation': 0.1.653(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@18.3.1)(typescript@6.0.3)
       fs-extra: 11.1.0
@@ -21785,6 +22111,7 @@ snapshots:
       unist-util-visit: 4.1.2
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
+      - '@types/node'
       - '@types/react'
       - bare-abort-controller
       - bare-buffer
@@ -21874,7 +22201,7 @@ snapshots:
       leven: 4.0.0
       yaml: 2.8.0
 
-  '@mintlify/prebuild@1.0.977(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@18.3.1)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)':
+  '@mintlify/prebuild@1.0.977(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@20.17.6)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@18.3.1)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)':
     dependencies:
       '@mintlify/common': 1.0.835(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@18.3.1)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
       '@mintlify/openapi-parser': 0.0.8
@@ -21887,11 +22214,12 @@ snapshots:
       js-yaml: 4.1.0
       openapi-types: 12.1.3
       sharp: 0.33.5
-      sharp-ico: 0.1.5
+      sharp-ico: 0.1.5(@types/node@20.17.6)
       unist-util-visit: 4.1.2
       uuid: 11.1.0
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
+      - '@types/node'
       - '@types/react'
       - bare-abort-controller
       - bare-buffer
@@ -21906,7 +22234,7 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@mintlify/prebuild@1.0.977(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)':
+  '@mintlify/prebuild@1.0.977(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@20.17.6)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)':
     dependencies:
       '@mintlify/common': 1.0.835(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
       '@mintlify/openapi-parser': 0.0.8
@@ -21919,11 +22247,12 @@ snapshots:
       js-yaml: 4.1.0
       openapi-types: 12.1.3
       sharp: 0.33.5
-      sharp-ico: 0.1.5
+      sharp-ico: 0.1.5(@types/node@20.17.6)
       unist-util-visit: 4.1.2
       uuid: 11.1.0
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
+      - '@types/node'
       - '@types/react'
       - bare-abort-controller
       - bare-buffer
@@ -21938,10 +22267,10 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@mintlify/previewing@4.0.1038(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)':
+  '@mintlify/previewing@4.0.1038(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@20.17.6)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)':
     dependencies:
       '@mintlify/common': 1.0.835(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
-      '@mintlify/prebuild': 1.0.977(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
+      '@mintlify/prebuild': 1.0.977(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/node@20.17.6)(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.19.3)(typescript@6.0.3)(yaml@2.6.0)
       '@mintlify/validation': 0.1.653(@radix-ui/react-popover@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       adm-zip: 0.5.16
       better-opn: 3.0.2
@@ -21963,6 +22292,7 @@ snapshots:
       yargs: 17.7.1
     transitivePeerDependencies:
       - '@radix-ui/react-popover'
+      - '@types/node'
       - '@types/react'
       - bare-abort-controller
       - bare-buffer
@@ -22299,6 +22629,10 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.3.0':
     optional: true
+
+  '@noble/ciphers@2.2.0': {}
+
+  '@noble/hashes@2.2.0': {}
 
   '@node-oauth/formats@1.0.0': {}
 
@@ -24073,11 +24407,19 @@ snapshots:
 
   '@prisma/client-runtime-utils@7.1.0': {}
 
-  '@prisma/client@7.1.0(prisma@7.1.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3))(typescript@6.0.3)':
+  '@prisma/client@7.1.0(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
       '@prisma/client-runtime-utils': 7.1.0
     optionalDependencies:
-      prisma: 7.1.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
+      prisma: 7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3)
+      typescript: 5.9.3
+    optional: true
+
+  '@prisma/client@7.1.0(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3))(typescript@6.0.3)':
+    dependencies:
+      '@prisma/client-runtime-utils': 7.1.0
+    optionalDependencies:
+      prisma: 7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3)
       typescript: 6.0.3
 
   '@prisma/config@7.1.0':
@@ -24092,6 +24434,29 @@ snapshots:
   '@prisma/debug@6.8.2': {}
 
   '@prisma/debug@7.1.0': {}
+
+  '@prisma/dev@0.15.0(typescript@5.9.3)':
+    dependencies:
+      '@electric-sql/pglite': 0.3.2
+      '@electric-sql/pglite-socket': 0.0.6(@electric-sql/pglite@0.3.2)
+      '@electric-sql/pglite-tools': 0.2.7(@electric-sql/pglite@0.3.2)
+      '@hono/node-server': 1.19.6(hono@4.10.6)
+      '@mrleebo/prisma-ast': 0.12.1
+      '@prisma/get-platform': 6.8.2
+      '@prisma/query-plan-executor': 6.18.0
+      foreground-child: 3.3.1
+      get-port-please: 3.1.2
+      hono: 4.10.6
+      http-status-codes: 2.3.0
+      pathe: 2.0.3
+      proper-lockfile: 4.1.2
+      remeda: 2.21.3
+      std-env: 3.9.0
+      valibot: 1.2.0(typescript@5.9.3)
+      zeptomatch: 2.0.2
+    transitivePeerDependencies:
+      - typescript
+    optional: true
 
   '@prisma/dev@0.15.0(typescript@6.0.3)':
     dependencies:
@@ -24128,9 +24493,9 @@ snapshots:
       '@prisma/fetch-engine': 7.1.0
       '@prisma/get-platform': 7.1.0
 
-  '@prisma/extension-read-replicas@0.5.0(@prisma/client@7.1.0(prisma@7.1.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3))(typescript@6.0.3))':
+  '@prisma/extension-read-replicas@0.5.0(@prisma/client@7.1.0(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3))(typescript@6.0.3))':
     dependencies:
-      '@prisma/client': 7.1.0(prisma@7.1.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3))(typescript@6.0.3)
+      '@prisma/client': 7.1.0(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3))(typescript@6.0.3)
 
   '@prisma/fetch-engine@7.1.0':
     dependencies:
@@ -24168,6 +24533,13 @@ snapshots:
       - supports-color
 
   '@prisma/query-plan-executor@6.18.0': {}
+
+  '@prisma/studio-core@0.8.2(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
+    dependencies:
+      '@types/react': 19.2.7
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+    optional: true
 
   '@prisma/studio-core@0.8.2(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -27271,6 +27643,8 @@ snapshots:
 
   '@sinclair/typebox@0.34.49': {}
 
+  '@sindresorhus/fnv1a@3.1.0': {}
+
   '@sindresorhus/is@5.6.0': {}
 
   '@sindresorhus/slugify@2.2.0':
@@ -27918,6 +28292,16 @@ snapshots:
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
+  '@tanstack/react-router@1.169.1(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      '@tanstack/react-store': 0.9.3(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      '@tanstack/router-core': 1.169.1
+      isbot: 5.1.35
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+    optional: true
+
   '@tanstack/react-router@1.169.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -27935,6 +28319,15 @@ snapshots:
       isbot: 5.1.35
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
+
+  '@tanstack/react-start-client@1.166.47(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
+    dependencies:
+      '@tanstack/react-router': 1.169.1(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      '@tanstack/router-core': 1.169.1
+      '@tanstack/start-client-core': 1.168.1
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+    optional: true
 
   '@tanstack/react-start-client@1.166.47(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
@@ -27961,6 +28354,29 @@ snapshots:
       react-dom: 19.2.1(react@19.2.1)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
+
+  '@tanstack/react-start-rsc@0.0.37(crossws@0.4.10(srvx@0.11.22))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.24.2)(lightningcss@1.32.0))':
+    dependencies:
+      '@tanstack/react-router': 1.169.1(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      '@tanstack/react-start-server': 1.166.48(crossws@0.4.10(srvx@0.11.22))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      '@tanstack/router-core': 1.169.1
+      '@tanstack/router-utils': 1.161.7
+      '@tanstack/start-client-core': 1.168.1
+      '@tanstack/start-fn-stubs': 1.161.6
+      '@tanstack/start-plugin-core': 1.169.13(@tanstack/react-router@1.169.1(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(crossws@0.4.10(srvx@0.11.22))(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.24.2)(lightningcss@1.32.0))
+      '@tanstack/start-server-core': 1.167.26(crossws@0.4.10(srvx@0.11.22))
+      '@tanstack/start-storage-context': 1.166.34
+      pathe: 2.0.3
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+    transitivePeerDependencies:
+      - '@rsbuild/core'
+      - crossws
+      - supports-color
+      - vite
+      - vite-plugin-solid
+      - webpack
+    optional: true
 
   '@tanstack/react-start-rsc@0.0.37(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.20.2)(lightningcss@1.32.0)(postcss@8.4.47))':
     dependencies:
@@ -28028,6 +28444,19 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
+  '@tanstack/react-start-server@1.166.48(crossws@0.4.10(srvx@0.11.22))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
+    dependencies:
+      '@tanstack/history': 1.161.6
+      '@tanstack/react-router': 1.169.1(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      '@tanstack/router-core': 1.169.1
+      '@tanstack/start-client-core': 1.168.1
+      '@tanstack/start-server-core': 1.167.26(crossws@0.4.10(srvx@0.11.22))
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+    transitivePeerDependencies:
+      - crossws
+    optional: true
+
   '@tanstack/react-start-server@1.166.48(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
       '@tanstack/history': 1.161.6
@@ -28083,6 +28512,30 @@ snapshots:
       - supports-color
       - vite-plugin-solid
       - webpack
+
+  '@tanstack/react-start@1.167.58(crossws@0.4.10(srvx@0.11.22))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.24.2)(lightningcss@1.32.0))':
+    dependencies:
+      '@tanstack/react-router': 1.169.1(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      '@tanstack/react-start-client': 1.166.47(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      '@tanstack/react-start-rsc': 0.0.37(crossws@0.4.10(srvx@0.11.22))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.24.2)(lightningcss@1.32.0))
+      '@tanstack/react-start-server': 1.166.48(crossws@0.4.10(srvx@0.11.22))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      '@tanstack/router-utils': 1.161.7
+      '@tanstack/start-client-core': 1.168.1
+      '@tanstack/start-plugin-core': 1.169.13(@tanstack/react-router@1.169.1(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(crossws@0.4.10(srvx@0.11.22))(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.24.2)(lightningcss@1.32.0))
+      '@tanstack/start-server-core': 1.167.26(crossws@0.4.10(srvx@0.11.22))
+      pathe: 2.0.3
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - crossws
+      - react-server-dom-rspack
+      - supports-color
+      - vite-plugin-solid
+      - webpack
+    optional: true
 
   '@tanstack/react-start@1.167.58(crossws@0.4.10(srvx@0.11.22))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.20.2)(lightningcss@1.32.0)(postcss@8.4.47))':
     dependencies:
@@ -28159,6 +28612,14 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
       use-sync-external-store: 1.6.0(react@19.2.1)
+
+  '@tanstack/react-store@0.9.3(react-dom@19.0.1(react@19.0.1))(react@19.0.1)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+      use-sync-external-store: 1.6.0(react@19.0.1)
+    optional: true
 
   '@tanstack/react-store@0.9.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)':
     dependencies:
@@ -28262,6 +28723,29 @@ snapshots:
       webpack: 5.92.0(esbuild@0.24.2)(lightningcss@1.32.0)(postcss@8.5.6)
     transitivePeerDependencies:
       - supports-color
+
+  '@tanstack/router-plugin@1.167.31(@tanstack/react-router@1.169.1(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.24.2)(lightningcss@1.32.0))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@tanstack/router-core': 1.169.1
+      '@tanstack/router-generator': 1.166.39
+      '@tanstack/router-utils': 1.161.7
+      '@tanstack/virtual-file-routes': 1.161.7
+      chokidar: 3.6.0
+      unplugin: 3.0.0
+      zod: 3.25.76
+    optionalDependencies:
+      '@tanstack/react-router': 1.169.1(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      vite: 7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0)
+      webpack: 5.92.0(esbuild@0.24.2)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   '@tanstack/router-plugin@1.167.31(@tanstack/react-router@1.169.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.20.2)(lightningcss@1.32.0)(postcss@8.4.47))':
     dependencies:
@@ -28408,6 +28892,41 @@ snapshots:
       - supports-color
       - vite-plugin-solid
       - webpack
+
+  '@tanstack/start-plugin-core@1.169.13(@tanstack/react-router@1.169.1(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(crossws@0.4.10(srvx@0.11.22))(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.24.2)(lightningcss@1.32.0))':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/core': 7.29.0
+      '@babel/types': 7.29.0
+      '@rolldown/pluginutils': 1.0.0-beta.40
+      '@tanstack/router-core': 1.169.1
+      '@tanstack/router-generator': 1.166.39
+      '@tanstack/router-plugin': 1.167.31(@tanstack/react-router@1.169.1(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.24.2)(lightningcss@1.32.0))
+      '@tanstack/router-utils': 1.161.7
+      '@tanstack/start-client-core': 1.168.1
+      '@tanstack/start-server-core': 1.167.26(crossws@0.4.10(srvx@0.11.22))
+      cheerio: 1.0.0
+      exsolve: 1.0.8
+      lightningcss: 1.32.0
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      seroval: 1.5.1
+      source-map: 0.7.6
+      srvx: 0.11.22
+      tinyglobby: 0.2.17
+      ufo: 1.6.3
+      vitefu: 1.1.2(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))
+      xmlbuilder2: 4.0.3
+      zod: 3.25.76
+    optionalDependencies:
+      vite: 7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - '@tanstack/react-router'
+      - crossws
+      - supports-color
+      - vite-plugin-solid
+      - webpack
+    optional: true
 
   '@tanstack/start-plugin-core@1.169.13(@tanstack/react-router@1.169.1(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(crossws@0.4.10(srvx@0.11.22))(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.20.2)(lightningcss@1.32.0)(postcss@8.4.47))':
     dependencies:
@@ -28646,6 +29165,10 @@ snapshots:
   '@types/babel__traverse@7.28.0':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@types/better-sqlite3@7.6.13':
+    dependencies:
+      '@types/node': 22.19.0
 
   '@types/bn.js@5.1.5':
     dependencies:
@@ -29342,6 +29865,23 @@ snapshots:
 
   '@webgpu/types@0.1.66': {}
 
+  '@workos-inc/authkit-nextjs@4.3.1(@workos-inc/node@10.9.0)(next@15.5.19(@babel/core@7.26.0)(@opentelemetry/api@1.9.1)(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3)':
+    dependencies:
+      '@sindresorhus/fnv1a': 3.1.0
+      '@workos-inc/node': 10.9.0
+      iron-session: 8.0.4
+      jose: 5.10.0
+      next: 15.5.19(@babel/core@7.26.0)(@opentelemetry/api@1.9.1)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      path-to-regexp: 6.3.0
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+      server-only: 0.0.1
+      valibot: 1.2.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
+  '@workos-inc/node@10.9.0': {}
+
   '@xstate/fsm@1.6.5': {}
 
   '@xtuc/ieee754@1.2.0': {}
@@ -29928,6 +30468,49 @@ snapshots:
 
   bcryptjs@3.0.2: {}
 
+  better-auth@1.6.25(@opentelemetry/api@1.9.1)(@prisma/client@7.1.0(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3))(typescript@5.9.3))(@tanstack/react-start@1.167.58(crossws@0.4.10(srvx@0.11.22))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.24.2)(lightningcss@1.32.0)))(better-sqlite3@11.10.0)(mysql2@3.15.3)(next@15.5.19(@babel/core@7.26.0)(@opentelemetry/api@1.9.1)(react-dom@19.0.1(react@19.0.1))(react@19.0.1))(pg@8.16.3)(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(vitest@1.6.0(@types/node@20.17.6)(jsdom@24.1.3)(lightningcss@1.32.0)(terser@5.49.0)):
+    dependencies:
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2)
+      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.4)
+      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@prisma/client@7.1.0(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3))(typescript@5.9.3))(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3))
+      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.7(zod@4.3.6))(jose@6.1.3)(kysely@0.29.4)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.7(zod@4.3.6)
+      defu: 6.1.7
+      jose: 6.1.3
+      kysely: 0.29.4
+      nanostores: 1.4.2
+      zod: 4.3.6
+    optionalDependencies:
+      '@prisma/client': 7.1.0(prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3))(typescript@5.9.3)
+      '@tanstack/react-start': 1.167.58(crossws@0.4.10(srvx@0.11.22))(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(webpack@5.92.0(esbuild@0.24.2)(lightningcss@1.32.0))
+      better-sqlite3: 11.10.0
+      mysql2: 3.15.3
+      next: 15.5.19(@babel/core@7.26.0)(@opentelemetry/api@1.9.1)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      pg: 8.16.3
+      prisma: 7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3)
+      react: 19.0.1
+      react-dom: 19.0.1(react@19.0.1)
+      vitest: 1.6.0(@types/node@20.17.6)(jsdom@24.1.3)(lightningcss@1.32.0)(terser@5.49.0)
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-call@1.3.7(zod@4.3.6):
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.2
+    optionalDependencies:
+      zod: 4.3.6
+
   better-opn@3.0.2:
     dependencies:
       open: 8.4.2
@@ -29936,9 +30519,18 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
 
   birpc@4.0.0: {}
 
@@ -29947,7 +30539,6 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   bl@5.1.0:
     dependencies:
@@ -30076,7 +30667,7 @@ snapshots:
 
   browserslist@4.24.4:
     dependencies:
-      caniuse-lite: 1.0.30001751
+      caniuse-lite: 1.0.30001806
       electron-to-chromium: 1.5.89
       node-releases: 2.0.19
       update-browserslist-db: 1.1.1(browserslist@4.24.4)
@@ -30346,8 +30937,7 @@ snapshots:
     dependencies:
       readdirp: 4.0.2
 
-  chownr@1.1.4:
-    optional: true
+  chownr@1.1.4: {}
 
   chownr@2.0.0: {}
 
@@ -30846,9 +31436,10 @@ snapshots:
 
   date-fns@4.1.0: {}
 
-  db0@0.3.4(@electric-sql/pglite@0.3.2)(mysql2@3.15.3):
+  db0@0.3.4(@electric-sql/pglite@0.3.2)(better-sqlite3@11.10.0)(mysql2@3.15.3):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.2
+      better-sqlite3: 11.10.0
       mysql2: 3.15.3
 
   debug@2.6.9:
@@ -32184,8 +32775,7 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
-  expand-template@2.0.3:
-    optional: true
+  expand-template@2.0.3: {}
 
   export-to-csv@1.4.0: {}
 
@@ -32423,6 +33013,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  file-uri-to-path@1.0.0: {}
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -32550,8 +33142,7 @@ snapshots:
     dependencies:
       js-yaml: 3.14.1
 
-  fs-constants@1.0.0:
-    optional: true
+  fs-constants@1.0.0: {}
 
   fs-extra@11.1.0:
     dependencies:
@@ -32762,8 +33353,7 @@ snapshots:
       nypm: 0.6.2
       pathe: 2.0.3
 
-  github-from-package@0.0.0:
-    optional: true
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -33506,6 +34096,14 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
+  iron-session@8.0.4:
+    dependencies:
+      cookie: 0.7.2
+      iron-webcrypto: 1.2.1
+      uncrypto: 0.1.3
+
+  iron-webcrypto@1.2.1: {}
+
   is-alphabetical@1.0.4: {}
 
   is-alphabetical@2.0.1: {}
@@ -33986,6 +34584,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  kysely@0.29.4: {}
 
   language-subtag-registry@0.3.23: {}
 
@@ -34937,8 +35537,7 @@ snapshots:
 
   mitt@3.0.1: {}
 
-  mkdirp-classic@0.5.3:
-    optional: true
+  mkdirp-classic@0.5.3: {}
 
   mkdirp@1.0.4: {}
 
@@ -35031,8 +35630,9 @@ snapshots:
 
   nanoid@5.1.5: {}
 
-  napi-build-utils@2.0.0:
-    optional: true
+  nanostores@1.4.2: {}
+
+  napi-build-utils@2.0.0: {}
 
   natural-compare@1.4.0: {}
 
@@ -35214,7 +35814,7 @@ snapshots:
     dependencies:
       '@next/env': 15.5.19
       '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001751
+      caniuse-lite: 1.0.30001806
       postcss: 8.4.31
       react: 19.0.1
       react-dom: 19.0.1(react@19.0.1)
@@ -35238,7 +35838,7 @@ snapshots:
     dependencies:
       '@next/env': 15.5.19
       '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001751
+      caniuse-lite: 1.0.30001806
       postcss: 8.4.31
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
@@ -35428,12 +36028,12 @@ snapshots:
       jsonpath-plus: 10.4.0
       lodash.topath: 4.5.2
 
-  nitro@3.0.0(@electric-sql/pglite@0.3.2)(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(chokidar@4.0.3)(lru-cache@11.2.2)(mysql2@3.15.3)(rolldown@1.1.2)(vite@7.3.1(@types/node@22.19.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(xml2js@0.6.2):
+  nitro@3.0.0(@electric-sql/pglite@0.3.2)(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(better-sqlite3@11.10.0)(chokidar@4.0.3)(lru-cache@11.2.2)(mysql2@3.15.3)(rolldown@1.1.2)(vite@7.3.1(@types/node@22.19.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(xml2js@0.6.2):
     dependencies:
       consola: 3.4.2
       cookie-es: 2.0.0
       crossws: 0.4.4(srvx@0.8.16)
-      db0: 0.3.4(@electric-sql/pglite@0.3.2)(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.3.2)(better-sqlite3@11.10.0)(mysql2@3.15.3)
       esbuild: 0.25.11
       fetchdts: 0.1.7
       h3: 2.0.1-rc.2(crossws@0.4.4(srvx@0.8.16))
@@ -35446,7 +36046,7 @@ snapshots:
       srvx: 0.8.16
       undici: 7.18.2
       unenv: 2.0.0-rc.21
-      unstorage: 2.0.0-alpha.3(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(chokidar@4.0.3)(db0@0.3.4(@electric-sql/pglite@0.3.2)(mysql2@3.15.3))(lru-cache@11.2.2)(ofetch@1.5.1)
+      unstorage: 2.0.0-alpha.3(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(chokidar@4.0.3)(db0@0.3.4(@electric-sql/pglite@0.3.2)(better-sqlite3@11.10.0)(mysql2@3.15.3))(lru-cache@11.2.2)(ofetch@1.5.1)
     optionalDependencies:
       rolldown: 1.1.2
       vite: 7.3.1(@types/node@22.19.0)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0)
@@ -35480,12 +36080,12 @@ snapshots:
       - sqlite3
       - uploadthing
 
-  nitro@3.0.0(@electric-sql/pglite@0.3.2)(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(chokidar@4.0.3)(lru-cache@11.2.2)(mysql2@3.15.3)(rolldown@1.1.2)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(xml2js@0.6.2):
+  nitro@3.0.0(@electric-sql/pglite@0.3.2)(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(better-sqlite3@11.10.0)(chokidar@4.0.3)(lru-cache@11.2.2)(mysql2@3.15.3)(rolldown@1.1.2)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0))(xml2js@0.6.2):
     dependencies:
       consola: 3.4.2
       cookie-es: 2.0.0
       crossws: 0.4.4(srvx@0.8.16)
-      db0: 0.3.4(@electric-sql/pglite@0.3.2)(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.3.2)(better-sqlite3@11.10.0)(mysql2@3.15.3)
       esbuild: 0.25.11
       fetchdts: 0.1.7
       h3: 2.0.1-rc.2(crossws@0.4.4(srvx@0.8.16))
@@ -35498,7 +36098,7 @@ snapshots:
       srvx: 0.8.16
       undici: 7.18.2
       unenv: 2.0.0-rc.21
-      unstorage: 2.0.0-alpha.3(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(chokidar@4.0.3)(db0@0.3.4(@electric-sql/pglite@0.3.2)(mysql2@3.15.3))(lru-cache@11.2.2)(ofetch@1.5.1)
+      unstorage: 2.0.0-alpha.3(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(chokidar@4.0.3)(db0@0.3.4(@electric-sql/pglite@0.3.2)(better-sqlite3@11.10.0)(mysql2@3.15.3))(lru-cache@11.2.2)(ofetch@1.5.1)
     optionalDependencies:
       rolldown: 1.1.2
       vite: 7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.0)
@@ -35539,7 +36139,6 @@ snapshots:
   node-abi@3.89.0:
     dependencies:
       semver: 7.8.5
-    optional: true
 
   node-addon-api@4.3.0:
     optional: true
@@ -35965,6 +36564,8 @@ snapshots:
 
   path-to-regexp@6.2.2: {}
 
+  path-to-regexp@6.3.0: {}
+
   path-to-regexp@8.4.2: {}
 
   path-type@3.0.0:
@@ -36151,7 +36752,7 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -36248,7 +36849,6 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.4
       tunnel-agent: 0.6.0
-    optional: true
 
   prelude-ls@1.2.1: {}
 
@@ -36268,7 +36868,25 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 18.3.1
 
-  prisma@7.1.0(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
+  prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)(typescript@5.9.3):
+    dependencies:
+      '@prisma/config': 7.1.0
+      '@prisma/dev': 0.15.0(typescript@5.9.3)
+      '@prisma/engines': 7.1.0
+      '@prisma/studio-core': 0.8.2(@types/react@19.2.7)(react-dom@19.0.1(react@19.0.1))(react@19.0.1)
+      mysql2: 3.15.3
+      postgres: 3.4.7
+    optionalDependencies:
+      better-sqlite3: 11.10.0
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - magicast
+      - react
+      - react-dom
+    optional: true
+
+  prisma@7.1.0(@types/react@19.2.7)(better-sqlite3@11.10.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@6.0.3):
     dependencies:
       '@prisma/config': 7.1.0
       '@prisma/dev': 0.15.0(typescript@6.0.3)
@@ -36277,6 +36895,7 @@ snapshots:
       mysql2: 3.15.3
       postgres: 3.4.7
     optionalDependencies:
+      better-sqlite3: 11.10.0
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/react'
@@ -37704,6 +38323,8 @@ snapshots:
 
   set-cookie-parser@2.7.1: {}
 
+  set-cookie-parser@3.1.2: {}
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -37728,11 +38349,13 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  sharp-ico@0.1.5:
+  sharp-ico@0.1.5(@types/node@20.17.6):
     dependencies:
       decode-ico: 0.4.1
       ico-endec: 0.1.6
-      sharp: 0.34.5
+      sharp: 0.35.3(@types/node@20.17.6)
+    transitivePeerDependencies:
+      - '@types/node'
 
   sharp@0.33.5:
     dependencies:
@@ -37762,7 +38385,7 @@ snapshots:
 
   sharp@0.34.5:
     dependencies:
-      '@img/colour': 1.0.0
+      '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
@@ -37790,6 +38413,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
+    optional: true
 
   sharp@0.35.3(@types/node@20.17.6):
     dependencies:
@@ -37932,8 +38556,7 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1:
-    optional: true
+  simple-concat@1.0.1: {}
 
   simple-eval@1.0.1:
     dependencies:
@@ -37944,7 +38567,6 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-    optional: true
 
   simple-swizzle@0.2.4:
     dependencies:
@@ -38561,7 +39183,6 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
-    optional: true
 
   tar-fs@3.1.2:
     dependencies:
@@ -38581,7 +39202,6 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   tar-stream@3.1.7:
     dependencies:
@@ -38971,7 +39591,6 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   turbo-darwin-64@2.8.17:
     optional: true
@@ -39145,6 +39764,8 @@ snapshots:
       '@quansync/fs': 1.0.0
       quansync: 1.0.0
 
+  uncrypto@0.1.3: {}
+
   underscore.string@3.3.6:
     dependencies:
       sprintf-js: 1.1.3
@@ -39283,11 +39904,11 @@ snapshots:
     dependencies:
       rolldown: 1.1.2
 
-  unstorage@2.0.0-alpha.3(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(chokidar@4.0.3)(db0@0.3.4(@electric-sql/pglite@0.3.2)(mysql2@3.15.3))(lru-cache@11.2.2)(ofetch@1.5.1):
+  unstorage@2.0.0-alpha.3(@vercel/functions@3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3))(chokidar@4.0.3)(db0@0.3.4(@electric-sql/pglite@0.3.2)(better-sqlite3@11.10.0)(mysql2@3.15.3))(lru-cache@11.2.2)(ofetch@1.5.1):
     optionalDependencies:
       '@vercel/functions': 3.7.6(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.18.3)
       chokidar: 4.0.3
-      db0: 0.3.4(@electric-sql/pglite@0.3.2)(mysql2@3.15.3)
+      db0: 0.3.4(@electric-sql/pglite@0.3.2)(better-sqlite3@11.10.0)(mysql2@3.15.3)
       lru-cache: 11.2.2
       ofetch: 1.5.1
 
@@ -39413,6 +40034,11 @@ snapshots:
     dependencies:
       react: 18.3.1
 
+  use-sync-external-store@1.6.0(react@19.0.1):
+    dependencies:
+      react: 19.0.1
+    optional: true
+
   use-sync-external-store@1.6.0(react@19.2.1):
     dependencies:
       react: 19.2.1
@@ -39438,6 +40064,10 @@ snapshots:
   uuid@9.0.1: {}
 
   uzip@0.20201231.0: {}
+
+  valibot@1.2.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   valibot@1.2.0(typescript@6.0.3):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,3 +62,4 @@ allowBuilds:
   lmdb: true
   msgpackr-extract: true
   unrs-resolver: false
+  better-sqlite3: true


### PR DESCRIPTION
Two runnable example apps for the external auth integrations, used to verify the flows end-to-end against real providers:

- `examples/workos-integration-demo` — hosted AuthKit sign-in, then exchanges the WorkOS access token.
- `examples/better-auth-integration-demo` — a self-hosted Better Auth instance (email/password, JWT plugin with a `jwks` endpoint), then exchanges its JWT.

Each renders the provider session, the exchange result, and the resulting Hexclave user, so a broken exchange is visible rather than silent. Both read configuration from `.env.local.example` placeholders and fail loudly on missing env vars rather than falling back to defaults; no provider credentials are committed.

`better-sqlite3` is added to `allowBuilds` in `pnpm-workspace.yaml` for the Better Auth demo's local database.


Link to Devin session: https://app.devin.ai/sessions/9ca1de7e4a9f41feb1e8fbcd61136270
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are isolated to new example apps and lockfile/workspace build config; no production auth or API behavior is modified.
> 
> **Overview**
> Adds **two runnable Next.js examples** under `examples/` to exercise external auth token exchange against a local Hexclave backend, with UI that surfaces provider session details, decoded JWT claims, and the resulting Hexclave user so failed exchanges are obvious.
> 
> The **WorkOS demo** (`workos-integration-demo`, port 8110) wires AuthKit middleware, hosted sign-in/callback routes, and server routes that call Hexclave’s `POST /api/latest/auth/external/token` with `provider_id: "workos-integration"`, then optionally loads `/api/v1/users/me`. The client uses `workosTokenStore` from `@hexclave/next` with `automaticSideEffects: false`.
> 
> The **Better Auth demo** (`better-auth-integration-demo`, port 8111) runs a self-hosted Better Auth instance on SQLite (`better-sqlite3`) with the JWT plugin (custom payload including `sid`), exposes token/exchange API routes with `provider_id: "better-auth-integration"`, and uses `betterAuthTokenStore` on the client.
> 
> Both apps ship `.env.local.example` placeholders and **throw on missing** Hexclave env vars. **`pnpm-workspace.yaml`** gains `better-sqlite3: true` under `allowBuilds` for the Better Auth SQLite dependency; **`pnpm-lock.yaml`** picks up the new workspace packages and transitive deps (`better-auth`, `@workos-inc/authkit-nextjs`, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a29d925126c3b70a2b80e7d36377e3f520534ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two demo apps for WorkOS AuthKit and Better Auth to exchange provider tokens with Hexclave and run the `@hexclave/next` session flow end-to-end, with strict runtime env checks. The Better Auth page is now forced dynamic to avoid stale session state.

- **New Features**
  - `examples/workos-integration-demo`: Hosted WorkOS sign-in via `@workos-inc/authkit-nextjs`, middleware, and callback routes; request-time WorkOS config and redirect URI validation; exchanges the provider access token with Hexclave and uses `HexclaveClientApp` with `workosTokenStore` to load the Hexclave session/user and support sign-out. Runs on port 8110.
  - `examples/better-auth-integration-demo`: Self-hosted `better-auth` (JWT plugin with `jwks`) on local `better-sqlite3`; token/exchange/sign-out APIs; page rendering is forced dynamic to prevent stale session; uses `HexclaveClientApp` with `betterAuthTokenStore` to load the Hexclave session/user and support sign-out. Runs on port 8111.
  - Both apps show the provider session, decoded JWT claims, the exchange result, and the resulting Hexclave user. Missing env vars throw at runtime.

- **Dependencies**
  - Added `better-sqlite3` to `allowBuilds` in `pnpm-workspace.yaml`.
  - New example app deps: `@workos-inc/authkit-nextjs`, `better-auth`, `better-sqlite3`.

<sup>Written for commit 5f4472dc77a3d6b7442e31be6ed761a49db2ee23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

