### PR TITLE
Resolve the nearest package.json when stamping tsdown builds

### DIFF
--- a/configs/tsdown/plugins.test.ts
+++ b/configs/tsdown/plugins.test.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { createBasePlugin } from './plugins.ts';
@@ -22,6 +23,29 @@ describe('tsdown base plugin', () => {
 
     expect(result).not.toBeNull();
     expect(typeof result === 'string' ? result : result?.code).toMatch(/js @hexclave\/js@\d+\.\d+\.\d+/);
+    expect(typeof result === 'string' ? result : result?.code).not.toContain('@hexclave/monorepo@0.0.0');
+  });
+
+  it('resolves the package root when tsdown cwd is a nested config directory', async () => {
+    const plugin = createBasePlugin({});
+    if (typeof plugin.transform !== 'function') {
+      throw new Error('Expected the tsdown base plugin to define a transform hook.');
+    }
+
+    if (typeof plugin.buildStart !== 'function') {
+      throw new Error('Expected the tsdown base plugin to define a buildStart hook.');
+    }
+    const packageRoot = fileURLToPath(new URL('../../apps/backend', import.meta.url));
+    const nestedConfigDirectory = join(packageRoot, 'scripts');
+    Reflect.apply(plugin.buildStart, undefined, [{ cwd: nestedConfigDirectory }]);
+    const result = await Reflect.apply(plugin.transform, undefined, [
+      'const clientVersion = "STACK_COMPILE_TIME_CLIENT_PACKAGE_VERSION_SENTINEL";',
+      join(packageRoot, 'src/index.ts'),
+      {},
+    ]);
+
+    expect(result).not.toBeNull();
+    expect(typeof result === 'string' ? result : result?.code).toMatch(/js @hexclave\/backend@\d+\.\d+\.\d+/);
     expect(typeof result === 'string' ? result : result?.code).not.toContain('@hexclave/monorepo@0.0.0');
   });
 });

--- a/configs/tsdown/plugins.ts
+++ b/configs/tsdown/plugins.ts
@@ -1,10 +1,28 @@
 import fs from 'fs';
+import { dirname, join, resolve } from 'node:path';
 import type { Rolldown } from 'tsdown';
 
 const SOURCE_FILE_PATTERN = /\.(jsx?|tsx?)$/;
 const USE_CLIENT_DIRECTIVE_PATTERN = /["']use\s+client["']/i;
 const USE_CLIENT_AT_TOP_PATTERN = /^\s*["']use\s+client["']\s*;?/;
 const CLIENT_VERSION_SENTINEL = 'STACK_COMPILE_TIME_CLIENT_PACKAGE_VERSION_SENTINEL';
+
+function findNearestPackageJson(cwd: string): string {
+  let currentDirectory = resolve(cwd);
+
+  while (true) {
+    const packageJsonPath = join(currentDirectory, 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      return packageJsonPath;
+    }
+
+    const parentDirectory = dirname(currentDirectory);
+    if (parentDirectory === currentDirectory) {
+      throw new Error(`Could not find a package.json from tsdown cwd ${cwd} up to the filesystem root.`);
+    }
+    currentDirectory = parentDirectory;
+  }
+}
 
 export const createBasePlugin = (_options: {}): Rolldown.Plugin => {
   let packageVersionLabel: string | undefined;
@@ -13,10 +31,12 @@ export const createBasePlugin = (_options: {}): Rolldown.Plugin => {
     name: 'stackframe tsdown plugin (private)',
     buildStart({ cwd }: Rolldown.NormalizedInputOptions) {
       // Workspace builds run tsdown from the monorepo root, so the process's cwd would stamp every
-      // package with the root package.json; Rolldown's per-config cwd is the package being built.
-      const { name, version }: { name?: unknown, version?: unknown } = JSON.parse(fs.readFileSync(`${cwd}/package.json`, 'utf-8'));
+      // package with the root package.json. Rolldown's per-config cwd may be nested below the
+      // package root, so resolve the nearest package.json instead.
+      const packageJsonPath = findNearestPackageJson(cwd);
+      const { name, version }: { name?: unknown, version?: unknown } = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
       if (typeof name !== 'string' || typeof version !== 'string') {
-        throw new Error(`Expected ${cwd}/package.json to have a string name and version.`);
+        throw new Error(`Expected ${packageJsonPath} to have a string name and version.`);
       }
       packageVersionLabel = `js ${name}@${version}`;
     },


### PR DESCRIPTION
The version-stamping `buildStart` hook read `${cwd}/package.json`, but Rolldown's per-config `cwd` can be nested below the package root — for `apps/backend/scripts/db-migrations.tsdown.config.ts` it is `apps/backend/scripts`, which has no manifest, so the Docker `build-self-host-migration-script` step failed with `ENOENT ... /app/apps/backend/scripts/package.json`.

Now the hook walks up from `cwd` to the nearest `package.json` (erroring clearly if it reaches the filesystem root), so nested configs still stamp their own package's `name@version` rather than the monorepo root's. Added a plugin test for the nested-config-directory case.

Link to Devin session: https://app.devin.ai/sessions/a72ea5a491a34ca594792ebc9746143f
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized build-plugin change with a regression test; no runtime auth, data, or API behavior changes.
> 
> **Overview**
> Fixes **tsdown client version stamping** when Rolldown’s per-config `cwd` sits in a subdirectory (e.g. `apps/backend/scripts`) instead of the package root.
> 
> The `buildStart` hook no longer reads `${cwd}/package.json` directly. It walks up from `cwd` via **`findNearestPackageJson`** until it finds a manifest, with a clear error if none exists before the filesystem root. Version labels still use that package’s `name@version`, not the monorepo root.
> 
> A plugin test covers the nested-config-directory case (`apps/backend/scripts` → `@hexclave/backend@…`), matching the failure that broke **`build-self-host-migration-script`** in Docker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89885563d6031313a27e5c8898a2750a1d7cfe34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes version stamping in the `tsdown` base plugin by resolving the nearest package.json from the per-config `cwd`. This ensures nested configs (e.g., `apps/backend/scripts`) stamp their own `name@version` and prevents the Docker migration build from failing.

- **Bug Fixes**
  - Walk up from `cwd` to the nearest package.json; throw a clear error at the filesystem root.
  - Read that package.json to stamp `name@version` instead of assuming `${cwd}/package.json`.
  - Added a test for a nested config directory to cover this case.

<sup>Written for commit 89885563d6031313a27e5c8898a2750a1d7cfe34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package detection when running builds from nested directories.
  * Client version labels now use the correct backend package instead of a monorepo fallback.
  * Validation errors now identify the resolved package path and report when no package file can be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->