### PR TITLE
Add the Email API app page to the dashboard

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/playground/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/playground/page-client.tsx
@@ -445,6 +445,7 @@ export default function PageClient() {
   const [dgSelectionMode, setDgSelectionMode] = useState<DataGridSelectionMode>("none");
   const [dgRowHeight, setDgRowHeight] = useState(44);
   const [dgShowToolbar, setDgShowToolbar] = useState(true);
+  const [dgStickyTop, setDgStickyTop] = useState<"inherited" | "local">("inherited");
   const [dgState, setDgState] = useState(() => createDefaultDataGridState(DEMO_GRID_COLUMNS));
   const dgData = useDataSource({ data: DEMO_GRID_USERS, columns: DEMO_GRID_COLUMNS, getRowId: (r: DemoGridUser) => r.id, sorting: dgState.sorting, quickSearch: dgState.quickSearch, pagination: dgState.pagination, paginationMode: "client" });
 
@@ -941,6 +942,7 @@ export default function PageClient() {
             selectionMode={dgSelectionMode}
             rowHeight={dgRowHeight}
             toolbar={dgShowToolbar ? undefined : false}
+            stickyTop={dgStickyTop === "local" ? 0 : undefined}
             maxHeight={400}
           />
         </div>
@@ -1753,6 +1755,23 @@ export default function PageClient() {
           <PropField label="Toolbar">
             <BoolToggle value={dgShowToolbar} onChange={setDgShowToolbar} on="Shown" off="Hidden" />
           </PropField>
+          <PropField label="Sticky top">
+            <DesignSelectorDropdown
+              value={dgStickyTop}
+              onValueChange={(v) => {
+                if (v === "inherited" || v === "local") {
+                  setDgStickyTop(v);
+                  return;
+                }
+                throw new Error(`Unknown sticky top mode "${v}"`);
+              }}
+              options={[
+                { value: "inherited", label: "Inherited" },
+                { value: "local", label: "Local (0px)" },
+              ]}
+              size="sm"
+            />
+          </PropField>
         </div>
       );
     }
@@ -2333,6 +2352,7 @@ export default function PageClient() {
   selectionMode="${dgSelectionMode}"
   rowHeight={${dgRowHeight}}
   toolbar={${dgShowToolbar ? "undefined" : "false"}}
+  stickyTop={${dgStickyTop === "local" ? "0" : "undefined"}}
   maxHeight={400}
 />`;
     }

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/playground/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/playground/page-client.tsx
@@ -445,7 +445,7 @@ export default function PageClient() {
   const [dgSelectionMode, setDgSelectionMode] = useState<DataGridSelectionMode>("none");
   const [dgRowHeight, setDgRowHeight] = useState(44);
   const [dgShowToolbar, setDgShowToolbar] = useState(true);
-  const [dgStickyTop, setDgStickyTop] = useState<"inherited" | "local">("inherited");
+  const [dgStickyTop, setDgStickyTop] = useState<"default" | "local">("default");
   const [dgState, setDgState] = useState(() => createDefaultDataGridState(DEMO_GRID_COLUMNS));
   const dgData = useDataSource({ data: DEMO_GRID_USERS, columns: DEMO_GRID_COLUMNS, getRowId: (r: DemoGridUser) => r.id, sorting: dgState.sorting, quickSearch: dgState.quickSearch, pagination: dgState.pagination, paginationMode: "client" });
 
@@ -942,7 +942,7 @@ export default function PageClient() {
             selectionMode={dgSelectionMode}
             rowHeight={dgRowHeight}
             toolbar={dgShowToolbar ? undefined : false}
-            stickyTop={dgStickyTop === "local" ? 0 : undefined}
+            stickyTop={dgStickyTop === "local" ? 80 : undefined}
             maxHeight={400}
           />
         </div>
@@ -1759,15 +1759,15 @@ export default function PageClient() {
             <DesignSelectorDropdown
               value={dgStickyTop}
               onValueChange={(v) => {
-                if (v === "inherited" || v === "local") {
+                if (v === "default" || v === "local") {
                   setDgStickyTop(v);
                   return;
                 }
                 throw new Error(`Unknown sticky top mode "${v}"`);
               }}
               options={[
-                { value: "inherited", label: "Inherited" },
-                { value: "local", label: "Local (0px)" },
+                { value: "default", label: "Default (0px)" },
+                { value: "local", label: "Local (80px)" },
               ]}
               size="sm"
             />
@@ -2352,7 +2352,7 @@ export default function PageClient() {
   selectionMode="${dgSelectionMode}"
   rowHeight={${dgRowHeight}}
   toolbar={${dgShowToolbar ? "undefined" : "false"}}
-  stickyTop={${dgStickyTop === "local" ? "0" : "undefined"}}
+  stickyTop={${dgStickyTop === "local" ? "80" : "undefined"}}
   maxHeight={400}
 />`;
     }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/email-api-logic.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/email-api-logic.test.ts
@@ -1,0 +1,51 @@
+import type { AdminEmailOutboxStatus } from "@hexclave/next";
+import { describe, expect, it } from "vitest";
+import { countEmailsSince, getDeliverySuccessRate, groupEmailsBySource, isEmailApiEmail } from "./email-api-logic";
+
+const email = (overrides: {
+  createdWith: "draft" | "programmatic-call",
+  emailProgrammaticCallTemplateId: string | null,
+  createdAt?: Date,
+  status?: AdminEmailOutboxStatus,
+  simpleStatus?: "in-progress" | "ok" | "error",
+}) => ({
+  createdWith: overrides.createdWith,
+  emailProgrammaticCallTemplateId: overrides.emailProgrammaticCallTemplateId,
+  createdAt: overrides.createdAt ?? new Date("2025-01-01T00:00:00Z"),
+  status: overrides.status ?? "sent" as const,
+  simpleStatus: overrides.simpleStatus ?? "ok" as const,
+});
+
+describe("Email API analytics", () => {
+  it("only includes programmatic-call rows", () => {
+    expect(isEmailApiEmail(email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null }))).toBe(true);
+    expect(isEmailApiEmail(email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: "tpl" }))).toBe(true);
+    expect(isEmailApiEmail(email({ createdWith: "draft", emailProgrammaticCallTemplateId: null }))).toBe(false);
+  });
+
+  it("counts rows on the window boundaries", () => {
+    const now = new Date("2025-01-02T00:00:00Z");
+    const rows = [
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, createdAt: new Date("2025-01-01T00:00:00Z") }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, createdAt: new Date("2025-01-01T00:00:01Z") }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, createdAt: now }),
+    ];
+    expect(countEmailsSince(rows, now, 24 * 60 * 60 * 1000)).toBe(3);
+  });
+
+  it("groups template sends and raw HTML separately", () => {
+    const rows = [
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: "tpl-1", status: "sent" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: "tpl-1", status: "bounced" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "queued" }),
+    ];
+    const groups = groupEmailsBySource(rows, new Map([["tpl-1", "Welcome"]]));
+    expect(groups.map((group) => [group.displayName, group.count])).toEqual([["Welcome", 2], ["Raw HTML", 1]]);
+    expect(groups[0].statuses).toEqual({ sent: 1, bounced: 1 });
+  });
+
+  it("returns zero for empty delivery data", () => {
+    expect(getDeliverySuccessRate([])).toBe(0);
+    expect(getDeliverySuccessRate([email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "sent" }), email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "bounced" })])).toBe(0.5);
+  });
+});

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/email-api-logic.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/email-api-logic.test.ts
@@ -2,18 +2,26 @@ import type { AdminEmailOutboxStatus } from "@hexclave/next";
 import { describe, expect, it } from "vitest";
 import { countEmailsSince, getDeliverySuccessRate, groupEmailsBySource, isEmailApiEmail } from "./email-api-logic";
 
+type EmailFixture = {
+  createdWith: "draft" | "programmatic-call",
+  emailProgrammaticCallTemplateId: string | null,
+  createdAt: Date,
+  status: AdminEmailOutboxStatus,
+  simpleStatus: "in-progress" | "ok" | "error",
+};
+
 const email = (overrides: {
   createdWith: "draft" | "programmatic-call",
   emailProgrammaticCallTemplateId: string | null,
   createdAt?: Date,
   status?: AdminEmailOutboxStatus,
   simpleStatus?: "in-progress" | "ok" | "error",
-}) => ({
+}): EmailFixture => ({
   createdWith: overrides.createdWith,
   emailProgrammaticCallTemplateId: overrides.emailProgrammaticCallTemplateId,
   createdAt: overrides.createdAt ?? new Date("2025-01-01T00:00:00Z"),
-  status: overrides.status ?? "sent" as const,
-  simpleStatus: overrides.simpleStatus ?? "ok" as const,
+  status: overrides.status ?? "sent",
+  simpleStatus: overrides.simpleStatus ?? "ok",
 });
 
 describe("Email API analytics", () => {
@@ -33,6 +41,16 @@ describe("Email API analytics", () => {
     expect(countEmailsSince(rows, now, 24 * 60 * 60 * 1000)).toBe(3);
   });
 
+  it("includes rows created after the initially captured time", () => {
+    const capturedNow = new Date("2025-01-02T00:00:00Z");
+    const refreshedRow = email({
+      createdWith: "programmatic-call",
+      emailProgrammaticCallTemplateId: null,
+      createdAt: new Date("2025-01-02T00:00:01Z"),
+    });
+    expect(countEmailsSince([refreshedRow], capturedNow, 24 * 60 * 60 * 1000)).toBe(1);
+  });
+
   it("groups template sends and raw HTML separately", () => {
     const rows = [
       email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: "tpl-1", status: "sent" }),
@@ -41,23 +59,27 @@ describe("Email API analytics", () => {
     ];
     const groups = groupEmailsBySource(rows, new Map([["tpl-1", "Welcome"]]));
     expect(groups.map((group) => [group.displayName, group.count])).toEqual([["Welcome", 2], ["Raw HTML", 1]]);
-    expect(groups[0].statuses).toEqual({ sent: 1, bounced: 1 });
+    expect(groups[0].statuses).toEqual(new Map([["sent", 1], ["bounced", 1]]));
   });
 
-  it("returns no rate when all rows are in progress", () => {
+  it("returns no rate when all rows are non-outcome statuses", () => {
     expect(getDeliverySuccessRate([
       email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "queued", simpleStatus: "in-progress" }),
-      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "sending", simpleStatus: "in-progress" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "delivery-delayed", simpleStatus: "ok" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "skipped", simpleStatus: "ok" }),
     ])).toBeNull();
   });
 
-  it("calculates terminal delivery success and excludes delayed rows", () => {
+  it("counts spam as delivered and excludes delayed and skipped rows", () => {
     expect(getDeliverySuccessRate([
       email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "sent", simpleStatus: "ok" }),
       email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "opened", simpleStatus: "ok" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "marked-as-spam", simpleStatus: "ok" }),
       email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "bounced", simpleStatus: "error" }),
-      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "delivery-delayed", simpleStatus: "in-progress" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "server-error", simpleStatus: "error" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "delivery-delayed", simpleStatus: "ok" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "skipped", simpleStatus: "ok" }),
       email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "queued", simpleStatus: "in-progress" }),
-    ])).toBe(2 / 3);
+    ])).toBe(3 / 5);
   });
 });

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/email-api-logic.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/email-api-logic.test.ts
@@ -44,8 +44,20 @@ describe("Email API analytics", () => {
     expect(groups[0].statuses).toEqual({ sent: 1, bounced: 1 });
   });
 
-  it("returns zero for empty delivery data", () => {
-    expect(getDeliverySuccessRate([])).toBe(0);
-    expect(getDeliverySuccessRate([email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "sent" }), email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "bounced" })])).toBe(0.5);
+  it("returns no rate when all rows are in progress", () => {
+    expect(getDeliverySuccessRate([
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "queued", simpleStatus: "in-progress" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "sending", simpleStatus: "in-progress" }),
+    ])).toBeNull();
+  });
+
+  it("calculates terminal delivery success and excludes delayed rows", () => {
+    expect(getDeliverySuccessRate([
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "sent", simpleStatus: "ok" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "opened", simpleStatus: "ok" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "bounced", simpleStatus: "error" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "delivery-delayed", simpleStatus: "in-progress" }),
+      email({ createdWith: "programmatic-call", emailProgrammaticCallTemplateId: null, status: "queued", simpleStatus: "in-progress" }),
+    ])).toBe(2 / 3);
   });
 });

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/email-api-logic.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/email-api-logic.ts
@@ -1,4 +1,5 @@
 import type { AdminEmailOutbox, AdminEmailOutboxStatus } from "@hexclave/next";
+import { throwErr } from "@hexclave/shared/dist/utils/errors";
 import { stringCompare } from "@hexclave/shared/dist/utils/strings";
 
 export type EmailApiSource = {
@@ -6,7 +7,7 @@ export type EmailApiSource = {
   displayName: string,
   count: number,
   lastSentAt: Date | null,
-  statuses: Partial<Record<AdminEmailOutboxStatus, number>>,
+  statuses: Map<AdminEmailOutboxStatus, number>,
 };
 
 export function isEmailApiEmail(email: Pick<AdminEmailOutbox, "createdWith">): boolean {
@@ -21,7 +22,7 @@ export function countEmailsSince(
   const start = now.getTime() - durationMillis;
   return emails.filter((email) => {
     const createdAt = email.createdAt.getTime();
-    return createdAt >= start && createdAt <= now.getTime();
+    return createdAt >= start;
   }).length;
 }
 
@@ -40,24 +41,101 @@ export function groupEmailsBySource(
         : templateNames.get(id) ?? `Template (${id.slice(0, 8)}...)`,
       count: 0,
       lastSentAt: null,
-      statuses: {},
+      statuses: new Map(),
     };
     source.count++;
     source.lastSentAt = source.lastSentAt == null || email.createdAt > source.lastSentAt
       ? email.createdAt
       : source.lastSentAt;
-    source.statuses[email.status] = (source.statuses[email.status] ?? 0) + 1;
+    source.statuses.set(email.status, (source.statuses.get(email.status) ?? 0) + 1);
     groups.set(id, source);
   }
   return [...groups.values()].sort((a, b) => b.count - a.count || stringCompare(a.displayName, b.displayName));
 }
 
-export function getDeliverySuccessRate(emails: Pick<AdminEmailOutbox, "status" | "simpleStatus">[]): number | null {
-  const terminalEmails = emails.filter((email) => email.simpleStatus !== "in-progress");
-  if (terminalEmails.length === 0) return null;
-  return terminalEmails.filter((email) => (
-    email.status === "sent" ||
-    email.status === "opened" ||
-    email.status === "clicked"
-  )).length / terminalEmails.length;
+type DeliveryOutcome = "success" | "failure" | "excluded";
+
+function assertNever(value: never): never {
+  return throwErr(`Unhandled email delivery value: ${value}`);
+}
+
+function classifyDeliveryStatus(status: AdminEmailOutboxStatus): DeliveryOutcome {
+  switch (status) {
+    case "sent": {
+      return "success";
+    }
+    case "opened": {
+      return "success";
+    }
+    case "clicked": {
+      return "success";
+    }
+    case "marked-as-spam": {
+      // Spam complaints still represent delivered messages; skipped and delayed rows do not.
+      return "success";
+    }
+    case "bounced": {
+      return "failure";
+    }
+    case "render-error": {
+      return "failure";
+    }
+    case "server-error": {
+      return "failure";
+    }
+    case "paused": {
+      return "excluded";
+    }
+    case "preparing": {
+      return "excluded";
+    }
+    case "rendering": {
+      return "excluded";
+    }
+    case "scheduled": {
+      return "excluded";
+    }
+    case "queued": {
+      return "excluded";
+    }
+    case "sending": {
+      return "excluded";
+    }
+    case "delivery-delayed": {
+      return "excluded";
+    }
+    case "skipped": {
+      // Delayed rows are still in flight, while skipped rows were never attempted.
+      return "excluded";
+    }
+    default: {
+      return assertNever(status);
+    }
+  }
+}
+
+export function getDeliverySuccessRate(emails: Pick<AdminEmailOutbox, "status">[]): number | null {
+  let successes = 0;
+  let failures = 0;
+  for (const email of emails) {
+    const outcome = classifyDeliveryStatus(email.status);
+    switch (outcome) {
+      case "success": {
+        successes++;
+        break;
+      }
+      case "failure": {
+        failures++;
+        break;
+      }
+      case "excluded": {
+        break;
+      }
+      default: {
+        return assertNever(outcome);
+      }
+    }
+  }
+  const terminalCount = successes + failures;
+  return terminalCount === 0 ? null : successes / terminalCount;
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/email-api-logic.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/email-api-logic.ts
@@ -1,0 +1,63 @@
+import type { AdminEmailOutbox, AdminEmailOutboxStatus } from "@hexclave/next";
+import { stringCompare } from "@hexclave/shared/dist/utils/strings";
+
+export type EmailApiSource = {
+  id: string,
+  displayName: string,
+  count: number,
+  lastSentAt: Date | null,
+  statuses: Partial<Record<AdminEmailOutboxStatus, number>>,
+};
+
+export function isEmailApiEmail(email: Pick<AdminEmailOutbox, "createdWith">): boolean {
+  return email.createdWith === "programmatic-call";
+}
+
+export function countEmailsSince(
+  emails: Pick<AdminEmailOutbox, "createdAt">[],
+  now: Date,
+  durationMillis: number,
+): number {
+  const start = now.getTime() - durationMillis;
+  return emails.filter((email) => {
+    const createdAt = email.createdAt.getTime();
+    return createdAt >= start && createdAt <= now.getTime();
+  }).length;
+}
+
+export function groupEmailsBySource(
+  emails: Pick<AdminEmailOutbox, "createdAt" | "status" | "emailProgrammaticCallTemplateId">[],
+  templateNames: ReadonlyMap<string, string>,
+): EmailApiSource[] {
+  const groups = new Map<string, EmailApiSource>();
+  for (const email of emails) {
+    const id = email.emailProgrammaticCallTemplateId ?? "html";
+    const existing = groups.get(id);
+    const source = existing ?? {
+      id,
+      displayName: id === "html"
+        ? "Raw HTML"
+        : templateNames.get(id) ?? `Template (${id.slice(0, 8)}...)`,
+      count: 0,
+      lastSentAt: null,
+      statuses: {},
+    };
+    source.count++;
+    source.lastSentAt = source.lastSentAt == null || email.createdAt > source.lastSentAt
+      ? email.createdAt
+      : source.lastSentAt;
+    source.statuses[email.status] = (source.statuses[email.status] ?? 0) + 1;
+    groups.set(id, source);
+  }
+  return [...groups.values()].sort((a, b) => b.count - a.count || stringCompare(a.displayName, b.displayName));
+}
+
+export function getDeliverySuccessRate(emails: Pick<AdminEmailOutbox, "status">[]): number {
+  if (emails.length === 0) return 0;
+  return emails.filter((email) => (
+    email.status === "sent" ||
+    email.status === "opened" ||
+    email.status === "clicked" ||
+    email.status === "delivery-delayed"
+  )).length / emails.length;
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/email-api-logic.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/email-api-logic.ts
@@ -52,12 +52,12 @@ export function groupEmailsBySource(
   return [...groups.values()].sort((a, b) => b.count - a.count || stringCompare(a.displayName, b.displayName));
 }
 
-export function getDeliverySuccessRate(emails: Pick<AdminEmailOutbox, "status">[]): number {
-  if (emails.length === 0) return 0;
-  return emails.filter((email) => (
+export function getDeliverySuccessRate(emails: Pick<AdminEmailOutbox, "status" | "simpleStatus">[]): number | null {
+  const terminalEmails = emails.filter((email) => email.simpleStatus !== "in-progress");
+  if (terminalEmails.length === 0) return null;
+  return terminalEmails.filter((email) => (
     email.status === "sent" ||
     email.status === "opened" ||
-    email.status === "clicked" ||
-    email.status === "delivery-delayed"
-  )).length / emails.length;
+    email.status === "clicked"
+  )).length / terminalEmails.length;
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
@@ -7,7 +7,7 @@ import {
   DesignCard,
 } from "@/components/design-components";
 import { CopyPromptButton } from "@/components/ui";
-import { LinkIcon, MailboxIcon, SparkleIcon } from "@phosphor-icons/react";
+import { CodeIcon, MailboxIcon, SparkleIcon } from "@phosphor-icons/react";
 import type { AdminEmailOutbox } from "@hexclave/next";
 import {
   DataGrid,
@@ -15,7 +15,7 @@ import {
   type DataGridColumnDef,
 } from "@hexclave/dashboard-ui-components";
 import { useCallback, useMemo } from "react";
-import { ALL_APPS_FRONTEND, getItemPath } from "@/lib/apps-frontend";
+import { ALL_APPS_FRONTEND, getAppPath, getItemPath } from "@/lib/apps-frontend";
 import { AppEnabledGuard } from "../app-enabled-guard";
 import { PageLayout } from "../page-layout";
 import { useAdminApp } from "../use-admin-app";
@@ -24,6 +24,11 @@ import { SentEmailsView } from "../email-sent/sent-emails-view";
 import { countEmailsSince, getDeliverySuccessRate, groupEmailsBySource, isEmailApiEmail, type EmailApiSource } from "./email-api-logic";
 
 const DAY = 24 * 60 * 60 * 1000;
+
+type StatTile = {
+  label: string,
+  value: number | string,
+};
 
 function formatDate(date: Date | null): string {
   return date == null ? "Never" : date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
@@ -53,17 +58,18 @@ function ApiStatsAndSources({ emails, templateNames }: {
     paramPrefix: "emailsource",
     initial: { sorting: [{ columnId: "count", direction: "desc" }] },
   });
-  const windows = [
-    ["24h", countEmailsSince(emails, now, DAY)],
-    ["7d", countEmailsSince(emails, now, 7 * DAY)],
-    ["30d", countEmailsSince(emails, now, 30 * DAY)],
+  const rate = getDeliverySuccessRate(emails);
+  const stats: StatTile[] = [
+    { label: "24h", value: countEmailsSince(emails, now, DAY) },
+    { label: "7d", value: countEmailsSince(emails, now, 7 * DAY) },
+    { label: "30d", value: countEmailsSince(emails, now, 30 * DAY) },
+    { label: "Success", value: rate == null ? "—" : `${Math.round(rate * 100)}%` },
   ];
-  const successRate = Math.round(getDeliverySuccessRate(emails) * 100);
 
   return (
     <div className="flex flex-col gap-4">
       <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-        {[...windows, ["Success", `${successRate}%`]].map(([label, value]) => (
+        {stats.map(({ label, value }) => (
           <DesignCard key={label} glassmorphic contentClassName="p-3">
             <div className="text-xs uppercase tracking-wider text-muted-foreground">{label}</div>
             <div className="mt-1 text-xl font-semibold">{value}</div>
@@ -99,9 +105,7 @@ function PromptCard({ title, prompt }: { title: string, prompt: string }) {
         <div className="mb-1 text-sm font-medium">{title}</div>
         <p className="text-xs leading-relaxed text-muted-foreground">{prompt}</p>
       </div>
-      <CopyPromptButton content={prompt} aria-label={`Copy ${title} prompt`} className="shrink-0">
-        <SparkleIcon className="text-purple-500 dark:text-purple-400" />
-      </CopyPromptButton>
+      <CopyPromptButton content={prompt} aria-label={`Copy ${title} prompt`} className="shrink-0" />
     </div>
   );
 }
@@ -115,12 +119,16 @@ export default function PageClient() {
     [templates],
   );
   const templateId = templates[0]?.id ?? "replace-with-template-id";
-  const emailSettingsHref = getItemPath(project.id, ALL_APPS_FRONTEND.emails, ALL_APPS_FRONTEND.emails.navigationItems[3]);
+  const emailSettingsItem = ALL_APPS_FRONTEND.emails.navigationItems.find((item) => item.displayName === "Email Settings");
+  const emailSettingsHref = emailSettingsItem == null
+    ? null
+    : getItemPath(project.id, ALL_APPS_FRONTEND.emails, emailSettingsItem);
+  const apiKeysHref = getAppPath(project.id, ALL_APPS_FRONTEND["api-keys"]);
 
   const filterFn = useCallback((email: AdminEmailOutbox) => isEmailApiEmail(email), []);
   const snippets = useMemo(() => ({
     setup: `pnpm add @hexclave/next\n\n# .env\nNEXT_PUBLIC_HEXCLAVE_PROJECT_ID=${project.id}\nHEXCLAVE_SECRET_SERVER_KEY=your_server_key`,
-    html: `import { hexclaveServerApp } from "@hexclave/next/server";\n\nawait hexclaveServerApp.sendEmail({\n  userIds: ["user-id"],\n  subject: "Welcome to Acme",\n  html: "<h1>Welcome!</h1><p>Thanks for joining.</p>",\n});`,
+    html: `import { hexclaveServerApp } from "@/hexclave/server";\n\nawait hexclaveServerApp.sendEmail({\n  userIds: ["user-id"],\n  subject: "Welcome to Acme",\n  html: "<h1>Welcome!</h1><p>Thanks for joining.</p>",\n});`,
     template: `await hexclaveServerApp.sendEmail({\n  userIds: ["user-id"],\n  templateId: "${templateId}",\n  variables: { firstName: "Ada", plan: "Pro" },\n});`,
     emails: `await hexclaveServerApp.sendEmail({\n  emails: ["customer@example.com"],\n  subject: "Your receipt",\n  html: "<p>Thanks for your purchase.</p>",\n});\n// Arbitrary addresses cannot unsubscribe; use this for transactional mail only.`,
     curl: `curl -X POST https://api.hexclave.com/api/v1/emails/send-email \\\n  -H "Content-Type: application/json" \\\n  -H "X-Stack-Access-Type: server" \\\n  -H "X-Stack-Project-Id: ${project.id}" \\\n  -H "X-Stack-Secret-Server-Key: $HEXCLAVE_SECRET_SERVER_KEY" \\\n  -d '${JSON.stringify({ user_ids: ["user-id"], template_id: templateId, variables: { firstName: "Ada" } })}'`,
@@ -143,11 +151,11 @@ export default function PageClient() {
           description={<>
             The Email API queues messages from trusted server code. Keep your server key private and configure a custom email server before sending; the shared development server cannot deliver email.
             <br /><br />
-            Configure delivery in <StyledLink href={emailSettingsHref}>Email Settings</StyledLink> and manage credentials in <StyledLink href={`/projects/${project.id}/project-keys`}>API Keys</StyledLink>. Read the <StyledLink href="https://docs.hexclave.com/guides/apps/emails/overview">Email API documentation</StyledLink> for the full guide.
+            Configure delivery {emailSettingsHref == null ? "in Email Settings" : <><StyledLink href={emailSettingsHref}>in Email Settings</StyledLink></>} and manage credentials in <StyledLink href={apiKeysHref}>API Keys</StyledLink>. Read the <StyledLink href="https://docs.hexclave.com/guides/apps/emails/overview">Email API documentation</StyledLink> for the full guide.
           </>}
         />
 
-        <DesignCard title="Usage" subtitle="Copy a complete example into your server application" icon={LinkIcon} glassmorphic>
+        <DesignCard title="Usage" subtitle="Copy a complete example into your server application" icon={CodeIcon} glassmorphic>
           <div className="flex flex-col gap-4">
             <CodeBlock language="bash" title="Install and configure" content={snippets.setup} icon="code" />
             <CodeBlock language="typescript" title="Send raw HTML to users" content={snippets.html} icon="code" />

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
@@ -309,7 +309,7 @@ export default function PageClient() {
             <div><h2 className="text-lg font-semibold">Delivery</h2><p className="text-sm text-muted-foreground">See whether API-attributed sends reached a terminal delivery state.</p></div>
             <StyledLink href={sentHref}>Open full sent view</StyledLink>
           </div>
-          <SentEmailsView filterFn={filterFn} renderActions={(emails) => <ApiStatsAndSources emails={emails} templateNames={templateNames} />} />
+          <SentEmailsView stickyTop={0} filterFn={filterFn} renderActions={(emails) => <ApiStatsAndSources emails={emails} templateNames={templateNames} />} />
         </section>
 
         <DesignCard title="Quickstart" subtitle="Choose a transport and send shape; every example uses this project’s credentials." icon={CodeIcon} glassmorphic>

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
@@ -152,7 +152,7 @@ export default function PageClient() {
           variant="info"
           title="Server-side email delivery"
           description={<>
-            The Email API queues messages from trusted server code. Keep your server key private and configure a custom email server before sending; the shared development server cannot deliver email.
+            The Email API queues messages from trusted server code. Keep your server key private. The shared development server delivers mail with a [Hexclave dev email] subject prefix and an injected development notice; configure a custom email server to send from your own domain without this branding.
             <br /><br />
             Configure delivery <StyledLink href={emailSettingsHref}>in Email Settings</StyledLink> and manage credentials in <StyledLink href={apiKeysHref}>API Keys</StyledLink>. Read the <StyledLink href="https://docs.hexclave.com/guides/apps/emails/overview">Email API documentation</StyledLink> for the full guide.
           </>}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { CodeBlock } from "@/components/code-block";
+import { StyledLink } from "@/components/link";
+import {
+  DesignAlert,
+  DesignCard,
+} from "@/components/design-components";
+import { CopyPromptButton } from "@/components/ui";
+import { LinkIcon, MailboxIcon, SparkleIcon } from "@phosphor-icons/react";
+import type { AdminEmailOutbox } from "@hexclave/next";
+import {
+  DataGrid,
+  useDataGridUrlState,
+  type DataGridColumnDef,
+} from "@hexclave/dashboard-ui-components";
+import { useCallback, useMemo } from "react";
+import { ALL_APPS_FRONTEND, getItemPath } from "@/lib/apps-frontend";
+import { AppEnabledGuard } from "../app-enabled-guard";
+import { PageLayout } from "../page-layout";
+import { useAdminApp } from "../use-admin-app";
+import { STATUS_LABELS, getStatusBadgeColor } from "../email-sent/email-status-utils";
+import { SentEmailsView } from "../email-sent/sent-emails-view";
+import { countEmailsSince, getDeliverySuccessRate, groupEmailsBySource, isEmailApiEmail, type EmailApiSource } from "./email-api-logic";
+
+const DAY = 24 * 60 * 60 * 1000;
+
+function formatDate(date: Date | null): string {
+  return date == null ? "Never" : date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}
+
+const sourceColumns: DataGridColumnDef<EmailApiSource>[] = [
+  { id: "source", header: "Source", flex: 1, minWidth: 150, type: "string", accessor: (row) => row.displayName },
+  { id: "count", header: "Sends", width: 90, type: "number", accessor: (row) => row.count },
+  { id: "lastSentAt", header: "Last sent", width: 190, type: "string", accessor: (row) => formatDate(row.lastSentAt) },
+  {
+    id: "status",
+    header: "Status",
+    flex: 1,
+    minWidth: 180,
+    type: "string",
+    accessor: (row) => Object.entries(row.statuses).map(([status, count]) => `${STATUS_LABELS[status as keyof typeof STATUS_LABELS]}: ${count}`).join(" · "),
+  },
+];
+
+function ApiStatsAndSources({ emails, templateNames }: {
+  emails: AdminEmailOutbox[],
+  templateNames: ReadonlyMap<string, string>,
+}) {
+  const now = useMemo(() => new Date(), []);
+  const sources = useMemo(() => groupEmailsBySource(emails, templateNames), [emails, templateNames]);
+  const [gridState, setGridState] = useDataGridUrlState(sourceColumns, {
+    paramPrefix: "emailsource",
+    initial: { sorting: [{ columnId: "count", direction: "desc" }] },
+  });
+  const windows = [
+    ["24h", countEmailsSince(emails, now, DAY)],
+    ["7d", countEmailsSince(emails, now, 7 * DAY)],
+    ["30d", countEmailsSince(emails, now, 30 * DAY)],
+  ];
+  const successRate = Math.round(getDeliverySuccessRate(emails) * 100);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        {[...windows, ["Success", `${successRate}%`]].map(([label, value]) => (
+          <DesignCard key={label} glassmorphic contentClassName="p-3">
+            <div className="text-xs uppercase tracking-wider text-muted-foreground">{label}</div>
+            <div className="mt-1 text-xl font-semibold">{value}</div>
+          </DesignCard>
+        ))}
+      </div>
+      <DesignCard title="By source" subtitle="API sends grouped by raw HTML or template" icon={MailboxIcon} glassmorphic contentClassName="p-3">
+        {sources.length === 0 ? (
+          <div className="py-6 text-center text-sm text-muted-foreground">
+            No Email API sends yet. Run one of the examples above to see delivery sources here.
+          </div>
+        ) : (
+          <DataGrid<EmailApiSource>
+            columns={sourceColumns}
+            rows={sources}
+            getRowId={(row) => row.id}
+            totalRowCount={sources.length}
+            state={gridState}
+            onChange={setGridState}
+            fillHeight={false}
+            footer={false}
+          />
+        )}
+      </DesignCard>
+    </div>
+  );
+}
+
+function PromptCard({ title, prompt }: { title: string, prompt: string }) {
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-lg border border-border/60 bg-foreground/[0.02] p-3">
+      <div className="min-w-0">
+        <div className="mb-1 text-sm font-medium">{title}</div>
+        <p className="text-xs leading-relaxed text-muted-foreground">{prompt}</p>
+      </div>
+      <CopyPromptButton content={prompt} aria-label={`Copy ${title} prompt`} className="shrink-0">
+        <SparkleIcon className="text-purple-500 dark:text-purple-400" />
+      </CopyPromptButton>
+    </div>
+  );
+}
+
+export default function PageClient() {
+  const adminApp = useAdminApp();
+  const project = adminApp.useProject();
+  const templates = adminApp.useEmailTemplates();
+  const templateNames = useMemo(
+    () => new Map(templates.map((template) => [template.id, template.displayName])),
+    [templates],
+  );
+  const templateId = templates[0]?.id ?? "replace-with-template-id";
+  const emailSettingsHref = getItemPath(project.id, ALL_APPS_FRONTEND.emails, ALL_APPS_FRONTEND.emails.navigationItems[3]);
+
+  const filterFn = useCallback((email: AdminEmailOutbox) => isEmailApiEmail(email), []);
+  const snippets = useMemo(() => ({
+    setup: `pnpm add @hexclave/next\n\n# .env\nNEXT_PUBLIC_HEXCLAVE_PROJECT_ID=${project.id}\nHEXCLAVE_SECRET_SERVER_KEY=your_server_key`,
+    html: `import { hexclaveServerApp } from "@hexclave/next/server";\n\nawait hexclaveServerApp.sendEmail({\n  userIds: ["user-id"],\n  subject: "Welcome to Acme",\n  html: "<h1>Welcome!</h1><p>Thanks for joining.</p>",\n});`,
+    template: `await hexclaveServerApp.sendEmail({\n  userIds: ["user-id"],\n  templateId: "${templateId}",\n  variables: { firstName: "Ada", plan: "Pro" },\n});`,
+    emails: `await hexclaveServerApp.sendEmail({\n  emails: ["customer@example.com"],\n  subject: "Your receipt",\n  html: "<p>Thanks for your purchase.</p>",\n});\n// Arbitrary addresses cannot unsubscribe; use this for transactional mail only.`,
+    curl: `curl -X POST https://api.hexclave.com/api/v1/emails/send-email \\\n  -H "Content-Type: application/json" \\\n  -H "X-Stack-Access-Type: server" \\\n  -H "X-Stack-Project-Id: ${project.id}" \\\n  -H "X-Stack-Secret-Server-Key: $HEXCLAVE_SECRET_SERVER_KEY" \\\n  -d '${JSON.stringify({ user_ids: ["user-id"], template_id: templateId, variables: { firstName: "Ada" } })}'`,
+  }), [project.id, templateId]);
+
+  const prompts = [
+    ["Welcome email on signup", `In project ${project.id}, implement a server-side signup flow that sends a transactional welcome email through hexclaveServerApp.sendEmail to the newly created user's ID. Use raw HTML, include a subject, keep the server key out of client bundles, and make the send failure observable without blocking the signup response.`],
+    ["Templated notification", `In project ${project.id}, send a notification with the Email API using template ${templateId}. Pass variables firstName and plan, validate the variables before sending, and show me the exact server-only TypeScript code plus a test that proves the template ID and variables are forwarded.`],
+    ["Scheduled announcement", `For project ${project.id}, schedule an announcement to all users with hexclaveServerApp.sendEmail. Use a template when available, set scheduledAt to an explicit future Date, and explain how to inspect the resulting outbox rows and safely retry failures.`],
+    ["Unsubscribe-aware marketing", `Design an unsubscribe-respecting marketing send for project ${project.id}. Use a notification category name so opted-out users are skipped, send only to user IDs rather than arbitrary emails, and include the server-side implementation, consent assumptions, and a verification checklist.`],
+    ["Read delivery status", `For project ${project.id}, add an admin-only diagnostic that reads the email outbox after an Email API send and reports queued, sent, bounced, and error statuses. Do not expose the server key or internal error details, and include pagination and a useful retry recommendation.`],
+  ];
+
+  return (
+    <AppEnabledGuard appId="email-api">
+      <PageLayout title="Email API" description="Send transactional email from your server and monitor delivery">
+        <DesignAlert
+          variant="info"
+          title="Server-side email delivery"
+          description={<>
+            The Email API queues messages from trusted server code. Keep your server key private and configure a custom email server before sending; the shared development server cannot deliver email.
+            <br /><br />
+            Configure delivery in <StyledLink href={emailSettingsHref}>Email Settings</StyledLink> and manage credentials in <StyledLink href={`/projects/${project.id}/project-keys`}>API Keys</StyledLink>. Read the <StyledLink href="https://docs.hexclave.com/guides/apps/emails/overview">Email API documentation</StyledLink> for the full guide.
+          </>}
+        />
+
+        <DesignCard title="Usage" subtitle="Copy a complete example into your server application" icon={LinkIcon} glassmorphic>
+          <div className="flex flex-col gap-4">
+            <CodeBlock language="bash" title="Install and configure" content={snippets.setup} icon="code" />
+            <CodeBlock language="typescript" title="Send raw HTML to users" content={snippets.html} icon="code" />
+            <CodeBlock language="typescript" title={templates.length > 0 ? `Send template (${templates[0].displayName})` : "Send a template"} content={snippets.template} icon="code" />
+            {templates.length === 0 && <p className="text-xs text-muted-foreground">No email templates exist yet, so the example uses a placeholder ID. Create one in Email Templates, then replace it before running the snippet.</p>}
+            <CodeBlock language="typescript" title="Send to arbitrary email addresses" content={snippets.emails} icon="code" />
+            <CodeBlock language="bash" title="REST API with curl" content={snippets.curl} icon="code" />
+          </div>
+        </DesignCard>
+
+        <DesignCard title="Prompts" subtitle="Ready-to-paste tasks for your AI coding agent" icon={SparkleIcon} glassmorphic>
+          <div className="flex flex-col gap-2">
+            {prompts.map(([title, prompt]) => <PromptCard key={title} title={title} prompt={prompt} />)}
+          </div>
+        </DesignCard>
+
+        <SentEmailsView
+          filterFn={filterFn}
+          renderActions={(emails) => (
+            <ApiStatsAndSources emails={emails} templateNames={templateNames} />
+          )}
+        />
+      </PageLayout>
+    </AppEnabledGuard>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
@@ -5,6 +5,8 @@ import { StyledLink } from "@/components/link";
 import {
   DesignAlert,
   DesignCard,
+  DesignEmptyState,
+  DesignMetricCard,
 } from "@/components/design-components";
 import { CopyPromptButton } from "@/components/ui";
 import { CodeIcon, MailboxIcon, SparkleIcon } from "@phosphor-icons/react";
@@ -19,7 +21,7 @@ import { ALL_APPS_FRONTEND, getAppPath, getItemPath } from "@/lib/apps-frontend"
 import { AppEnabledGuard } from "../app-enabled-guard";
 import { PageLayout } from "../page-layout";
 import { useAdminApp } from "../use-admin-app";
-import { STATUS_LABELS, getStatusBadgeColor } from "../email-sent/email-status-utils";
+import { STATUS_LABELS } from "../email-sent/email-status-utils";
 import { SentEmailsView } from "../email-sent/sent-emails-view";
 import { countEmailsSince, getDeliverySuccessRate, groupEmailsBySource, isEmailApiEmail, type EmailApiSource } from "./email-api-logic";
 
@@ -70,17 +72,16 @@ function ApiStatsAndSources({ emails, templateNames }: {
     <div className="flex flex-col gap-4">
       <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
         {stats.map(({ label, value }) => (
-          <DesignCard key={label} glassmorphic contentClassName="p-3">
-            <div className="text-xs uppercase tracking-wider text-muted-foreground">{label}</div>
-            <div className="mt-1 text-xl font-semibold">{value}</div>
-          </DesignCard>
+          <DesignMetricCard key={label} label={label} value={value} />
         ))}
       </div>
       <DesignCard title="By source" subtitle="API sends grouped by raw HTML or template" icon={MailboxIcon} glassmorphic contentClassName="p-3">
         {sources.length === 0 ? (
-          <div className="py-6 text-center text-sm text-muted-foreground">
-            No Email API sends yet. Run one of the examples above to see delivery sources here.
-          </div>
+          <DesignEmptyState
+            icon={MailboxIcon}
+            title="No Email API sends yet"
+            description="Run one of the examples above to see delivery sources here."
+          />
         ) : (
           <DataGrid<EmailApiSource>
             columns={sourceColumns}
@@ -100,13 +101,15 @@ function ApiStatsAndSources({ emails, templateNames }: {
 
 function PromptCard({ title, prompt }: { title: string, prompt: string }) {
   return (
-    <div className="flex items-start justify-between gap-3 rounded-lg border border-border/60 bg-foreground/[0.02] p-3">
-      <div className="min-w-0">
-        <div className="mb-1 text-sm font-medium">{title}</div>
-        <p className="text-xs leading-relaxed text-muted-foreground">{prompt}</p>
+    <DesignCard glassmorphic contentClassName="p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="mb-1 text-sm font-medium">{title}</div>
+          <p className="text-xs leading-relaxed text-muted-foreground">{prompt}</p>
+        </div>
+        <CopyPromptButton content={prompt} aria-label={`Copy ${title} prompt`} className="shrink-0" />
       </div>
-      <CopyPromptButton content={prompt} aria-label={`Copy ${title} prompt`} className="shrink-0" />
-    </div>
+    </DesignCard>
   );
 }
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
@@ -6,6 +6,7 @@ import {
   DesignAlert,
   DesignButton,
   DesignCard,
+  DesignCardTint,
   DesignCategoryTabs,
   DesignEmptyState,
   DesignMetricCard,
@@ -145,13 +146,15 @@ function ApiStatsAndSources({ emails, templateNames }: {
 
 function PromptCard({ title, prompt }: { title: string, prompt: string }) {
   return (
-    <div className="flex items-center justify-between gap-3 rounded-xl border border-black/[0.06] bg-white/60 p-3 dark:border-white/[0.06] dark:bg-white/[0.03]">
-      <div className="min-w-0">
-        <div className="mb-1 text-sm font-medium">{title}</div>
-        <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">{prompt}</p>
+    <DesignCard contentClassName="p-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="mb-1 text-sm font-medium">{title}</div>
+          <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">{prompt}</p>
+        </div>
+        <CopyPromptButton content={prompt} aria-label={`Copy ${title} prompt`} className="shrink-0" />
       </div>
-      <CopyPromptButton content={prompt} aria-label={`Copy ${title} prompt`} className="shrink-0" />
-    </div>
+    </DesignCard>
   );
 }
 
@@ -160,18 +163,18 @@ function ReferenceTable() {
     <DesignCard title="SendEmail reference" subtitle="Choose exactly one recipient selector and one content source" icon={FileTextIcon} glassmorphic>
       <div className="flex flex-col gap-4">
         <div className="grid gap-3 md:grid-cols-2">
-          <div className="rounded-xl bg-blue-500/[0.06] p-3 ring-1 ring-blue-500/10">
-            <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-blue-700 dark:text-blue-300">Exactly one recipient</div>
-            <div className="space-y-1 text-sm"><code>userIds</code> <span className="text-muted-foreground">Known users</span></div>
-            <div className="space-y-1 text-sm"><code>allUsers</code> <span className="text-muted-foreground">Every user</span></div>
-            <div className="space-y-1 text-sm"><code>emails</code> <span className="text-muted-foreground">Transactional addresses; no unsubscribe</span></div>
-          </div>
-          <div className="rounded-xl bg-purple-500/[0.06] p-3 ring-1 ring-purple-500/10">
-            <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-purple-700 dark:text-purple-300">Exactly one content source</div>
-            <div className="space-y-1 text-sm"><code>html</code> <span className="text-muted-foreground">Inline markup</span></div>
-            <div className="space-y-1 text-sm"><code>templateId</code> <span className="text-muted-foreground">Email Templates app</span></div>
-            <div className="space-y-1 text-sm"><code>draftId</code> <span className="text-muted-foreground">Email Drafts app</span></div>
-          </div>
+          <DesignCardTint gradient="blue" className="p-3">
+            <div className="mb-2 text-xs font-semibold uppercase tracking-wide">Exactly one recipient</div>
+            <div className="text-sm"><code>userIds</code> <span className="text-muted-foreground">Known users</span></div>
+            <div className="text-sm"><code>allUsers</code> <span className="text-muted-foreground">Every user</span></div>
+            <div className="text-sm"><code>emails</code> <span className="text-muted-foreground">Transactional addresses; no unsubscribe</span></div>
+          </DesignCardTint>
+          <DesignCardTint gradient="purple" className="p-3">
+            <div className="mb-2 text-xs font-semibold uppercase tracking-wide">Exactly one content source</div>
+            <div className="text-sm"><code>html</code> <span className="text-muted-foreground">Inline markup</span></div>
+            <div className="text-sm"><code>templateId</code> <span className="text-muted-foreground">Email Templates app</span></div>
+            <div className="text-sm"><code>draftId</code> <span className="text-muted-foreground">Email Drafts app</span></div>
+          </DesignCardTint>
         </div>
         <DesignTable>
           <DesignTableHeader><DesignTableRow><DesignTableHead>Optional field</DesignTableHead><DesignTableHead>Meaning</DesignTableHead></DesignTableRow></DesignTableHeader>
@@ -183,11 +186,11 @@ function ReferenceTable() {
             <DesignTableRow><DesignTableCell><code>scheduledAt</code></DesignTableCell><DesignTableCell>Queue the send for a future date.</DesignTableCell></DesignTableRow>
           </DesignTableBody>
         </DesignTable>
-        <div className="rounded-xl bg-foreground/[0.03] p-3 text-sm">
+        <DesignCard gradient="default" contentClassName="p-3 text-sm">
           <div className="font-medium">REST endpoint</div>
           <code className="text-xs">POST https://api.hexclave.com/api/v1/emails/send-email</code>
           <p className="mt-2 text-xs text-muted-foreground">Required headers: <code>X-Stack-Access-Type: server</code>, <code>X-Stack-Project-Id</code>, and <code>X-Stack-Secret-Server-Key</code>.</p>
-        </div>
+        </DesignCard>
       </div>
     </DesignCard>
   );
@@ -213,15 +216,17 @@ function TemplatesCard({ templates, templatesHref }: {
           <DesignButton asChild size="sm" variant="outline"><a href={templatesHref}>Create a template</a></DesignButton>
         </DesignEmptyState>
       ) : (
-        <div className="divide-y divide-black/[0.06] dark:divide-white/[0.06]">
+        <div className="flex flex-col gap-2">
           {templates.map((template) => (
-            <div key={template.id} className="flex items-center justify-between gap-3 py-2 first:pt-0 last:pb-0">
-              <span className="truncate text-sm">{template.displayName}</span>
-              <div className="flex min-w-0 items-center gap-1">
-                <code className="truncate text-xs text-muted-foreground">{template.id}</code>
-                <CopyButton content={template.id} variant="ghost" />
+            <DesignCard key={template.id} gradient="default" contentClassName="p-3">
+              <div className="flex min-w-0 items-center justify-between gap-3">
+                <span className="truncate text-sm">{template.displayName}</span>
+                <div className="flex min-w-0 shrink-0 items-center gap-1">
+                  <code className="max-w-[min(24rem,50vw)] truncate text-xs text-muted-foreground">{template.id}</code>
+                  <CopyButton content={template.id} variant="ghost" />
+                </div>
               </div>
-            </div>
+            </DesignCard>
           ))}
         </div>
       )}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
@@ -152,7 +152,7 @@ export default function PageClient() {
           variant="info"
           title="Server-side email delivery"
           description={<>
-            The Email API queues messages from trusted server code. Keep your server key private. The shared development server delivers mail with a [Hexclave dev email] subject prefix and an injected development notice; configure a custom email server to send from your own domain without this branding.
+            The Email API queues messages from trusted server code. Keep your server key private. On the shared development server, custom email content receives a [Hexclave dev email] subject prefix and an injected development notice; configure a custom email server to send from your own domain without this branding.
             <br /><br />
             Configure delivery <StyledLink href={emailSettingsHref}>in Email Settings</StyledLink> and manage credentials in <StyledLink href={apiKeysHref}>API Keys</StyledLink>. Read the <StyledLink href="https://docs.hexclave.com/guides/apps/emails/overview">Email API documentation</StyledLink> for the full guide.
           </>}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
@@ -4,29 +4,56 @@ import { CodeBlock } from "@/components/code-block";
 import { StyledLink } from "@/components/link";
 import {
   DesignAlert,
+  DesignButton,
   DesignCard,
+  DesignCategoryTabs,
   DesignEmptyState,
   DesignMetricCard,
+  DesignPillToggle,
+  DesignTable,
+  DesignTableBody,
+  DesignTableCell,
+  DesignTableHead,
+  DesignTableHeader,
+  DesignTableRow,
 } from "@/components/design-components";
-import { CopyPromptButton } from "@/components/ui";
-import { CodeIcon, MailboxIcon, SparkleIcon } from "@phosphor-icons/react";
+import { CopyButton, CopyPromptButton } from "@/components/ui";
+import {
+  ArrowSquareOutIcon,
+  CodeIcon,
+  EnvelopeSimpleIcon,
+  FileTextIcon,
+  GearIcon,
+  KeyIcon,
+  MailboxIcon,
+  SparkleIcon,
+} from "@phosphor-icons/react";
 import type { AdminEmailOutbox } from "@hexclave/next";
-import { throwErr } from "@hexclave/shared/dist/utils/errors";
 import {
   DataGrid,
   useDataGridUrlState,
   type DataGridColumnDef,
 } from "@hexclave/dashboard-ui-components";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
+import { throwErr } from "@hexclave/shared/dist/utils/errors";
 import { ALL_APPS_FRONTEND, getAppPath, getItemPath } from "@/lib/apps-frontend";
 import { AppEnabledGuard } from "../app-enabled-guard";
 import { PageLayout } from "../page-layout";
 import { useAdminApp } from "../use-admin-app";
 import { STATUS_LABELS } from "../email-sent/email-status-utils";
 import { SentEmailsView } from "../email-sent/sent-emails-view";
-import { countEmailsSince, getDeliverySuccessRate, groupEmailsBySource, isEmailApiEmail, type EmailApiSource } from "./email-api-logic";
+import {
+  countEmailsSince,
+  getDeliverySuccessRate,
+  groupEmailsBySource,
+  isEmailApiEmail,
+  type EmailApiSource,
+} from "./email-api-logic";
 
 const DAY = 24 * 60 * 60 * 1000;
+
+type SendMode = "typescript" | "rest";
+type SendFlavor = "html" | "template" | "emails";
 
 type StatTile = {
   label: string,
@@ -34,7 +61,19 @@ type StatTile = {
 };
 
 function formatDate(date: Date | null): string {
-  return date == null ? "Never" : date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+  return date == null
+    ? "Never"
+    : date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}
+
+function selectSendMode(id: string): SendMode {
+  if (id === "typescript" || id === "rest") return id;
+  return throwErr(`Unknown send mode: ${id}`);
+}
+
+function selectSendFlavor(id: string): SendFlavor {
+  if (id === "html" || id === "template" || id === "emails") return id;
+  return throwErr(`Unknown send flavor: ${id}`);
 }
 
 const sourceColumns: DataGridColumnDef<EmailApiSource>[] = [
@@ -47,7 +86,9 @@ const sourceColumns: DataGridColumnDef<EmailApiSource>[] = [
     flex: 1,
     minWidth: 180,
     type: "string",
-    accessor: (row) => [...row.statuses.entries()].map(([status, count]) => `${STATUS_LABELS[status]}: ${count}`).join(" · "),
+    accessor: (row) => [...row.statuses.entries()]
+      .map(([status, count]) => `${STATUS_LABELS[status]}: ${count}`)
+      .join(" · "),
   },
 ];
 
@@ -63,38 +104,40 @@ function ApiStatsAndSources({ emails, templateNames }: {
   });
   const rate = getDeliverySuccessRate(emails);
   const stats: StatTile[] = [
-    { label: "24h", value: countEmailsSince(emails, now, DAY) },
-    { label: "7d", value: countEmailsSince(emails, now, 7 * DAY) },
-    { label: "30d", value: countEmailsSince(emails, now, 30 * DAY) },
-    { label: "Success", value: rate == null ? "—" : `${Math.round(rate * 100)}%` },
+    { label: "Sent · last 24h", value: countEmailsSince(emails, now, DAY) },
+    { label: "Sent · last 7d", value: countEmailsSince(emails, now, 7 * DAY) },
+    { label: "Sent · last 30d", value: countEmailsSince(emails, now, 30 * DAY) },
+    { label: "Delivery success", value: rate == null ? "—" : `${Math.round(rate * 100)}%` },
   ];
+
+  if (emails.length === 0) {
+    return (
+      <DesignCard glassmorphic contentClassName="p-1">
+        <DesignEmptyState
+          icon={MailboxIcon}
+          title="No API sends yet"
+          description="Use the quickstart below to send your first message, then return here to inspect delivery."
+        />
+      </DesignCard>
+    );
+  }
 
   return (
     <div className="flex flex-col gap-4">
       <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-        {stats.map(({ label, value }) => (
-          <DesignMetricCard key={label} label={label} value={value} />
-        ))}
+        {stats.map(({ label, value }) => <DesignMetricCard key={label} label={label} value={value} />)}
       </div>
-      <DesignCard title="By source" subtitle="API sends grouped by raw HTML or template" icon={MailboxIcon} glassmorphic contentClassName="p-3">
-        {sources.length === 0 ? (
-          <DesignEmptyState
-            icon={MailboxIcon}
-            title="No Email API sends yet"
-            description="Run one of the examples above to see delivery sources here."
-          />
-        ) : (
-          <DataGrid<EmailApiSource>
-            columns={sourceColumns}
-            rows={sources}
-            getRowId={(row) => row.id}
-            totalRowCount={sources.length}
-            state={gridState}
-            onChange={setGridState}
-            fillHeight={false}
-            footer={false}
-          />
-        )}
+      <DesignCard title="By source" subtitle="Raw HTML and template sends" icon={MailboxIcon} glassmorphic contentClassName="p-3">
+        <DataGrid<EmailApiSource>
+          columns={sourceColumns}
+          rows={sources}
+          getRowId={(row) => row.id}
+          totalRowCount={sources.length}
+          state={gridState}
+          onChange={setGridState}
+          fillHeight={false}
+          footer={false}
+        />
       </DesignCard>
     </div>
   );
@@ -102,14 +145,86 @@ function ApiStatsAndSources({ emails, templateNames }: {
 
 function PromptCard({ title, prompt }: { title: string, prompt: string }) {
   return (
-    <DesignCard glassmorphic contentClassName="p-3">
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <div className="mb-1 text-sm font-medium">{title}</div>
-          <p className="text-xs leading-relaxed text-muted-foreground">{prompt}</p>
-        </div>
-        <CopyPromptButton content={prompt} aria-label={`Copy ${title} prompt`} className="shrink-0" />
+    <div className="flex items-center justify-between gap-3 rounded-xl border border-black/[0.06] bg-white/60 p-3 dark:border-white/[0.06] dark:bg-white/[0.03]">
+      <div className="min-w-0">
+        <div className="mb-1 text-sm font-medium">{title}</div>
+        <p className="line-clamp-2 text-xs leading-relaxed text-muted-foreground">{prompt}</p>
       </div>
+      <CopyPromptButton content={prompt} aria-label={`Copy ${title} prompt`} className="shrink-0" />
+    </div>
+  );
+}
+
+function ReferenceTable() {
+  return (
+    <DesignCard title="SendEmail reference" subtitle="Choose exactly one recipient selector and one content source" icon={FileTextIcon} glassmorphic>
+      <div className="flex flex-col gap-4">
+        <div className="grid gap-3 md:grid-cols-2">
+          <div className="rounded-xl bg-blue-500/[0.06] p-3 ring-1 ring-blue-500/10">
+            <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-blue-700 dark:text-blue-300">Exactly one recipient</div>
+            <div className="space-y-1 text-sm"><code>userIds</code> <span className="text-muted-foreground">Known users</span></div>
+            <div className="space-y-1 text-sm"><code>allUsers</code> <span className="text-muted-foreground">Every user</span></div>
+            <div className="space-y-1 text-sm"><code>emails</code> <span className="text-muted-foreground">Transactional addresses; no unsubscribe</span></div>
+          </div>
+          <div className="rounded-xl bg-purple-500/[0.06] p-3 ring-1 ring-purple-500/10">
+            <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-purple-700 dark:text-purple-300">Exactly one content source</div>
+            <div className="space-y-1 text-sm"><code>html</code> <span className="text-muted-foreground">Inline markup</span></div>
+            <div className="space-y-1 text-sm"><code>templateId</code> <span className="text-muted-foreground">Email Templates app</span></div>
+            <div className="space-y-1 text-sm"><code>draftId</code> <span className="text-muted-foreground">Email Drafts app</span></div>
+          </div>
+        </div>
+        <DesignTable>
+          <DesignTableHeader><DesignTableRow><DesignTableHead>Optional field</DesignTableHead><DesignTableHead>Meaning</DesignTableHead></DesignTableRow></DesignTableHeader>
+          <DesignTableBody>
+            <DesignTableRow><DesignTableCell><code>subject</code></DesignTableCell><DesignTableCell>Override the message subject.</DesignTableCell></DesignTableRow>
+            <DesignTableRow><DesignTableCell><code>variables</code></DesignTableCell><DesignTableCell>Values used when rendering a template.</DesignTableCell></DesignTableRow>
+            <DesignTableRow><DesignTableCell><code>themeId</code></DesignTableCell><DesignTableCell>Apply a project email theme, or disable it with <code>false</code>.</DesignTableCell></DesignTableRow>
+            <DesignTableRow><DesignTableCell><code>notificationCategoryName</code></DesignTableCell><DesignTableCell>Use <code>Transactional</code> or <code>Marketing</code>; marketing sends respect unsubscribes.</DesignTableCell></DesignTableRow>
+            <DesignTableRow><DesignTableCell><code>scheduledAt</code></DesignTableCell><DesignTableCell>Queue the send for a future date.</DesignTableCell></DesignTableRow>
+          </DesignTableBody>
+        </DesignTable>
+        <div className="rounded-xl bg-foreground/[0.03] p-3 text-sm">
+          <div className="font-medium">REST endpoint</div>
+          <code className="text-xs">POST https://api.hexclave.com/api/v1/emails/send-email</code>
+          <p className="mt-2 text-xs text-muted-foreground">Required headers: <code>X-Stack-Access-Type: server</code>, <code>X-Stack-Project-Id</code>, and <code>X-Stack-Secret-Server-Key</code>.</p>
+        </div>
+      </div>
+    </DesignCard>
+  );
+}
+
+function TemplatesCard({ templates, templatesHref }: {
+  templates: { id: string, displayName: string }[],
+  templatesHref: string,
+}) {
+  return (
+    <DesignCard
+      title="Templates"
+      subtitle={<span>Reusable content from the Emails app · <StyledLink href={templatesHref}>Manage templates</StyledLink></span>}
+      icon={FileTextIcon}
+      glassmorphic
+    >
+      {templates.length === 0 ? (
+        <DesignEmptyState
+          icon={FileTextIcon}
+          title="No templates yet"
+          description="Create a template in the Emails app, then use its exact ID in templateId."
+        >
+          <DesignButton asChild size="sm" variant="outline"><a href={templatesHref}>Create a template</a></DesignButton>
+        </DesignEmptyState>
+      ) : (
+        <div className="divide-y divide-black/[0.06] dark:divide-white/[0.06]">
+          {templates.map((template) => (
+            <div key={template.id} className="flex items-center justify-between gap-3 py-2 first:pt-0 last:pb-0">
+              <span className="truncate text-sm">{template.displayName}</span>
+              <div className="flex min-w-0 items-center gap-1">
+                <code className="truncate text-xs text-muted-foreground">{template.id}</code>
+                <CopyButton content={template.id} variant="ghost" />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
     </DesignCard>
   );
 }
@@ -118,16 +233,24 @@ export default function PageClient() {
   const adminApp = useAdminApp();
   const project = adminApp.useProject();
   const templates = adminApp.useEmailTemplates();
-  const templateNames = useMemo(
-    () => new Map(templates.map((template) => [template.id, template.displayName])),
-    [templates],
-  );
+  const emailServer = project.useConfig().emails.server;
+  const [sendMode, setSendMode] = useState<SendMode>("typescript");
+  const [sendFlavor, setSendFlavor] = useState<SendFlavor>("html");
+  const templateNames = useMemo(() => new Map(templates.map((template) => [template.id, template.displayName])), [templates]);
   const templateId = templates[0]?.id ?? "replace-with-template-id";
   const emailSettingsItem = ALL_APPS_FRONTEND.emails.navigationItems.find((item) => item.displayName === "Email Settings")
     ?? throwErr("Email Settings navigation item is missing from the emails app registry");
+  const templatesItem = ALL_APPS_FRONTEND.emails.navigationItems.find((item) => item.displayName === "Templates")
+    ?? throwErr("Templates navigation item is missing from the emails app registry");
+  const sentItem = ALL_APPS_FRONTEND.emails.navigationItems.find((item) => item.displayName === "Sent")
+    ?? throwErr("Sent navigation item is missing from the emails app registry");
+  const draftsItem = ALL_APPS_FRONTEND.emails.navigationItems.find((item) => item.displayName === "Drafts")
+    ?? throwErr("Drafts navigation item is missing from the emails app registry");
   const emailSettingsHref = getItemPath(project.id, ALL_APPS_FRONTEND.emails, emailSettingsItem);
+  const templatesHref = getItemPath(project.id, ALL_APPS_FRONTEND.emails, templatesItem);
+  const sentHref = getItemPath(project.id, ALL_APPS_FRONTEND.emails, sentItem);
+  const draftsHref = getItemPath(project.id, ALL_APPS_FRONTEND.emails, draftsItem);
   const apiKeysHref = getAppPath(project.id, ALL_APPS_FRONTEND["api-keys"]);
-
   const filterFn = useCallback((email: AdminEmailOutbox) => isEmailApiEmail(email), []);
   const snippets = useMemo(() => ({
     setup: `pnpm add @hexclave/next\n\n# .env\nNEXT_PUBLIC_HEXCLAVE_PROJECT_ID=${project.id}\nHEXCLAVE_SECRET_SERVER_KEY=your_server_key`,
@@ -136,51 +259,84 @@ export default function PageClient() {
     emails: `await hexclaveServerApp.sendEmail({\n  emails: ["customer@example.com"],\n  subject: "Your receipt",\n  html: "<p>Thanks for your purchase.</p>",\n});\n// Arbitrary addresses cannot unsubscribe; use this for transactional mail only.`,
     curl: `curl -X POST https://api.hexclave.com/api/v1/emails/send-email \\\n  -H "Content-Type: application/json" \\\n  -H "X-Stack-Access-Type: server" \\\n  -H "X-Stack-Project-Id: ${project.id}" \\\n  -H "X-Stack-Secret-Server-Key: $HEXCLAVE_SECRET_SERVER_KEY" \\\n  -d '${JSON.stringify({ user_ids: ["user-id"], template_id: templateId, variables: { firstName: "Ada" } })}'`,
   }), [project.id, templateId]);
-
   const prompts = [
-    ["Welcome email on signup", `In project ${project.id}, implement a server-side signup flow that sends a transactional welcome email through hexclaveServerApp.sendEmail to the newly created user's ID. Use raw HTML, include a subject, keep the server key out of client bundles, and make the send failure observable without blocking the signup response.`],
-    ["Templated notification", `In project ${project.id}, send a notification with the Email API using template ${templateId}. Pass variables firstName and plan, validate the variables before sending, and show me the exact server-only TypeScript code plus a test that proves the template ID and variables are forwarded.`],
-    ["Scheduled announcement", `For project ${project.id}, schedule an announcement to all users with hexclaveServerApp.sendEmail. Use a template when available, set scheduledAt to an explicit future Date, and explain how to inspect the resulting outbox rows and safely retry failures.`],
-    ["Unsubscribe-aware marketing", `Design an unsubscribe-respecting marketing send for project ${project.id}. Use a notification category name so opted-out users are skipped, send only to user IDs rather than arbitrary emails, and include the server-side implementation, consent assumptions, and a verification checklist.`],
-    ["Read delivery status", `For project ${project.id}, add an admin-only diagnostic that reads the email outbox after an Email API send and reports queued, sent, bounced, and error statuses. Do not expose the server key or internal error details, and include pagination and a useful retry recommendation.`],
+    ["Welcome on signup", `In project ${project.id}, send a server-side transactional welcome email to a newly created user with hexclaveServerApp.sendEmail. Keep the key private and include a test.`],
+    ["Templated notification", `In project ${project.id}, send template ${templateId} with firstName and plan variables. Validate the payload and show the exact server-only TypeScript implementation.`],
+    ["Scheduled announcement", `For project ${project.id}, schedule a future announcement to all users with a template, then explain how to inspect the outbox and retry failures safely.`],
+    ["Unsubscribe-aware marketing", `Design a ${project.id} marketing send using notificationCategoryName: "Marketing", user IDs, consent checks, and a verification checklist. Never send marketing to arbitrary emails.`],
+    ["Read delivery status", `Add an admin-only ${project.id} diagnostic that paginates the email outbox and summarizes queued, sent, bounced, and error statuses without exposing secrets or internal errors.`],
   ];
+  const activeContent = sendMode === "rest" ? snippets.curl : snippets[sendFlavor];
+  const activeTitle = sendMode === "rest"
+    ? "REST / curl"
+    : sendFlavor === "html" ? "Raw HTML" : sendFlavor === "template" ? "Email template" : "Arbitrary address";
 
   return (
     <AppEnabledGuard appId="email-api">
-      <PageLayout title="Email API" description="Send transactional email from your server and monitor delivery">
+      <PageLayout
+        title="Email API"
+        description="Send from your server, connect to the Emails app, and observe delivery."
+        actions={
+          <div className="flex flex-wrap gap-2">
+            <DesignButton asChild size="sm" variant="outline"><a href={emailSettingsHref}><GearIcon className="mr-1.5 h-4 w-4" />Email Settings</a></DesignButton>
+            <DesignButton asChild size="sm" variant="outline"><a href={apiKeysHref}><KeyIcon className="mr-1.5 h-4 w-4" />API Keys</a></DesignButton>
+            <DesignButton asChild size="sm" variant="ghost"><a href="https://docs.hexclave.com/guides/apps/emails/overview" target="_blank" rel="noreferrer"><ArrowSquareOutIcon className="mr-1.5 h-4 w-4" />Docs</a></DesignButton>
+          </div>
+        }
+      >
         <DesignAlert
-          variant="info"
-          title="Server-side email delivery"
-          description={<>
-            The Email API queues messages from trusted server code. Keep your server key private. On the shared development server, custom email content receives a [Hexclave dev email] subject prefix and an injected development notice; configure a custom email server to send from your own domain without this branding.
-            <br /><br />
-            Configure delivery <StyledLink href={emailSettingsHref}>in Email Settings</StyledLink> and manage credentials in <StyledLink href={apiKeysHref}>API Keys</StyledLink>. Read the <StyledLink href="https://docs.hexclave.com/guides/apps/emails/overview">Email API documentation</StyledLink> for the full guide.
-          </>}
+          variant={emailServer.isShared ? "info" : "success"}
+          title={emailServer.isShared ? "Shared development server" : "Custom email server connected"}
+          description={
+            <div className="space-y-1">
+              <p>The Email API is server-side only. Keep your server key private.</p>
+              {emailServer.isShared ? (
+                <p>Custom email content receives a [Hexclave dev email] subject prefix and an injected development notice. <StyledLink href={emailSettingsHref}>Configure Email Settings</StyledLink> for unbranded delivery.</p>
+              ) : (
+                <p>Sends go from your project&apos;s own domain through the configured email server.</p>
+              )}
+            </div>
+          }
         />
 
-        <DesignCard title="Usage" subtitle="Copy a complete example into your server application" icon={CodeIcon} glassmorphic>
-          <div className="flex flex-col gap-4">
-            <CodeBlock language="bash" title="Install and configure" content={snippets.setup} icon="code" />
-            <CodeBlock language="typescript" title="Send raw HTML to users" content={snippets.html} icon="code" />
-            <CodeBlock language="typescript" title={templates.length > 0 ? `Send template (${templates[0].displayName})` : "Send a template"} content={snippets.template} icon="code" />
-            {templates.length === 0 && <p className="text-xs text-muted-foreground">No email templates exist yet, so the example uses a placeholder ID. Create one in Email Templates, then replace it before running the snippet.</p>}
-            <CodeBlock language="typescript" title="Send to arbitrary email addresses" content={snippets.emails} icon="code" />
-            <CodeBlock language="bash" title="REST API with curl" content={snippets.curl} icon="code" />
+        <section className="flex flex-col gap-3">
+          <div className="flex items-end justify-between gap-3">
+            <div><h2 className="text-lg font-semibold">Delivery</h2><p className="text-sm text-muted-foreground">See whether API-attributed sends reached a terminal delivery state.</p></div>
+            <StyledLink href={sentHref}>Open full sent view</StyledLink>
+          </div>
+          <SentEmailsView filterFn={filterFn} renderActions={(emails) => <ApiStatsAndSources emails={emails} templateNames={templateNames} />} />
+        </section>
+
+        <DesignCard title="Quickstart" subtitle="Choose a transport and send shape; every example uses this project’s credentials." icon={CodeIcon} glassmorphic>
+          <div className="flex flex-col gap-3">
+            <CodeBlock language="bash" title="Install and configure once" content={snippets.setup} icon="terminal" compact />
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <DesignPillToggle options={[{ id: "typescript", label: "TypeScript SDK", icon: CodeIcon }, { id: "rest", label: "REST / curl", icon: ArrowSquareOutIcon }]} selected={sendMode} onSelect={(id) => setSendMode(selectSendMode(id))} size="sm" />
+              {sendMode === "typescript" && <DesignCategoryTabs categories={[{ id: "html", label: "Raw HTML" }, { id: "template", label: "Template" }, { id: "emails", label: "Arbitrary address" }]} selectedCategory={sendFlavor} onSelect={(id) => setSendFlavor(selectSendFlavor(id))} size="sm" />}
+            </div>
+            <CodeBlock language={sendMode === "rest" ? "bash" : "typescript"} title={activeTitle} content={activeContent} icon={sendMode === "rest" ? "terminal" : "code"} />
+            {sendFlavor === "template" && templates.length === 0 && sendMode === "typescript" && <p className="text-xs text-muted-foreground">No template exists yet. Create one below before replacing the placeholder ID.</p>}
+            {sendFlavor === "emails" && sendMode === "typescript" && <p className="text-xs text-muted-foreground">Arbitrary addresses cannot unsubscribe, so use this shape for transactional mail only.</p>}
           </div>
         </DesignCard>
 
-        <DesignCard title="Prompts" subtitle="Ready-to-paste tasks for your AI coding agent" icon={SparkleIcon} glassmorphic>
-          <div className="flex flex-col gap-2">
+        <ReferenceTable />
+        <TemplatesCard templates={templates} templatesHref={templatesHref} />
+
+        <DesignCard title="Related Emails surfaces" subtitle="Keep content, settings, and delivery close to your integration." icon={EnvelopeSimpleIcon} glassmorphic>
+          <div className="flex flex-wrap gap-x-5 gap-y-2 text-sm">
+            <StyledLink href={templatesHref}>Templates</StyledLink>
+            <StyledLink href={draftsHref}>Drafts</StyledLink>
+            <StyledLink href={sentHref}>Sent emails</StyledLink>
+            <StyledLink href={emailSettingsHref}>Email Settings</StyledLink>
+          </div>
+        </DesignCard>
+
+        <DesignCard title="Prompts" subtitle="Compact starting points for your coding agent." icon={SparkleIcon} glassmorphic>
+          <div className="grid gap-2 md:grid-cols-2">
             {prompts.map(([title, prompt]) => <PromptCard key={title} title={title} prompt={prompt} />)}
           </div>
         </DesignCard>
-
-        <SentEmailsView
-          filterFn={filterFn}
-          renderActions={(emails) => (
-            <ApiStatsAndSources emails={emails} templateNames={templateNames} />
-          )}
-        />
       </PageLayout>
     </AppEnabledGuard>
   );

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page-client.tsx
@@ -11,6 +11,7 @@ import {
 import { CopyPromptButton } from "@/components/ui";
 import { CodeIcon, MailboxIcon, SparkleIcon } from "@phosphor-icons/react";
 import type { AdminEmailOutbox } from "@hexclave/next";
+import { throwErr } from "@hexclave/shared/dist/utils/errors";
 import {
   DataGrid,
   useDataGridUrlState,
@@ -46,7 +47,7 @@ const sourceColumns: DataGridColumnDef<EmailApiSource>[] = [
     flex: 1,
     minWidth: 180,
     type: "string",
-    accessor: (row) => Object.entries(row.statuses).map(([status, count]) => `${STATUS_LABELS[status as keyof typeof STATUS_LABELS]}: ${count}`).join(" · "),
+    accessor: (row) => [...row.statuses.entries()].map(([status, count]) => `${STATUS_LABELS[status]}: ${count}`).join(" · "),
   },
 ];
 
@@ -54,7 +55,7 @@ function ApiStatsAndSources({ emails, templateNames }: {
   emails: AdminEmailOutbox[],
   templateNames: ReadonlyMap<string, string>,
 }) {
-  const now = useMemo(() => new Date(), []);
+  const now = new Date();
   const sources = useMemo(() => groupEmailsBySource(emails, templateNames), [emails, templateNames]);
   const [gridState, setGridState] = useDataGridUrlState(sourceColumns, {
     paramPrefix: "emailsource",
@@ -122,10 +123,9 @@ export default function PageClient() {
     [templates],
   );
   const templateId = templates[0]?.id ?? "replace-with-template-id";
-  const emailSettingsItem = ALL_APPS_FRONTEND.emails.navigationItems.find((item) => item.displayName === "Email Settings");
-  const emailSettingsHref = emailSettingsItem == null
-    ? null
-    : getItemPath(project.id, ALL_APPS_FRONTEND.emails, emailSettingsItem);
+  const emailSettingsItem = ALL_APPS_FRONTEND.emails.navigationItems.find((item) => item.displayName === "Email Settings")
+    ?? throwErr("Email Settings navigation item is missing from the emails app registry");
+  const emailSettingsHref = getItemPath(project.id, ALL_APPS_FRONTEND.emails, emailSettingsItem);
   const apiKeysHref = getAppPath(project.id, ALL_APPS_FRONTEND["api-keys"]);
 
   const filterFn = useCallback((email: AdminEmailOutbox) => isEmailApiEmail(email), []);
@@ -154,7 +154,7 @@ export default function PageClient() {
           description={<>
             The Email API queues messages from trusted server code. Keep your server key private and configure a custom email server before sending; the shared development server cannot deliver email.
             <br /><br />
-            Configure delivery {emailSettingsHref == null ? "in Email Settings" : <><StyledLink href={emailSettingsHref}>in Email Settings</StyledLink></>} and manage credentials in <StyledLink href={apiKeysHref}>API Keys</StyledLink>. Read the <StyledLink href="https://docs.hexclave.com/guides/apps/emails/overview">Email API documentation</StyledLink> for the full guide.
+            Configure delivery <StyledLink href={emailSettingsHref}>in Email Settings</StyledLink> and manage credentials in <StyledLink href={apiKeysHref}>API Keys</StyledLink>. Read the <StyledLink href="https://docs.hexclave.com/guides/apps/emails/overview">Email API documentation</StyledLink> for the full guide.
           </>}
         />
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-api/page.tsx
@@ -1,0 +1,9 @@
+import PageClient from "./page-client";
+
+export const metadata = {
+  title: "Email API",
+};
+
+export default function Page() {
+  return <PageClient />;
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/sent-emails-view.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/sent-emails-view.tsx
@@ -48,9 +48,10 @@ const emailColumns: DataGridColumnDef<AdminEmailOutbox>[] = [
 type SentEmailsViewProps = {
   filterFn: (email: AdminEmailOutbox) => boolean,
   renderActions?: (emails: AdminEmailOutbox[], refresh: () => Promise<void>) => ReactNode,
+  stickyTop?: number | string,
 };
 
-export function SentEmailsView({ filterFn, renderActions }: SentEmailsViewProps) {
+export function SentEmailsView({ filterFn, renderActions, stickyTop }: SentEmailsViewProps) {
   const hexclaveAdminApp = useAdminApp();
   const projectId = useProjectId();
   const router = useRouter();
@@ -145,6 +146,7 @@ export function SentEmailsView({ filterFn, renderActions }: SentEmailsViewProps)
               state={gridState}
               onChange={setGridState}
               fillHeight={false}
+              stickyTop={stickyTop}
               onRowClick={(row) => {
                 router.push(`/projects/${projectId}/email-viewer/${row.id}`);
               }}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/sent-emails-view.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/sent-emails-view.tsx
@@ -107,7 +107,7 @@ export function SentEmailsView({ filterFn, renderActions }: SentEmailsViewProps)
   return (
     <div className="flex gap-4">
       <div className="flex-1 flex flex-col gap-4">
-        {renderActions && !loading && renderActions(filtered, refreshEmails)}
+        {renderActions != null && !loading && renderActions(filtered, refreshEmails)}
 
         {/* Delivery Stats */}
         <DesignCard gradient="default" glassmorphic contentClassName="p-3">

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/sent-emails-view.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/sent-emails-view.tsx
@@ -107,7 +107,7 @@ export function SentEmailsView({ filterFn, renderActions }: SentEmailsViewProps)
   return (
     <div className="flex gap-4">
       <div className="flex-1 flex flex-col gap-4">
-        {renderActions && !loading && filtered.length > 0 && renderActions(filtered, refreshEmails)}
+        {renderActions && !loading && renderActions(filtered, refreshEmails)}
 
         {/* Delivery Stats */}
         <DesignCard gradient="default" glassmorphic contentClassName="p-3">

--- a/apps/dashboard/src/lib/apps-frontend.tsx
+++ b/apps/dashboard/src/lib/apps-frontend.tsx
@@ -276,6 +276,7 @@ export const ALL_APPS_FRONTEND = {
   "email-api": {
     icon: MailboxIcon,
     href: "email-api",
+    documentationHref: "https://docs.hexclave.com/guides/apps/emails/overview",
     navigationItems: [
       { displayName: "Email API", href: "." },
     ],

--- a/apps/dashboard/src/lib/apps-frontend.tsx
+++ b/apps/dashboard/src/lib/apps-frontend.tsx
@@ -276,7 +276,6 @@ export const ALL_APPS_FRONTEND = {
   "email-api": {
     icon: MailboxIcon,
     href: "email-api",
-    documentationHref: "https://docs.hexclave.com/guides/apps/emails/overview",
     navigationItems: [
       { displayName: "Email API", href: "." },
     ],

--- a/packages/dashboard-ui-components/src/components/data-grid/data-grid.test.tsx
+++ b/packages/dashboard-ui-components/src/components/data-grid/data-grid.test.tsx
@@ -203,7 +203,7 @@ function DataGridHarness(props: { fillHeight?: boolean }) {
   );
 }
 
-function PaginatedDataGridHarness() {
+function PaginatedDataGridHarness(props: { stickyTop?: number | string } = {}) {
   const [state, setState] = useState(() => createDefaultDataGridState(columns));
 
   return (
@@ -216,6 +216,7 @@ function PaginatedDataGridHarness() {
         onChange={setState}
         paginationMode="paginated"
         fillHeight={false}
+        stickyTop={props.stickyTop}
       />
     </div>
   );
@@ -350,6 +351,13 @@ describe("DataGrid infinite scroll observer", () => {
     const grid = container.querySelector<HTMLElement>('[role="grid"]');
     expect(grid).not.toBeNull();
     expect(grid?.style.maxHeight).toBe("");
+  });
+
+  it("writes an explicit sticky offset to the grid contract", () => {
+    const { container } = render(<PaginatedDataGridHarness stickyTop={0} />);
+
+    const grid = container.querySelector<HTMLElement>('[role="grid"]');
+    expect(grid?.style.getPropertyValue("--data-grid-sticky-top")).toBe("0px");
   });
 });
 

--- a/packages/dashboard-ui-components/src/components/data-grid/data-grid.tsx
+++ b/packages/dashboard-ui-components/src/components/data-grid/data-grid.tsx
@@ -1037,6 +1037,7 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
       clipEl.style.setProperty("--data-grid-sticky-overlap", `${overlap}px`);
     };
     updateClip();
+    const frame = requestAnimationFrame(updateClip);
     bodyEl.addEventListener("scroll", updateClip);
     window.addEventListener("scroll", updateClip, true);
     window.addEventListener("resize", updateClip);
@@ -1048,9 +1049,10 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
       bodyEl.removeEventListener("scroll", updateClip);
       window.removeEventListener("scroll", updateClip, true);
       window.removeEventListener("resize", updateClip);
+      cancelAnimationFrame(frame);
       observer.disconnect();
     };
-  }, []);
+  }, [isLoading, rows.length, totalRowCount, visibleColumns.length]);
 
   // Keep header + body horizontal offsets locked. When the scrollbar lives under
   // the column headers (`horizontalScrollbarPosition="top"`), the header is the
@@ -1172,8 +1174,15 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
       >
         <div
           ref={stickyChromeRef}
-          className="sticky z-30 w-full min-w-0 shrink-0 overflow-visible rounded-t-[calc(var(--radius)*2)] bg-white/90 dark:bg-background backdrop-blur-xl"
-          style={{ top: stickyTop ?? (effectiveMaxHeight != null ? 0 : "var(--data-grid-sticky-top, 0px)") }}
+          className={cn(
+            "z-30 w-full min-w-0 shrink-0 overflow-visible rounded-t-[calc(var(--radius)*2)] bg-white/90 dark:bg-background backdrop-blur-xl",
+            isBounded ? "sticky" : "relative",
+          )}
+          style={{
+            top: isBounded
+              ? stickyTop ?? (effectiveMaxHeight != null ? 0 : "var(--data-grid-sticky-top, 0px)")
+              : 0,
+          }}
         >
           {toolbar !== false && (
             <div className="relative bg-transparent">
@@ -1260,7 +1269,9 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
             className="relative z-0"
             style={{
               minWidth: totalContentWidth,
-              clipPath: "inset(var(--data-grid-sticky-overlap, 0px) 0 0 0)",
+              ...(isBounded
+                ? { clipPath: "inset(var(--data-grid-sticky-overlap, 0px) 0 0 0)" }
+                : {}),
             }}
           >
             {isLoading && (

--- a/packages/dashboard-ui-components/src/components/data-grid/data-grid.tsx
+++ b/packages/dashboard-ui-components/src/components/data-grid/data-grid.tsx
@@ -951,11 +951,14 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
 
   const cssVars = useMemo<CSSProperties>(() => {
     const vars: Record<string, string | number> = { "--grid-total-w": `${totalContentWidth}px` };
+    if (stickyTop != null) {
+      vars["--data-grid-sticky-top"] = typeof stickyTop === "number" ? `${stickyTop}px` : stickyTop;
+    }
     for (const col of visibleColumns) {
       vars[`--col-${col.id}-size`] = columnSizes[col.id];
     }
     return vars as CSSProperties;
-  }, [visibleColumns, columnSizes, totalContentWidth]);
+  }, [stickyTop, visibleColumns, columnSizes, totalContentWidth]);
 
   // ── Selection handlers ───────────────────────────────────────
   const fireSelection = useCallback(
@@ -1174,15 +1177,8 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
       >
         <div
           ref={stickyChromeRef}
-          className={cn(
-            "z-30 w-full min-w-0 shrink-0 overflow-visible rounded-t-[calc(var(--radius)*2)] bg-white/90 dark:bg-background backdrop-blur-xl",
-            isBounded ? "sticky" : "relative",
-          )}
-          style={{
-            top: isBounded
-              ? stickyTop ?? (effectiveMaxHeight != null ? 0 : "var(--data-grid-sticky-top, 0px)")
-              : 0,
-          }}
+          className="sticky z-30 w-full min-w-0 shrink-0 overflow-visible rounded-t-[calc(var(--radius)*2)] bg-white/90 dark:bg-background backdrop-blur-xl"
+          style={{ top: stickyTop ?? (effectiveMaxHeight != null ? 0 : "var(--data-grid-sticky-top, 0px)") }}
         >
           {toolbar !== false && (
             <div className="relative bg-transparent">
@@ -1269,9 +1265,7 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
             className="relative z-0"
             style={{
               minWidth: totalContentWidth,
-              ...(isBounded
-                ? { clipPath: "inset(var(--data-grid-sticky-overlap, 0px) 0 0 0)" }
-                : {}),
+              clipPath: "inset(var(--data-grid-sticky-overlap, 0px) 0 0 0)",
             }}
           >
             {isLoading && (


### PR DESCRIPTION
The `email-api` app was registered in `apps-config.ts`/`apps-frontend.tsx` but had no route, so its nav item 404'd. This adds the page, laid out for someone integrating the API rather than as a docs dump, and pairing with the Emails app.

Sections, top to bottom:
- **Status** — shared development server vs. custom email server, read off `emails.server.isShared`. The shared-server branding caveat (`[Hexclave dev email]` subject prefix + injected notice, applied to custom content only) is only shown when it actually applies.
- **Delivery** — first, because that's what you come back for: 24h/7d/30d volume, delivery success rate, a breakdown by source (raw HTML bucketed separately, template ids resolved to display names), and the existing `SentEmailsView` recipients grid / domain reputation card. Zero sends collapses to one empty state pointing at the quickstart instead of four zeroes.
- **Quickstart** — one card with a transport toggle (TypeScript SDK / REST) and a send-shape toggle (raw HTML / template / arbitrary address), so at most two code blocks are on screen. Snippets carry the real project id and a real template id when one exists.
- **`sendEmail` reference** — the recipient selector (`userIds` | `allUsers` | `emails`) and content source (`html` | `templateId` | `draftId`) are XOR, which is the easiest thing to get wrong, so they're two tinted panels rather than prose; then the optional fields and the REST endpoint + required headers.
- **Templates** — template sends need the exact id string, so the project's templates are listed with copy buttons and a link into the Emails app.
- **Prompts** — ready-to-paste agent tasks, clamped to two lines each.

API-attributed means `createdWith === "programmatic-call"`; draft-triggered sends stay attributed to the Emails app.

The success rate classifies each row off the `status` discriminant rather than `simpleStatus`, because `simpleStatus` is not a proxy for "delivery finished": `delivery-delayed` and `skipped` are both `simpleStatus: "ok"` despite not being delivery outcomes. So:
- delivered: `sent`, `opened`, `clicked`, `marked-as-spam` (a spam complaint still means the mail arrived)
- failed: `bounced`, `render-error`, `server-error`
- excluded from both numerator and denominator: everything still in flight (including `delivery-delayed`) plus `skipped`, which was never attempted (e.g. a suppressed recipient)

The classifier is an exhaustive `switch`, so adding a status to the SDK is a compile error here rather than a silently miscounted row. When sends exist but none have reached an outcome yet, the tile renders `—` instead of a misleading `0%`.

`SentEmailsView` previously suppressed its `renderActions` slot when the filtered list was empty, which would have hidden the zero-state section; it now renders the slot regardless.

The pure aggregation logic lives in `email-api-logic.ts` with unit tests (predicate, window boundaries, source grouping, success-rate classification per status).

Verified against a local development environment: sent an email through the REST endpoint and confirmed the tiles, source breakdown and recipient row populate; page checked in light and dark mode.


Link to Devin session: https://app.devin.ai/sessions/60fa20f22aed4f3eb7b8432b051dbcdc
Requested by: @N2D4