### PR TITLE
Give the sign-up rule stats tests a deadline-based ClickHouse poll

### DIFF
--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/sign-up-rules-stats.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/sign-up-rules-stats.test.ts
@@ -3,6 +3,31 @@ import { describe } from "vitest";
 import { it } from "../../../../../helpers";
 import { Auth, Project, backendContext, niceBackendFetch } from "../../../../backend-helpers";
 
+const CLICKHOUSE_EVENT_POLL_TIMEOUT_MS = 60_000;
+const CLICKHOUSE_EVENT_POLL_INTERVAL_MS = 500;
+
+// Analytics events reach ClickHouse asynchronously, and full-suite CI runners can take many seconds per request.
+async function pollUntil<T>(
+  getValue: () => Promise<T>,
+  predicate: (value: T) => boolean,
+  describeValue: (value: T) => string,
+  timeoutDescription: string,
+): Promise<T> {
+  const deadline = performance.now() + CLICKHOUSE_EVENT_POLL_TIMEOUT_MS;
+  let value = await getValue();
+  while (!predicate(value)) {
+    const remainingMs = deadline - performance.now();
+    if (remainingMs <= 0) {
+      throw new Error(
+        `Timed out after ${CLICKHOUSE_EVENT_POLL_TIMEOUT_MS / 1000}s waiting for ${timeoutDescription}. Last value: ${describeValue(value)}`,
+      );
+    }
+    await wait(Math.min(CLICKHOUSE_EVENT_POLL_INTERVAL_MS, remainingMs));
+    value = await getValue();
+  }
+  return value;
+}
+
 
 describe("without project access", () => {
   backendContext.set({
@@ -135,15 +160,13 @@ describe("with admin access", () => {
     const { userId } = await Auth.Password.signUpWithEmail();
 
     const getStats = () => niceBackendFetch("/api/v1/internal/sign-up-rules-stats", { accessType: "admin" });
-    let response = await getStats();
-    for (let attempt = 0; attempt < 15; attempt++) {
-      const testRule = response.status === 200
-        ? response.body.rule_triggers.find((rule: { rule_id: string }) => rule.rule_id === "test-rule")
-        : undefined;
-      if (testRule?.total_count > 0) break;
-      await wait(500);
-      response = await getStats();
-    }
+    const response = await pollUntil(
+      getStats,
+      (value) => value.status === 200
+        && value.body.rule_triggers.some((rule: { rule_id: string; total_count: number }) => rule.rule_id === "test-rule" && rule.total_count > 0),
+      (value) => `stats response status=${value.status}, body=${JSON.stringify(value.body)}`,
+      "test-rule trigger in sign-up rule stats",
+    );
 
     expect(response.status, "Timed out waiting for sign-up rule stats").toBe(200);
     const testRule = response.body.rule_triggers.find((rule: { rule_id: string }) => rule.rule_id === "test-rule");
@@ -203,10 +226,8 @@ describe("with admin access", () => {
     await Auth.Password.signUpWithEmail();
 
     // Wait for the ClickHouse event to appear and verify via a raw COALESCE query
-    let chResult: any;
-    for (let attempt = 0; attempt < 15; attempt++) {
-      await wait(500);
-      chResult = await niceBackendFetch("/api/v1/analytics/query", {
+    const chResult = await pollUntil(
+      () => niceBackendFetch("/api/v1/analytics/query", {
         method: "POST",
         accessType: "server",
         body: {
@@ -222,9 +243,11 @@ describe("with admin access", () => {
           `,
           params: {},
         },
-      });
-      if (chResult.status === 200 && chResult.body?.result?.length > 0) break;
-    }
+      }),
+      (value) => value.status === 200 && value.body?.result?.length > 0,
+      (value) => `ClickHouse query response status=${value.status}, body=${JSON.stringify(value.body)}`,
+      "sign-up-rule-trigger event in ClickHouse",
+    );
 
     expect(chResult.status).toBe(200);
     expect(chResult.body.result.length).toBeGreaterThan(0);


### PR DESCRIPTION
The two sign-up-rule-stats tests polled for the ClickHouse trigger event with a fixed 15 × 500ms loop, i.e. a ~7.5s budget. Analytics events are ingested asynchronously, and on a runner executing the full suite individual signup/flush requests can take upwards of 10s, so the budget has no headroom there and the test flakes.

Both loops now poll on a 60s deadline (same order as `waitUntilReplicasHaveCaughtUp`) with the interval unchanged, via a small local `pollUntil` helper. On timeout the failure now names the missing event and includes the last response body, instead of surfacing as `TypeError: actual value must be number or bigint, received "undefined"` from the downstream assertion.

Test-only change; assertions and the inline snapshot are untouched. Locally the event shows up after ~1.5s, so the wait is unchanged in the common case.

Link to Devin session: https://app.devin.ai/sessions/2591db2286bd4bce89895b3c1f037c0e
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change to e2e wait logic; no production or API behavior modified.
> 
> **Overview**
> **Replaces brittle fixed-loop waits** in the sign-up-rules-stats e2e tests with a local **`pollUntil`** helper that polls every 500ms until a **60s deadline**, matching the patience used elsewhere for async infrastructure (e.g. replica catch-up).
> 
> The two tests that wait for analytics events in ClickHouse—one polling the internal stats endpoint for `test-rule`, one polling a raw analytics COALESCE query—no longer use **15 × 500ms (~7.5s)** loops that could flake on slow full-suite CI. **Assertions and inline snapshots are unchanged**; only wait logic and failure reporting differ. On timeout, errors now name what was missing and include the **last response body** instead of failing later with confusing assertion errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad1517926db5e147c41a7164ea1ced2f4f8e8321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the sign-up-rule-stats e2e tests from fixed 15×500ms retries (~7.5s) to a 60s deadline-based poll to handle async ClickHouse ingestion delays. CI flakes are reduced; on timeout, tests now report the missing event and include the last response instead of failing with a TypeError.

- Adds a local `pollUntil` helper (500ms interval, 60s timeout, aligned with `waitUntilReplicasHaveCaughtUp`).
- Uses `pollUntil` for both the internal sign-up-rule stats endpoint check and the raw `/api/v1/analytics/query` ClickHouse query.
- Test-only change; assertions and snapshots unchanged. Typical run time unchanged; worst-case wait increases to 60s.

<sup>Written for commit 92a4e5da798658c38010691d5618538016561ca1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of sign-up-rule statistics when results are generated asynchronously.
  * Tests now wait for expected results instead of relying on fixed retry counts.
  * Enhanced timeout reporting makes intermittent test failures easier to diagnose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->