### PR TITLE
Take the monthly email quota debit off the email send path

### DIFF
--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -8,7 +8,7 @@ import { getHexclaveServerApp } from "@/hexclave";
 import { ITEM_IDS } from "@hexclave/shared/dist/plans";
 import { getTenancy, Tenancy } from "@/lib/tenancies";
 import { getPrismaClientForTenancy, globalPrismaClient, retryTransaction, type PrismaClientTransaction } from "@/prisma-client";
-import { allPromisesAndWaitUntilEach } from "@/utils/background-tasks";
+import { allPromisesAndWaitUntilEach, runAsynchronouslyAndWaitUntil } from "@/utils/background-tasks";
 import { withTraceSpan } from "@/utils/telemetry";
 import { groupBy } from "@hexclave/shared/dist/utils/arrays";
 import { getEnvBoolean, getNodeEnvironment } from "@hexclave/shared/dist/utils/env";
@@ -785,8 +785,7 @@ async function processSingleEmail(context: TenancyProcessingContext, row: EmailO
       try {
         const app = getHexclaveServerApp();
         const emailItem = await app.getItem({ itemId: ITEM_IDS.emailsPerMonth, teamId: context.billingTeamId });
-        const isDebited = await emailItem.tryDecreaseQuantity(1);
-        if (!isDebited) {
+        if (emailItem.quantity < 1) {
           const errorMessage = "Monthly email sending limit exceeded for your plan. Please upgrade your plan or wait until next month.";
           // Intentionally do NOT increment sendRetries or append to
           // sendAttemptErrors. sendRetries tracks SMTP attempts, and a quota
@@ -822,6 +821,25 @@ async function processSingleEmail(context: TenancyProcessingContext, row: EmailO
           });
           return;
         }
+
+        // The gate is now a read, so concurrent in-flight sends can overshoot
+        // the monthly quota by a bounded amount. We accept that tradeoff to
+        // keep the potentially slow self-call off the send path; steady-state
+        // enforcement is unchanged.
+        runAsynchronouslyAndWaitUntil(async () => {
+          const isDebited = await emailItem.tryDecreaseQuantity(1);
+          if (!isDebited) {
+            captureError("email-queue-step:monthly-email-quota-debit-after-send", new HexclaveAssertionError(
+              "Email send passed the read-based monthly quota gate but its asynchronous quota debit was rejected",
+              {
+                emailId: row.id,
+                tenancyId: row.tenancyId,
+                billingTeamId: context.billingTeamId,
+                remainingQuotaAtGate: emailItem.quantity,
+              },
+            ));
+          }
+        });
       } catch (error) {
         captureError("email-queue-step:monthly-email-quota-check", error);
       }

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -827,15 +827,28 @@ async function processSingleEmail(context: TenancyProcessingContext, row: EmailO
         // keep the potentially slow self-call off the send path; steady-state
         // enforcement is unchanged.
         runAsynchronouslyAndWaitUntil(async () => {
-          const isDebited = await emailItem.tryDecreaseQuantity(1);
-          if (!isDebited) {
+          try {
+            const isDebited = await emailItem.tryDecreaseQuantity(1);
+            if (!isDebited) {
+              captureError("email-queue-step:monthly-email-quota-debit-after-send", new HexclaveAssertionError(
+                "Email send passed the read-based monthly quota gate but its asynchronous quota debit was rejected",
+                {
+                  emailId: row.id,
+                  tenancyId: row.tenancyId,
+                  billingTeamId: context.billingTeamId,
+                  remainingQuotaAtGate: emailItem.quantity,
+                },
+              ));
+            }
+          } catch (error) {
             captureError("email-queue-step:monthly-email-quota-debit-after-send", new HexclaveAssertionError(
-              "Email send passed the read-based monthly quota gate but its asynchronous quota debit was rejected",
+              "Email send passed the read-based monthly quota gate but its asynchronous quota debit failed",
               {
                 emailId: row.id,
                 tenancyId: row.tenancyId,
                 billingTeamId: context.billingTeamId,
                 remainingQuotaAtGate: emailItem.quantity,
+                cause: error,
               },
             ));
           }


### PR DESCRIPTION
The monthly-email quota debit in `processSingleEmail` was awaited between claiming an outbox row (`startedSendingAt` is stamped in `prepareSendPlan`) and actually sending it. `tryDecreaseQuantity` is a backend self-call over HTTP (`updateItemQuantity` + a cache refresh), and under load it measured 6-16s per email, so rows sat in `sending` for tens of seconds and the queue step's `send:` phase regularly hit 20-30s.

The gate now reads the quantity we already fetched, and the debit runs off the send path:

```ts
const emailItem = await app.getItem({ itemId: ITEM_IDS.emailsPerMonth, teamId: context.billingTeamId });
if (emailItem.quantity < 1) { /* unchanged terminal quota rejection */ }
runAsynchronouslyAndWaitUntil(async () => {
  if (!await emailItem.tryDecreaseQuantity(1)) captureError(...);
});
```

Tradeoff: the gate is a read rather than an atomic debit, so concurrent in-flight sends can overshoot the monthly quota by a bounded amount (a debit rejected after the fact is reported via `captureError`). Steady-state enforcement, the terminal rejection behavior/metadata, and the fail-open-when-bulldozer-is-unreachable behavior are unchanged.


Link to Devin session: https://app.devin.ai/sessions/2591db2286bd4bce89895b3c1f037c0e
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes billing quota enforcement timing on the email send path; overshoot is possible under concurrency though steady-state behavior and fail-open semantics are preserved.
> 
> **Overview**
> **Moves the monthly email quota debit off the hot send path** in `processSingleEmail` so outbox rows are not held in `sending` while waiting on a slow bulldozer `tryDecreaseQuantity` HTTP self-call (previously ~6–16s under load).
> 
> The quota **gate** still uses `getItem` for `emailsPerMonth`, but now rejects when **`emailItem.quantity < 1`** instead of blocking on an atomic debit. **`tryDecreaseQuantity(1)`** runs in **`runAsynchronouslyAndWaitUntil`** after the gate passes; a rejected async debit is logged via **`captureError`** (`monthly-email-quota-debit-after-send`). Terminal “limit exceeded” handling, fail-open when bulldozer is unreachable, and **`sendRetries === 0`** semantics are unchanged.
> 
> **Tradeoff:** the gate is read-only, so concurrent sends can **overshoot** the monthly cap by a bounded amount until async debits catch up.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84051583aa9dd2d9a12124a6aa153b44256ee9bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves monthly email quota debit off the send path to eliminate multi‑second latency per email. Previously we awaited `tryDecreaseQuantity(1)` before sending; now we gate on a read (`quantity < 1` rejects) and debit asynchronously after send, capturing both rejected debits and thrown failures with context.

- In-flight sends can overshoot the monthly quota; rejected or failed async debits are captured under key: email-queue-step:monthly-email-quota-debit-after-send. Steady-state enforcement, terminal rejection behavior/metadata, fail-open semantics, and `sendRetries` handling are unchanged.
- Review: confirm no awaits remain between `startedSendingAt` and SMTP send; verify `runAsynchronouslyAndWaitUntil` wraps the debit; check capture includes `emailId`, `tenancyId`, `billingTeamId`, and `remainingQuotaAtGate`.
- Monitoring: watch send-phase latency and alert on increases in the new capture key. No migrations or config changes.

<sup>Written for commit ee010372cd0b569df96636f781ed7bc4cc7f00c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monthly email quota handling by checking the latest available quantity before sending.
  * Email delivery is no longer unnecessarily delayed by quota updates.
  * Added improved error tracking for quota update failures, including relevant account and billing details for troubleshooting.
  * Quota-related failures are handled in the background so they do not interrupt email processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->