### PR TITLE
Retry bulldozer requests that provably never left the backend

### DIFF
--- a/apps/backend/src/lib/bulldozer-server-client.test.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.test.ts
@@ -164,6 +164,17 @@ describe("fetchBulldozerServerJson", () => {
     })).toBe("/v1/tenancy%2Fid/customers/user/customer%3Fid/owned-products");
   });
 
+  it("preserves a path prefix in the configured Bulldozer URL", async () => {
+    vi.stubEnv("HEXCLAVE_BULLDOZER_SERVER_URL", "http://localhost:8146/bulldozer");
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ success: true }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchBulldozerServerJson<{ success: true }>({ method: "POST", path: "/update-quantity" }))
+      .resolves.toEqual({ success: true });
+
+    expect(fetchMock).toHaveBeenCalledWith("http://localhost:8146/bulldozer/update-quantity", expect.anything());
+  });
+
   it("does not retry an ambiguous socket failure", async () => {
     const fetchMock = vi.fn().mockRejectedValue(errorWithCode("ECONNRESET"));
     vi.stubGlobal("fetch", fetchMock);

--- a/apps/backend/src/lib/bulldozer-server-client.test.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { fetchBulldozerServerJson, isRetriableBulldozerFetchError } from "./bulldozer-server-client";
+
+function errorWithCode(code: string): Error & { code: string } {
+  return Object.assign(new Error(code), { code });
+}
+
+describe("isRetriableBulldozerFetchError", () => {
+  it("accepts nested connect-phase errors", () => {
+    expect(isRetriableBulldozerFetchError(new TypeError("fetch failed", {
+      cause: errorWithCode("ECONNREFUSED"),
+    }))).toBe(true);
+  });
+
+  it("accepts aggregates when every address failed safely", () => {
+    expect(isRetriableBulldozerFetchError(new TypeError("fetch failed", {
+      cause: new AggregateError([
+        errorWithCode("ECONNREFUSED"),
+        errorWithCode("ENOTFOUND"),
+      ]),
+    }))).toBe(true);
+  });
+
+  it("rejects aggregates containing an ambiguous or unsafe failure", () => {
+    expect(isRetriableBulldozerFetchError(new TypeError("fetch failed", {
+      cause: new AggregateError([
+        errorWithCode("ECONNREFUSED"),
+        errorWithCode("ECONNRESET"),
+      ]),
+    }))).toBe(false);
+    expect(isRetriableBulldozerFetchError(errorWithCode("ETIMEDOUT"))).toBe(false);
+  });
+});
+
+describe("fetchBulldozerServerJson", () => {
+  it("retries a refused connection and returns the later response", async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed", { cause: errorWithCode("ECONNREFUSED") }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resultPromise = fetchBulldozerServerJson<{ success: true }>({ method: "POST", path: "/update-quantity", body: { quantity: 1 } });
+    await vi.runAllTimersAsync();
+
+    await expect(resultPromise).resolves.toEqual({ success: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it("does not retry an HTTP error", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response("bad request", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchBulldozerServerJson({ method: "POST", path: "/update-quantity" })).rejects.toThrow("Bulldozer server request failed");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry an ambiguous socket failure", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(errorWithCode("ECONNRESET"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchBulldozerServerJson({ method: "POST", path: "/update-quantity" })).rejects.toMatchObject({ code: "ECONNRESET" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/backend/src/lib/bulldozer-server-client.test.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.test.ts
@@ -52,7 +52,13 @@ describe("fetchBulldozerServerJson", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const resultPromise = fetchBulldozerServerJson<{ success: true }>({ method: "POST", path: "/update-quantity", body: { quantity: 1 } });
-    await vi.runAllTimersAsync();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(249);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
 
     await expect(resultPromise).resolves.toEqual({ success: true });
     expect(fetchMock).toHaveBeenCalledTimes(2);
@@ -73,7 +79,15 @@ describe("fetchBulldozerServerJson", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const request = expect(fetchBulldozerServerJson({ method: "POST", path: "/update-quantity" })).rejects.toBe(failures[4]);
-    await vi.runAllTimersAsync();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    for (const [index, delay] of retryDelays.entries()) {
+      await vi.advanceTimersByTimeAsync(delay - 1);
+      expect(fetchMock).toHaveBeenCalledTimes(index + 1);
+      await vi.advanceTimersByTimeAsync(1);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(fetchMock).toHaveBeenCalledTimes(index + 2);
+    }
 
     await request;
     expect(fetchMock).toHaveBeenCalledTimes(5);
@@ -108,6 +122,28 @@ describe("fetchBulldozerServerJson", () => {
         attempts: 3,
       },
     });
+  });
+
+  it("does not emit a recovery diagnostic when the retried response is not ok", async () => {
+    vi.useFakeTimers();
+    const capturedErrorsBefore = globalVar.hexclaveCapturedErrors?.length ?? 0;
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(new TypeError("fetch failed", {
+        cause: errorWithCode("ECONNREFUSED"),
+      }))
+      .mockResolvedValueOnce(new Response("bad request", { status: 500 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = expect(fetchBulldozerServerJson({ method: "POST", path: "/recovery-http-error" }))
+      .rejects.toThrow("Bulldozer server request failed");
+    await vi.advanceTimersByTimeAsync(250);
+
+    await request;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const capturedErrors = (globalVar.hexclaveCapturedErrors ?? [])
+      .slice(capturedErrorsBefore)
+      .filter((entry: { location: string }) => entry.location === "bulldozer-server-connect-retry");
+    expect(capturedErrors).toHaveLength(0);
   });
 
   it("does not retry an HTTP error", async () => {

--- a/apps/backend/src/lib/bulldozer-server-client.test.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { fetchBulldozerServerJson, isRetriableBulldozerFetchError } from "./bulldozer-server-client";
 
 function errorWithCode(code: string): Error & { code: string } {
   return Object.assign(new Error(code), { code });
 }
+
+beforeEach(() => {
+  vi.stubEnv("HEXCLAVE_BULLDOZER_SERVER_SECRET", "test-secret");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
 
 describe("isRetriableBulldozerFetchError", () => {
   it("accepts nested connect-phase errors", () => {
@@ -45,7 +55,6 @@ describe("fetchBulldozerServerJson", () => {
 
     await expect(resultPromise).resolves.toEqual({ success: true });
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    vi.useRealTimers();
   });
 
   it("does not retry an HTTP error", async () => {

--- a/apps/backend/src/lib/bulldozer-server-client.test.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { globalVar } from "@hexclave/shared/dist/utils/globals";
-import { fetchBulldozerServerJson, isRetriableBulldozerFetchError } from "./bulldozer-server-client";
+import { bulldozerCustomerPath, fetchBulldozerServerJson, isRetriableBulldozerFetchError } from "./bulldozer-server-client";
 
 function errorWithCode(code: string): Error & { code: string } {
   return Object.assign(new Error(code), { code });
@@ -62,6 +62,7 @@ describe("fetchBulldozerServerJson", () => {
 
     await expect(resultPromise).resolves.toEqual({ success: true });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, "http://localhost:8146/update-quantity", expect.anything());
   });
 
   it("rethrows the original error after exhausting all safe connection retries", async () => {
@@ -114,7 +115,7 @@ describe("fetchBulldozerServerJson", () => {
     await expect(resultPromise).resolves.toEqual({ success: true });
     const capturedErrors = (globalVar.hexclaveCapturedErrors ?? [])
       .slice(capturedErrorsBefore)
-      .filter((entry) => entry.location === "bulldozer-server-connect-retry");
+      .filter((entry: { location: string }) => entry.location === "bulldozer-server-connect-retry");
     expect(capturedErrors).toHaveLength(1);
     expect(capturedErrors[0].error).toMatchObject({
       cause: firstFailure,
@@ -152,6 +153,15 @@ describe("fetchBulldozerServerJson", () => {
 
     await expect(fetchBulldozerServerJson({ method: "POST", path: "/update-quantity" })).rejects.toThrow("Bulldozer server request failed");
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("encodes customer path segments without double-encoding", () => {
+    expect(bulldozerCustomerPath({
+      tenancyId: "tenancy/id",
+      customerType: "user",
+      customerId: "customer?id",
+      suffix: "owned-products",
+    })).toBe("/v1/tenancy%2Fid/customers/user/customer%3Fid/owned-products");
   });
 
   it("does not retry an ambiguous socket failure", async () => {

--- a/apps/backend/src/lib/bulldozer-server-client.test.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { globalVar } from "@hexclave/shared/dist/utils/globals";
 import { fetchBulldozerServerJson, isRetriableBulldozerFetchError } from "./bulldozer-server-client";
 
 function errorWithCode(code: string): Error & { code: string } {
@@ -55,6 +56,58 @@ describe("fetchBulldozerServerJson", () => {
 
     await expect(resultPromise).resolves.toEqual({ success: true });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows the original error after exhausting all safe connection retries", async () => {
+    vi.useFakeTimers();
+    const retryDelays = [250, 500, 1_000, 2_000];
+    const failures = Array.from({ length: 5 }, (_, index) => new TypeError(`fetch failed ${index}`, {
+      cause: errorWithCode("ECONNREFUSED"),
+    }));
+    const fetchMock = vi.fn().mockRejectedValueOnce(failures[0])
+      .mockRejectedValueOnce(failures[1])
+      .mockRejectedValueOnce(failures[2])
+      .mockRejectedValueOnce(failures[3])
+      .mockRejectedValueOnce(failures[4]);
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    vi.stubGlobal("fetch", fetchMock);
+
+    const request = expect(fetchBulldozerServerJson({ method: "POST", path: "/update-quantity" })).rejects.toBe(failures[4]);
+    await vi.runAllTimersAsync();
+
+    await request;
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(setTimeoutSpy.mock.calls.map(([, delay]) => delay)).toEqual(retryDelays);
+  });
+
+  it("emits one recovery diagnostic with the first failure and final attempt count", async () => {
+    vi.useFakeTimers();
+    const firstFailure = new TypeError("first fetch failed", {
+      cause: errorWithCode("ECONNREFUSED"),
+    });
+    const fetchMock = vi.fn()
+      .mockRejectedValueOnce(firstFailure)
+      .mockRejectedValueOnce(new TypeError("second fetch failed", {
+        cause: errorWithCode("ECONNREFUSED"),
+      }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true }), { status: 200 }));
+    const capturedErrorsBefore = globalVar.hexclaveCapturedErrors?.length ?? 0;
+    vi.stubGlobal("fetch", fetchMock);
+
+    const resultPromise = fetchBulldozerServerJson<{ success: true }>({ method: "POST", path: "/recovery-after-several" });
+    await vi.runAllTimersAsync();
+
+    await expect(resultPromise).resolves.toEqual({ success: true });
+    const capturedErrors = (globalVar.hexclaveCapturedErrors ?? [])
+      .slice(capturedErrorsBefore)
+      .filter((entry) => entry.location === "bulldozer-server-connect-retry");
+    expect(capturedErrors).toHaveLength(1);
+    expect(capturedErrors[0].error).toMatchObject({
+      cause: firstFailure,
+      extraData: {
+        attempts: 3,
+      },
+    });
   });
 
   it("does not retry an HTTP error", async () => {

--- a/apps/backend/src/lib/bulldozer-server-client.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.ts
@@ -1,5 +1,6 @@
 import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { captureError, HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+import { urlString } from "@hexclave/shared/dist/utils/urls";
 
 const BULLDOZER_FETCH_MAX_ATTEMPTS = 5;
 const BULLDOZER_FETCH_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000];
@@ -53,17 +54,13 @@ function getBulldozerServerBaseUrl(): string {
   return `http://localhost:${getEnvVariable("NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX", "81")}46`;
 }
 
-function encodePathSegment(segment: string): string {
-  return encodeURIComponent(segment);
-}
-
 export function bulldozerCustomerPath(options: {
   tenancyId: string,
   customerType: "user" | "team" | "custom",
   customerId: string,
   suffix: string,
 }): string {
-  return `/v1/${encodePathSegment(options.tenancyId)}/customers/${encodePathSegment(options.customerType)}/${encodePathSegment(options.customerId)}/${options.suffix}`;
+  return urlString`/v1/${options.tenancyId}/customers/${options.customerType}/${options.customerId}/${options.suffix}`;
 }
 
 export async function fetchBulldozerServerJson<T>(options: {
@@ -77,7 +74,7 @@ export async function fetchBulldozerServerJson<T>(options: {
     while (true) {
       attempt++;
       try {
-        const response = await fetch(`${getBulldozerServerBaseUrl()}${options.path}`, {
+        const response = await fetch(new URL(options.path, getBulldozerServerBaseUrl()).toString(), {
           method: options.method,
           headers: {
             "content-type": "application/json",

--- a/apps/backend/src/lib/bulldozer-server-client.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.ts
@@ -71,39 +71,39 @@ export async function fetchBulldozerServerJson<T>(options: {
   path: string,
   body?: unknown,
 }): Promise<T> {
-  let response: Response | undefined;
-  for (let attempt = 0; attempt < BULLDOZER_FETCH_MAX_ATTEMPTS; attempt++) {
-    try {
-      response = await fetch(`${getBulldozerServerBaseUrl()}${options.path}`, {
-        method: options.method,
-        headers: {
-          "content-type": "application/json",
-          "authorization": `Bearer ${getEnvVariable("HEXCLAVE_BULLDOZER_SERVER_SECRET")}`,
-        },
-        ...options.body === undefined ? {} : { body: JSON.stringify(options.body) },
-      });
-      break;
-    } catch (error) {
-      if (!isRetriableBulldozerFetchError(error) || attempt === BULLDOZER_FETCH_MAX_ATTEMPTS - 1) {
-        throw error;
+  let attempt = 0;
+  let firstRetryError: unknown;
+  const response = await (async (): Promise<Response> => {
+    while (true) {
+      attempt++;
+      try {
+        const response = await fetch(`${getBulldozerServerBaseUrl()}${options.path}`, {
+          method: options.method,
+          headers: {
+            "content-type": "application/json",
+            "authorization": `Bearer ${getEnvVariable("HEXCLAVE_BULLDOZER_SERVER_SECRET")}`,
+          },
+          ...options.body === undefined ? {} : { body: JSON.stringify(options.body) },
+        });
+
+        if (attempt > 1) {
+          captureError("bulldozer-server-connect-retry", new HexclaveAssertionError("Bulldozer server request recovered after connect-phase failures", {
+            cause: firstRetryError,
+            attempts: attempt,
+            method: options.method,
+            path: options.path,
+          }));
+        }
+        return response;
+      } catch (error) {
+        if (!isRetriableBulldozerFetchError(error) || attempt >= BULLDOZER_FETCH_MAX_ATTEMPTS) {
+          throw error;
+        }
+        firstRetryError ??= error;
+        await new Promise((resolve) => setTimeout(resolve, BULLDOZER_FETCH_RETRY_DELAYS_MS[attempt - 1]));
       }
-
-      captureError("bulldozer-server-connect-retry", new HexclaveAssertionError("Retrying a bulldozer server request after a connect-phase failure", {
-        cause: error,
-        attempt: attempt + 1,
-        method: options.method,
-        path: options.path,
-      }));
-      await new Promise((resolve) => setTimeout(resolve, BULLDOZER_FETCH_RETRY_DELAYS_MS[attempt]));
     }
-  }
-
-  if (response === undefined) {
-    throw new HexclaveAssertionError("Bulldozer server request did not produce a response", {
-      method: options.method,
-      path: options.path,
-    });
-  }
+  })();
 
   if (!response.ok) {
     const responseText = await response.text();

--- a/apps/backend/src/lib/bulldozer-server-client.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.ts
@@ -1,5 +1,49 @@
 import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
-import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+import { captureError, HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+
+const BULLDOZER_FETCH_MAX_ATTEMPTS = 5;
+const BULLDOZER_FETCH_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000];
+const SAFE_CONNECT_ERROR_CODES = new Set(["ECONNREFUSED", "ENOTFOUND", "EAI_AGAIN", "EAI_FAIL"]);
+
+type ErrorWithCause = {
+  cause?: unknown,
+  code?: unknown,
+  errors?: unknown,
+};
+
+function isErrorWithCause(value: unknown): value is ErrorWithCause {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * A fetch failure is safe to retry only when every low-level error is a
+ * connect-phase failure. In particular, ECONNRESET and timeouts are excluded:
+ * they can happen after a non-idempotent request reached bulldozer.
+ */
+export function isRetriableBulldozerFetchError(error: unknown): boolean {
+  const visited = new Set<object>();
+  let foundSafeCode = false;
+
+  function visit(value: unknown): boolean {
+    if (!isErrorWithCause(value)) return false;
+    if (visited.has(value)) return true;
+    visited.add(value);
+
+    const code = typeof value.code === "string" ? value.code : undefined;
+    if (code !== undefined) {
+      if (!SAFE_CONNECT_ERROR_CODES.has(code)) return false;
+      foundSafeCode = true;
+    }
+
+    const children: unknown[] = [];
+    if ("cause" in value && value.cause !== undefined) children.push(value.cause);
+    if ("errors" in value && Array.isArray(value.errors)) children.push(...value.errors);
+    if (children.length === 0) return code !== undefined;
+    return children.every(visit);
+  }
+
+  return visit(error) && foundSafeCode;
+}
 
 function getBulldozerServerBaseUrl(): string {
   const configuredUrl = getEnvVariable("HEXCLAVE_BULLDOZER_SERVER_URL", "");
@@ -27,14 +71,39 @@ export async function fetchBulldozerServerJson<T>(options: {
   path: string,
   body?: unknown,
 }): Promise<T> {
-  const response = await fetch(`${getBulldozerServerBaseUrl()}${options.path}`, {
-    method: options.method,
-    headers: {
-      "content-type": "application/json",
-      "authorization": `Bearer ${getEnvVariable("HEXCLAVE_BULLDOZER_SERVER_SECRET")}`,
-    },
-    ...options.body === undefined ? {} : { body: JSON.stringify(options.body) },
-  });
+  let response: Response | undefined;
+  for (let attempt = 0; attempt < BULLDOZER_FETCH_MAX_ATTEMPTS; attempt++) {
+    try {
+      response = await fetch(`${getBulldozerServerBaseUrl()}${options.path}`, {
+        method: options.method,
+        headers: {
+          "content-type": "application/json",
+          "authorization": `Bearer ${getEnvVariable("HEXCLAVE_BULLDOZER_SERVER_SECRET")}`,
+        },
+        ...options.body === undefined ? {} : { body: JSON.stringify(options.body) },
+      });
+      break;
+    } catch (error) {
+      if (!isRetriableBulldozerFetchError(error) || attempt === BULLDOZER_FETCH_MAX_ATTEMPTS - 1) {
+        throw error;
+      }
+
+      captureError("bulldozer-server-connect-retry", new HexclaveAssertionError("Retrying a bulldozer server request after a connect-phase failure", {
+        cause: error,
+        attempt: attempt + 1,
+        method: options.method,
+        path: options.path,
+      }));
+      await new Promise((resolve) => setTimeout(resolve, BULLDOZER_FETCH_RETRY_DELAYS_MS[attempt]));
+    }
+  }
+
+  if (response === undefined) {
+    throw new HexclaveAssertionError("Bulldozer server request did not produce a response", {
+      method: options.method,
+      path: options.path,
+    });
+  }
 
   if (!response.ok) {
     const responseText = await response.text();

--- a/apps/backend/src/lib/bulldozer-server-client.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.ts
@@ -74,7 +74,7 @@ export async function fetchBulldozerServerJson<T>(options: {
     while (true) {
       attempt++;
       try {
-        const response = await fetch(new URL(options.path, getBulldozerServerBaseUrl()).toString(), {
+        const response = await fetch(`${getBulldozerServerBaseUrl()}${options.path}`, {
           method: options.method,
           headers: {
             "content-type": "application/json",

--- a/apps/backend/src/lib/bulldozer-server-client.ts
+++ b/apps/backend/src/lib/bulldozer-server-client.ts
@@ -86,7 +86,7 @@ export async function fetchBulldozerServerJson<T>(options: {
           ...options.body === undefined ? {} : { body: JSON.stringify(options.body) },
         });
 
-        if (attempt > 1) {
+        if (attempt > 1 && response.ok) {
           captureError("bulldozer-server-connect-retry", new HexclaveAssertionError("Bulldozer server request recovered after connect-phase failures", {
             cause: firstRetryError,
             attempts: attempt,

--- a/apps/backend/src/lib/payments/bulldozer-dual-write.ts
+++ b/apps/backend/src/lib/payments/bulldozer-dual-write.ts
@@ -8,6 +8,7 @@
  */
 
 import { bulldozerCustomerPath, fetchBulldozerServerJson } from "@/lib/bulldozer-server-client";
+import { urlString } from "@hexclave/shared/dist/utils/urls";
 import type { ManualTransactionRow } from "@/lib/payments/schema/types";
 
 function dateToMillis(d: Date | null | undefined): number | null {
@@ -204,7 +205,7 @@ export async function bulldozerWriteSubscription(
   sub: Parameters<typeof subscriptionToStoredRow>[0],
 ) {
   await postBulldozerRow(
-    `/v1/${encodeURIComponent(sub.tenancyId)}/stripe/subscriptions/changed`,
+    urlString`/v1/${sub.tenancyId}/stripe/subscriptions/changed`,
     subscriptionToStoredRow(sub),
   );
 }
@@ -213,7 +214,7 @@ export async function bulldozerWriteSubscriptionInvoice(
   inv: Parameters<typeof subscriptionInvoiceToStoredRow>[0],
 ) {
   await postBulldozerRow(
-    `/v1/${encodeURIComponent(inv.tenancyId)}/stripe/subscription-invoices/changed`,
+    urlString`/v1/${inv.tenancyId}/stripe/subscription-invoices/changed`,
     subscriptionInvoiceToStoredRow(inv),
   );
 }
@@ -222,7 +223,7 @@ export async function bulldozerWriteOneTimePurchase(
   purchase: Parameters<typeof oneTimePurchaseToStoredRow>[0],
 ) {
   await postBulldozerRow(
-    `/v1/${encodeURIComponent(purchase.tenancyId)}/stripe/one-time-purchases/changed`,
+    urlString`/v1/${purchase.tenancyId}/stripe/one-time-purchases/changed`,
     oneTimePurchaseToStoredRow(purchase),
   );
 }
@@ -246,7 +247,7 @@ export async function bulldozerWriteManualTransaction(
   transaction: ManualTransactionRow,
 ) {
   await postBulldozerRow(
-    `/v1/${encodeURIComponent(readManualTransactionTenancyId(transaction))}/transactions/${encodeURIComponent(transactionId)}/refund`,
+    urlString`/v1/${readManualTransactionTenancyId(transaction)}/transactions/${transactionId}/refund`,
     manualTransactionToStoredRow(transaction),
   );
 }


### PR DESCRIPTION
A single `ECONNREFUSED` from `fetchBulldozerServerJson` fails the whole API request, so a brief bulldozer restart takes out any endpoint doing a plan/quota lookup.

Bulldozer calls include non-idempotent writes (`.../update-quantity`), so the retry predicate is "the request provably never reached the server", not "the request failed":

```
retriable  = every error in the cause chain / AggregateError members is
             ECONNREFUSED | ENOTFOUND | EAI_AGAIN | EAI_FAIL
not retried= ECONNRESET, timeouts, aborts (may have already applied)
             non-ok HTTP responses (the server answered)
             JSON parse failures
```

Undici reports these as `TypeError: fetch failed` with the real error on `cause`, often an `AggregateError` over per-address attempts, so the classifier walks the chain and members rather than reading a top-level `code`; a mixed aggregate is treated as unsafe.

5 attempts, backoff 250/500/1000/2000ms (~3.75s total, against a ~1.7s measured restart). A recovered request reports once to Sentry with the attempt count and the original error attached, so a genuine flap doesn't become invisible; an exhausted budget throws the original error.

Link to Devin session: https://app.devin.ai/sessions/67031df980aa4612941319e86eef0069
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Retries apply to all bulldozer calls including non-idempotent writes; misclassification could duplicate side effects, though the predicate explicitly excludes ambiguous socket/timeout failures.
> 
> **Overview**
> **`fetchBulldozerServerJson`** now retries up to **5** times with **250/500/1000/2000ms** backoff when `fetch` fails in a way that implies the request never reached bulldozer, instead of failing the whole API call on a single transient refusal (e.g. during restart).
> 
> A new **`isRetriableBulldozerFetchError`** walks `cause` chains and **`AggregateError`** members and only allows **`ECONNREFUSED`**, **`ENOTFOUND`**, **`EAI_AGAIN`**, and **`EAI_FAIL`**. **`ECONNRESET`**, timeouts, mixed aggregates, and non-OK HTTP responses are not retried so non-idempotent POSTs (e.g. **`/update-quantity`**) are not duplicated when the server may have already applied the write.
> 
> After a successful retry, **`captureError`** reports once to Sentry with attempt count and the original error. Unit tests cover the classifier and retry vs no-retry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17fbb3b442255cf45b065e559e3e091819cab05a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add safe, limited retries to the bulldozer client for connect-phase failures, and build bulldozer paths safely while preserving configured base URL prefixes. Keeps plan/quota endpoints stable during short restarts and avoids malformed or double-encoded paths.

- **Bug Fixes**
  - Retry only when every error in the cause/AggregateError chain is one of: `ECONNREFUSED`, `ENOTFOUND`, `EAI_AGAIN`, `EAI_FAIL`. No retries for `ECONNRESET`, timeouts/aborts, non-OK HTTP responses, or JSON parse errors.
  - Up to 5 attempts with 250/500/1000/2000ms backoff. After a successful retry (response.ok), report once via `captureError` from `@hexclave/shared` with attempt count; no diagnostic if the retried response is non-OK; otherwise throw the original error.
  - Tests cover aggregates, recovery diagnostics (including the non-OK case), backoff timing, customer path encoding, and preserving base URL prefixes.

- **Refactors**
  - Build request paths with `urlString` and keep any base URL prefix (e.g. `/bulldozer`), eliminating manual per-segment encoding in customer/Stripe/transaction endpoints.

<sup>Written for commit ba9d8b95d82b5f8287e4e2eb72591354433985f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resilience when connecting to the Bulldozer server by retrying temporary connection failures.
  - Retries now use increasing delays and stop after a limited number of attempts.
  - Prevented retries for HTTP errors and unrecognized network failures.
  - Preserved the original error details when all retry attempts fail.
  - Added diagnostics when a connection successfully recovers after a retry.
  - Improved URL handling for customer, subscription, invoice, purchase, and transaction requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->