### PR TITLE
Report which API URL failed instead of only the last one

### DIFF
--- a/packages/shared/src/interface/client-interface.test.ts
+++ b/packages/shared/src/interface/client-interface.test.ts
@@ -528,6 +528,33 @@ describe("_withFallback", () => {
     }
   });
 
+  it("reports the primary URL and attributes every fallback failure", async () => {
+    const urls = urlList(3);
+    const log = mockFetch(() => "fail");
+
+    const iface = createClientInterface({ apiUrls: urls });
+    const request = sendRequest(iface);
+    await expect(request).rejects.toMatchObject({
+      name: "ApiUrlsFailedError",
+      message: expect.stringContaining(`primary URL ${urls[0]}`),
+    });
+
+    try {
+      await request;
+      throw new Error("Expected all API URLs to fail");
+    } catch (error) {
+      if (!(error instanceof AggregateError)) throw new Error("Expected an aggregate API URL error");
+      if (!(error.cause instanceof Error)) throw new Error("Expected the primary error as the aggregate cause");
+      expect(error.cause.message).toContain("Failed to fetch");
+      expect(error.errors).toHaveLength(urls.length);
+      for (const [index, urlFailure] of error.errors.entries()) {
+        if (!(urlFailure instanceof Error)) throw new Error("Expected each URL failure to be an Error");
+        expect(urlFailure.message).toContain(urls[index]);
+      }
+    }
+    expect(log).toHaveLength(urls.length * 2);
+  });
+
   it("bypasses fallback when apiUrlOverride is provided", async () => {
     const log: string[] = [];
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {

--- a/packages/shared/src/interface/client-interface.test.ts
+++ b/packages/shared/src/interface/client-interface.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { KnownErrors } from "../known-errors";
 import { InternalSession, RefreshToken } from "../sessions";
 import { Result } from "../utils/results";
-import { HexclaveClientInterface } from "./client-interface";
+import { ApiUrlsFailedError, HexclaveClientInterface } from "./client-interface";
 
 function createClientInterface(options?: {
   baseUrl?: string,
@@ -543,13 +543,14 @@ describe("_withFallback", () => {
       await request;
       throw new Error("Expected all API URLs to fail");
     } catch (error) {
-      if (!(error instanceof AggregateError)) throw new Error("Expected an aggregate API URL error");
+      if (!(error instanceof ApiUrlsFailedError)) throw new Error("Expected an aggregate API URL error");
       if (!(error.cause instanceof Error)) throw new Error("Expected the primary error as the aggregate cause");
       expect(error.cause.message).toContain("Failed to fetch");
       expect(error.errors).toHaveLength(urls.length);
-      for (const [index, urlFailure] of error.errors.entries()) {
-        if (!(urlFailure instanceof Error)) throw new Error("Expected each URL failure to be an Error");
-        expect(urlFailure.message).toContain(urls[index]);
+      expect(error.urlFailures).toHaveLength(urls.length);
+      for (const [index, urlFailure] of error.urlFailures.entries()) {
+        expect(urlFailure.url).toBe(`${urls[index]}/api/v1`);
+        expect(urlFailure.error).toBe(error.errors[index]);
       }
     }
     expect(log).toHaveLength(urls.length * 2);

--- a/packages/shared/src/interface/client-interface.test.ts
+++ b/packages/shared/src/interface/client-interface.test.ts
@@ -565,6 +565,19 @@ describe("_withFallback", () => {
     expect(log).toHaveLength(urls.length * 2);
   });
 
+  it("preserves framework error digests on the aggregate error", () => {
+    const dynamicError = Object.assign(new Error("Dynamic server usage"), {
+      digest: "DYNAMIC_SERVER_USAGE",
+    });
+
+    const error = new ApiUrlsFailedError([{
+      url: "http://primary.test/api/v1",
+      error: dynamicError,
+    }]);
+
+    expect(error.digest).toBe("DYNAMIC_SERVER_USAGE");
+  });
+
   it("bypasses fallback when apiUrlOverride is provided", async () => {
     const log: string[] = [];
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {

--- a/packages/shared/src/interface/client-interface.test.ts
+++ b/packages/shared/src/interface/client-interface.test.ts
@@ -530,7 +530,15 @@ describe("_withFallback", () => {
 
   it("reports the primary URL and attributes every fallback failure", async () => {
     const urls = urlList(3);
-    const log = mockFetch(() => "fail");
+    const attemptsByUrl = new Map<string, number>();
+    const log: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      log.push(url);
+      const attempt = (attemptsByUrl.get(url) ?? 0) + 1;
+      attemptsByUrl.set(url, attempt);
+      throw new TypeError(`Failed to fetch ${url} on attempt ${attempt}`);
+    }));
 
     const iface = createClientInterface({ apiUrls: urls });
     const request = sendRequest(iface);
@@ -545,12 +553,13 @@ describe("_withFallback", () => {
     } catch (error) {
       if (!(error instanceof ApiUrlsFailedError)) throw new Error("Expected an aggregate API URL error");
       if (!(error.cause instanceof Error)) throw new Error("Expected the primary error as the aggregate cause");
-      expect(error.cause.message).toContain("Failed to fetch");
+      expect(error.cause.message).toContain(`${urls[0]}/api/v1/users/me on attempt 2`);
       expect(error.errors).toHaveLength(urls.length);
       expect(error.urlFailures).toHaveLength(urls.length);
       for (const [index, urlFailure] of error.urlFailures.entries()) {
         expect(urlFailure.url).toBe(`${urls[index]}/api/v1`);
         expect(urlFailure.error).toBe(error.errors[index]);
+        expect(urlFailure.error.message).toContain(`${urls[index]}/api/v1/users/me on attempt 2`);
       }
     }
     expect(log).toHaveLength(urls.length * 2);

--- a/packages/shared/src/interface/client-interface.ts
+++ b/packages/shared/src/interface/client-interface.ts
@@ -28,6 +28,26 @@ import { TeamApiKeysCrud, UserApiKeysCrud, teamApiKeysCreateInputSchema, teamApi
 import { ProjectPermissionsCrud } from './crud/project-permissions';
 import { AdminUserProjectsCrud, ClientProjectsCrud } from './crud/projects';
 import { SessionsCrud } from './crud/sessions';
+
+type ApiUrlFailure = {
+  url: string,
+  error: Error,
+};
+
+export class ApiUrlsFailedError extends AggregateError {
+  readonly urlFailures: readonly ApiUrlFailure[];
+
+  constructor(urlFailures: readonly ApiUrlFailure[]) {
+    const primaryFailure = urlFailures[0];
+    super(
+      urlFailures.map(({ url, error }) => new Error(`Request to ${url} failed`, { cause: error })),
+      `All API URLs failed; primary URL ${primaryFailure.url} failed: ${primaryFailure.error.message}`,
+      { cause: primaryFailure.error },
+    );
+    this.name = "ApiUrlsFailedError";
+    this.urlFailures = urlFailures;
+  }
+}
 import { TeamInvitationCrud } from './crud/team-invitation';
 import { TeamMemberProfilesCrud } from './crud/team-member-profiles';
 import { TeamPermissionsCrud } from './crud/team-permissions';
@@ -303,7 +323,7 @@ export class HexclaveClientInterface {
     apiUrls: string[],
     cb: (apiUrl: string, retryOptions: { maxAttempts: number, skipDiagnostics: boolean }) => Promise<T>,
   ): Promise<T> {
-    let lastError: Error | undefined;
+    const errorsByUrl = new Map<number, Error>();
 
     for (let pass = 0; pass < 2; pass++) {
       for (let i = 0; i < apiUrls.length; i++) {
@@ -315,12 +335,15 @@ export class HexclaveClientInterface {
           return result;
         } catch (e) {
           if (this._shouldSkipFallback(e)) throw e;
-          lastError = e instanceof Error ? e : new Error(String(e));
+          errorsByUrl.set(i, e instanceof Error ? e : new Error(String(e)));
         }
       }
     }
 
-    throw lastError!;
+    throw new ApiUrlsFailedError(apiUrls.map((url, i) => ({
+      url,
+      error: errorsByUrl.get(i) ?? throwErr(`Missing failure for API URL ${url}`),
+    })));
   }
 
   getAnalyticsApiUrl() {

--- a/packages/shared/src/interface/client-interface.ts
+++ b/packages/shared/src/interface/client-interface.ts
@@ -28,6 +28,10 @@ import { TeamApiKeysCrud, UserApiKeysCrud, teamApiKeysCreateInputSchema, teamApi
 import { ProjectPermissionsCrud } from './crud/project-permissions';
 import { AdminUserProjectsCrud, ClientProjectsCrud } from './crud/projects';
 import { SessionsCrud } from './crud/sessions';
+import { TeamInvitationCrud } from './crud/team-invitation';
+import { TeamMemberProfilesCrud } from './crud/team-member-profiles';
+import { TeamPermissionsCrud } from './crud/team-permissions';
+import { TeamsCrud } from './crud/teams';
 
 type ApiUrlFailure = {
   url: string,
@@ -40,7 +44,7 @@ export class ApiUrlsFailedError extends AggregateError {
   constructor(urlFailures: readonly ApiUrlFailure[]) {
     const primaryFailure = urlFailures[0];
     super(
-      urlFailures.map(({ url, error }) => new Error(`Request to ${url} failed`, { cause: error })),
+      urlFailures.map(({ error }) => error),
       `All API URLs failed; primary URL ${primaryFailure.url} failed: ${primaryFailure.error.message}`,
       { cause: primaryFailure.error },
     );
@@ -48,10 +52,6 @@ export class ApiUrlsFailedError extends AggregateError {
     this.urlFailures = urlFailures;
   }
 }
-import { TeamInvitationCrud } from './crud/team-invitation';
-import { TeamMemberProfilesCrud } from './crud/team-member-profiles';
-import { TeamPermissionsCrud } from './crud/team-permissions';
-import { TeamsCrud } from './crud/teams';
 
 export type RequestLogEntry = {
   path: string,

--- a/packages/shared/src/interface/client-interface.ts
+++ b/packages/shared/src/interface/client-interface.ts
@@ -40,6 +40,7 @@ export type ApiUrlFailure = {
 
 export class ApiUrlsFailedError extends AggregateError {
   readonly urlFailures: readonly ApiUrlFailure[];
+  readonly digest?: unknown;
 
   constructor(urlFailures: readonly ApiUrlFailure[]) {
     const primaryFailure = urlFailures[0] ?? throwErr("ApiUrlsFailedError requires at least one URL failure");
@@ -50,6 +51,12 @@ export class ApiUrlsFailedError extends AggregateError {
     );
     this.name = "ApiUrlsFailedError";
     this.urlFailures = urlFailures;
+    if ("digest" in primaryFailure.error) {
+      Object.defineProperty(this, "digest", {
+        value: primaryFailure.error.digest,
+        enumerable: true,
+      });
+    }
   }
 }
 

--- a/packages/shared/src/interface/client-interface.ts
+++ b/packages/shared/src/interface/client-interface.ts
@@ -33,7 +33,7 @@ import { TeamMemberProfilesCrud } from './crud/team-member-profiles';
 import { TeamPermissionsCrud } from './crud/team-permissions';
 import { TeamsCrud } from './crud/teams';
 
-type ApiUrlFailure = {
+export type ApiUrlFailure = {
   url: string,
   error: Error,
 };
@@ -42,7 +42,7 @@ export class ApiUrlsFailedError extends AggregateError {
   readonly urlFailures: readonly ApiUrlFailure[];
 
   constructor(urlFailures: readonly ApiUrlFailure[]) {
-    const primaryFailure = urlFailures[0];
+    const primaryFailure = urlFailures[0] ?? throwErr("ApiUrlsFailedError requires at least one URL failure");
     super(
       urlFailures.map(({ error }) => error),
       `All API URLs failed; primary URL ${primaryFailure.url} failed: ${primaryFailure.error.message}`,


### PR DESCRIPTION
`_iterateUrls` tries `[primary, ...fallbacks]` over two passes, keeps only `lastError`, and throws that. For a primary of `http://localhost:8102`, `getHardcodedFallbackUrls` returns `http://localhost:8110`, which nothing listens on outside the `e2e-fallback-tests` workflow — so in normal CI *any* failing backend self-call surfaces as an `ECONNREFUSED` against a port that was never up, hiding the actual primary failure.

Concretely, in run 31347402547 three `POST /api/v1/analytics/query` failures reported a refused connection at the SDK layer, which reads as "the backend was down" while the backend was demonstrably serving requests in the same second. The real cause was the same bulldozer outage as the other failures in that run.

Now the last failure per URL is retained and thrown as an `ApiUrlsFailedError` (an `AggregateError`) whose message names the primary URL, whose `cause` is the primary's error, whose `errors` are the original error objects, and which carries per-URL attribution on `urlFailures`.

Unchanged: `_shouldSkipFallback` still short-circuits `KnownError`s and non-retryable 4xx before any fallback, single-URL lists still take the 5-retry path, and sticky mode is untouched. No caller pattern-matches on the previously-thrown raw error.

Link to Devin session: https://app.devin.ai/sessions/67031df980aa4612941319e86eef0069
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3d7e8c4402633af6dd6157dfa0305bbccd940032. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve API fallback errors to report which URL failed and why, naming the real primary failure instead of a misleading fallback error. Errors are now aggregated and attributed per URL for clearer CI and debugging.

- **Bug Fixes**
  - Throw `ApiUrlsFailedError` that names the primary URL; preserves framework error digests on the aggregate; `cause` is the primary error.
  - Preserve per-URL failures via `errors` and `urlFailures` (includes the `/api/v1` base URL).
  - Keep existing retry rules unchanged; add tests verifying primary attribution, two-pass attempts, digest propagation, and recording of all fallback failures.

<sup>Written for commit b14e2019cdb0c83d9698c306cafa8f8fb82e7d89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when requests fail across all available API URLs.
  * Errors now identify each failed URL and its underlying cause.
  * Preserved the first failure as the primary error for clearer troubleshooting.
  * Normalized API paths and aligned failure details across retry attempts.
  * Preserved diagnostic information from the primary failure in the combined error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->