### PR TITLE
Wait for dev watchers to settle in the custom-base-port setup tests

### DIFF
--- a/.github/workflows/setup-tests-with-custom-base-port.yaml
+++ b/.github/workflows/setup-tests-with-custom-base-port.yaml
@@ -75,6 +75,17 @@ jobs:
           tail: true
           wait-for: 120s
           log-output-if: true
+
+      # Same mitigation as in setup-tests.yaml, see the comment there. The
+      # readiness gate only proves that 6902 and 6946 accept connections, but
+      # build-packages:watch afterwards does a full non-watch tsdown pass that
+      # rewrites packages/*/dist, which restarts watch-based dev tasks such as
+      # bulldozer-js and briefly takes their ports down tens of seconds later.
+      # That caused the ECONNREFUSED failures in run 31351708006, all within
+      # the first minute of the suite.
+      - name: Allow development watchers to settle
+        run: sleep 60
+
       - name: Run tests (first attempt)
         id: run-tests-first-attempt
         continue-on-error: ${{ (github.head_ref || github.ref_name) != 'main' && (github.head_ref || github.ref_name) != 'dev' }}


### PR DESCRIPTION
#1918 added a 60s settle step to `setup-tests.yaml`, but `setup-tests-with-custom-base-port.yaml` has the same readiness gate and the same problem. Run 31351708006 failed with 14 tests failing, all `ECONNREFUSED` from `fetchBulldozerServerJson`, clustered ~45s into the suite — same signature as the failures #1918 fixed: `build-packages:watch` does a full non-watch tsdown pass after the gate passes, rewriting `packages/*/dist`, which restarts `bulldozer-js` and briefly takes its port down.

Adds the same `sleep 60` step after the readiness gate, with a comment pointing at the longer explanation in `setup-tests.yaml`. Same caveat applies: mitigation, not a guarantee.


Link to Devin session: https://app.devin.ai/sessions/6cdd0d2ff8084f6097b5fd924f6a2e09
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only timing change with no application or production behavior impact.
> 
> **Overview**
> Adds the same **60-second settle step** used in `setup-tests.yaml` to `setup-tests-with-custom-base-port.yaml`, placed after the dev server readiness gate and before the test run.
> 
> The comment documents that the gate only confirms ports are up initially; a later `build-packages:watch` tsdown pass can restart services like **bulldozer-js** and cause transient `ECONNREFUSED` failures (as in run 31351708006). This is described as a mitigation, not a hard guarantee.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 476dbfcd2e54605d3961574c4b91de80490c4863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a 60s wait after the readiness gate in `setup-tests-with-custom-base-port.yaml` so dev watchers can settle and we avoid early `ECONNREFUSED` failures. Mirrors the mitigation in `setup-tests.yaml` to reduce flakiness when services briefly restart after the initial build.

<sup>Written for commit 476dbfcd2e54605d3961574c4b91de80490c4863. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a brief stabilization delay after development services start before automated tests run, improving reliability for watch-based development tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->