### PR TITLE
Fix flaky email burst claim tests by claiming under the tenancy lock

### DIFF
--- a/apps/backend/src/lib/email-queue-step.test.tsx
+++ b/apps/backend/src/lib/email-queue-step.test.tsx
@@ -1,11 +1,18 @@
 import { BooleanTrue, EmailOutboxCreatedWith } from "@/generated/prisma/client";
-import { globalPrismaClient } from "@/prisma-client";
+import { globalPrismaClient, type PrismaClientTransaction } from "@/prisma-client";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { randomUUID } from "node:crypto";
 import { _forTesting } from "./email-queue-step";
 import { DEFAULT_BRANCH_ID, getSoleTenancyFromProjectBranch } from "./tenancies";
 
-const { claimEmailsForSending, failEmailsStuckInSending, STUCK_EMAIL_TIMEOUT_MS, updateLastExecutionTime } = _forTesting;
+const {
+  claimEmailsForSending,
+  claimEmailsForSendingWithinLock,
+  failEmailsStuckInSending,
+  STUCK_EMAIL_TIMEOUT_MS,
+  updateLastExecutionTime,
+  withTenancyClaimLock,
+} = _forTesting;
 
 describe.sequential("updateLastExecutionTime", () => {
   const metadataKeys: string[] = [];
@@ -186,8 +193,8 @@ describe.sequential("claimEmailsForSending burst allowance", () => {
     await globalPrismaClient.project.delete({ where: { id: testProjectId } });
   });
 
-  const makeRow = async (startedSendingAt: Date | null) => {
-    return await globalPrismaClient.emailOutbox.create({
+  const makeRow = async (tx: PrismaClientTransaction, startedSendingAt: Date | null) => {
+    return await tx.emailOutbox.create({
       data: {
         tenancyId: testTenancyId,
         tsxSource: testFilter.tsxSource,
@@ -216,43 +223,62 @@ describe.sequential("claimEmailsForSending burst allowance", () => {
   });
 
   it("claims up to the burst limit when the rate quota is zero", async () => {
-    await Promise.all(Array.from({ length: BURST_SEND_LIMIT }, () => makeRow(null)));
-    const claimed = await claimEmailsForSending(testTenancyId, 0);
+    const claimed = await withTenancyClaimLock(testTenancyId, async (tx) => {
+      await Promise.all(Array.from({ length: BURST_SEND_LIMIT }, () => makeRow(tx, null)));
+      return await claimEmailsForSendingWithinLock(tx, testTenancyId, 0);
+    });
 
     expect(claimed).toHaveLength(BURST_SEND_LIMIT);
   });
 
   it("does not claim more after the burst limit has been reached", async () => {
-    await Promise.all(Array.from({ length: BURST_SEND_LIMIT + 1 }, () => makeRow(null)));
-    const firstClaim = await claimEmailsForSending(testTenancyId, 0);
-    const secondClaim = await claimEmailsForSending(testTenancyId, 0);
+    const [firstClaim, secondClaim] = await withTenancyClaimLock(testTenancyId, async (tx) => {
+      await Promise.all(Array.from({ length: BURST_SEND_LIMIT + 1 }, () => makeRow(tx, null)));
+      const firstClaim = await claimEmailsForSendingWithinLock(tx, testTenancyId, 0);
+      const secondClaim = await claimEmailsForSendingWithinLock(tx, testTenancyId, 0);
+      return [firstClaim, secondClaim];
+    });
 
     expect(firstClaim).toHaveLength(BURST_SEND_LIMIT);
     expect(secondClaim).toHaveLength(0);
   });
 
   it("does not count claims older than the burst window", async () => {
-    const oldRows = await Promise.all(Array.from({ length: BURST_SEND_LIMIT }, () => makeRow(new Date(Date.now() - 11 * 60 * 1000))));
-    await Promise.all(Array.from({ length: 3 }, () => makeRow(null)));
-    const claimed = await claimEmailsForSending(testTenancyId, 0);
+    const { claimed, oldRows } = await withTenancyClaimLock(testTenancyId, async (tx) => {
+      const oldRows = await Promise.all(Array.from({ length: BURST_SEND_LIMIT }, () => makeRow(tx, new Date(Date.now() - 11 * 60 * 1000))));
+      await Promise.all(Array.from({ length: 3 }, () => makeRow(tx, null)));
+      const claimed = await claimEmailsForSendingWithinLock(tx, testTenancyId, 0);
+      return { claimed, oldRows };
+    });
 
     expect(claimed).toHaveLength(3);
     expect(oldRows).toHaveLength(BURST_SEND_LIMIT);
   });
 
   it("does not double-consume the burst when workers claim concurrently", async () => {
-    await Promise.all(Array.from({ length: BURST_SEND_LIMIT * 2 }, () => makeRow(null)));
+    await Promise.all(Array.from({ length: BURST_SEND_LIMIT * 2 }, () => makeRow(globalPrismaClient, null)));
     const [firstClaim, secondClaim] = await Promise.all([
       claimEmailsForSending(testTenancyId, 0),
       claimEmailsForSending(testTenancyId, 0),
     ]);
 
-    expect(firstClaim.length + secondClaim.length).toBe(BURST_SEND_LIMIT);
+    // An external queue step in CI may claim some rows, so assert the DB-level invariant rather
+    // than relying on the two return values to account for every claim.
+    const claimedRows = await globalPrismaClient.emailOutbox.count({
+      where: {
+        ...testFilter,
+        startedSendingAt: { gte: new Date(Date.now() - 10 * 60 * 1000) },
+      },
+    });
+    expect(claimedRows).toBe(BURST_SEND_LIMIT);
+    expect(firstClaim.length + secondClaim.length).toBeLessThanOrEqual(BURST_SEND_LIMIT);
   });
 
   it("uses the rate quota when it exceeds the burst allowance", async () => {
-    await Promise.all(Array.from({ length: 12 }, () => makeRow(null)));
-    const claimed = await claimEmailsForSending(testTenancyId, 12);
+    const claimed = await withTenancyClaimLock(testTenancyId, async (tx) => {
+      await Promise.all(Array.from({ length: 12 }, () => makeRow(tx, null)));
+      return await claimEmailsForSendingWithinLock(tx, testTenancyId, 12);
+    });
 
     expect(claimed).toHaveLength(12);
   });

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -7,7 +7,7 @@ import { arePlanLimitsEnforced, getBillingTeamId } from "@/lib/plan-entitlements
 import { getHexclaveServerApp } from "@/hexclave";
 import { ITEM_IDS } from "@hexclave/shared/dist/plans";
 import { getTenancy, Tenancy } from "@/lib/tenancies";
-import { getPrismaClientForTenancy, globalPrismaClient, retryTransaction } from "@/prisma-client";
+import { getPrismaClientForTenancy, globalPrismaClient, retryTransaction, type PrismaClientTransaction } from "@/prisma-client";
 import { allPromisesAndWaitUntilEach } from "@/utils/background-tasks";
 import { withTraceSpan } from "@/utils/telemetry";
 import { groupBy } from "@hexclave/shared/dist/utils/arrays";
@@ -214,9 +214,11 @@ async function failEmailsStuckInSending(additionalWhere?: Prisma.EmailOutboxWher
 
 export const _forTesting = {
   claimEmailsForSending,
+  claimEmailsForSendingWithinLock,
   failEmailsStuckInSending,
   STUCK_EMAIL_TIMEOUT_MS,
   updateLastExecutionTime,
+  withTenancyClaimLock,
 };
 
 async function updateLastExecutionTime(key = "EMAIL_QUEUE_METADATA_KEY"): Promise<number> {
@@ -600,16 +602,42 @@ async function claimEmailsForSending(tenancyId: string, limit: number): Promise<
     `;
     if (!locked) return [];
 
-    // Claim queued emails for sending, at least `limit` of them (the tenancy's capacity rate for this
-    // step) but always enough to stay at BURST_SEND_LIMIT claims within the burst window. Without the
-    // burst, a tenancy at the default capacity of 200 emails/hour would wait ~18s on average before its
-    // first email leaves the queue, which is far too slow for things like sign-in codes; letting small
-    // senders briefly exceed their nominal hourly capacity is a deliberate trade for that latency.
-    // The burst is counted over claims (`startedSendingAt`) rather than completed sends so that a claim
-    // by a concurrent, unsynchronized worker counts against the window as soon as it commits, and it is
-    // computed inside the claiming statement itself so the two cannot drift apart.
-    // Note: queueReadyEmails() handles the time-based logic, so we just look for isQueued = TRUE
-    return await tx.$queryRaw<EmailOutbox[]>(Prisma.sql`
+    return await claimEmailsForSendingWithinLock(tx, tenancyId, limit);
+  });
+}
+
+async function withTenancyClaimLock<T>(
+  tenancyId: string,
+  callback: (tx: PrismaClientTransaction) => Promise<T>,
+): Promise<T> {
+  // Tests create rows and claim them under this lock so concurrent production queue steps cannot
+  // see the uncommitted rows or claim them before the test's transaction finishes.
+  return await retryTransaction(globalPrismaClient, async (tx) => {
+    await tx.$executeRaw`
+      SELECT pg_advisory_xact_lock(
+        ${EMAIL_QUEUE_CLAIM_LOCK_CLASS}::int,
+        hashtext(${tenancyId}::text)
+      )
+    `;
+    return await callback(tx);
+  });
+}
+
+async function claimEmailsForSendingWithinLock(
+  tx: PrismaClientTransaction,
+  tenancyId: string,
+  limit: number,
+): Promise<EmailOutbox[]> {
+  // Claim queued emails for sending, at least `limit` of them (the tenancy's capacity rate for this
+  // step) but always enough to stay at BURST_SEND_LIMIT claims within the burst window. Without the
+  // burst, a tenancy at the default capacity of 200 emails/hour would wait ~18s on average before its
+  // first email leaves the queue, which is far too slow for things like sign-in codes; letting small
+  // senders briefly exceed their nominal hourly capacity is a deliberate trade for that latency.
+  // The burst is counted over claims (`startedSendingAt`) rather than completed sends so that a claim
+  // by a concurrent, unsynchronized worker counts against the window as soon as it commits, and it is
+  // computed inside the claiming statement itself so the two cannot drift apart.
+  // Note: queueReadyEmails() handles the time-based logic, so we just look for isQueued = TRUE
+  return await tx.$queryRaw<EmailOutbox[]>(Prisma.sql`
     WITH selected AS (
       SELECT "tenancyId", "id"
       FROM "EmailOutbox"
@@ -642,7 +670,6 @@ async function claimEmailsForSending(tenancyId: string, limit: number): Promise<
     WHERE e."tenancyId" = selected."tenancyId" AND e."id" = selected."id"
     RETURNING e.*;
     `);
-  });
 }
 
 async function processSendPlan(plan: TenancySendBatch[]): Promise<void> {


### PR DESCRIPTION
The `claimEmailsForSending burst allowance` tests write real outbox rows into the shared dev DB, and CI runs full email queue steps against that same DB concurrently (background `run-email-queue`, the e2e queue-step endpoint test, and `runEmailQueueStep()` fired on every send). `prepareSendPlan` scans all tenancies with queued rows, so it picks up the test's throwaway tenancy and either claims the rows first or wins the advisory lock — leaving the test's own claim empty (`expected 10, got 0`).

Splits the claiming path so tests can do their setup inside the lock:

```
withTenancyClaimLock(tenancyId, cb)          // blocking pg_advisory_xact_lock, then cb(tx)
claimEmailsForSendingWithinLock(tx, id, n)   // the claiming CTE/UPDATE, lock assumed held
claimEmailsForSending(id, n)                 // unchanged production path: retryTransaction
                                             // + pg_try_advisory_xact_lock + the above
```

The burst tests now create their rows and claim them inside one locked transaction, so a concurrent queue step can neither see the uncommitted rows nor take the lock. The concurrent-workers test genuinely needs two transactions, so it keeps using the production path and asserts the DB-level invariant instead (exactly `BURST_SEND_LIMIT` rows end up claimed within the window, whoever claimed them).


Link to Devin session: https://app.devin.ai/sessions/188ffc6ada974476a2c5f6b7796691b4
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Production send claiming behavior is a straight refactor with no logic change; risk is limited to test-only helpers exported under `_forTesting`.
> 
> **Overview**
> **Fixes flaky burst-claim tests** when CI runs real email queue steps against the same dev DB as integration tests.
> 
> The email claiming CTE/UPDATE is extracted into **`claimEmailsForSendingWithinLock`**, which assumes the per-tenancy advisory lock is already held. Production **`claimEmailsForSending`** is unchanged: `retryTransaction` + `pg_try_advisory_xact_lock`, then that helper.
> 
> Tests get **`withTenancyClaimLock`**, which takes a **blocking** `pg_advisory_xact_lock` and runs setup + claims in one transaction so concurrent queue workers cannot see uncommitted outbox rows or steal claims.
> 
> Burst allowance specs create rows and call **`claimEmailsForSendingWithinLock`** inside that lock. The concurrent-workers case still uses the production API and now asserts a **DB invariant** (exactly `BURST_SEND_LIMIT` rows claimed in the burst window) because background queue steps in CI may claim some rows outside the test’s return values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d589ca7bd2ff3a90a82b169b276e710668aa9b3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky email burst-claim tests by creating and claiming rows under a tenancy-level advisory lock so concurrent queue steps can’t steal the lock or rows. Production behavior is unchanged; CI tests are now deterministic.

- **Bug Fixes**
  - Added `withTenancyClaimLock(tenancyId, cb)` to run setup and claims under `pg_advisory_xact_lock`.
  - Split claim logic into `claimEmailsForSendingWithinLock(tx, tenancyId, limit)` and reused it inside `claimEmailsForSending`.
  - Updated burst tests to create rows and claim within the lock; the concurrent-workers test now asserts the DB-level invariant (`BURST_SEND_LIMIT`) instead of summing return values.
  - Test helper now accepts a transaction for row creation.

<sup>Written for commit d589ca7bd2ff3a90a82b169b276e710668aa9b3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email delivery reliability when multiple workers process queued messages simultaneously.
  * Prevented duplicate claims during high-volume or concurrent email-sending activity.
  * Strengthened database-wide coordination to ensure each queued email is handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->