### PR TITLE
ci: keep the useful e2e run diagnostics on every push

### DIFF
--- a/.github/scripts/process-attribution.sh
+++ b/.github/scripts/process-attribution.sh
@@ -79,7 +79,8 @@ read_process_rss_kb() {
 }
 
 read_host_cpu() {
-  awk '$1 == "cpu" { for (i = 2; i <= 9; i++) total += $i; idle = $5 + $6; printf "%.6f|%.6f", total, idle; exit }' /proc/stat
+  awk -v clock_ticks="$clock_ticks" \
+    '$1 == "cpu" { for (i = 2; i <= 9; i++) total += $i / clock_ticks; idle = ($5 + $6) / clock_ticks; printf "%.6f|%.6f", total, idle; exit }' /proc/stat
 }
 
 read_container_cpu() {
@@ -93,9 +94,6 @@ read_container_cpu() {
     cpu_stat="$(awk '$1 == "usage_usec" { print $2 }' "/sys/fs/cgroup${cgroup_path}/cpu.stat")"
     usage_usec="${cpu_stat:-0}"
     awk -v usage_usec="$usage_usec" 'BEGIN { printf "%.6f", usage_usec / 1000000 }'
-  elif [[ -f "/sys/fs/cgroup${cgroup_path}/cpuacct.usage" ]]; then
-    cpu_stat="$(<"/sys/fs/cgroup${cgroup_path}/cpuacct.usage")"
-    awk -v usage_nanoseconds="${cpu_stat:-0}" 'BEGIN { printf "%.6f", usage_nanoseconds / 1000000000 }'
   else
     return 1
   fi
@@ -151,7 +149,7 @@ if [[ "$1" == snapshot ]]; then
   else
     printf 'host_cpu_total_seconds|0\nhost_cpu_busy_seconds|0\nload_average_1_5_15|%s\n' "$load_average"
   fi
-  printf '%s|%s\n' "$host_cpu" > "${RUNNER_TEMP:-/tmp}/hexclave-host-attribution.state.untracked.tsv"
+  printf '%s\n' "$host_cpu" > "${RUNNER_TEMP:-/tmp}/hexclave-host-attribution.state.untracked.tsv"
   echo
 
   echo "Per-process CPU and RSS"
@@ -186,7 +184,7 @@ while read -r major minor device reads reads_merged sectors_read read_ms writes 
           write_ms - previous_write_ms, weighted_io_ms - previous_weighted_io_ms
       }'
   fi
-done < /proc/diskstats
+done < <(cat /proc/diskstats 2>/dev/null || true)
 mv "$current_disk_state" "$disk_state_file"
 
 for stat_file in /proc/[0-9]*/stat; do
@@ -197,8 +195,10 @@ for stat_file in /proc/[0-9]*/stat; do
   [[ -n "$command_line" ]] || continue
   label="$(read_process_label "$command_line" || true)"
   [[ -n "$label" ]] || continue
-  cpu_seconds="$(read_process_cpu_seconds "$stat_file")"
-  rss_kb="$(read_process_rss_kb "/proc/$pid")"
+  cpu_seconds="$(read_process_cpu_seconds "$stat_file" || true)"
+  [[ -n "$cpu_seconds" ]] || continue
+  rss_kb="$(read_process_rss_kb "/proc/$pid" || true)"
+  [[ -n "$rss_kb" ]] || continue
   previous_cpu="${previous_process_cpu[$pid]:-0}"
   cpu_delta="$(awk -v current="$cpu_seconds" -v previous="$previous_cpu" 'BEGIN { delta = current - previous; printf "%.6f", delta < 0 ? 0 : delta }')"
   printf '%s|%s|%s|%s|%s|%s\n' "$pid" "$label" "$cpu_seconds" "$cpu_delta" "$rss_kb" "$command_line" >> "$current_state"

--- a/.github/scripts/process-attribution.sh
+++ b/.github/scripts/process-attribution.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+case "${1:-}" in
+  reset|snapshot)
+    ;;
+  *)
+    echo "Usage: $0 {reset|snapshot}" >&2
+    exit 2
+    ;;
+esac
+
+state_file="${RUNNER_TEMP:-/tmp}/hexclave-process-attribution.state.untracked.tsv"
+container_state_file="${RUNNER_TEMP:-/tmp}/hexclave-container-attribution.state.untracked.tsv"
+disk_state_file="${RUNNER_TEMP:-/tmp}/hexclave-disk-attribution.state.untracked.tsv"
+container_io_state_file="${RUNNER_TEMP:-/tmp}/hexclave-container-io-attribution.state.untracked.tsv"
+clock_ticks="$(getconf CLK_TCK)"
+
+declare -A previous_process_cpu
+declare -A previous_container_cpu
+declare -A previous_disk_stats
+declare -A previous_container_io
+
+if [[ "$1" == reset ]]; then
+  "$0" snapshot >/dev/null
+  exit 0
+fi
+
+if [[ -f "$state_file" ]]; then
+  while IFS='|' read -r pid label cpu_seconds; do
+    [[ -n "$pid" ]] && previous_process_cpu["$pid"]="$cpu_seconds"
+  done < "$state_file"
+fi
+
+if [[ -f "$container_state_file" ]]; then
+  while IFS='|' read -r container_id container_name cpu_seconds; do
+    [[ -n "$container_id" ]] && previous_container_cpu["$container_id"]="$cpu_seconds"
+  done < "$container_state_file"
+fi
+
+if [[ -f "$disk_state_file" ]]; then
+  while IFS='|' read -r device reads sectors_read read_ms writes sectors_written write_ms weighted_io_ms; do
+    [[ -n "$device" ]] && previous_disk_stats["$device"]="$reads|$sectors_read|$read_ms|$writes|$sectors_written|$write_ms|$weighted_io_ms"
+  done < "$disk_state_file"
+fi
+
+if [[ -f "$container_io_state_file" ]]; then
+  while IFS='|' read -r container_id read_bytes write_bytes read_ops write_ops; do
+    [[ -n "$container_id" ]] && previous_container_io["$container_id"]="$read_bytes|$write_bytes|$read_ops|$write_ops"
+  done < "$container_io_state_file"
+fi
+
+read_process_label() {
+  local command_line="$1"
+  case "$command_line" in
+    *"bulldozer"*|*"start:bulldozer"*) printf '%s' "bulldozer" ;;
+    *"run-cron-jobs"*) printf '%s' "cron-jobs" ;;
+    *"run-email-queue"*) printf '%s' "email-queue" ;;
+    *"apps/mcp"*|*"start:mcp"*) printf '%s' "mcp" ;;
+    *"apps/dashboard"*|*"start:dashboard"*) printf '%s' "dashboard" ;;
+    *"stack-backend"*|*"apps/backend"*|*"dist/server.mjs"*) printf '%s' "backend" ;;
+    *) return 1 ;;
+  esac
+}
+
+read_process_cpu_seconds() {
+  local stat_file="$1"
+  local stat_line fields
+  stat_line="$(<"$stat_file")"
+  stat_line="${stat_line#*) }"
+  read -r -a fields <<< "$stat_line"
+  awk -v user_ticks="${fields[11]}" -v system_ticks="${fields[12]}" -v clock_ticks="$clock_ticks" \
+    'BEGIN { printf "%.6f", (user_ticks + system_ticks) / clock_ticks }'
+}
+
+read_process_rss_kb() {
+  awk '$1 == "VmRSS:" { print $2; found = 1 } END { if (!found) print 0 }' "$1/status"
+}
+
+read_host_cpu() {
+  awk '$1 == "cpu" { for (i = 2; i <= 9; i++) total += $i; idle = $5 + $6; printf "%.6f|%.6f", total, idle; exit }' /proc/stat
+}
+
+read_container_cpu() {
+  local container_pid="$1"
+  local cgroup_path cpu_stat usage_usec
+  cgroup_path="$(awk -F: '$1 == "0" { print $3 }' "/proc/$container_pid/cgroup" 2>/dev/null || true)"
+  if [[ -z "$cgroup_path" ]]; then
+    return 1
+  fi
+  if [[ -f "/sys/fs/cgroup${cgroup_path}/cpu.stat" ]]; then
+    cpu_stat="$(awk '$1 == "usage_usec" { print $2 }' "/sys/fs/cgroup${cgroup_path}/cpu.stat")"
+    usage_usec="${cpu_stat:-0}"
+    awk -v usage_usec="$usage_usec" 'BEGIN { printf "%.6f", usage_usec / 1000000 }'
+  elif [[ -f "/sys/fs/cgroup${cgroup_path}/cpuacct.usage" ]]; then
+    cpu_stat="$(<"/sys/fs/cgroup${cgroup_path}/cpuacct.usage")"
+    awk -v usage_nanoseconds="${cpu_stat:-0}" 'BEGIN { printf "%.6f", usage_nanoseconds / 1000000000 }'
+  else
+    return 1
+  fi
+}
+
+read_container_io() {
+  local container_pid="$1"
+  local cgroup_path io_stat
+  cgroup_path="$(awk -F: '$1 == "0" { print $3 }' "/proc/$container_pid/cgroup" 2>/dev/null || true)"
+  [[ -n "$cgroup_path" ]] || return 1
+  io_stat="/sys/fs/cgroup${cgroup_path}/io.stat"
+  [[ -f "$io_stat" ]] || return 1
+  awk '{
+    for (i = 2; i <= NF; i++) {
+      split($i, value, "=")
+      if (value[1] == "rbytes") read_bytes += value[2]
+      else if (value[1] == "wbytes") write_bytes += value[2]
+      else if (value[1] == "rios") read_ops += value[2]
+      else if (value[1] == "wios") write_ops += value[2]
+    }
+  } END {
+    printf "%.0f|%.0f|%.0f|%.0f\n", read_bytes, write_bytes, read_ops, write_ops
+  }' "$io_stat"
+}
+
+if [[ "$1" == snapshot ]]; then
+  echo
+  echo "========== Process and container attribution =========="
+  echo "CPU values are deltas since the previous snapshot; process rows retain each matching PID."
+  echo
+fi
+
+current_state="$(mktemp "${RUNNER_TEMP:-/tmp}/hexclave-process-attribution.XXXXXX.untracked")"
+current_container_state="$(mktemp "${RUNNER_TEMP:-/tmp}/hexclave-container-attribution.XXXXXX.untracked")"
+current_disk_state="$(mktemp "${RUNNER_TEMP:-/tmp}/hexclave-disk-attribution.XXXXXX.untracked")"
+current_container_io_state="$(mktemp "${RUNNER_TEMP:-/tmp}/hexclave-container-io-attribution.XXXXXX.untracked")"
+current_container_io_output="$(mktemp "${RUNNER_TEMP:-/tmp}/hexclave-container-io-output.XXXXXX.untracked")"
+trap 'rm -f "$current_state" "$current_container_state" "$current_disk_state" "$current_container_io_state" "$current_container_io_output"' EXIT
+
+if [[ "$1" == snapshot ]]; then
+  echo "Host CPU and load"
+  host_cpu="$(read_host_cpu)"
+  host_total_cpu="${host_cpu%%|*}"
+  host_idle_cpu="${host_cpu##*|}"
+  load_average="$(awk '{ print $1 "|" $2 "|" $3 }' /proc/loadavg)"
+  previous_host_file="${RUNNER_TEMP:-/tmp}/hexclave-host-attribution.state.untracked.tsv"
+  if [[ -f "$previous_host_file" ]]; then
+    IFS='|' read -r previous_host_total previous_host_idle < "$previous_host_file"
+    awk -v total="$host_total_cpu" -v idle="$host_idle_cpu" \
+      -v previous_total="$previous_host_total" -v previous_idle="$previous_host_idle" \
+      -v load_values="$load_average" \
+      'BEGIN { printf "host_cpu_total_seconds|%.6f\nhost_cpu_busy_seconds|%.6f\nload_average_1_5_15|%s\n", total - previous_total, (total - previous_total) - (idle - previous_idle), load_values }'
+  else
+    printf 'host_cpu_total_seconds|0\nhost_cpu_busy_seconds|0\nload_average_1_5_15|%s\n' "$load_average"
+  fi
+  printf '%s|%s\n' "$host_cpu" > "${RUNNER_TEMP:-/tmp}/hexclave-host-attribution.state.untracked.tsv"
+  echo
+
+  echo "Per-process CPU and RSS"
+  echo "label|pid|cpu_seconds_delta|cpu_seconds_total|rss_kb|command"
+fi
+
+if [[ "$1" == snapshot ]]; then
+  echo
+  echo "Per-device block I/O"
+  echo "device|reads_delta|sectors_read_delta|read_ms_delta|writes_delta|sectors_written_delta|write_ms_delta|weighted_io_ms_delta"
+fi
+
+while read -r major minor device reads reads_merged sectors_read read_ms writes writes_merged sectors_written write_ms ios_in_progress io_ms weighted_io_ms; do
+  [[ -n "$device" ]] || continue
+  current="$reads|$sectors_read|$read_ms|$writes|$sectors_written|$write_ms|$weighted_io_ms"
+  printf '%s|%s\n' "$device" "$current" >> "$current_disk_state"
+  if [[ "$1" == snapshot ]]; then
+    previous="${previous_disk_stats[$device]:-0|0|0|0|0|0|0}"
+    IFS='|' read -r previous_reads previous_sectors_read previous_read_ms previous_writes previous_sectors_written previous_write_ms previous_weighted_io_ms <<< "$previous"
+    awk -v device="$device" \
+      -v reads="$reads" -v previous_reads="$previous_reads" \
+      -v sectors_read="$sectors_read" -v previous_sectors_read="$previous_sectors_read" \
+      -v read_ms="$read_ms" -v previous_read_ms="$previous_read_ms" \
+      -v writes="$writes" -v previous_writes="$previous_writes" \
+      -v sectors_written="$sectors_written" -v previous_sectors_written="$previous_sectors_written" \
+      -v write_ms="$write_ms" -v previous_write_ms="$previous_write_ms" \
+      -v weighted_io_ms="$weighted_io_ms" -v previous_weighted_io_ms="$previous_weighted_io_ms" \
+      'BEGIN {
+        printf "%s|%.0f|%.0f|%.0f|%.0f|%.0f|%.0f|%.0f\n", device,
+          reads - previous_reads, sectors_read - previous_sectors_read, read_ms - previous_read_ms,
+          writes - previous_writes, sectors_written - previous_sectors_written,
+          write_ms - previous_write_ms, weighted_io_ms - previous_weighted_io_ms
+      }'
+  fi
+done < /proc/diskstats
+mv "$current_disk_state" "$disk_state_file"
+
+for stat_file in /proc/[0-9]*/stat; do
+  [[ -r "$stat_file" ]] || continue
+  pid="${stat_file#/proc/}"
+  pid="${pid%/stat}"
+  command_line="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
+  [[ -n "$command_line" ]] || continue
+  label="$(read_process_label "$command_line" || true)"
+  [[ -n "$label" ]] || continue
+  cpu_seconds="$(read_process_cpu_seconds "$stat_file")"
+  rss_kb="$(read_process_rss_kb "/proc/$pid")"
+  previous_cpu="${previous_process_cpu[$pid]:-0}"
+  cpu_delta="$(awk -v current="$cpu_seconds" -v previous="$previous_cpu" 'BEGIN { delta = current - previous; printf "%.6f", delta < 0 ? 0 : delta }')"
+  printf '%s|%s|%s|%s|%s|%s\n' "$pid" "$label" "$cpu_seconds" "$cpu_delta" "$rss_kb" "$command_line" >> "$current_state"
+  if [[ "$1" == snapshot ]]; then
+    printf '%s|%s|%s|%s|%s|%s\n' "$label" "$pid" "$cpu_delta" "$cpu_seconds" "$rss_kb" "$command_line"
+  fi
+done
+
+mv "$current_state" "$state_file"
+
+if [[ "$1" == snapshot ]]; then
+  echo
+  echo "Per-container CPU"
+  echo "container|id|cpu_seconds_delta|cpu_seconds_total"
+  while IFS='|' read -r container_id container_name container_pid; do
+    [[ -n "$container_id" ]] || continue
+    cpu_seconds="$(read_container_cpu "$container_pid" || true)"
+    [[ -n "$cpu_seconds" ]] || continue
+    previous_cpu="${previous_container_cpu[$container_id]:-0}"
+    cpu_delta="$(awk -v current="$cpu_seconds" -v previous="$previous_cpu" 'BEGIN { delta = current - previous; printf "%.6f", delta < 0 ? 0 : delta }')"
+    printf '%s|%s|%s|%s\n' "$container_name" "$container_id" "$cpu_delta" "$cpu_seconds"
+    printf '%s|%s|%s\n' "$container_id" "$container_name" "$cpu_seconds" >> "$current_container_state"
+    io_values="$(read_container_io "$container_pid" || true)"
+    if [[ -n "$io_values" ]]; then
+      IFS='|' read -r read_bytes write_bytes read_ops write_ops <<< "$io_values"
+      previous_io="${previous_container_io[$container_id]:-0|0|0|0}"
+      IFS='|' read -r previous_read_bytes previous_write_bytes previous_read_ops previous_write_ops <<< "$previous_io"
+      printf '%s|%s|%s|%s|%s\n' "$container_id" "$read_bytes" "$write_bytes" "$read_ops" "$write_ops" >> "$current_container_io_state"
+      printf '%s|%s|%s|%s|%s\n' "$container_name" \
+        "$((read_bytes - previous_read_bytes))" "$((write_bytes - previous_write_bytes))" \
+        "$((read_ops - previous_read_ops))" "$((write_ops - previous_write_ops))" >> "$current_container_io_output"
+    fi
+  done < <(docker ps -q | while read -r container_id; do
+    docker inspect --format '{{.Id}}|{{.Name}}|{{.State.Pid}}' "$container_id" | sed 's#|/#|#'
+  done)
+  echo
+  echo "Per-container block I/O"
+  echo "container|read_bytes_delta|write_bytes_delta|read_ops_delta|write_ops_delta"
+  cat "$current_container_io_output"
+else
+  while IFS='|' read -r container_id container_name container_pid; do
+    [[ -n "$container_id" ]] || continue
+    cpu_seconds="$(read_container_cpu "$container_pid" || true)"
+    [[ -n "$cpu_seconds" ]] || continue
+    printf '%s|%s|%s\n' "$container_id" "$container_name" "$cpu_seconds" >> "$current_container_state"
+    io_values="$(read_container_io "$container_pid" || true)"
+    if [[ -n "$io_values" ]]; then
+      printf '%s|%s\n' "$container_id" "$io_values" >> "$current_container_io_state"
+    fi
+  done < <(docker ps -q | while read -r container_id; do
+    docker inspect --format '{{.Id}}|{{.Name}}|{{.State.Pid}}' "$container_id" | sed 's#|/#|#'
+  done)
+fi
+
+mv "$current_container_state" "$container_state_file"
+mv "$current_container_io_state" "$container_io_state_file"

--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -230,7 +230,11 @@ jobs:
           pnpm test run --reporter=default --reporter=json \
             --outputFile="$RUNNER_TEMP/e2e-test-results-pass1.untracked.json" 2>&1 |
             tee "$RUNNER_TEMP/e2e-test-output-pass1.untracked.log"
-          exit "${PIPESTATUS[0]}"
+          pipeline_status=("${PIPESTATUS[@]}")
+          if [[ "${pipeline_status[1]}" -ne 0 ]]; then
+            echo "::warning::tee failed while capturing pass 1 output; the test result is still used for the step status"
+          fi
+          exit "${pipeline_status[0]}"
 
       - name: Snapshot PostgreSQL attribution after pass 1
         if: always()
@@ -259,7 +263,11 @@ jobs:
           pnpm test run --reporter=default --reporter=json \
             --outputFile="$RUNNER_TEMP/e2e-test-results-pass2.untracked.json" 2>&1 |
             tee "$RUNNER_TEMP/e2e-test-output-pass2.untracked.log"
-          exit "${PIPESTATUS[0]}"
+          pipeline_status=("${PIPESTATUS[@]}")
+          if [[ "${pipeline_status[1]}" -ne 0 ]]; then
+            echo "::warning::tee failed while capturing pass 2 output; the test result is still used for the step status"
+          fi
+          exit "${pipeline_status[0]}"
 
       - name: Snapshot PostgreSQL attribution after pass 2
         if: always() && steps.run_tests_pass2.outcome != 'skipped'
@@ -288,7 +296,11 @@ jobs:
           pnpm test run --reporter=default --reporter=json \
             --outputFile="$RUNNER_TEMP/e2e-test-results-pass3.untracked.json" 2>&1 |
             tee "$RUNNER_TEMP/e2e-test-output-pass3.untracked.log"
-          exit "${PIPESTATUS[0]}"
+          pipeline_status=("${PIPESTATUS[@]}")
+          if [[ "${pipeline_status[1]}" -ne 0 ]]; then
+            echo "::warning::tee failed while capturing pass 3 output; the test result is still used for the step status"
+          fi
+          exit "${pipeline_status[0]}"
 
       - name: Snapshot PostgreSQL attribution after pass 3
         if: always() && steps.run_tests_pass3.outcome != 'skipped'

--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -332,7 +332,7 @@ jobs:
         with:
           name: e2e-api-bulldozer
           path: ${{ runner.temp }}/hexclave-bulldozer.untracked.log
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Capture bulldozer-js diagnostics
         if: always()
@@ -353,7 +353,7 @@ jobs:
         with:
           name: e2e-api-bulldozer-diagnostics
           path: ${{ runner.temp }}/hexclave-bulldozer-diagnostics.untracked.json
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Upload E2E timing diagnostics
         if: always()
@@ -364,7 +364,7 @@ jobs:
             ${{ runner.temp }}/e2e-test-results-pass*.untracked.json
             ${{ runner.temp }}/e2e-test-output-pass*.untracked.log
             ${{ runner.temp }}/freestyle-mock-diagnostics-pass*.untracked.json
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Print Docker Compose logs
         if: always()

--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - dev
   pull_request:
+  workflow_dispatch:
 
 # A concurrency group only ever runs one run at a time, so the sha is part of the group on main/dev:
 # otherwise consecutive dev pushes queue behind each other (and GitHub cancels the older queued run),
@@ -131,6 +132,7 @@ jobs:
         uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635 # v1.0.7
         env:
           HEXCLAVE_BULLDOZER_JS_USE_TMP_LMDB: "1"
+          HEXCLAVE_BULLDOZER_DIAGNOSTICS: "true"
         with:
           run: |
             bulldozer_log="$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
@@ -212,38 +214,99 @@ jobs:
       - name: Wait 10 seconds
         run: sleep 10
 
+      - name: Reset process attribution
+        continue-on-error: true
+        run: .github/scripts/process-attribution.sh reset || true
+
       - name: Reset PostgreSQL statement attribution
         continue-on-error: true
         run: .github/scripts/postgres-attribution.sh reset
 
       - name: Run tests
         id: run_tests_pass1
-        run: pnpm test run
+        timeout-minutes: 60
+        run: |
+          set -o pipefail
+          pnpm test run --reporter=default --reporter=json \
+            --outputFile="$RUNNER_TEMP/e2e-test-results-pass1.untracked.json" 2>&1 |
+            tee "$RUNNER_TEMP/e2e-test-output-pass1.untracked.log"
+          exit "${PIPESTATUS[0]}"
 
       - name: Snapshot PostgreSQL attribution after pass 1
         if: always()
         continue-on-error: true
         run: .github/scripts/postgres-attribution.sh snapshot
 
+      - name: Snapshot process attribution after pass 1
+        if: always()
+        continue-on-error: true
+        run: |
+          .github/scripts/process-attribution.sh snapshot || true
+          pnpm -C apps/backend run with-env:test bash -c \
+            '
+              mock_port="${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}22"
+              curl --fail --silent --show-error \
+                "http://localhost:${mock_port}/diagnostics?reset=true" \
+                > "$RUNNER_TEMP/freestyle-mock-diagnostics-pass1.untracked.json"
+            ' || true
+
       - name: Run tests again (attempt 1)
         id: run_tests_pass2
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
-        run: pnpm test run
+        timeout-minutes: 75
+        run: |
+          set -o pipefail
+          pnpm test run --reporter=default --reporter=json \
+            --outputFile="$RUNNER_TEMP/e2e-test-results-pass2.untracked.json" 2>&1 |
+            tee "$RUNNER_TEMP/e2e-test-output-pass2.untracked.log"
+          exit "${PIPESTATUS[0]}"
 
       - name: Snapshot PostgreSQL attribution after pass 2
         if: always() && steps.run_tests_pass2.outcome != 'skipped'
         continue-on-error: true
         run: .github/scripts/postgres-attribution.sh snapshot
 
+      - name: Snapshot process attribution after pass 2
+        if: always() && steps.run_tests_pass2.outcome != 'skipped'
+        continue-on-error: true
+        run: |
+          .github/scripts/process-attribution.sh snapshot || true
+          pnpm -C apps/backend run with-env:test bash -c \
+            '
+              mock_port="${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}22"
+              curl --fail --silent --show-error \
+                "http://localhost:${mock_port}/diagnostics?reset=true" \
+                > "$RUNNER_TEMP/freestyle-mock-diagnostics-pass2.untracked.json"
+            ' || true
+
       - name: Run tests again (attempt 2)
         id: run_tests_pass3
         if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev'
-        run: pnpm test run
+        timeout-minutes: 105
+        run: |
+          set -o pipefail
+          pnpm test run --reporter=default --reporter=json \
+            --outputFile="$RUNNER_TEMP/e2e-test-results-pass3.untracked.json" 2>&1 |
+            tee "$RUNNER_TEMP/e2e-test-output-pass3.untracked.log"
+          exit "${PIPESTATUS[0]}"
 
       - name: Snapshot PostgreSQL attribution after pass 3
         if: always() && steps.run_tests_pass3.outcome != 'skipped'
         continue-on-error: true
         run: .github/scripts/postgres-attribution.sh snapshot
+
+      - name: Snapshot process attribution after pass 3
+        if: always() && steps.run_tests_pass3.outcome != 'skipped'
+        continue-on-error: true
+        run: |
+          .github/scripts/process-attribution.sh snapshot || true
+          pnpm -C apps/backend run with-env:test bash -c \
+            '
+              mock_port="${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}22"
+              curl --fail --silent --show-error \
+                "http://localhost:${mock_port}/diagnostics?reset=true" \
+                > "$RUNNER_TEMP/freestyle-mock-diagnostics-pass3.untracked.json"
+            ' || true
 
       - name: Run perf tests
         env:
@@ -264,11 +327,43 @@ jobs:
           tail -n 2000 "$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
 
       - name: Upload bulldozer-js logs
-        if: ${{ failure() }}
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-api-bulldozer
           path: ${{ runner.temp }}/hexclave-bulldozer.untracked.log
+          if-no-files-found: error
+
+      - name: Capture bulldozer-js diagnostics
+        if: always()
+        continue-on-error: true
+        run: |
+          pnpm -C apps/backend run with-env:test bash -c \
+            '
+              bulldozer_port="${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}46"
+              curl --fail --silent --show-error \
+                -H "Authorization: Bearer ${HEXCLAVE_BULLDOZER_SERVER_SECRET}" \
+                "http://localhost:${bulldozer_port}/diagnostics" \
+                > "$RUNNER_TEMP/hexclave-bulldozer-diagnostics.untracked.json"
+            '
+
+      - name: Upload bulldozer-js diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-api-bulldozer-diagnostics
+          path: ${{ runner.temp }}/hexclave-bulldozer-diagnostics.untracked.json
+          if-no-files-found: error
+
+      - name: Upload E2E timing diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-api-test-timing-diagnostics
+          path: |
+            ${{ runner.temp }}/e2e-test-results-pass*.untracked.json
+            ${{ runner.temp }}/e2e-test-output-pass*.untracked.log
+            ${{ runner.temp }}/freestyle-mock-diagnostics-pass*.untracked.json
           if-no-files-found: error
 
       - name: Print Docker Compose logs

--- a/apps/bulldozer-js/src/databases/low-level/implementations/lmdb.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/lmdb.ts
@@ -1,4 +1,5 @@
 import { encodeBase64 } from "@hexclave/shared/dist/utils/bytes";
+import { captureError } from "@hexclave/shared/dist/utils/errors";
 import { wait } from "@hexclave/shared/dist/utils/promises";
 import { createUuidV7Generator } from "@hexclave/shared/dist/utils/uuids";
 import * as lmdb from "lmdb";
@@ -278,7 +279,14 @@ export function declareLmdbLowLevelDatabase(options: {
     const now = performance.now();
     const elapsedMs = now - activityWindowStartedAt;
     const elapsedSeconds = elapsedMs / 1000;
-    const storeSizeBytes = bulldozerDiagnosticsEnabled ? getStoreSizeBytes(options.path) : undefined;
+    let storeSizeBytes: number | undefined;
+    if (bulldozerDiagnosticsEnabled) {
+      try {
+        storeSizeBytes = getStoreSizeBytes(options.path);
+      } catch (error) {
+        captureError("bulldozer-js:lmdb-diagnostics-store-size", error);
+      }
+    }
     const diagnostics: LmdbDiagnostics = {
       dbId,
       ...(storeSizeBytes === undefined ? {} : { storeSizeBytes }),

--- a/apps/bulldozer-js/src/databases/low-level/implementations/lmdb.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/lmdb.ts
@@ -135,20 +135,43 @@ export type LmdbDiagnostics = {
   combinedSeqDurabilityResolvesPerSecond: number,
   averageCombinedSeqAvailabilityResolveMs: number,
   averageCombinedSeqDurabilityResolveMs: number,
+  mapSizes: {
+    seqToAvailability: number,
+    seqToDurability: number,
+    combinedSeqToAvailability: number,
+    combinedSeqToDurability: number,
+    combinedSeqDependencies: number,
+    debugEntriesByStoreId: number,
+  },
   currentVersion: number,
 };
 
 let latestLmdbDiagnostics: LmdbDiagnostics | null = null;
 const bulldozerDiagnosticsEnabled = process.env.HEXCLAVE_BULLDOZER_DIAGNOSTICS === "true";
 
-function getStoreSizeBytes(path: string): number {
+function isExpectedStoreSizeError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = "code" in error ? error.code : undefined;
+  return code === "ENOENT" || code === "EACCES" || code === "EPERM" || code === "ENOTDIR";
+}
+
+function getStoreSizeBytes(path: string): number | undefined {
   try {
-    return readdirSync(path, { withFileTypes: true }).reduce((total, entry) => {
+    let total = 0;
+    for (const entry of readdirSync(path, { withFileTypes: true })) {
       const entryPath = `${path}/${entry.name}`;
-      return total + (entry.isDirectory() ? getStoreSizeBytes(entryPath) : statSync(entryPath).size);
-    }, 0);
-  } catch {
-    return 0;
+      if (entry.isDirectory()) {
+        const nestedSize = getStoreSizeBytes(entryPath);
+        if (nestedSize === undefined) return undefined;
+        total += nestedSize;
+      } else {
+        total += statSync(entryPath).size;
+      }
+    }
+    return total;
+  } catch (error) {
+    if (isExpectedStoreSizeError(error)) return undefined;
+    throw error;
   }
 }
 
@@ -255,9 +278,10 @@ export function declareLmdbLowLevelDatabase(options: {
     const now = performance.now();
     const elapsedMs = now - activityWindowStartedAt;
     const elapsedSeconds = elapsedMs / 1000;
-    const diagnostics = {
+    const storeSizeBytes = bulldozerDiagnosticsEnabled ? getStoreSizeBytes(options.path) : undefined;
+    const diagnostics: LmdbDiagnostics = {
       dbId,
-      ...(bulldozerDiagnosticsEnabled ? { storeSizeBytes: getStoreSizeBytes(options.path) } : {}),
+      ...(storeSizeBytes === undefined ? {} : { storeSizeBytes }),
       elapsedMs,
       putsPerSecond: activityStats.puts / elapsedSeconds,
       averagePutBytes: activityStats.puts === 0 ? 0 : activityStats.putBytes / activityStats.puts,
@@ -676,6 +700,7 @@ export function declareLmdbLowLevelDatabase(options: {
     close() {
       if (closePromise === null) {
         isClosing = true;
+        clearInterval(activityInterval);
         closePromise = traceSpanHot({ description: "bulldozer-js.low-level.lmdb.close", attributes: { "bulldozer.low_level.backend": "lmdb" } }, async () => {
           try {
             if (pendingCommitFlushPromise !== null) await pendingCommitFlushPromise;

--- a/apps/bulldozer-js/src/databases/low-level/implementations/lmdb.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/lmdb.ts
@@ -250,52 +250,52 @@ export function declareLmdbLowLevelDatabase(options: {
   };
   let activityStats = emptyActivityStats();
   let activityWindowStartedAt = performance.now();
-  if (!shouldSuppressPeriodicBulldozerLogs) {
-    const activityInterval = setInterval(() => {
-      if (!hasActivity(activityStats)) return;
-      const now = performance.now();
-      const elapsedMs = now - activityWindowStartedAt;
-      const elapsedSeconds = elapsedMs / 1000;
-      const diagnostics = {
-        dbId,
-        ...(bulldozerDiagnosticsEnabled ? { storeSizeBytes: getStoreSizeBytes(options.path) } : {}),
-        elapsedMs,
-        putsPerSecond: activityStats.puts / elapsedSeconds,
-        averagePutBytes: activityStats.puts === 0 ? 0 : activityStats.putBytes / activityStats.puts,
-        averagePutAwaitMs: activityStats.puts === 0 ? 0 : activityStats.putAwaitTotalMs / activityStats.puts,
-        transactionsPerSecond: activityStats.transactions / elapsedSeconds,
-        averageTransactionMs: activityStats.transactions === 0 ? 0 : activityStats.transactionTotalMs / activityStats.transactions,
-        averageTransactionQueueWaitMs: activityStats.transactions === 0 ? 0 : activityStats.transactionQueueWaitTotalMs / activityStats.transactions,
-        averageTransactionActionMs: activityStats.transactions === 0 ? 0 : activityStats.transactionActionTotalMs / activityStats.transactions,
-        averageMetaPutMs: activityStats.transactions === 0 ? 0 : activityStats.metaPutTotalMs / activityStats.transactions,
-        averageTransactionCommitTailMs: activityStats.transactions === 0 ? 0 : activityStats.transactionCommitTailTotalMs / activityStats.transactions,
-        requiredSeqWaitsPerSecond: activityStats.requiredSeqWaits / elapsedSeconds,
-        averageRequiredSeqWaitMs: activityStats.requiredSeqWaits === 0 ? 0 : activityStats.requiredSeqWaitTotalMs / activityStats.requiredSeqWaits,
-        waitUntilAvailableResolvesPerSecond: activityStats.waitUntilAvailableResolves / elapsedSeconds,
-        waitUntilDurableResolvesPerSecond: activityStats.waitUntilDurableResolves / elapsedSeconds,
-        averageSeqToAvailabilityResolveMs: activityStats.waitUntilAvailableResolves === 0 ? 0 : activityStats.waitUntilAvailableResolveTotalMs / activityStats.waitUntilAvailableResolves,
-        averageSeqToDurabilityResolveMs: activityStats.waitUntilDurableResolves === 0 ? 0 : activityStats.waitUntilDurableResolveTotalMs / activityStats.waitUntilDurableResolves,
-        combinedSeqAvailabilityResolvesPerSecond: activityStats.combinedSeqAvailabilityResolves / elapsedSeconds,
-        combinedSeqDurabilityResolvesPerSecond: activityStats.combinedSeqDurabilityResolves / elapsedSeconds,
-        averageCombinedSeqAvailabilityResolveMs: activityStats.combinedSeqAvailabilityResolves === 0 ? 0 : activityStats.combinedSeqAvailabilityResolveTotalMs / activityStats.combinedSeqAvailabilityResolves,
-        averageCombinedSeqDurabilityResolveMs: activityStats.combinedSeqDurabilityResolves === 0 ? 0 : activityStats.combinedSeqDurabilityResolveTotalMs / activityStats.combinedSeqDurabilityResolves,
-        mapSizes: {
-          seqToAvailability: seqToAvailability.size,
-          seqToDurability: seqToDurability.size,
-          combinedSeqToAvailability: combinedSeqToAvailability.size,
-          combinedSeqToDurability: combinedSeqToDurability.size,
-          combinedSeqDependencies: combinedSeqDependencies.size,
-          debugEntriesByStoreId: debugEntriesByStoreId.size,
-        },
-        currentVersion,
-      };
-      latestLmdbDiagnostics = diagnostics;
+  const activityInterval = setInterval(() => {
+    if (!hasActivity(activityStats)) return;
+    const now = performance.now();
+    const elapsedMs = now - activityWindowStartedAt;
+    const elapsedSeconds = elapsedMs / 1000;
+    const diagnostics = {
+      dbId,
+      ...(bulldozerDiagnosticsEnabled ? { storeSizeBytes: getStoreSizeBytes(options.path) } : {}),
+      elapsedMs,
+      putsPerSecond: activityStats.puts / elapsedSeconds,
+      averagePutBytes: activityStats.puts === 0 ? 0 : activityStats.putBytes / activityStats.puts,
+      averagePutAwaitMs: activityStats.puts === 0 ? 0 : activityStats.putAwaitTotalMs / activityStats.puts,
+      transactionsPerSecond: activityStats.transactions / elapsedSeconds,
+      averageTransactionMs: activityStats.transactions === 0 ? 0 : activityStats.transactionTotalMs / activityStats.transactions,
+      averageTransactionQueueWaitMs: activityStats.transactions === 0 ? 0 : activityStats.transactionQueueWaitTotalMs / activityStats.transactions,
+      averageTransactionActionMs: activityStats.transactions === 0 ? 0 : activityStats.transactionActionTotalMs / activityStats.transactions,
+      averageMetaPutMs: activityStats.transactions === 0 ? 0 : activityStats.metaPutTotalMs / activityStats.transactions,
+      averageTransactionCommitTailMs: activityStats.transactions === 0 ? 0 : activityStats.transactionCommitTailTotalMs / activityStats.transactions,
+      requiredSeqWaitsPerSecond: activityStats.requiredSeqWaits / elapsedSeconds,
+      averageRequiredSeqWaitMs: activityStats.requiredSeqWaits === 0 ? 0 : activityStats.requiredSeqWaitTotalMs / activityStats.requiredSeqWaits,
+      waitUntilAvailableResolvesPerSecond: activityStats.waitUntilAvailableResolves / elapsedSeconds,
+      waitUntilDurableResolvesPerSecond: activityStats.waitUntilDurableResolves / elapsedSeconds,
+      averageSeqToAvailabilityResolveMs: activityStats.waitUntilAvailableResolves === 0 ? 0 : activityStats.waitUntilAvailableResolveTotalMs / activityStats.waitUntilAvailableResolves,
+      averageSeqToDurabilityResolveMs: activityStats.waitUntilDurableResolves === 0 ? 0 : activityStats.waitUntilDurableResolveTotalMs / activityStats.waitUntilDurableResolves,
+      combinedSeqAvailabilityResolvesPerSecond: activityStats.combinedSeqAvailabilityResolves / elapsedSeconds,
+      combinedSeqDurabilityResolvesPerSecond: activityStats.combinedSeqDurabilityResolves / elapsedSeconds,
+      averageCombinedSeqAvailabilityResolveMs: activityStats.combinedSeqAvailabilityResolves === 0 ? 0 : activityStats.combinedSeqAvailabilityResolveTotalMs / activityStats.combinedSeqAvailabilityResolves,
+      averageCombinedSeqDurabilityResolveMs: activityStats.combinedSeqDurabilityResolves === 0 ? 0 : activityStats.combinedSeqDurabilityResolveTotalMs / activityStats.combinedSeqDurabilityResolves,
+      mapSizes: {
+        seqToAvailability: seqToAvailability.size,
+        seqToDurability: seqToDurability.size,
+        combinedSeqToAvailability: combinedSeqToAvailability.size,
+        combinedSeqToDurability: combinedSeqToDurability.size,
+        combinedSeqDependencies: combinedSeqDependencies.size,
+        debugEntriesByStoreId: debugEntriesByStoreId.size,
+      },
+      currentVersion,
+    };
+    latestLmdbDiagnostics = diagnostics;
+    if (!shouldSuppressPeriodicBulldozerLogs) {
       console.debug("bulldozer-js low-level lmdb activity", diagnostics);
-      activityStats = emptyActivityStats();
-      activityWindowStartedAt = now;
-    }, 5_000);
-    activityInterval.unref();
-  }
+    }
+    activityStats = emptyActivityStats();
+    activityWindowStartedAt = now;
+  }, 5_000);
+  activityInterval.unref();
   const initialSeq = [dbId, initialSeqId] as unknown as LmdbSeq;
   const toSeq = (seqId: string) => [dbId, seqId] as unknown as LmdbSeq;
 

--- a/apps/bulldozer-js/src/databases/low-level/implementations/lmdb.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/lmdb.ts
@@ -2,6 +2,7 @@ import { encodeBase64 } from "@hexclave/shared/dist/utils/bytes";
 import { wait } from "@hexclave/shared/dist/utils/promises";
 import { createUuidV7Generator } from "@hexclave/shared/dist/utils/uuids";
 import * as lmdb from "lmdb";
+import { readdirSync, statSync } from "node:fs";
 import { shouldSuppressPeriodicBulldozerLogs } from "../../../logging.js";
 import { traceSpanHot } from "../../../otel.js";
 import { DatabaseSeq } from "../../index.js";
@@ -111,6 +112,50 @@ type LmdbActivityStats = {
   combinedSeqDurabilityResolveTotalMs: number,
 };
 
+export type LmdbDiagnostics = {
+  dbId: string,
+  storeSizeBytes?: number,
+  elapsedMs: number,
+  putsPerSecond: number,
+  averagePutBytes: number,
+  averagePutAwaitMs: number,
+  transactionsPerSecond: number,
+  averageTransactionMs: number,
+  averageTransactionQueueWaitMs: number,
+  averageTransactionActionMs: number,
+  averageMetaPutMs: number,
+  averageTransactionCommitTailMs: number,
+  requiredSeqWaitsPerSecond: number,
+  averageRequiredSeqWaitMs: number,
+  waitUntilAvailableResolvesPerSecond: number,
+  waitUntilDurableResolvesPerSecond: number,
+  averageSeqToAvailabilityResolveMs: number,
+  averageSeqToDurabilityResolveMs: number,
+  combinedSeqAvailabilityResolvesPerSecond: number,
+  combinedSeqDurabilityResolvesPerSecond: number,
+  averageCombinedSeqAvailabilityResolveMs: number,
+  averageCombinedSeqDurabilityResolveMs: number,
+  currentVersion: number,
+};
+
+let latestLmdbDiagnostics: LmdbDiagnostics | null = null;
+const bulldozerDiagnosticsEnabled = process.env.HEXCLAVE_BULLDOZER_DIAGNOSTICS === "true";
+
+function getStoreSizeBytes(path: string): number {
+  try {
+    return readdirSync(path, { withFileTypes: true }).reduce((total, entry) => {
+      const entryPath = `${path}/${entry.name}`;
+      return total + (entry.isDirectory() ? getStoreSizeBytes(entryPath) : statSync(entryPath).size);
+    }, 0);
+  } catch {
+    return 0;
+  }
+}
+
+export function getLmdbDiagnostics(): LmdbDiagnostics | null {
+  return latestLmdbDiagnostics == null ? null : { ...latestLmdbDiagnostics };
+}
+
 function emptyActivityStats(): LmdbActivityStats {
   return {
     puts: 0,
@@ -211,8 +256,9 @@ export function declareLmdbLowLevelDatabase(options: {
       const now = performance.now();
       const elapsedMs = now - activityWindowStartedAt;
       const elapsedSeconds = elapsedMs / 1000;
-      console.debug("bulldozer-js low-level lmdb activity", {
+      const diagnostics = {
         dbId,
+        ...(bulldozerDiagnosticsEnabled ? { storeSizeBytes: getStoreSizeBytes(options.path) } : {}),
         elapsedMs,
         putsPerSecond: activityStats.puts / elapsedSeconds,
         averagePutBytes: activityStats.puts === 0 ? 0 : activityStats.putBytes / activityStats.puts,
@@ -242,7 +288,9 @@ export function declareLmdbLowLevelDatabase(options: {
           debugEntriesByStoreId: debugEntriesByStoreId.size,
         },
         currentVersion,
-      });
+      };
+      latestLmdbDiagnostics = diagnostics;
+      console.debug("bulldozer-js low-level lmdb activity", diagnostics);
       activityStats = emptyActivityStats();
       activityWindowStartedAt = now;
     }, 5_000);

--- a/apps/bulldozer-js/src/databases/low-level/implementations/lmdb.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/lmdb.ts
@@ -247,6 +247,7 @@ export function declareLmdbLowLevelDatabase(options: {
   let pendingCommitFlushTimer: ReturnType<typeof setTimeout> | null = null;
   let pendingCommitFlushPromise: Promise<void> | null = null;
   let isClosing = false;
+  let storeSizeDiagnosticsDisabled = false;
   let closePromise: Promise<void> | null = null;
   const inFlightReads = new Set<Promise<unknown>>();
   let readErrorDuringClose: unknown | undefined;
@@ -280,10 +281,12 @@ export function declareLmdbLowLevelDatabase(options: {
     const elapsedMs = now - activityWindowStartedAt;
     const elapsedSeconds = elapsedMs / 1000;
     let storeSizeBytes: number | undefined;
-    if (bulldozerDiagnosticsEnabled) {
+    if (bulldozerDiagnosticsEnabled && !storeSizeDiagnosticsDisabled) {
       try {
         storeSizeBytes = getStoreSizeBytes(options.path);
       } catch (error) {
+        // Disable sizing after the first unexpected failure so a persistent error cannot flood CI logs every 5 seconds.
+        storeSizeDiagnosticsDisabled = true;
         captureError("bulldozer-js:lmdb-diagnostics-store-size", error);
       }
     }

--- a/apps/bulldozer-js/src/index.ts
+++ b/apps/bulldozer-js/src/index.ts
@@ -14,7 +14,7 @@ import { isBulldozerRequestAuthorized } from "./auth.js";
 import { declareBulldozerDatabase, type BulldozerDatabase } from "./databases/bulldozer/index.js";
 import { declareInMemoryLowLevelDatabase } from "./databases/low-level/implementations/in-memory.js";
 import { declareInstantAvailabilityLowLevelDatabase } from "./databases/low-level/implementations/instant-availability.js";
-import { declareLmdbLowLevelDatabase } from "./databases/low-level/implementations/lmdb.js";
+import { declareLmdbLowLevelDatabase, getLmdbDiagnostics } from "./databases/low-level/implementations/lmdb.js";
 import type { LowLevelDatabase } from "./databases/low-level/index.js";
 import { declarePiledriverDatabase, type PiledriverObject } from "./databases/piledriver/index.js";
 import "./load-env.js";
@@ -972,6 +972,7 @@ const app = new Elysia({ adapter: node() })
     }
   })
   .get("/health", () => ({ ok: true }))
+  .get("/diagnostics", () => getLmdbDiagnostics() ?? { available: false })
   .get("/v1/manual-transactions", ({ query }) => handler("list-manual-transactions", async () => {
     // Cross-instance export surface: backend pages this to back up refunds into Prisma.
     const { limit, cursor } = parseManualTransactionsListQuery(query);

--- a/apps/bulldozer-js/src/logging.ts
+++ b/apps/bulldozer-js/src/logging.ts
@@ -3,6 +3,4 @@
 // they drown out the interesting output, and in CI (NODE_ENV=test) the e2e
 // suites fire thousands of bulldozer requests, producing ~100k lines that bury
 // the actual failure. Keep them only when NODE_ENV is neither of those.
-export const shouldSuppressPeriodicBulldozerLogs =
-  (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test")
-  && process.env.HEXCLAVE_BULLDOZER_DIAGNOSTICS !== "true";
+export const shouldSuppressPeriodicBulldozerLogs = process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";

--- a/apps/bulldozer-js/src/logging.ts
+++ b/apps/bulldozer-js/src/logging.ts
@@ -3,4 +3,6 @@
 // they drown out the interesting output, and in CI (NODE_ENV=test) the e2e
 // suites fire thousands of bulldozer requests, producing ~100k lines that bury
 // the actual failure. Keep them only when NODE_ENV is neither of those.
-export const shouldSuppressPeriodicBulldozerLogs = process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test";
+export const shouldSuppressPeriodicBulldozerLogs =
+  (process.env.NODE_ENV === "development" || process.env.NODE_ENV === "test")
+  && process.env.HEXCLAVE_BULLDOZER_DIAGNOSTICS !== "true";

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -51,6 +51,15 @@ const MAX_BRIDGE_RESPONSE_BYTES = 8 * 1024 * 1024;
 // below it, while runtime retirement bounds callbacks that outlive their job.
 const HOST_FETCH_TIMEOUT_MS = 5 * 60_000;
 const MAX_BRIDGE_REDIRECTS = 5;
+const requestMetrics = {
+  requests: 0,
+  completed: 0,
+  active: 0,
+  maxQueueDepth: 0,
+  totalDurationMs: 0,
+  maxDurationMs: 0,
+  durationBuckets: [0, 0, 0, 0, 0, 0],
+};
 const MODULE_CACHE_DIR =
   process.env.HEXCLAVE_FREESTYLE_MOCK_MODULE_CACHE_DIR || "/app/module-cache";
 const DEFAULT_NODE_MODULES_DIR = "/app/guest-node-modules/node_modules";
@@ -136,6 +145,42 @@ class QueueFullError extends ClientError {
   constructor() {
     super(429, "Execution queue is full");
   }
+}
+
+function recordRequestDuration(durationMs) {
+  requestMetrics.completed++;
+  requestMetrics.active--;
+  requestMetrics.totalDurationMs += durationMs;
+  requestMetrics.maxDurationMs = Math.max(requestMetrics.maxDurationMs, durationMs);
+  const bucket = durationMs < 100
+    ? 0
+    : durationMs < 500
+      ? 1
+      : durationMs < 1_000
+        ? 2
+        : durationMs < 5_000
+          ? 3
+          : durationMs < 30_000
+            ? 4
+            : 5;
+  requestMetrics.durationBuckets[bucket]++;
+}
+
+function readRequestMetrics() {
+  return {
+    ...requestMetrics,
+    durationBuckets: [...requestMetrics.durationBuckets],
+    queueDepth: jobQueue.queue.length,
+  };
+}
+
+function resetRequestMetrics() {
+  requestMetrics.requests = 0;
+  requestMetrics.completed = 0;
+  requestMetrics.maxQueueDepth = 0;
+  requestMetrics.totalDurationMs = 0;
+  requestMetrics.maxDurationMs = 0;
+  requestMetrics.durationBuckets.fill(0);
 }
 
 function formatError(error) {
@@ -1244,11 +1289,20 @@ const defaultEntry = await runtimeCache.acquire({
 runtimeCache.release(defaultEntry);
 
 const server = createServer(async (request, response) => {
+  const requestStartedAt = performance.now();
+  let trackedRequest = false;
   try {
     const url = new URL(
       request.url || "/",
       `http://${request.headers.host || "localhost"}`,
     );
+    if (request.method === "GET" && url.pathname === "/diagnostics") {
+      const responseBody = JSON.stringify(readRequestMetrics());
+      if (url.searchParams.get("reset") === "true") resetRequestMetrics();
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(responseBody);
+      return;
+    }
     const isExecutePath =
       request.method === "POST" &&
       /^\/execute\/v[123]\/script$/.test(url.pathname);
@@ -1257,6 +1311,9 @@ const server = createServer(async (request, response) => {
       response.end("Not found");
       return;
     }
+    trackedRequest = true;
+    requestMetrics.requests++;
+    requestMetrics.active++;
     const body = await readRequestBody(request);
     if (
       !body ||
@@ -1272,6 +1329,10 @@ const server = createServer(async (request, response) => {
         : {};
     config.nodeModules = normalizeNodeModules(config.nodeModules);
     const timeoutMs = resolveTimeout(config.timeout);
+    requestMetrics.maxQueueDepth = Math.max(
+      requestMetrics.maxQueueDepth,
+      jobQueue.queue.length,
+    );
     const result = await jobQueue.submit(body.script, config, timeoutMs);
     sendJson(response, result.statusCode, result.payload);
   } catch (error) {
@@ -1281,6 +1342,8 @@ const server = createServer(async (request, response) => {
     }
     logInternalError("request", error);
     sendJson(response, 500, { error: "Internal server error", logs: [] });
+  } finally {
+    if (trackedRequest) recordRequestDuration(performance.now() - requestStartedAt);
   }
 });
 

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -1184,6 +1184,10 @@ class JobQueue {
         settled: false,
         resolve,
       });
+      requestMetrics.maxQueueDepth = Math.max(
+        requestMetrics.maxQueueDepth,
+        this.queue.length,
+      );
       this.dispatch();
     });
   }
@@ -1329,10 +1333,6 @@ const server = createServer(async (request, response) => {
         : {};
     config.nodeModules = normalizeNodeModules(config.nodeModules);
     const timeoutMs = resolveTimeout(config.timeout);
-    requestMetrics.maxQueueDepth = Math.max(
-      requestMetrics.maxQueueDepth,
-      jobQueue.queue.length,
-    );
     const result = await jobQueue.submit(body.script, config, timeoutMs);
     sendJson(response, result.statusCode, result.payload);
   } catch (error) {


### PR DESCRIPTION
Keeps the parts of the e2e performance instrumentation that are worth having on every run, and leaves out everything that distorts what it measures.

**Kept**

- `timeout-minutes` on the three test passes. A post-suite vitest close-hang previously burned ~6 runner-hours per run *and* skipped the attribution snapshots; a bounded failure is strictly better.
- Per-pass machine-readable timings: `--reporter=default --reporter=json --outputFile=…`, tee'd to a log, vitest's exit status preserved via `PIPESTATUS`. Default reporter stays on so the console output is unchanged.
- Per-pass process/container attribution (`.github/scripts/process-attribution.sh`): per-process CPU + RSS, per-container CPU, block-device and per-container I/O deltas, alongside the existing PostgreSQL statement snapshots.
- `GET /diagnostics` on bulldozer-js (store size, commit tail, seq→durability latencies, map sizes) and on the freestyle mock (queue depth, duration histogram), captured per pass.
- Artifacts upload on `always()` rather than only on failure, with `if-no-files-found: warn` so a diagnostics hiccup can't fail an otherwise green run.
- `workflow_dispatch`, for manual reruns.

**Deliberately not kept:** span aggregation, forced trace sampling and Prisma instrumentation (~30% of backend CPU — it changes the thing it measures), CPU profiling, request correlation, the e2e client-side instrumentation, and the extra repeat passes.

Two behaviour notes:

- The LMDB activity snapshot interval now always runs so `/diagnostics` has something to serve; the periodic log line stays behind the existing `shouldSuppressPeriodicBulldozerLogs` check, so CI log volume is unchanged.
- `storeSizeBytes` walks the store directory, so it stays gated behind `HEXCLAVE_BULLDOZER_DIAGNOSTICS`, which is only set for the e2e job.


Link to Devin session: https://app.devin.ai/sessions/57e15d18ad4a40bfb57e9174cd1f9ca8
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI observability and test-only mock/diagnostics endpoints; bulldozer `/diagnostics` remains behind existing bearer auth, with minor always-on LMDB sampling overhead in e2e only.
> 
> **Overview**
> Extends the **E2E API** workflow so useful performance signals are captured on **every** run (not only failures), without reintroducing heavy instrumentation that skews measurements.
> 
> **CI workflow:** Adds `workflow_dispatch`, per-pass **timeouts** (60/75/105 min), and Vitest **JSON + tee** logs while preserving exit codes. New **`process-attribution.sh`** snapshots host CPU/load, labeled process CPU/RSS, block I/O, and Docker container CPU/I/O deltas around each test pass (paired with existing Postgres attribution). After each pass it curls **freestyle-mock** `GET /diagnostics?reset=true`; at the end it fetches **bulldozer** `/diagnostics` and uploads bulldozer logs, bulldozer diagnostics, and timing artifacts on **`always()`** with warn-if-missing.
> 
> **Bulldozer-js:** LMDB activity aggregation always runs (5s interval) so `/diagnostics` can return throughput/latency/map stats; periodic **console** logging stays gated. Optional **`HEXCLAVE_BULLDOZER_DIAGNOSTICS`** adds on-disk store size to that payload. E2E sets that env when starting bulldozer.
> 
> **Freestyle-mock:** Tracks execute-path queue depth and request duration histograms, exposed at unauthenticated **`GET /diagnostics`** with optional metric reset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce67edda4eb9b237c015a8b87a318defa322ca7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps lightweight e2e diagnostics on every push without skewing performance. Previously artifacts uploaded only on failures; now we capture per-pass timings and system attribution, bound test hangs, expose `/diagnostics`, and disable LMDB store-size collection after the first unexpected error to prevent log floods.

- CI
  - Add `.github/scripts/process-attribution.sh` with per-pass snapshots: labeled process CPU/RSS, per-container CPU and block I/O, per-device disk deltas, and host CPU/load; reset before pass 1.
  - Run Vitest with default + JSON reporter, tee’d logs, and per-pass timeouts (60/75/105 min); preserve exit codes; continue diagnostics on error; upload artifacts on `always()` with `if-no-files-found: warn`; add `workflow_dispatch`.
  - Capture `/diagnostics` from `bulldozer-js` (Bearer auth) and the freestyle mock after each pass; reset mock metrics after capture.

- Runtime behavior
  - `bulldozer-js`: add `/diagnostics` returning latest LMDB metrics; the sampler always runs so diagnostics stay fresh while console logging remains gated by `shouldSuppressPeriodicBulldozerLogs`. Include `storeSizeBytes` only when `HEXCLAVE_BULLDOZER_DIAGNOSTICS=true` (set in e2e); on unexpected store-size errors, call `captureError` once and disable sizing thereafter; ignore expected FS errors; clear the sampler interval on DB close.
  - Freestyle mock: add `/diagnostics` with queue depth and duration histogram; supports `?reset=true`.

<sup>Written for commit 3ffb0f617bd86fb0b6688e763a338a88bb3b86f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authenticated diagnostics for LMDB storage health, activity, capacity, and version information.
  - Added mock-server diagnostics for request counts, active requests, queue depth, and execution durations.
  - Added optional reset support for mock-server metrics.
  - Added manual triggering for end-to-end test workflows.

- **Bug Fixes**
  - Improved end-to-end test diagnostics with timeouts, log capture, process metrics, and troubleshooting artifacts.
  - Diagnostic collection continues when regular logging is suppressed.
  - Missing diagnostic files no longer cause workflow artifact uploads to fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->