### PR TITLE
Feed the fast-fail selector prompt to Codex over stdin

### DIFF
--- a/.github/workflows/fast-fail-tests.yaml
+++ b/.github/workflows/fast-fail-tests.yaml
@@ -143,7 +143,11 @@ jobs:
           # request is sent unauthenticated and fails with 401.
           printenv OPENAI_API_KEY | codex login --with-api-key
 
-          # Pass the prompt over stdin to avoid Linux's per-argument length limit.
+          # `codex exec` runs non-interactively. We keep it read-only and never
+          # prompt for approvals so it can't hang CI. It's given the diff + test
+          # list directly in the prompt, so it doesn't need to explore the repo.
+          # The prompt goes through stdin (`-`) because as a single argv entry it
+          # exceeds Linux's per-argument limit (MAX_ARG_STRLEN, 128 KiB).
           codex exec - \
             --skip-git-repo-check \
             -s read-only \

--- a/.github/workflows/fast-fail-tests.yaml
+++ b/.github/workflows/fast-fail-tests.yaml
@@ -54,7 +54,7 @@ jobs:
 
           git diff --name-only "$merge_base" "$HEAD_SHA" > changed-files.txt || true
           # Cap the patch so the prompt stays within a reasonable size.
-          git diff "$merge_base" "$HEAD_SHA" | head -c 200000 > diff.patch || true
+          git diff "$merge_base" "$HEAD_SHA" | head -c 60000 > diff.patch || true
 
           echo "Changed files:"
           cat changed-files.txt || true
@@ -143,16 +143,13 @@ jobs:
           # request is sent unauthenticated and fails with 401.
           printenv OPENAI_API_KEY | codex login --with-api-key
 
-          # `codex exec` runs non-interactively. We keep it read-only and never
-          # prompt for approvals so it can't hang CI. It's given the diff + test
-          # list directly in the prompt, so it doesn't need to explore the repo.
-          codex exec \
+          # Pass the prompt over stdin to avoid Linux's per-argument length limit.
+          codex exec - \
             --skip-git-repo-check \
             -s read-only \
             -c approval_policy="never" \
             --output-schema schema.json \
-            --output-last-message codex-out.json \
-            "$(cat prompt.txt)"
+            --output-last-message codex-out.json < prompt.txt
 
           echo "Codex raw output:"
           cat codex-out.json


### PR DESCRIPTION
The `select-tests` job never actually ran the selector: it died with `codex: Argument list too long` (exit 126) on every PR. The prompt was passed as one argv entry (`"$(cat prompt.txt)"`), and a single argument is capped at `MAX_ARG_STRLEN` = 128 KiB on Linux, while the prompt (up to 200 KB of diff plus the full test-file list) is reliably larger.

```diff
-codex exec ... "$(cat prompt.txt)"
+codex exec - ... < prompt.txt
```

`codex exec --help` (0.142.5): "If not provided as an argument (or if `-` is used), instructions are read from stdin."

Also lowers the diff cap from 200 KB to 60 KB to keep the prompt small.


Link to Devin session: https://app.devin.ai/sessions/e63ab6f36b2f461ba4e821046d55ca85
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only change; no application runtime or security-sensitive code paths.
> 
> **Overview**
> Fixes the **fast-fail** `select-tests` job, which was failing every run with `codex: Argument list too long` because the full `prompt.txt` was passed as a single CLI argument (Linux caps that at 128 KiB).
> 
> The workflow now runs `codex exec -` and feeds **`prompt.txt` on stdin** instead of `"$(cat prompt.txt)"`, with a short comment explaining the limit. The **diff patch cap** in the same workflow is reduced from **200 KB to 60 KB** so the prompt stays smaller alongside the full test-file list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 831e3c9b60d0fcf933e216fcacec0c7a3ad6f32e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send the fast‑fail test selector prompt to `codex` via stdin to stop “Argument list too long” CI failures and restore the `select-tests` job. Also lower the diff cap from 200 KB to 60 KB to keep the prompt small.

- **Bug Fixes**
  - Use `codex exec - < prompt.txt` instead of passing the entire prompt as a single argument.
  - Reduce diff size cap to 60 KB so the prompt stays within safe limits.

<sup>Written for commit 831e3c9b60d0fcf933e216fcacec0c7a3ad6f32e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced the amount of generated change data processed during automated checks.
  * Improved how automated review prompts are provided while preserving read-only, non-interactive execution.
  * Maintained structured output handling for consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->