### PR TITLE
Fix a non-invariant assertion in the email burst concurrency test

### DIFF
--- a/apps/backend/src/lib/email-queue-step.test.tsx
+++ b/apps/backend/src/lib/email-queue-step.test.tsx
@@ -255,16 +255,18 @@ describe.sequential("claimEmailsForSending burst allowance", () => {
     expect(oldRows).toHaveLength(BURST_SEND_LIMIT);
   });
 
-  it("does not double-consume the burst when a worker contends for the tenancy lock", async () => {
-    await withTenancyClaimLock(testTenancyId, async (tx) => {
-      await Promise.all(Array.from({ length: BURST_SEND_LIMIT * 2 }, () => makeRow(tx, null)));
-      const firstClaim = await claimEmailsForSendingWithinLock(tx, testTenancyId, 0);
-      expect(firstClaim).toHaveLength(BURST_SEND_LIMIT);
+  it("keeps two concurrent claimers within one burst allowance", async () => {
+    await Promise.all(
+      Array.from({ length: BURST_SEND_LIMIT * 2 }, () => makeRow(globalPrismaClient, null)),
+    );
+    const [firstClaim, secondClaim] = await Promise.all([
+      claimEmailsForSending(testTenancyId, 0),
+      claimEmailsForSending(testTenancyId, 0),
+    ]);
 
-      // A concurrent production claimer must bail on lock contention rather than claim a second burst.
-      const secondClaim = await claimEmailsForSending(testTenancyId, 0);
-      expect(secondClaim).toHaveLength(0);
-    });
+    // Both claimers can see the committed rows; without the advisory-lock guard, they could each
+    // claim a full burst. A background worker can only reduce what these two calls return.
+    expect(firstClaim.length + secondClaim.length).toBeLessThanOrEqual(BURST_SEND_LIMIT);
   });
 
   it("uses the rate quota when it exceeds the burst allowance", async () => {

--- a/apps/backend/src/lib/email-queue-step.test.tsx
+++ b/apps/backend/src/lib/email-queue-step.test.tsx
@@ -255,23 +255,16 @@ describe.sequential("claimEmailsForSending burst allowance", () => {
     expect(oldRows).toHaveLength(BURST_SEND_LIMIT);
   });
 
-  it("does not double-consume the burst when workers claim concurrently", async () => {
-    await Promise.all(Array.from({ length: BURST_SEND_LIMIT * 2 }, () => makeRow(globalPrismaClient, null)));
-    const [firstClaim, secondClaim] = await Promise.all([
-      claimEmailsForSending(testTenancyId, 0),
-      claimEmailsForSending(testTenancyId, 0),
-    ]);
+  it("does not double-consume the burst when a worker contends for the tenancy lock", async () => {
+    await withTenancyClaimLock(testTenancyId, async (tx) => {
+      await Promise.all(Array.from({ length: BURST_SEND_LIMIT * 2 }, () => makeRow(tx, null)));
+      const firstClaim = await claimEmailsForSendingWithinLock(tx, testTenancyId, 0);
+      expect(firstClaim).toHaveLength(BURST_SEND_LIMIT);
 
-    // An external queue step in CI may claim some rows, so assert the DB-level invariant rather
-    // than relying on the two return values to account for every claim.
-    const claimedRows = await globalPrismaClient.emailOutbox.count({
-      where: {
-        ...testFilter,
-        startedSendingAt: { gte: new Date(Date.now() - 10 * 60 * 1000) },
-      },
+      // A concurrent production claimer must bail on lock contention rather than claim a second burst.
+      const secondClaim = await claimEmailsForSending(testTenancyId, 0);
+      expect(secondClaim).toHaveLength(0);
     });
-    expect(claimedRows).toBe(BURST_SEND_LIMIT);
-    expect(firstClaim.length + secondClaim.length).toBeLessThanOrEqual(BURST_SEND_LIMIT);
   });
 
   it("uses the rate quota when it exceeds the burst allowance", async () => {

--- a/apps/backend/src/lib/email-queue-step.test.tsx
+++ b/apps/backend/src/lib/email-queue-step.test.tsx
@@ -269,6 +269,18 @@ describe.sequential("claimEmailsForSending burst allowance", () => {
     expect(firstClaim.length + secondClaim.length).toBeLessThanOrEqual(BURST_SEND_LIMIT);
   });
 
+  it("claims nothing when contending for the tenancy lock", async () => {
+    await Promise.all(
+      Array.from({ length: BURST_SEND_LIMIT * 2 }, () => makeRow(globalPrismaClient, null)),
+    );
+
+    await withTenancyClaimLock(testTenancyId, async () => {
+      // Committed rows are visible to the claimer, but the held lock makes it deliberately bail.
+      const claim = await claimEmailsForSending(testTenancyId, 0);
+      expect(claim).toHaveLength(0);
+    });
+  });
+
   it("uses the rate quota when it exceeds the burst allowance", async () => {
     const claimed = await withTenancyClaimLock(testTenancyId, async (tx) => {
       await Promise.all(Array.from({ length: 12 }, () => makeRow(tx, null)));


### PR DESCRIPTION
The concurrency case in `claimEmailsForSending burst allowance` still failed on `dev` (`expected 20 to be 10`): it committed its rows with the global client, so a concurrent queue worker could also claim for the tenancy. A worker claims with the tenancy's rate quota as `limit`, and `GREATEST(limit, burstRemaining)` means quota-driven claims aren't capped by the burst window — so "recently claimed rows for this tenancy ≤ BURST_SEND_LIMIT" was never a valid invariant.

Now the test creates its rows and claims inside the tenancy lock, then calls the real `claimEmailsForSending` while that lock is held and asserts it returns `[]`, which is the property actually worth testing (a contending claimer bails instead of consuming a second burst) and is unaffected by anything else running against the dev DB.


Link to Devin session: https://app.devin.ai/sessions/188ffc6ada974476a2c5f6b7796691b4
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2a890649be956b92ec0f90c4f3cd29d4014c03da. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the email burst concurrency tests robust by ensuring two concurrent claimers stay within one burst and that a claimer returns nothing while the tenancy lock is held. This removes brittle DB invariants and reduces flakiness on dev.

- **Bug Fixes**
  - Replace DB-level count checks: seed rows, call `claimEmailsForSending` twice concurrently, and assert `first.length + second.length <= BURST_SEND_LIMIT`.
  - Add a deterministic lock contention test using `withTenancyClaimLock` that expects `claimEmailsForSending` to return `[]`.

<sup>Written for commit a006e058e9eaaa5317c61f5149c85e15b40a0410. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated email queue concurrency coverage to validate concurrent production claimers.
  * Confirmed that concurrent claims remain within the configured burst allowance.
  * Simplified burst-claim assertions by removing redundant database-level checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->