### PR TITLE
Stop dev-branch CI runs from queueing behind each other

### DIFF
--- a/.github/workflows/all-good.yaml
+++ b/.github/workflows/all-good.yaml
@@ -7,6 +7,10 @@ on:
       - dev
   pull_request:
 
+# A concurrency group only ever runs one run at a time, so the sha is part of the group on main/dev:
+# otherwise consecutive dev pushes queue behind each other (and GitHub cancels the older queued run),
+# so one slow or hung run silently skips CI for every commit after it. PRs and feature branches stay
+# grouped per ref, where cancelling superseded runs is what we want.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}

--- a/.github/workflows/all-good.yaml
+++ b/.github/workflows/all-good.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:

--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -5,7 +5,7 @@ on:
     - cron: '30 11 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:

--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -4,8 +4,9 @@ on:
   schedule:
     - cron: '30 11 * * *'
 
+# Grouped per ref (not per sha) on purpose: this mutates PR branches, so runs must stay serialized.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:

--- a/.github/workflows/bulldozer-serialization-compat.yaml
+++ b/.github/workflows/bulldozer-serialization-compat.yaml
@@ -20,6 +20,10 @@ on:
 permissions:
   contents: read
 
+# A concurrency group only ever runs one run at a time, so the sha is part of the group on main/dev:
+# otherwise consecutive dev pushes queue behind each other (and GitHub cancels the older queued run),
+# so one slow or hung run silently skips CI for every commit after it. PRs and feature branches stay
+# grouped per ref, where cancelling superseded runs is what we want.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/dev' }}

--- a/.github/workflows/bulldozer-serialization-compat.yaml
+++ b/.github/workflows/bulldozer-serialization-compat.yaml
@@ -21,7 +21,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/dev' }}
 
 # *_DIR vars are repo-relative (used for diffing/overlaying). *_HARNESS_REL vars are relative to the

--- a/.github/workflows/check-prisma-migrations.yaml
+++ b/.github/workflows/check-prisma-migrations.yaml
@@ -7,6 +7,10 @@ on:
       - dev
   pull_request:
 
+# A concurrency group only ever runs one run at a time, so the sha is part of the group on main/dev:
+# otherwise consecutive dev pushes queue behind each other (and GitHub cancels the older queued run),
+# so one slow or hung run silently skips CI for every commit after it. PRs and feature branches stay
+# grouped per ref, where cancelling superseded runs is what we want.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}

--- a/.github/workflows/check-prisma-migrations.yaml
+++ b/.github/workflows/check-prisma-migrations.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:

--- a/.github/workflows/db-migration-backwards-compatibility.yaml
+++ b/.github/workflows/db-migration-backwards-compatibility.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+# A concurrency group only ever runs one run at a time, so the sha is part of the group on main/dev:
+# otherwise consecutive dev pushes queue behind each other (and GitHub cancels the older queued run),
+# so one slow or hung run silently skips CI for every commit after it. PRs and feature branches stay
+# grouped per ref, where cancelling superseded runs is what we want.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/dev' }}

--- a/.github/workflows/db-migration-backwards-compatibility.yaml
+++ b/.github/workflows/db-migration-backwards-compatibility.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/dev' }}
 
 jobs:

--- a/.github/workflows/docker-server-build-push.yaml
+++ b/.github/workflows/docker-server-build-push.yaml
@@ -6,12 +6,15 @@ on:
       - main
       - dev
 
+# Grouped per ref (not per sha) on purpose: this pushes the moving `dev`/`latest` image tags, so runs
+# must stay serialized, otherwise a slower run for an older commit can overwrite a newer commit's tag.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:
   build-server:
+    timeout-minutes: 90
     name: Docker Build and Push Server
     runs-on: ubicloud-standard-8
     steps:

--- a/.github/workflows/docker-server-build-push.yaml
+++ b/.github/workflows/docker-server-build-push.yaml
@@ -7,7 +7,7 @@ on:
       - dev
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:

--- a/.github/workflows/docker-server-build-run.yaml
+++ b/.github/workflows/docker-server-build-run.yaml
@@ -7,6 +7,10 @@ on:
       - dev
   pull_request:
 
+# A concurrency group only ever runs one run at a time, so the sha is part of the group on main/dev:
+# otherwise consecutive dev pushes queue behind each other (and GitHub cancels the older queued run),
+# so one slow or hung run silently skips CI for every commit after it. PRs and feature branches stay
+# grouped per ref, where cancelling superseded runs is what we want.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}

--- a/.github/workflows/docker-server-build-run.yaml
+++ b/.github/workflows/docker-server-build-run.yaml
@@ -8,11 +8,12 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:
   docker:
+    timeout-minutes: 45
     runs-on: ubicloud-standard-8
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -7,6 +7,10 @@ on:
       - dev
   pull_request:
 
+# A concurrency group only ever runs one run at a time, so the sha is part of the group on main/dev:
+# otherwise consecutive dev pushes queue behind each other (and GitHub cancels the older queued run),
+# so one slow or hung run silently skips CI for every commit after it. PRs and feature branches stay
+# grouped per ref, where cancelling superseded runs is what we want.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}

--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:
@@ -28,6 +28,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
+    timeout-minutes: 150
     needs: wait-for-fast-fail
     name: E2E Tests (Node ${{ matrix.node-version }}, Freestyle ${{ matrix.freestyle-mode }})
     runs-on: ubicloud-standard-8

--- a/.github/workflows/e2e-fallback-tests.yaml
+++ b/.github/workflows/e2e-fallback-tests.yaml
@@ -9,6 +9,10 @@ on:
       - dev
   pull_request:
 
+# A concurrency group only ever runs one run at a time, so the sha is part of the group on main/dev:
+# otherwise consecutive dev pushes queue behind each other (and GitHub cancels the older queued run),
+# so one slow or hung run silently skips CI for every commit after it. PRs and feature branches stay
+# grouped per ref, where cancelling superseded runs is what we want.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}

--- a/.github/workflows/e2e-fallback-tests.yaml
+++ b/.github/workflows/e2e-fallback-tests.yaml
@@ -10,7 +10,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:
@@ -30,6 +30,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   build:
+    timeout-minutes: 150
     needs: wait-for-fast-fail
     name: E2E Fallback Tests (Node ${{ matrix.node-version }})
     runs-on: ubicloud-standard-8

--- a/.github/workflows/fast-fail-tests.yaml
+++ b/.github/workflows/fast-fail-tests.yaml
@@ -18,7 +18,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:
@@ -188,6 +188,7 @@ jobs:
           echo "test_files=$selected" >> "$GITHUB_OUTPUT"
 
   fast-fail-tests:
+    timeout-minutes: 45
     name: fast-fail-tests
     needs: select-tests
     if: ${{ needs.select-tests.outputs.test_files != '' }}

--- a/.github/workflows/fast-fail-tests.yaml
+++ b/.github/workflows/fast-fail-tests.yaml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+# A concurrency group only ever runs one run at a time, so the sha is part of the group on main/dev:
+# otherwise consecutive dev pushes queue behind each other (and GitHub cancels the older queued run),
+# so one slow or hung run silently skips CI for every commit after it. PRs and feature branches stay
+# grouped per ref, where cancelling superseded runs is what we want.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}

--- a/.github/workflows/lint-and-build.yaml
+++ b/.github/workflows/lint-and-build.yaml
@@ -7,6 +7,10 @@ on:
       - dev
   pull_request:
 
+# A concurrency group only ever runs one run at a time, so the sha is part of the group on main/dev:
+# otherwise consecutive dev pushes queue behind each other (and GitHub cancels the older queued run),
+# so one slow or hung run silently skips CI for every commit after it. PRs and feature branches stay
+# grouped per ref, where cancelling superseded runs is what we want.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}

--- a/.github/workflows/lint-and-build.yaml
+++ b/.github/workflows/lint-and-build.yaml
@@ -8,11 +8,12 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:
   lint_and_build:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/setup-tests-with-custom-base-port.yaml
+++ b/.github/workflows/setup-tests-with-custom-base-port.yaml
@@ -7,6 +7,10 @@ on:
       - dev
   pull_request:
 
+# A concurrency group only ever runs one run at a time, so the sha is part of the group on main/dev:
+# otherwise consecutive dev pushes queue behind each other (and GitHub cancels the older queued run),
+# so one slow or hung run silently skips CI for every commit after it. PRs and feature branches stay
+# grouped per ref, where cancelling superseded runs is what we want.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}

--- a/.github/workflows/setup-tests-with-custom-base-port.yaml
+++ b/.github/workflows/setup-tests-with-custom-base-port.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 env:
@@ -32,6 +32,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   setup-tests-with-custom-base-port:
+    timeout-minutes: 90
     needs: wait-for-fast-fail
     # `success()` is required because the custom `if` otherwise overrides the
     # implicit success() gate from `needs`, letting this run even if the gate failed.

--- a/.github/workflows/setup-tests.yaml
+++ b/.github/workflows/setup-tests.yaml
@@ -7,6 +7,10 @@ on:
       - dev
   pull_request:
 
+# A concurrency group only ever runs one run at a time, so the sha is part of the group on main/dev:
+# otherwise consecutive dev pushes queue behind each other (and GitHub cancels the older queued run),
+# so one slow or hung run silently skips CI for every commit after it. PRs and feature branches stay
+# grouped per ref, where cancelling superseded runs is what we want.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}

--- a/.github/workflows/setup-tests.yaml
+++ b/.github/workflows/setup-tests.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 env:
@@ -32,6 +32,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   setup-tests:
+    timeout-minutes: 90
     needs: wait-for-fast-fail
     # `success()` is required because the custom `if` otherwise overrides the
     # implicit success() gate from `needs`, letting this run even if the gate failed.

--- a/.github/workflows/table-of-contents.yaml
+++ b/.github/workflows/table-of-contents.yaml
@@ -7,8 +7,10 @@ on:
       - dev
   pull_request:
 
+# Grouped per ref (not per sha) on purpose: this pushes a commit back to the branch, so runs must stay
+# serialized to avoid racing pushes.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:

--- a/.github/workflows/table-of-contents.yaml
+++ b/.github/workflows/table-of-contents.yaml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:


### PR DESCRIPTION
Every CI workflow grouped its runs as `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: false` on `main`/`dev`. A concurrency group only ever runs one run at a time, and `cancel-in-progress: false` doesn't make runs parallel — it makes newcomers *queue*, and GitHub keeps only one queued run per group, so a third push cancels the pending second one. So one slow/hung run on `dev` silently skips CI for every commit after it.

The read-only test/check workflows now include the sha in the group on `main`/`dev`, so pushes there never share a group:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}${{ (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && format('-{0}', github.sha) || '' }}
```

PRs and feature branches are unchanged (grouped per ref, superseded runs cancelled). Three workflows deliberately stay serialized because they mutate shared state and ordering matters: `docker-server-build-push` (moving `dev`/`latest` image tags), `table-of-contents` (pushes a commit to the branch), `auto-update` (mutates PR branches).

Also adds `timeout-minutes` to the long-running jobs (none of them had one, so a hang burned the 6h default): e2e api/fallback 150, setup-tests 90, docker push 90, lint-and-build 60, docker build-run 45, fast-fail 45.


Link to Devin session: https://app.devin.ai/sessions/4a42b53127a64eca805a37e9faa77304
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions concurrency and timeouts; no application code or deploy logic is modified.
> 
> **Overview**
> Fixes **silent skipped CI** on `main`/`dev` when back-to-back pushes shared one concurrency group and queued runs were dropped.
> 
> Most workflows now append **`github.sha`** to the concurrency group on `main`/`dev`, so each push gets its own run while PRs still cancel superseded runs per ref. **`docker-server-build-push`**, **`table-of-contents`**, and **`auto-update`** stay serialized per ref (moving image tags, branch commits, PR branch updates) with new comments explaining why.
> 
> Adds **`timeout-minutes`** on heavy jobs (e.g. e2e 150, setup-tests/docker push 90, lint 60, fast-fail/docker build-run 45) instead of relying on the 6h default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01f3476d7722c87a48c1a4ff3497a32136a1324f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `dev` CI runs from queueing behind each other and getting dropped when a previous run is slow or hung. Switches read-only workflows on protected branches to per-SHA concurrency and adds sensible timeouts to long jobs.

- **Bug Fixes**
  - Use per-SHA concurrency for read-only workflows on `main`/`dev`; PRs and feature branches stay per-ref with cancel-in-progress.
  - Keep stateful workflows serialized: `docker-server-build-push`, `table-of-contents`, `auto-update`.
  - Add timeouts: e2e api/fallback 150m; setup-tests (+ custom-base-port) 90m; docker push 90m; lint-and-build 60m; docker build-run 45m; fast-fail 45m.

<sup>Written for commit 01f3476d7722c87a48c1a4ff3497a32136a1324f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workflow concurrency handling so separate commits on primary development branches run independently without unintended cancellation.

* **Reliability**
  * Added execution time limits to build, test, lint, and Docker jobs to prevent workflows from running indefinitely.
  * Preserved serialized processing where workflows modify branches or require ref-based coordination.

* **Documentation**
  * Added clarifying notes about workflow concurrency and serialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->