### PR TITLE
ci: attribute PostgreSQL statements per e2e test pass

### DIFF
--- a/.github/scripts/postgres-attribution.sh
+++ b/.github/scripts/postgres-attribution.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+case "${1:-}" in
+  reset|snapshot)
+    ;;
+  *)
+    echo "Usage: $0 {reset|snapshot}" >&2
+    exit 2
+    ;;
+esac
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+compose_file="$repo_root/docker/dependencies/docker.compose.yaml"
+
+if [[ "$1" == reset ]]; then
+  docker compose -f "$compose_file" exec -T db \
+    psql --no-psqlrc --set=ON_ERROR_STOP=1 --username=postgres --dbname=stackframe \
+    --command='SELECT pg_stat_statements_reset();'
+  exit 0
+fi
+
+docker compose -f "$compose_file" exec -T db \
+  psql --no-psqlrc --set=ON_ERROR_STOP=1 --username=postgres --dbname=stackframe <<'SQL'
+\pset pager off
+\pset format unaligned
+\pset fieldsep '|'
+\echo
+\echo '========== PostgreSQL statement attribution =========='
+\echo 'Statement statistics coverage since the previous snapshot'
+\echo
+WITH statements AS (
+  SELECT calls, total_exec_time
+  FROM pg_stat_statements
+  WHERE query NOT ILIKE '%pg_stat_statements%'
+),
+totals AS (
+  SELECT
+    count(*) AS tracked_entries,
+    sum(calls) AS total_calls,
+    sum(total_exec_time) AS total_exec_time
+  FROM statements
+),
+top_30 AS (
+  SELECT sum(total_exec_time) AS total_exec_time
+  FROM (
+    SELECT total_exec_time
+    FROM statements
+    ORDER BY total_exec_time DESC
+    LIMIT 30
+  ) AS limited
+)
+SELECT
+  tracked_entries,
+  total_calls,
+  round(coalesce(totals.total_exec_time, 0)::numeric, 1) AS all_statements_total_ms,
+  round(coalesce(top_30.total_exec_time, 0)::numeric, 1) AS top_30_total_ms,
+  round(
+    (100 * coalesce(top_30.total_exec_time, 0) / nullif(totals.total_exec_time, 0))::numeric,
+    1
+  ) AS top_30_coverage_pct
+FROM totals
+CROSS JOIN top_30;
+\echo
+\echo 'pg_stat_statements eviction/reset status'
+\echo
+SELECT
+  dealloc AS evicted_entries,
+  stats_reset
+FROM pg_stat_statements_info;
+\echo
+\echo 'Top statements by total execution time, split by database'
+\echo
+SELECT
+  d.datname AS database_name,
+  calls,
+  round(total_exec_time::numeric, 1) AS total_ms,
+  round(mean_exec_time::numeric, 1) AS mean_ms,
+  rows,
+  left(regexp_replace(query, E'[\\n\\r\\t]+', ' ', 'g'), 1000) AS query
+FROM pg_stat_statements AS s
+JOIN pg_database AS d ON d.oid = s.dbid
+WHERE query NOT ILIKE '%pg_stat_statements%'
+ORDER BY total_exec_time DESC
+LIMIT 30;
+\echo
+\echo 'Top statements aggregated across databases by queryid'
+\echo
+WITH statements AS (
+  SELECT
+    queryid,
+    calls,
+    total_exec_time,
+    rows,
+    query
+  FROM pg_stat_statements
+  WHERE query NOT ILIKE '%pg_stat_statements%'
+),
+aggregated AS (
+  SELECT
+    queryid,
+    sum(calls) AS calls,
+    sum(total_exec_time) AS total_exec_time,
+    sum(rows) AS rows,
+    count(*) AS database_count,
+    min(query) AS query
+  FROM statements
+  GROUP BY queryid
+)
+SELECT
+  queryid,
+  database_count,
+  calls,
+  round(total_exec_time::numeric, 1) AS total_ms,
+  round((total_exec_time / nullif(calls, 0))::numeric, 1) AS mean_ms,
+  rows,
+  left(regexp_replace(query, E'[\\n\\r\\t]+', ' ', 'g'), 1000) AS query
+FROM aggregated
+ORDER BY total_exec_time DESC
+LIMIT 30;
+\echo
+\echo 'Largest databases by on-disk size across the PostgreSQL cluster'
+\echo
+SELECT
+  datname AS database_name,
+  pg_size_pretty(pg_database_size(datname)) AS total_size,
+  pg_database_size(datname) AS total_size_bytes
+FROM pg_database
+ORDER BY pg_database_size(datname) DESC;
+\echo
+\echo 'Largest tables in the stackframe database by on-disk relation size'
+\echo
+SELECT
+  n.nspname AS schema,
+  c.relname AS table_name,
+  pg_size_pretty(pg_total_relation_size(c.oid)) AS total_size,
+  pg_total_relation_size(c.oid) AS total_size_bytes,
+  c.reltuples::bigint AS estimated_rows
+FROM pg_class AS c
+JOIN pg_namespace AS n ON n.oid = c.relnamespace
+WHERE c.relkind IN ('r', 'm', 'p')
+  AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+ORDER BY pg_total_relation_size(c.oid) DESC
+LIMIT 30;
+\echo
+\echo 'Resetting pg_stat_statements for the next pass'
+SELECT pg_stat_statements_reset();
+SQL

--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -218,16 +218,38 @@ jobs:
       - name: Wait 10 seconds
         run: sleep 10
 
+      - name: Reset PostgreSQL statement attribution
+        continue-on-error: true
+        run: .github/scripts/postgres-attribution.sh reset
+
       - name: Run tests
+        id: run_tests_pass1
         run: pnpm test run ${{ matrix.freestyle-mode == 'prod' && '--min-workers=1 --max-workers=1' || '' }} ${{ matrix.freestyle-mode == 'prod' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' && 'mail' || '' }}
 
+      - name: Snapshot PostgreSQL attribution after pass 1
+        if: always()
+        continue-on-error: true
+        run: .github/scripts/postgres-attribution.sh snapshot
+
       - name: Run tests again (attempt 1)
+        id: run_tests_pass2
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
         run: pnpm test run ${{ matrix.freestyle-mode == 'prod' && '--min-workers=1 --max-workers=1' || '' }}
 
+      - name: Snapshot PostgreSQL attribution after pass 2
+        if: always() && steps.run_tests_pass2.outcome != 'skipped'
+        continue-on-error: true
+        run: .github/scripts/postgres-attribution.sh snapshot
+
       - name: Run tests again (attempt 2)
+        id: run_tests_pass3
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
         run: pnpm test run ${{ matrix.freestyle-mode == 'prod' && '--min-workers=1 --max-workers=1' || '' }}
+
+      - name: Snapshot PostgreSQL attribution after pass 3
+        if: always() && steps.run_tests_pass3.outcome != 'skipped'
+        continue-on-error: true
+        run: .github/scripts/postgres-attribution.sh snapshot
 
       - name: Run perf tests
         if: matrix.freestyle-mode == 'mock'

--- a/docker/dev-postgres-with-extensions/Dockerfile
+++ b/docker/dev-postgres-with-extensions/Dockerfile
@@ -51,6 +51,7 @@ ENTRYPOINT ["sh", "-c", "\
     -c shared_preload_libraries='pg_stat_statements,pg_cron' \
     -c cron.database_name='stackframe' \
     -c pg_stat_statements.track=all \
+    -c pg_stat_statements.max=20000 \
     -c logging_collector=on \
     -c log_destination='stderr' \
     -c log_min_messages=log \


### PR DESCRIPTION
The e2e job runs the suite up to three times without resetting state, and each repeat is substantially slower than the one before. The slowdown is confined to tests that talk to the backend and is spread evenly across features, which points at a shared per-request cost over globally growing data — but the job's logs can't name the query responsible.

`pg_stat_statements` is already enabled on the dev postgres image, so this just snapshots it between passes:

```
reset  ->  pass 1  ->  snapshot+reset  ->  pass 2  ->  snapshot+reset  ->  pass 3  ->  snapshot+reset
```

Each snapshot prints, for that pass alone: top statements by total execution time both per-database and aggregated by `queryid` (the suite spreads work over many databases, so the same query would otherwise appear as several small unrelated rows), how much of the total time the top 30 covers, `pg_stat_statements_info.dealloc` so entry eviction is visible rather than silent, per-database sizes across the cluster, and the largest tables in `stackframe`.

The snapshot steps are `if: always()` with `continue-on-error`, so they still run when a pass fails but can't fail the job or mask a test failure. CI-only; local dev and production are unaffected. The Dockerfile change raises `pg_stat_statements.max`, which only matters because the many-databases-times-large-CTE-queries combination can exceed the 5000-entry default.


Link to Devin session: https://app.devin.ai/sessions/57e15d18ad4a40bfb57e9174cd1f9ca8
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only CI wiring and a dev Docker Postgres tuning; test outcomes and production are unchanged.
> 
> **Overview**
> Adds **CI-only PostgreSQL statement attribution** so repeated e2e passes can be tied to specific queries when later runs get slower without resetting DB state.
> 
> A new script `postgres-attribution.sh` supports **`reset`** (clears `pg_stat_statements`) and **`snapshot`** (prints per-pass coverage, top statements per database and aggregated by `queryid`, eviction stats, and DB/table size context, then resets for the next pass). The e2e workflow runs **reset before pass 1** and **snapshot after each of up to three test passes**, with `continue-on-error` and `if: always()` so diagnostics still appear on failures without failing the job.
> 
> The dev Postgres image sets **`pg_stat_statements.max=20000`** so multi-database e2e workloads are less likely to evict entries under the default limit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f958bbf090139e216c440caf9c595e649093de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds per-pass PostgreSQL query attribution to e2e tests to pinpoint the queries causing slowdowns across repeated runs. Snapshots and resets `pg_stat_statements` between passes; CI-only with no impact on local dev or prod.

- **New Features**
  - Add `.github/scripts/postgres-attribution.sh` to snapshot/reset stats and print top statements (per-db and aggregated by `queryid`), eviction info, DB sizes, and largest tables.
  - Update e2e workflow to reset before pass 1 and snapshot after each pass with `if: always()` and `continue-on-error`.
  - Increase `pg_stat_statements.max` to `20000` in the dev Postgres image to reduce entry eviction.

<sup>Written for commit 45f958bbf090139e216c440caf9c595e649093de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

