### PR TITLE
ci: drop the Freestyle prod E2E matrix leg

### DIFF
--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -34,7 +34,7 @@ jobs:
   build:
     timeout-minutes: 150
     needs: wait-for-fast-fail
-    name: E2E Tests (Node ${{ matrix.node-version }}, Freestyle ${{ matrix.freestyle-mode }})
+    name: E2E Tests (Node ${{ matrix.node-version }})
     runs-on: ubicloud-standard-8
     env:
       NODE_ENV: test
@@ -46,7 +46,6 @@ jobs:
     strategy:
       matrix:
         node-version: [22.x]
-        freestyle-mode: [mock, prod]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -76,11 +75,6 @@ jobs:
 
       - name: Create .env.test.local file for apps/backend
         run: cp apps/backend/.env.development apps/backend/.env.test.local
-
-      - name: Override Freestyle API key for prod mode
-        if: matrix.freestyle-mode == 'prod'
-        run: |
-          echo "HEXCLAVE_FREESTYLE_API_KEY=${{ secrets.STACK_FREESTYLE_REAL_API_KEY }}" >> apps/backend/.env.test.local
 
       - name: Create .env.test.local file for apps/dashboard
         run: cp apps/dashboard/.env.development apps/dashboard/.env.test.local
@@ -224,7 +218,7 @@ jobs:
 
       - name: Run tests
         id: run_tests_pass1
-        run: pnpm test run ${{ matrix.freestyle-mode == 'prod' && '--min-workers=1 --max-workers=1' || '' }} ${{ matrix.freestyle-mode == 'prod' && github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' && 'mail' || '' }}
+        run: pnpm test run
 
       - name: Snapshot PostgreSQL attribution after pass 1
         if: always()
@@ -234,7 +228,7 @@ jobs:
       - name: Run tests again (attempt 1)
         id: run_tests_pass2
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
-        run: pnpm test run ${{ matrix.freestyle-mode == 'prod' && '--min-workers=1 --max-workers=1' || '' }}
+        run: pnpm test run
 
       - name: Snapshot PostgreSQL attribution after pass 2
         if: always() && steps.run_tests_pass2.outcome != 'skipped'
@@ -244,7 +238,7 @@ jobs:
       - name: Run tests again (attempt 2)
         id: run_tests_pass3
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
-        run: pnpm test run ${{ matrix.freestyle-mode == 'prod' && '--min-workers=1 --max-workers=1' || '' }}
+        run: pnpm test run
 
       - name: Snapshot PostgreSQL attribution after pass 3
         if: always() && steps.run_tests_pass3.outcome != 'skipped'
@@ -252,7 +246,6 @@ jobs:
         run: .github/scripts/postgres-attribution.sh snapshot
 
       - name: Run perf tests
-        if: matrix.freestyle-mode == 'mock'
         env:
           HEXCLAVE_RUN_PERF_TESTS: "1"
         run: pnpm test run --min-workers=1 --max-workers=1 .perf.test
@@ -274,7 +267,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: e2e-api-bulldozer-${{ matrix.freestyle-mode }}
+          name: e2e-api-bulldozer
           path: ${{ runner.temp }}/hexclave-bulldozer.untracked.log
           if-no-files-found: error
 


### PR DESCRIPTION
Removes the `prod` leg of the E2E API tests matrix, so E2E only runs against the Freestyle mock. Drops the real-API-key override step and the prod-only single-worker/`mail` filter conditionals; perf tests now run unconditionally (they were mock-only).

Link to Devin session: https://app.devin.ai/sessions/b079f22640af4a6aad6266e73582d27a
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI no longer exercises Freestyle against the real API or prod-specific mail/worker settings, so regressions in that path could slip through until caught elsewhere.
> 
> **Overview**
> **Simplifies the E2E API GitHub Actions workflow** by dropping the `freestyle-mode` matrix (`mock` / `prod`), so CI no longer runs a second job against the real Freestyle API.
> 
> That removes the step that injected `STACK_FREESTYLE_REAL_API_KEY` into `apps/backend/.env.test.local` for prod runs. All `pnpm test run` invocations (including the main/dev retry passes) are now plain `pnpm test run`—no prod-only single-worker flags or optional `mail` test filter.
> 
> **Perf tests** (`.perf.test`) run on every workflow execution instead of only on the mock matrix leg. Failure artifact upload is renamed from `e2e-api-bulldozer-${{ matrix.freestyle-mode }}` to a single `e2e-api-bulldozer` name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 825791e325315cebdf48d96a1cd305ea66318164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dropped the Freestyle prod E2E matrix leg so E2E runs only against the mock service. This simplifies CI, removes real API key usage, and runs perf tests on every run.

- **Refactors**
  - Removed `freestyle-mode` from the matrix and updated the job name.
  - Deleted prod-only env override and test flags (`--min-workers=1 --max-workers=1`, `mail`).
  - Always run perf tests and simplified the artifact name.

<sup>Written for commit 825791e325315cebdf48d96a1cd305ea66318164. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end test execution to run without Freestyle-specific settings.
  * Expanded performance test coverage beyond mock mode.
  * Standardized the name used for uploaded test logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->