### PR TITLE
Stop the browser cookie poll loop when browser globals disappear

### DIFF
--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
@@ -497,6 +497,7 @@ describe("StackClientApp cross-domain auth", () => {
         tokenStore: "cookie",
         redirectMethod: "none",
         noAutomaticPrefetch: true,
+        automaticSideEffects: false,
         devTool: false,
       });
       const getBrowserCookieTokenStore = Reflect.get(clientApp, "_getBrowserCookieTokenStore");

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
@@ -472,6 +472,52 @@ describe("StackClientApp cross-domain auth", () => {
     expect(refreshedRawRefreshTokens).toEqual(["new-refresh-token"]);
   });
 
+  it("stops polling the browser cookie store when browser globals are removed", () => {
+    vi.useFakeTimers();
+    const clearIntervalSpy = vi.spyOn(globalThis, "clearInterval");
+    const previousWindow = globalThis.window;
+    const previousDocument = globalThis.document;
+
+    globalThis.document = createMockDocument();
+    globalThis.window = {
+      location: {
+        href: "https://demo.stack-auth.com/",
+        protocol: "https:",
+        hostname: "demo.stack-auth.com",
+      },
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    } as any;
+
+    try {
+      const clientApp = new StackClientApp({
+        baseUrl: "http://localhost:12345",
+        projectId: "00000000-0000-4000-8000-000000000007",
+        publishableClientKey: "stack-pk-test",
+        tokenStore: "cookie",
+        redirectMethod: "none",
+        noAutomaticPrefetch: true,
+        devTool: false,
+      });
+      const getBrowserCookieTokenStore = Reflect.get(clientApp, "_getBrowserCookieTokenStore");
+      if (typeof getBrowserCookieTokenStore !== "function") {
+        throw new Error("Expected StackClientApp to expose _getBrowserCookieTokenStore in tests.");
+      }
+      getBrowserCookieTokenStore.call(clientApp);
+
+      Reflect.set(globalThis, "window", previousWindow);
+      Reflect.set(globalThis, "document", previousDocument);
+
+      expect(() => vi.advanceTimersByTime(100)).not.toThrow();
+      expect(clearIntervalSpy).toHaveBeenCalledOnce();
+    } finally {
+      Reflect.set(globalThis, "window", previousWindow);
+      Reflect.set(globalThis, "document", previousDocument);
+      clearIntervalSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it("does not re-bounce nested cross-domain auth after the OAuth callback consumed code+state from the URL", async () => {
     const projectId = "00000000-0000-4000-8000-000000000008";
     const previousWindow = globalThis.window;

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -1586,7 +1586,12 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       this._storedBrowserCookieTokenStore = new Store<TokenObject>(this._getCurrentBrowserCookieTokenStoreValue(null));
       let hasSucceededInWriting = true;
 
-      setInterval(() => {
+      // Tests and server-side lifecycles can outlive browser globals, so stop polling when cookie reads no longer apply.
+      const pollInterval = setInterval(() => {
+        if (!isBrowserLike()) {
+          clearInterval(pollInterval);
+          return;
+        }
         if (hasSucceededInWriting) {
           const oldValue = this._storedBrowserCookieTokenStore!.get();
           const currentValue = this._getCurrentBrowserCookieTokenStoreValue(oldValue);
@@ -1595,6 +1600,7 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
           }
         }
       }, 100);
+      if (typeof pollInterval === "object") pollInterval.unref();
       this._storedBrowserCookieTokenStore.onChange((value) => {
         try {
           const refreshToken = value.refreshToken;


### PR DESCRIPTION
`_getBrowserCookieTokenStore()` installed a 100ms `setInterval` that synchronously reads `document.cookie` via `_getAllBrowserCookies()`, which asserts `isBrowserLike()`. The interval was never cleared, so once the environment stopped being browser-like (e.g. a test restoring `window`/`document` in teardown) the next tick threw `Cannot get browser cookies on the server!` as an uncaught exception — outside any promise, so `runAsynchronously` could never have caught it.

The poll loop now clears itself once cookie reads no longer apply, and the timer is `unref`'d (same pattern as `wait()`) so it can't keep a Node process alive.

Regression test asserts the tick after browser globals are removed doesn't throw and that the interval is cleared; it fails against the old code with the original assertion error.

Link to Devin session: https://app.devin.ai/sessions/b9b0019f722046a2b866c323075ffcea
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle fix in cookie token store polling with a regression test; no auth or API behavior changes for normal browser usage.
> 
> **Overview**
> Fixes a leak in **`_getBrowserCookieTokenStore()`** where the 100ms cookie sync **`setInterval`** kept running after the environment stopped being browser-like (e.g. tests restoring `window`/`document`), causing uncaught **`Cannot get browser cookies on the server!`** on the next tick.
> 
> The poll callback now **self-clears** when **`isBrowserLike()`** is false, and the timer is **`unref()`'d** so it does not keep a Node process alive. A cross-domain test asserts advancing timers after removing browser globals does not throw and that **`clearInterval`** runs once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86d55fe730708d7a3b243d6f3bbe52559a72ca0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the cookie polling loop in `StackClientApp` when browser globals disappear to prevent uncaught “Cannot get browser cookies on the server!” errors in tests and SSR. Also unrefs the timer so it won’t keep Node processes alive.

- **Bug Fixes**
  - Clear the 100ms cookie poll interval when `isBrowserLike()` returns false.
  - Call `unref()` on the interval to avoid keeping the process alive.
  - Add a regression test that disables automatic side effects, removes `window`/`document`, advances timers, asserts no throw, and verifies the interval is cleared.

<sup>Written for commit 1d67abb55fb59d8a497bafb237ac44b0a87dcbe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser cookie polling to stop safely when browser context is unavailable.
  * Prevented continued cookie access after server-side or test lifecycles.
  * Ensured polling timers are properly released when no longer needed, reducing unnecessary background activity.

* **Tests**
  * Added regression coverage for safely stopping polling when browser globals are removed and confirming no errors occur afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->