### PR TITLE
Point the onboarding call link at the team booking page

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/components.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/components.tsx
@@ -183,7 +183,7 @@ export function OnboardingPage(props: OnboardingPageProps) {
           <Typography variant="secondary" className="text-center text-xs">
             Need help?{" "}
             <a
-              href="https://cal.com/stack-konsti/chat"
+              href="https://cal.com/team/hexclave/onboarding-call"
               target="_blank"
               rel="noopener noreferrer"
               className="underline underline-offset-2 transition-colors hover:text-foreground hover:transition-none"


### PR DESCRIPTION
Updates the "Book an onboarding call" link in the new-project onboarding chrome to the team booking page (`https://cal.com/team/hexclave/onboarding-call`).

Link to Devin session: https://app.devin.ai/sessions/09c06e4483594cb8bbc37b4ed8ab15f4
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3bd7e84c4b178d67598e5cc39a50d99bde867533. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Points the “Book an onboarding call” link in the new-project onboarding to the Hexclave team booking page, replacing the previous Stack Konsti chat link. Users now schedule with the team at https://cal.com/team/hexclave/onboarding-call.

**Review notes**
- Change is limited to the anchor href in `apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/components.tsx`.
- Verify the link appears under “Need help?”, opens in a new tab, and retains the existing underline/hover styles.

<sup>Written for commit 3bd7e84c4b178d67598e5cc39a50d99bde867533. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the onboarding call link to direct users to the Hexclave scheduling page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->