### PR TITLE
Close LMDB databases in the bulldozer-js performance tests

### DIFF
--- a/apps/bulldozer-js/src/databases/bulldozer/performance.test.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/performance.test.ts
@@ -59,9 +59,14 @@ const oldCompatibleRowCounts = (process.env.BULLDOZER_OLD_COMPAT_ROW_COUNTS ?? "
 const oldCompatibleWarmupOps = 20;
 const oldCompatibleMeasuredOps = 80;
 const lmdbTempPaths: string[] = [];
+const databases: PerfDatabase[] = [];
 const perfBackend = process.env.BULLDOZER_PERF_BACKEND ?? "lmdb-instant";
 const perfSnapshotMode = process.env.BULLDOZER_PERF_SNAPSHOT_MODE ?? "plain";
 const emptyChanges = (): TableChanges => ({ addedRows: [], modifiedRows: [], deletedRows: [], addedGroups: [], deletedGroups: [] });
+const trackDatabase = (db: PerfDatabase) => {
+  databases.push(db);
+  return db;
+};
 const changedRowCount = (changes: Pick<TableChanges, "addedRows" | "modifiedRows" | "deletedRows">) =>
   changes.addedRows.length + changes.modifiedRows.length + changes.deletedRows.length;
 const collect = async <T>(iterable: AsyncIterable<T>) => {
@@ -80,11 +85,13 @@ const newLowLevelDb = () => {
   }
   return declareInMemoryLowLevelDatabase(crypto.randomUUID());
 };
-afterAll(() => {
+afterAll(async () => {
+  // An unclosed LMDB environment keeps native handles alive, preventing Vitest's worker and main process from exiting; remove its mapped directory only after closing it.
+  for (const db of databases.reverse()) await db.close();
   for (const path of lmdbTempPaths) rmSync(path, { recursive: true, force: true });
 });
 const newDb = (migrations: Migration) =>
-  declareBulldozerDatabase(declarePiledriverDatabase(newLowLevelDb()), { migrations });
+  trackDatabase(declareBulldozerDatabase(declarePiledriverDatabase(newLowLevelDb()), { migrations }));
 const writeSnapshot = async (db: PerfDatabase, updateSnapshot: SnapshotUpdater) =>
   perfSnapshotMode === "plain"
     ? await db.withSnapshot(updateSnapshot)
@@ -192,7 +199,7 @@ async function createPrefilledOldCompatibleBase(rowCount: number) {
     { type: "initTable", tableId: "rules", table: defineStoredTable(), inputTables: {} },
   ];
   const migrations: Migration = [baseMigration];
-  const db = declareBulldozerDatabase(piledriver, { migrations });
+  const db = trackDatabase(declareBulldozerDatabase(piledriver, { migrations }));
   await db.applyRemainingMigrations();
   const { durationMs } = await timed(async () => {
     await writeSnapshot(db, async snapshot => {
@@ -870,7 +877,7 @@ describe("Bulldozer old-compatible performance", () => {
       { type: "initTable", tableId: "usersA", table: defineStoredTable(), inputTables: {} },
       { type: "initTable", tableId: "usersB", table: defineStoredTable(), inputTables: {} },
     ];
-    const dbV1 = declareBulldozerDatabase(piledriver, { migrations: [baseMigration] });
+    const dbV1 = trackDatabase(declareBulldozerDatabase(piledriver, { migrations: [baseMigration] }));
     await dbV1.applyRemainingMigrations();
     await writeSnapshot(dbV1, async snapshot => {
       for (let i = 0; i < rowCount; i++) {
@@ -892,7 +899,7 @@ describe("Bulldozer old-compatible performance", () => {
       }), inputTables: { input: "usersB" } },
       { type: "initTable", tableId: "concatenated", table: defineConcatTable(), inputTables: { a: "groupedA", b: "groupedB" } },
     ];
-    const dbV2 = declareBulldozerDatabase(piledriver, { migrations: [baseMigration, derivedMigration] });
+    const dbV2 = trackDatabase(declareBulldozerDatabase(piledriver, { migrations: [baseMigration, derivedMigration] }));
     const init = await timed(async () => await dbV2.applyRemainingMigrations());
     logOldCompatibleMetric("virtual concat init equivalent", init.durationMs);
     const snapshot = (await dbV2.getSnapshot()).snapshot;
@@ -905,7 +912,7 @@ describe("Bulldozer old-compatible performance", () => {
 
   it.each(oldCompatibleRowCounts)("load test: prefilled stored table and derived views stay comparable (%i rows)", async rowCount => {
     const fixture = await createPrefilledOldCompatibleBase(rowCount);
-    let db = declareBulldozerDatabase(fixture.piledriver, { migrations: fixture.migrations });
+    let db = trackDatabase(declareBulldozerDatabase(fixture.piledriver, { migrations: fixture.migrations }));
     let snapshot = (await db.getSnapshot()).snapshot;
 
     const storedCount = await timed(async () => await countRows(snapshot, "users"));
@@ -949,7 +956,7 @@ describe("Bulldozer old-compatible performance", () => {
     let migrations = fixture.migrations;
     for (const derived of oldCompatibleDerivedSteps()) {
       migrations = [...migrations, derived.steps];
-      db = declareBulldozerDatabase(fixture.piledriver, { migrations });
+      db = trackDatabase(declareBulldozerDatabase(fixture.piledriver, { migrations }));
       const init = await timed(async () => await db.applyRemainingMigrations());
       logOldCompatibleMetric(derived.label, init.durationMs);
     }

--- a/apps/bulldozer-js/src/payments/schema/performance.test.ts
+++ b/apps/bulldozer-js/src/payments/schema/performance.test.ts
@@ -20,6 +20,7 @@ const PREFILL_ITEM_UPDATES_PER_USER = 4;
 const PREFILL_SOURCE_FACT_COUNT = PREFILL_USER_COUNT * (2 + PREFILL_ITEM_UPDATES_PER_USER);
 const MONTH_MS = 2_592_000_000;
 const tempPaths: string[] = [];
+const databases: Array<ReturnType<typeof declareBulldozerDatabase>> = [];
 const perfBackend = process.env.BULLDOZER_PAYMENTS_PERF_BACKEND ?? "lmdb-instant";
 
 const product = (includedItems: ProductSnapshot["includedItems"]): ProductSnapshot => ({
@@ -109,6 +110,7 @@ const newLowLevelDb = () => {
 const newPaymentsDb = async () => {
   const schema = createPaymentsSchema();
   const db = declareBulldozerDatabase(declarePiledriverDatabase(newLowLevelDb()), { migrations: schema.migrations });
+  databases.push(db);
   await db.applyRemainingMigrations();
   return { db, schema };
 };
@@ -239,6 +241,8 @@ describe("transactions listing performance", () => {
   });
 });
 
-afterAll(() => {
+afterAll(async () => {
+  // An unclosed LMDB environment keeps native handles alive, preventing Vitest's worker and main process from exiting; remove its mapped directory only after closing it.
+  for (const db of databases.reverse()) await db.close();
   for (const path of tempPaths) rmSync(path, { recursive: true, force: true });
 });


### PR DESCRIPTION
The test job sometimes finished all suites and then hung until the run was cancelled:

```
close timed out after 10000ms
Failed to terminate worker while running apps/bulldozer-js/src/payments/schema/performance.test.ts
Tests closed successfully but something prevents the main process from exiting
```

Both bulldozer-js performance suites default to the LMDB-backed `lmdb-instant` backend and created an LMDB environment per database, but their `afterAll` only `rmSync`ed the temp dirs — the environments were never closed, so their native handles kept the vitest worker (and then the main process) alive. `--reporter=hanging-process` on a local run showed a pile of stackless `FILEHANDLE` entries, matching LMDB's native handles.

Both suites now track every database they create and `await db.close()` (which forwards bulldozer → piledriver → low-level LMDB) before removing the mapped directories. Test-only change. Other LMDB-using suites (`lmdb.test.ts`, `lmdb-compression.test.ts`, `bulldozer/index.test.ts`) already closed their databases.

Validated by running both files twice: clean exit, no hanging-process output, no "failed to terminate worker".


Link to Devin session: https://app.devin.ai/sessions/f7b58c3f76294119b4220c2f39a9d920
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only teardown in two performance test files; no production or runtime API changes.
> 
> **Overview**
> Fixes Vitest workers and the main process hanging after bulldozer-js performance suites finish when using the default **LMDB** (`lmdb-instant`) backend.
> 
> Both `databases/bulldozer/performance.test.ts` and `payments/schema/performance.test.ts` now **register every bulldozer database** they open and, in **`afterAll`**, **`await db.close()`** (in reverse order) **before** `rmSync` on temp LMDB dirs. Unclosed LMDB environments were leaving native file handles open, which matched hanging-process output and worker termination timeouts.
> 
> Test-only teardown change; no production behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit facaae1a082437c53f05589b3830d95b7dd98984. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved performance-test cleanup by tracking created databases.
  * Databases are now closed in reverse creation order before temporary files are removed.
  * Updated test setup to consistently use the managed database lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes hanging Vitest workers in bulldozer-js performance tests by closing databases before deleting temp LMDB dirs. Test-only teardown change; no production impact.

- **Bug Fixes**
  - Track each database and await db.close() in afterAll (reverse order).
  - Delete temp LMDB directories only after close to release native file handles.
  - Affects the default `lmdb-instant` backend; other LMDB tests already closed databases.

<sup>Written for commit facaae1a082437c53f05589b3830d95b7dd98984. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

