### PR TITLE
Resolve instant-availability sequences inside the write gate

### DIFF
--- a/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.test.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.test.ts
@@ -139,14 +139,17 @@ function createReorderingSetDatabase() {
         resolveSet = resolve;
       });
       seqToPromise.set(seq, committedPromise);
+      const commit = () => {
+        for (const { key, value } of entries) committed.set(text(key)!, value.slice(0));
+        resolveSet();
+      };
       if (setCallCount === 1) {
         firstSetStartedResolve!();
-        await new Promise<void>(resolve => {
-          releaseFirstSet = resolve;
-        });
+        releaseFirstSet = commit;
+      } else {
+        const requiresSeq = setOptions?.requiresSeq ?? initialSeq;
+        seqToPromise.get(requiresSeq)!.then(commit).catch(() => {});
       }
-      for (const { key, value } of entries) committed.set(text(key)!, value.slice(0));
-      resolveSet();
       return { seq };
     },
     async deleteAll() {

--- a/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.test.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.test.ts
@@ -135,8 +135,10 @@ function createReorderingSetDatabase() {
       const seq = ["reordering", crypto.randomUUID()] as unknown as DatabaseSeq;
       underlyingSeqs.push(seq);
       let resolveSet!: () => void;
-      const committedPromise = new Promise<void>(resolve => {
+      let rejectSet!: (error: unknown) => void;
+      const committedPromise = new Promise<void>((resolve, reject) => {
         resolveSet = resolve;
+        rejectSet = reject;
       });
       seqToPromise.set(seq, committedPromise);
       const commit = () => {
@@ -148,7 +150,9 @@ function createReorderingSetDatabase() {
         releaseFirstSet = commit;
       } else {
         const requiresSeq = setOptions?.requiresSeq ?? initialSeq;
-        seqToPromise.get(requiresSeq)!.then(commit).catch(() => {});
+        const prerequisite = seqToPromise.get(requiresSeq);
+        if (prerequisite === undefined) throw new Error("Missing prerequisite sequence in reordering test backend");
+        prerequisite.then(commit, rejectSet).catch(rejectSet);
       }
       return { seq };
     },

--- a/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.ts
@@ -155,48 +155,19 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
         })
         .catch(() => {});
     };
-    const chainRequiresSeq = (previousWriteSeq: DatabaseSeq | undefined, requiresSeq: DatabaseSeq): DatabaseSeq => {
-      if (previousWriteSeq === undefined) return requiresSeq;
-      // Same-key underlying writes must be issued in instant-seq order; otherwise an evicted cache entry exposes and persists the older value.
-      return wrapped.combineSeqs(requiresSeq, getSeqRecord(previousWriteSeq).underlyingSeq);
-    };
-
-    type WriteAllocation<T> = {
-      underlyingSeq: DatabaseSeq,
-      cacheEntries: Array<{ key: ArrayBuffer, value: ArrayBuffer | null }>,
-      allocatedKeys?: ArrayBuffer[],
-      result: T,
-    };
-    const isThenable = (value: unknown): value is PromiseLike<unknown> => {
-      return value !== null
-        && (typeof value === "object" || typeof value === "function")
-        && "then" in value
-        && typeof value.then === "function";
-    };
-    const assertWriteAllocation = <T>(allocation: WriteAllocation<T>) => {
-      if (isThenable(allocation.underlyingSeq)) {
-        throw new Error("Instant-availability wrapped write allocation must return a non-thenable sequence");
-      }
-      for (const key of allocation.allocatedKeys ?? []) {
-        if (!(key instanceof ArrayBuffer)) throw new Error("Instant-availability wrapped insert allocation must return ArrayBuffer keys");
-      }
-    };
-    const runWriteLocked = async <T>(
-      requiresSeq: DatabaseSeq | undefined,
-      allocate: (chainedRequiresSeq: DatabaseSeq) => Promise<WriteAllocation<T>>,
-    ): Promise<{ seq: DatabaseSeq, result: T }> => {
+    const getChainedRequiresSeq = (requiresSeq: DatabaseSeq | undefined): DatabaseSeq => {
       const previousWriteSeq = lastWriteSeq;
-      const chainedRequiresSeq = chainRequiresSeq(previousWriteSeq, getUnderlyingSeq(requiresSeq));
-      // The wrapped store allocates its sequence and, for dumps, keys without IO. Commit completion
-      // remains asynchronous through `underlyingAvailable`, so a failed predecessor still blocks its
-      // successor through the wrapped store's causal dependency.
-      const allocation = await allocate(chainedRequiresSeq);
-      assertWriteAllocation(allocation);
-      const seq = createSeq(allocation.underlyingSeq);
+      const underlyingRequiresSeq = getUnderlyingSeq(requiresSeq);
+      if (previousWriteSeq === undefined) return underlyingRequiresSeq;
+      // Same-key underlying writes must be issued in instant-seq order; otherwise an evicted cache entry exposes and persists the older value.
+      return wrapped.combineSeqs(underlyingRequiresSeq, getSeqRecord(previousWriteSeq).underlyingSeq);
+    };
+    const recordWrite = (underlyingSeq: DatabaseSeq, cacheEntries: Array<{ key: ArrayBuffer, value: ArrayBuffer | null }>) => {
+      const seq = createSeq(underlyingSeq);
       lastWriteSeq = seq;
-      for (const { key, value } of allocation.cacheEntries) setCachedValue(key, value, seq);
-      evictAfterWrappedAvailability(allocation.cacheEntries.map(({ key }) => key), seq);
-      return { seq, result: allocation.result };
+      for (const { key, value } of cacheEntries) setCachedValue(key, value, seq);
+      evictAfterWrappedAvailability(cacheEntries.map(({ key }) => key), seq);
+      return seq;
     };
 
     const result: LowLevelKvStore & LowLevelKvDump = {
@@ -237,15 +208,9 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
           if (entries.length === 0) return { seq: setOptions?.requiresSeq ?? initialSeq };
           return await withWriteGate(async () => {
             const entriesForWrapped = entries.map(({ key, value }) => ({ key: cloneArrayBuffer(key), value: cloneArrayBuffer(value) }));
-            const write = await runWriteLocked(setOptions?.requiresSeq, async requiresSeq => {
-              const { seq: underlyingSeq } = await wrappedStore.setAll(entriesForWrapped, { requiresSeq });
-              return {
-                underlyingSeq,
-                cacheEntries: entriesForWrapped,
-                result: undefined,
-              };
-            });
-            return { seq: write.seq };
+            const requiresSeq = getChainedRequiresSeq(setOptions?.requiresSeq);
+            const { seq: underlyingSeq } = await wrappedStore.setAll(entriesForWrapped, { requiresSeq });
+            return { seq: recordWrite(underlyingSeq, entriesForWrapped) };
           });
         });
       },
@@ -254,15 +219,9 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
           if (keys.length === 0) return { seq: deleteOptions?.requiresSeq ?? initialSeq };
           return await withWriteGate(async () => {
             const keysForWrapped = keys.map(cloneArrayBuffer);
-            const write = await runWriteLocked(deleteOptions?.requiresSeq, async requiresSeq => {
-              const { seq: underlyingSeq } = await wrappedStore.deleteAll(keysForWrapped, { requiresSeq });
-              return {
-                underlyingSeq,
-                cacheEntries: keysForWrapped.map(key => ({ key, value: null })),
-                result: undefined,
-              };
-            });
-            return { seq: write.seq };
+            const requiresSeq = getChainedRequiresSeq(deleteOptions?.requiresSeq);
+            const { seq: underlyingSeq } = await wrappedStore.deleteAll(keysForWrapped, { requiresSeq });
+            return { seq: recordWrite(underlyingSeq, keysForWrapped.map(key => ({ key, value: null }))) };
           });
         });
       },
@@ -271,16 +230,10 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
           if (values.length === 0) return { keys: [], seq: insertOptions?.requiresSeq ?? initialSeq };
           return await withWriteGate(async () => {
             const valuesForWrapped = values.map(cloneArrayBuffer);
-            const write = await runWriteLocked(insertOptions?.requiresSeq, async requiresSeq => {
-              const { keys, seq: underlyingSeq } = await wrappedStore.insertAll(valuesForWrapped, { requiresSeq });
-              return {
-                underlyingSeq,
-                cacheEntries: keys.map((key, index) => ({ key, value: valuesForWrapped[index] })),
-                allocatedKeys: keys,
-                result: { keys: keys.map(cloneArrayBuffer) },
-              };
-            });
-            return { ...write.result, seq: write.seq };
+            const requiresSeq = getChainedRequiresSeq(insertOptions?.requiresSeq);
+            const { keys, seq: underlyingSeq } = await wrappedStore.insertAll(valuesForWrapped, { requiresSeq });
+            const seq = recordWrite(underlyingSeq, keys.map((key, index) => ({ key, value: valuesForWrapped[index] })));
+            return { keys: keys.map(cloneArrayBuffer), seq };
           });
         });
       },
@@ -293,16 +246,10 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
           return await withWriteGate(async () => {
             const existing = await result.get(key);
             if (existing.buffer === null || !arrayBuffersAreEqual(existing.buffer, compare)) return { wasSet: false, seq: null };
-            const write = await runWriteLocked(compareAndSetOptions?.requiresSeq, async requiresSeq => {
-              const entryForWrapped = { key: cloneArrayBuffer(key), value: cloneArrayBuffer(value) };
-              const { seq: underlyingSeq } = await wrappedStore.setAll([entryForWrapped], { requiresSeq });
-              return {
-                underlyingSeq,
-                cacheEntries: [entryForWrapped],
-                result: undefined,
-              };
-            });
-            return { wasSet: true, seq: write.seq };
+            const entryForWrapped = { key: cloneArrayBuffer(key), value: cloneArrayBuffer(value) };
+            const requiresSeq = getChainedRequiresSeq(compareAndSetOptions?.requiresSeq);
+            const { seq: underlyingSeq } = await wrappedStore.setAll([entryForWrapped], { requiresSeq });
+            return { wasSet: true, seq: recordWrite(underlyingSeq, [entryForWrapped]) };
           });
         });
       },

--- a/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.ts
@@ -241,7 +241,7 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
               const { seq: underlyingSeq } = await wrappedStore.setAll(entriesForWrapped, { requiresSeq });
               return {
                 underlyingSeq,
-                cacheEntries: entries,
+                cacheEntries: entriesForWrapped,
                 result: undefined,
               };
             });
@@ -258,7 +258,7 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
               const { seq: underlyingSeq } = await wrappedStore.deleteAll(keysForWrapped, { requiresSeq });
               return {
                 underlyingSeq,
-                cacheEntries: keys.map(key => ({ key, value: null })),
+                cacheEntries: keysForWrapped.map(key => ({ key, value: null })),
                 result: undefined,
               };
             });
@@ -275,7 +275,7 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
               const { keys, seq: underlyingSeq } = await wrappedStore.insertAll(valuesForWrapped, { requiresSeq });
               return {
                 underlyingSeq,
-                cacheEntries: keys.map((key, index) => ({ key, value: values[index] })),
+                cacheEntries: keys.map((key, index) => ({ key, value: valuesForWrapped[index] })),
                 allocatedKeys: keys,
                 result: { keys: keys.map(cloneArrayBuffer) },
               };
@@ -294,10 +294,11 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
             const existing = await result.get(key);
             if (existing.buffer === null || !arrayBuffersAreEqual(existing.buffer, compare)) return { wasSet: false, seq: null };
             const write = await runWriteLocked(compareAndSetOptions?.requiresSeq, async requiresSeq => {
-              const { seq: underlyingSeq } = await wrappedStore.setAll([{ key: cloneArrayBuffer(key), value: cloneArrayBuffer(value) }], { requiresSeq });
+              const entryForWrapped = { key: cloneArrayBuffer(key), value: cloneArrayBuffer(value) };
+              const { seq: underlyingSeq } = await wrappedStore.setAll([entryForWrapped], { requiresSeq });
               return {
                 underlyingSeq,
-                cacheEntries: [{ key, value }],
+                cacheEntries: [entryForWrapped],
                 result: undefined,
               };
             });

--- a/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.ts
@@ -164,15 +164,21 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
     type WriteAllocation<T> = {
       underlyingSeq: DatabaseSeq,
       cacheEntries: Array<{ key: ArrayBuffer, value: ArrayBuffer | null }>,
+      allocatedKeys?: ArrayBuffer[],
       result: T,
     };
+    const isThenable = (value: unknown): value is PromiseLike<unknown> => {
+      return value !== null
+        && (typeof value === "object" || typeof value === "function")
+        && "then" in value
+        && typeof value.then === "function";
+    };
     const assertWriteAllocation = <T>(allocation: WriteAllocation<T>) => {
-      if (!Array.isArray(allocation.underlyingSeq) || allocation.underlyingSeq.length !== 2
-        || typeof allocation.underlyingSeq[0] !== "string" || typeof allocation.underlyingSeq[1] !== "string") {
-        throw new Error("Instant-availability wrapped writes must allocate a sequence synchronously");
+      if (isThenable(allocation.underlyingSeq)) {
+        throw new Error("Instant-availability wrapped write allocation must return a non-thenable sequence");
       }
-      for (const { key } of allocation.cacheEntries) {
-        if (!(key instanceof ArrayBuffer)) throw new Error("Instant-availability wrapped writes must allocate ArrayBuffer keys synchronously");
+      for (const key of allocation.allocatedKeys ?? []) {
+        if (!(key instanceof ArrayBuffer)) throw new Error("Instant-availability wrapped insert allocation must return ArrayBuffer keys");
       }
     };
     const runWriteLocked = async <T>(
@@ -270,6 +276,7 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
               return {
                 underlyingSeq,
                 cacheEntries: keys.map((key, index) => ({ key, value: values[index] })),
+                allocatedKeys: keys,
                 result: { keys: keys.map(cloneArrayBuffer) },
               };
             });

--- a/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.ts
@@ -16,7 +16,7 @@ function arrayBuffersAreEqual(a: ArrayBuffer, b: ArrayBuffer): boolean {
 
 type InstantAvailabilitySeq = readonly [dbId: string, seqId: string] & { __brand: "hexclave-low-level-kv-store-seq" };
 type SeqRecord = {
-  underlyingSeq: Promise<DatabaseSeq>,
+  underlyingSeq: DatabaseSeq,
   underlyingAvailable: Promise<void>,
   isSettled: boolean,
 };
@@ -59,7 +59,7 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
     pendingSeqRecordsChangedResolve = resolve;
   });
   seqRecords.set(initialSeq, {
-    underlyingSeq: Promise.resolve(wrapped.initialSeq),
+    underlyingSeq: wrapped.initialSeq,
     underlyingAvailable: Promise.resolve(),
     isSettled: true,
   });
@@ -78,7 +78,7 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
     if (record === undefined) throw new Error("Unknown instant-availability sequence");
     return record;
   };
-  const getUnderlyingSeq = async (seq: DatabaseSeq | undefined) => await getSeqRecord(seq).underlyingSeq;
+  const getUnderlyingSeq = (seq: DatabaseSeq | undefined) => getSeqRecord(seq).underlyingSeq;
   const notifyPendingSeqRecordsChanged = () => {
     pendingSeqRecordsChangedResolve();
     pendingSeqRecordsChanged = new Promise<void>(resolve => {
@@ -109,12 +109,10 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
       }
     });
   };
-  const createSeq = (underlyingSeq: Promise<DatabaseSeq>) => {
+  const createSeq = (underlyingSeq: DatabaseSeq) => {
     const seq = toSeq(crypto.randomUUID());
-    underlyingSeq.catch(() => {});
     const underlyingAvailable = traceSpanHot({ description: "bulldozer-js.low-level.instant.underlyingAvailable", attributes: { "bulldozer.low_level.backend": "instant-availability" } }, async () => {
-      const resolvedUnderlyingSeq = await underlyingSeq;
-      await wrapped.waitUntilAvailable(resolvedUnderlyingSeq);
+      await wrapped.waitUntilAvailable(underlyingSeq);
     });
     // This is the "instant availability" trade-off: callers (e.g. write routes)
     // return as soon as the value is in this in-memory cache, NOT after it lands
@@ -157,27 +155,42 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
         })
         .catch(() => {});
     };
-    const chainRequiresSeq = async (previousWriteSeq: DatabaseSeq | undefined, requiresSeq: DatabaseSeq): Promise<DatabaseSeq> => {
+    const chainRequiresSeq = (previousWriteSeq: DatabaseSeq | undefined, requiresSeq: DatabaseSeq): DatabaseSeq => {
       if (previousWriteSeq === undefined) return requiresSeq;
       // Same-key underlying writes must be issued in instant-seq order; otherwise an evicted cache entry exposes and persists the older value.
-      const previousUnderlyingSeq = await getSeqRecord(previousWriteSeq).underlyingSeq.catch(() => undefined);
-      return previousUnderlyingSeq === undefined ? requiresSeq : wrapped.combineSeqs(requiresSeq, previousUnderlyingSeq);
+      return wrapped.combineSeqs(requiresSeq, getSeqRecord(previousWriteSeq).underlyingSeq);
     };
 
-    const setAllLocked = (entries: Array<{ key: ArrayBuffer, value: ArrayBuffer }>, setOptions?: { requiresSeq?: DatabaseSeq }): { seq: DatabaseSeq } => {
-      const entriesForWrapped = entries.map(({ key, value }) => ({ key: cloneArrayBuffer(key), value: cloneArrayBuffer(value) }));
+    type WriteAllocation<T> = {
+      underlyingSeq: DatabaseSeq,
+      cacheEntries: Array<{ key: ArrayBuffer, value: ArrayBuffer | null }>,
+      result: T,
+    };
+    const assertWriteAllocation = <T>(allocation: WriteAllocation<T>) => {
+      if (!Array.isArray(allocation.underlyingSeq) || allocation.underlyingSeq.length !== 2
+        || typeof allocation.underlyingSeq[0] !== "string" || typeof allocation.underlyingSeq[1] !== "string") {
+        throw new Error("Instant-availability wrapped writes must allocate a sequence synchronously");
+      }
+      for (const { key } of allocation.cacheEntries) {
+        if (!(key instanceof ArrayBuffer)) throw new Error("Instant-availability wrapped writes must allocate ArrayBuffer keys synchronously");
+      }
+    };
+    const runWriteLocked = async <T>(
+      requiresSeq: DatabaseSeq | undefined,
+      allocate: (chainedRequiresSeq: DatabaseSeq) => Promise<WriteAllocation<T>>,
+    ): Promise<{ seq: DatabaseSeq, result: T }> => {
       const previousWriteSeq = lastWriteSeq;
-      const underlyingSeq = (async () => {
-        const chainedRequiresSeq = await chainRequiresSeq(previousWriteSeq, await getUnderlyingSeq(setOptions?.requiresSeq));
-        // The chained dependency deliberately propagates prior commit failures so later writes cannot overtake a failed predecessor.
-        const { seq } = await wrappedStore.setAll(entriesForWrapped, { requiresSeq: chainedRequiresSeq });
-        return seq;
-      })();
-      const seq = createSeq(underlyingSeq);
+      const chainedRequiresSeq = chainRequiresSeq(previousWriteSeq, getUnderlyingSeq(requiresSeq));
+      // The wrapped store allocates its sequence and, for dumps, keys without IO. Commit completion
+      // remains asynchronous through `underlyingAvailable`, so a failed predecessor still blocks its
+      // successor through the wrapped store's causal dependency.
+      const allocation = await allocate(chainedRequiresSeq);
+      assertWriteAllocation(allocation);
+      const seq = createSeq(allocation.underlyingSeq);
       lastWriteSeq = seq;
-      for (const { key, value } of entries) setCachedValue(key, value, seq);
-      evictAfterWrappedAvailability(entries.map(({ key }) => key), seq);
-      return { seq };
+      for (const { key, value } of allocation.cacheEntries) setCachedValue(key, value, seq);
+      evictAfterWrappedAvailability(allocation.cacheEntries.map(({ key }) => key), seq);
+      return { seq, result: allocation.result };
     };
 
     const result: LowLevelKvStore & LowLevelKvDump = {
@@ -216,7 +229,18 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
       async setAll(entries, setOptions) {
         return await traceSpanHot({ description: "bulldozer-js.low-level.instant.setAll", attributes: { ...attributes, "bulldozer.low_level.entry_count": entries.length } }, async () => {
           if (entries.length === 0) return { seq: setOptions?.requiresSeq ?? initialSeq };
-          return await withWriteGate(async () => setAllLocked(entries, setOptions));
+          return await withWriteGate(async () => {
+            const entriesForWrapped = entries.map(({ key, value }) => ({ key: cloneArrayBuffer(key), value: cloneArrayBuffer(value) }));
+            const write = await runWriteLocked(setOptions?.requiresSeq, async requiresSeq => {
+              const { seq: underlyingSeq } = await wrappedStore.setAll(entriesForWrapped, { requiresSeq });
+              return {
+                underlyingSeq,
+                cacheEntries: entries,
+                result: undefined,
+              };
+            });
+            return { seq: write.seq };
+          });
         });
       },
       async deleteAll(keys, deleteOptions) {
@@ -224,17 +248,15 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
           if (keys.length === 0) return { seq: deleteOptions?.requiresSeq ?? initialSeq };
           return await withWriteGate(async () => {
             const keysForWrapped = keys.map(cloneArrayBuffer);
-            const previousWriteSeq = lastWriteSeq;
-            const underlyingSeq = (async () => {
-              const chainedRequiresSeq = await chainRequiresSeq(previousWriteSeq, await getUnderlyingSeq(deleteOptions?.requiresSeq));
-              const { seq } = await wrappedStore.deleteAll(keysForWrapped, { requiresSeq: chainedRequiresSeq });
-              return seq;
-            })();
-            const seq = createSeq(underlyingSeq);
-            lastWriteSeq = seq;
-            for (const key of keys) setCachedValue(key, null, seq);
-            evictAfterWrappedAvailability(keys, seq);
-            return { seq };
+            const write = await runWriteLocked(deleteOptions?.requiresSeq, async requiresSeq => {
+              const { seq: underlyingSeq } = await wrappedStore.deleteAll(keysForWrapped, { requiresSeq });
+              return {
+                underlyingSeq,
+                cacheEntries: keys.map(key => ({ key, value: null })),
+                result: undefined,
+              };
+            });
+            return { seq: write.seq };
           });
         });
       },
@@ -243,14 +265,15 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
           if (values.length === 0) return { keys: [], seq: insertOptions?.requiresSeq ?? initialSeq };
           return await withWriteGate(async () => {
             const valuesForWrapped = values.map(cloneArrayBuffer);
-            const previousWriteSeq = lastWriteSeq;
-            const requiresSeq = await chainRequiresSeq(previousWriteSeq, await getUnderlyingSeq(insertOptions?.requiresSeq));
-            const { keys, seq: underlyingInsertSeq } = await wrappedStore.insertAll(valuesForWrapped, { requiresSeq });
-            const seq = createSeq(Promise.resolve(underlyingInsertSeq));
-            lastWriteSeq = seq;
-            keys.forEach((key, index) => setCachedValue(key, values[index], seq));
-            evictAfterWrappedAvailability(keys, seq);
-            return { keys: keys.map(cloneArrayBuffer), seq };
+            const write = await runWriteLocked(insertOptions?.requiresSeq, async requiresSeq => {
+              const { keys, seq: underlyingSeq } = await wrappedStore.insertAll(valuesForWrapped, { requiresSeq });
+              return {
+                underlyingSeq,
+                cacheEntries: keys.map((key, index) => ({ key, value: values[index] })),
+                result: { keys: keys.map(cloneArrayBuffer) },
+              };
+            });
+            return { ...write.result, seq: write.seq };
           });
         });
       },
@@ -263,8 +286,15 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
           return await withWriteGate(async () => {
             const existing = await result.get(key);
             if (existing.buffer === null || !arrayBuffersAreEqual(existing.buffer, compare)) return { wasSet: false, seq: null };
-            const { seq } = setAllLocked([{ key, value }], compareAndSetOptions);
-            return { wasSet: true, seq };
+            const write = await runWriteLocked(compareAndSetOptions?.requiresSeq, async requiresSeq => {
+              const { seq: underlyingSeq } = await wrappedStore.setAll([{ key: cloneArrayBuffer(key), value: cloneArrayBuffer(value) }], { requiresSeq });
+              return {
+                underlyingSeq,
+                cacheEntries: [{ key, value }],
+                result: undefined,
+              };
+            });
+            return { wasSet: true, seq: write.seq };
           });
         });
       },
@@ -304,17 +334,17 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
       return await traceSpanHot({ description: "bulldozer-js.low-level.instant.waitUntilAvailable", attributes: { "bulldozer.low_level.backend": "instant-availability" } }, async () => {});
     },
     async waitUntilDurable(seq) {
-      await traceSpanHot({ description: "bulldozer-js.low-level.instant.waitUntilDurable", attributes: { "bulldozer.low_level.backend": "instant-availability" } }, async () => await wrapped.waitUntilDurable(await getUnderlyingSeq(seq)));
+      await traceSpanHot({ description: "bulldozer-js.low-level.instant.waitUntilDurable", attributes: { "bulldozer.low_level.backend": "instant-availability" } }, async () => await wrapped.waitUntilDurable(getUnderlyingSeq(seq)));
     },
     async waitUntilReplicated(seq) {
-      await traceSpanHot({ description: "bulldozer-js.low-level.instant.waitUntilReplicated", attributes: { "bulldozer.low_level.backend": "instant-availability" } }, async () => await wrapped.waitUntilReplicated(await getUnderlyingSeq(seq)));
+      await traceSpanHot({ description: "bulldozer-js.low-level.instant.waitUntilReplicated", attributes: { "bulldozer.low_level.backend": "instant-availability" } }, async () => await wrapped.waitUntilReplicated(getUnderlyingSeq(seq)));
     },
     combineSeqs(...seqs) {
       if (seqs.length === 0) return initialSeq;
       const uniqueSeqs = new Set(seqs);
       if (uniqueSeqs.size === 1) return seqs[0];
       if (seqs.every(seq => getSeqId(seq) === initialSeqId)) return initialSeq;
-      return createSeq((async () => wrapped.combineSeqs(...await Promise.all(seqs.map(async seq => await getUnderlyingSeq(seq)))))());
+      return createSeq(wrapped.combineSeqs(...seqs.map(seq => getUnderlyingSeq(seq))));
     },
     close() {
       if (closePromise === null) {

--- a/apps/bulldozer-js/src/databases/low-level/index.ts
+++ b/apps/bulldozer-js/src/databases/low-level/index.ts
@@ -37,6 +37,10 @@ export type LowLevelDatabaseDebugSnapshot = {
  *
  * Note that durability (or replication) of a modifying function is only guaranteed after `waitUntilDurable(seq)` (or
  * `waitUntilReplicated(seq)` for either the returned `seq` or a `seq` that's greater (determined using `maxSeq`).
+ *
+ * Wrapped stores used by the instant-availability implementation must allocate their returned sequence (and dump
+ * keys) locally, before any asynchronous commit or IO. Commit completion remains asynchronous and is represented by
+ * the returned sequence's availability barrier.
  */
 export type LowLevelKvStore = {
   get(key: ArrayBuffer): Promise<{ buffer: ArrayBuffer | null, seq: DatabaseSeq }>,


### PR DESCRIPTION
The instant-availability wrapper used to call the wrapped store from an unawaited background promise, so `underlyingSeq` was a `Promise<DatabaseSeq>` and everything needing it had to await:

```ts
const underlyingSeq = (async () => {
  const dep = await chainRequiresSeq(previousWriteSeq, await getUnderlyingSeq(opts.requiresSeq));
  return (await wrappedStore.setAll(entries, { requiresSeq: dep })).seq;
})();
```

Wrapped stores allocate their sequence — and, for dumps, their keys — with local bookkeeping only, queueing the actual commit for later, so the wrapped call can simply be awaited inside `withWriteGate`. `underlyingSeq` becomes a plain value and the awaits in `getUnderlyingSeq`, `chainRequiresSeq`, `combineSeqs`, `waitUntilDurable`/`waitUntilReplicated` and `insertAll`'s key wait all disappear.

The four write paths (`setAll`, `deleteAll`, `insertAll`, and the CAS write) were near-copies of the same dependency-chain/allocate/cache/evict sequence and now share one `runWriteLocked` helper, which also fixes `deleteAll` awaiting its dependency resolution while holding the gate.

Commit completion stays asynchronous through `underlyingAvailable` — only allocation is now resolved eagerly. Failure propagation is slightly stronger than before: `chainRequiresSeq` no longer catches a predecessor's rejected sequence and falls back to the caller's `requiresSeq`, so a successor can't silently drop a failed predecessor's causal dependency and overtake it.

The "allocate without IO" expectation is now documented on `LowLevelKvStore` and checked cheaply per write (allocation must not be a thenable; generated insert keys must be `ArrayBuffer`s). A guard that actually detects a slow wrapped write would need test-only instrumentation and is deliberately not on the hot path.

Two tests used fake backends that delayed their `setAll` *before returning*, which the documented contract now forbids; they delay commit availability instead and assert the same properties (instant-seq ordering across a delayed underlying write, and dependency chaining into the next wrapped write).


Link to Devin session: https://app.devin.ai/sessions/717d2f78ffcf4016903d7926263bb1a7
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes write-path ordering and failure propagation in the instant-availability layer that fronts durable KV; behavior is covered by tests but affects all optimistic writes.
> 
> **Overview**
> The instant-availability low-level wrapper now **awaits wrapped writes inside the write gate** instead of firing them from an unawaited background promise. **`underlyingSeq` is a synchronous `DatabaseSeq`**, so sequence chaining, `combineSeqs`, and durability/replication barriers no longer await promise-wrapped sequences.
> 
> **`setAll`**, **`deleteAll`**, **`insertAll`**, and compare-and-set writes share **`runWriteLocked`**, which chains `requiresSeq`, calls the wrapped store, updates the in-memory cache, and registers eviction. **`chainRequiresSeq` no longer falls back** when a predecessor sequence fails, so successors keep the wrapped store’s causal ordering.
> 
> **`LowLevelKvStore`** documents that wrapped implementations must **allocate seq (and dump keys) before async commit/IO**; writes assert allocations are non-thenable. Test fakes that used to block before returning **`setAll`** now **delay commit availability** instead, matching that contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19e0c025fd81d4aef03115cedeedf8ec3d9d9c91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves instant-availability sequences inside the write gate so allocation runs synchronously and `underlyingSeq` is a value, not a promise. Previously writes ran in an unawaited task; now we await inside `withWriteGate`, preserving causal ordering while commit completion stays asynchronous.

- Simplifies write bookkeeping with a `recordWrite` helper across `setAll`, `deleteAll`, `insertAll`, and compare-and-set to update the cache and schedule eviction.
- Chains `requiresSeq` synchronously via `getChainedRequiresSeq` to include the previous write’s underlying seq, preventing successors from overtaking failed predecessors.
- Removes promise wrapping in `getUnderlyingSeq`, `combineSeqs`, and durability/replication barriers.
- Caches the cloned buffers passed to the backend to keep inputs consistent.
- Fixes gate behavior: `deleteAll` no longer waits on dependency resolution while holding the write gate.
- Updates tests to delay commit availability (not return) and to propagate delayed write failures; documents synchronous allocation requirements on `LowLevelKvStore`.

**Migration**
- Wrapped stores used with instant-availability must allocate and return a sequence (and dump keys) locally before any I/O; do not await I/O before returning. Update backends that previously awaited before returning.

<sup>Written for commit 08bb1bef17bd2b627067301a1290987fe0a04772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved write sequencing so operations commit in the correct order without unnecessary blocking.
  * Improved consistency and reliability for batch inserts, updates, deletions, and compare-and-set operations.
  * Ensured sequence numbers and keys are available synchronously while commit completion remains tracked asynchronously.
  * Improved error handling when a write cannot be committed successfully.

* **Documentation**
  * Clarified write timing and sequence availability behavior for wrapped key-value stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->