### PR TITLE
Wait for dev watchers to settle before running setup tests

### DIFF
--- a/.github/workflows/setup-tests.yaml
+++ b/.github/workflows/setup-tests.yaml
@@ -75,6 +75,23 @@ jobs:
             echo "$?" > "$RUNNER_TEMP/hexclave-dev-exit-code.untracked.txt"
           ) &
           pnpm exec wait-on --timeout 120000 http://localhost:8102 tcp:localhost:8146
+
+      # The readiness gate only proves that 8102 and 8146 accept connections;
+      # both services normally listen within seconds. build-packages:watch then
+      # performs a full non-watch tsdown pass even though build:packages already
+      # ran, rewriting packages/*/dist (about 8.3k of 8.4k files in our
+      # reproduction, including about 270 content changes). Watch-based dev
+      # tasks such as bulldozer-js, which imports @hexclave/shared from dist,
+      # restart when those files land and briefly take their ports down. That
+      # caused the failures in run 31347402547; the observed bulldozer outage
+      # was about 1.7 seconds and happened tens of seconds after this gate.
+      # This is a mitigation, not a guarantee: a slow runner may still be
+      # rebuilding at 60 seconds, and codegen watchers can write files later.
+      # We keep the watchers enabled so this job still exercises pnpm run dev,
+      # and instead allow the initial rebuild and restarts to settle first.
+      - name: Allow development watchers to settle
+        run: sleep 60
+
       - name: Run tests (first attempt)
         id: run-tests-first-attempt
         continue-on-error: ${{ (github.head_ref || github.ref_name) != 'main' && (github.head_ref || github.ref_name) != 'dev' }}


### PR DESCRIPTION
The readiness gate in `setup-tests` only waits for ports 8102 and 8146 to accept connections, and both listen within seconds. But `build-packages:watch` doesn't start in watch mode — it first runs a full `tsdown --workspace='packages/*'` pass, which rewrites `packages/*/dist` even though `build:packages` already ran earlier in the job. Watch-based dev tasks restart when that lands: `bulldozer-js` runs `tsx watch` and imports `@hexclave/shared` from `dist`, so its port goes down for a moment, tens of seconds *after* the gate passed.

That's what caused the failures in run 31347402547 — 22 tests failed in a ~10s window ~40s into the suite, all `ECONNREFUSED` against bulldozer.

Reproduced locally: the tsdown pass rewrote ~8.3k of ~8.4k `packages/*/dist` files (~270 with changed content), `tsx` logged `change in packages/shared/dist/esm/utils/uuids.js Restarting...`, and bulldozer's port was unavailable for ~1.7s.

So this sleeps 60s after the gate. Deliberately not disabling the watchers, since the point of this job is to run exactly what `pnpm run dev` runs. It's a mitigation rather than a guarantee, and the comment says so: a slow enough runner can still be mid-rebuild at 60s, and the codegen watchers can write files later than that.

Link to Devin session: https://app.devin.ai/sessions/67031df980aa4612941319e86eef0069
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit e1bedd2a1271beae7bc52c342da0b34cdca632ee. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 60s pause in `setup-tests` to let dev watchers finish their initial rebuild before tests run. This reduces mid-suite ECONNREFUSED failures when `bulldozer-js` restarts after `build-packages:watch` rewrites `packages/*/dist`.

- **Bug Fixes**
  - Add "Allow development watchers to settle" step in `.github/workflows/setup-tests.yaml` (sleep 60s after readiness gate).
  - Keep watchers enabled to mirror `pnpm run dev`; this is a mitigation, not a guarantee.
  - Targets flakes caused by restarts when `@hexclave/shared` is rebuilt.

<sup>Written for commit e1bedd2a1271beae7bc52c342da0b34cdca632ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

