### PR TITLE
fix(external-db-sync): propagate EmailOutbox deletions to ClickHouse

### DIFF
--- a/apps/backend/src/lib/email-queue-step.test.tsx
+++ b/apps/backend/src/lib/email-queue-step.test.tsx
@@ -240,8 +240,8 @@ describe.sequential("claimEmailsForSending burst allowance", () => {
           tenancyId: row.tenancyId,
           emailOutboxId: row.id,
         });
+        await tx.emailOutbox.deleteMany({ where: { tenancyId: row.tenancyId, id: row.id } });
       }
-      await tx.emailOutbox.deleteMany({ where: testFilter });
     });
   });
 

--- a/apps/backend/src/lib/email-queue-step.test.tsx
+++ b/apps/backend/src/lib/email-queue-step.test.tsx
@@ -1,7 +1,8 @@
 import { BooleanTrue, EmailOutboxCreatedWith } from "@/generated/prisma/client";
-import { globalPrismaClient, type PrismaClientTransaction } from "@/prisma-client";
+import { globalPrismaClient, retryTransaction, type PrismaClientTransaction } from "@/prisma-client";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { randomUUID } from "node:crypto";
+import { recordExternalDbSyncDeletion } from "./external-db-sync";
 import { _forTesting } from "./email-queue-step";
 import { DEFAULT_BRANCH_ID, getSoleTenancyFromProjectBranch } from "./tenancies";
 
@@ -100,9 +101,17 @@ describe.sequential("failEmailsStuckInSending", () => {
   };
 
   afterAll(async () => {
-    for (const { tenancyId, id } of createdIds) {
-      await globalPrismaClient.emailOutbox.deleteMany({ where: { tenancyId, id } });
-    }
+    await retryTransaction(globalPrismaClient, async (tx) => {
+      for (const { tenancyId, id } of createdIds) {
+        // Deletions of synced tables only reach ClickHouse through DeletedRow.
+        await recordExternalDbSyncDeletion(tx, {
+          tableName: "EmailOutbox",
+          tenancyId,
+          emailOutboxId: id,
+        });
+        await tx.emailOutbox.deleteMany({ where: { tenancyId, id } });
+      }
+    });
   });
 
   it("marks a row as failed when startedSendingAt is older than the stuck timeout", async () => {
@@ -219,7 +228,21 @@ describe.sequential("claimEmailsForSending burst allowance", () => {
   };
 
   afterEach(async () => {
-    await globalPrismaClient.emailOutbox.deleteMany({ where: testFilter });
+    await retryTransaction(globalPrismaClient, async (tx) => {
+      const rows = await tx.emailOutbox.findMany({
+        where: testFilter,
+        select: { tenancyId: true, id: true },
+      });
+      for (const row of rows) {
+        // Deletions of synced tables only reach ClickHouse through DeletedRow.
+        await recordExternalDbSyncDeletion(tx, {
+          tableName: "EmailOutbox",
+          tenancyId: row.tenancyId,
+          emailOutboxId: row.id,
+        });
+      }
+      await tx.emailOutbox.deleteMany({ where: testFilter });
+    });
   });
 
   it("claims up to the burst limit when the rate quota is zero", async () => {

--- a/apps/backend/src/lib/external-db-sync-queue.test.ts
+++ b/apps/backend/src/lib/external-db-sync-queue.test.ts
@@ -1,12 +1,15 @@
 import { randomUUID } from "node:crypto";
-import { PrismaClient } from "@/generated/prisma/client";
+import { EmailOutboxCreatedWith, PrismaClient } from "@/generated/prisma/client";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { Pool } from "pg";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
-import { globalPrismaClient, globalPrismaSchema, sqlQuoteIdent } from "@/prisma-client";
+import { globalPrismaClient, globalPrismaSchema, retryTransaction, sqlQuoteIdent } from "@/prisma-client";
 import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { throwErr } from "@hexclave/shared/dist/utils/errors";
 import { enqueueExternalDbSync, enqueueExternalDbSyncBatch } from "./external-db-sync-queue";
+import { getClickhouseAdminClient } from "./clickhouse";
+import { recordExternalDbSyncDeletion, syncExternalDatabases } from "./external-db-sync";
+import { getSoleTenancyFromProjectBranch } from "./tenancies";
 
 const DEDUP_PREFIX = "sentinel-sync-key-";
 
@@ -172,6 +175,101 @@ describe("enqueueExternalDbSyncBatch (real DB, isolated schema)", () => {
 
       const rows = await findRowsForTenancies(ids);
       expect(rows).toHaveLength(BATCH_SIZE);
+    }
+  });
+});
+
+// Needs a real ClickHouse: without STACK_CLICKHOUSE_URL, syncExternalDatabases
+// skips the ClickHouse path and there is nothing to assert against.
+describe.skipIf(getEnvVariable("STACK_CLICKHOUSE_URL", "") === "")("recordExternalDbSyncDeletion (real DB)", () => {
+  it("writes an EmailOutbox tombstone that removes the row from ClickHouse", async () => {
+    const tenancy = await getSoleTenancyFromProjectBranch("internal", "main");
+    const id = randomUUID();
+    const clickhouse = getClickhouseAdminClient();
+    async function waitForClickhouseCount(expectedCount: number) {
+      for (let attempt = 0; attempt < 20; attempt += 1) {
+        const rows = await clickhouse.query({
+          query: `
+            SELECT count() AS count
+            FROM default.email_outboxes
+            WHERE project_id = 'internal' AND branch_id = 'main'
+              AND id = {id:UUID}
+          `,
+          query_params: { id },
+          format: "JSONEachRow",
+        }).then(async result => await result.json<{ count: string }>());
+        if (Number(rows[0]?.count ?? 0) === expectedCount) {
+          return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 250));
+      }
+      throw new Error(`Timed out waiting for ClickHouse count ${expectedCount}`);
+    }
+
+    await retryTransaction(globalPrismaClient, async (tx) => {
+      await tx.emailOutbox.create({
+        data: {
+          id,
+          tenancyId: tenancy.id,
+          tsxSource: `/* external-db-sync-test-${id} */`,
+          themeId: null,
+          isHighPriority: false,
+          to: { type: "custom-emails", emails: ["external-db-sync-test@example.com"] },
+          extraRenderVariables: {},
+          shouldSkipDeliverabilityCheck: true,
+          createdWith: EmailOutboxCreatedWith.PROGRAMMATIC_CALL,
+          scheduledAt: new Date(),
+          isQueued: true,
+          renderedByWorkerId: "00000000-0000-0000-0000-000000000000",
+          startedRenderingAt: new Date(),
+          finishedRenderingAt: new Date(),
+          renderedHtml: "<p>external DB sync test</p>",
+          renderedText: "external DB sync test",
+          renderedSubject: "external DB sync test",
+          renderedIsTransactional: false,
+          startedSendingAt: null,
+          finishedSendingAt: null,
+          sendRetries: 0,
+          nextSendRetryAt: null,
+          isPaused: true,
+        },
+      });
+    });
+
+    try {
+      await syncExternalDatabases(tenancy);
+      await waitForClickhouseCount(1);
+
+      await retryTransaction(globalPrismaClient, async (tx) => {
+        await recordExternalDbSyncDeletion(tx, {
+          tableName: "EmailOutbox",
+          tenancyId: tenancy.id,
+          emailOutboxId: id,
+        });
+        await tx.emailOutbox.delete({
+          where: { tenancyId_id: { tenancyId: tenancy.id, id } },
+        });
+      });
+
+      const tombstones = await globalPrismaClient.$queryRaw<{ primaryKey: { tenancyId: string, id: string } }[]>`
+        SELECT "primaryKey"
+        FROM "DeletedRow"
+        WHERE "tableName" = 'EmailOutbox'
+          AND "tenancyId" = ${tenancy.id}::uuid
+          AND "primaryKey"->>'id' = ${id}
+        ORDER BY "sequenceId" DESC
+        LIMIT 1
+      `;
+      expect(tombstones).toHaveLength(1);
+      expect(tombstones[0]?.primaryKey).toMatchObject({ tenancyId: tenancy.id, id });
+
+      await syncExternalDatabases(tenancy);
+      await waitForClickhouseCount(0);
+    } finally {
+      await globalPrismaClient.emailOutbox.deleteMany({
+        where: { tenancyId: tenancy.id, id },
+      });
+      await clickhouse.close();
     }
   });
 });

--- a/apps/backend/src/lib/external-db-sync-queue.test.ts
+++ b/apps/backend/src/lib/external-db-sync-queue.test.ts
@@ -183,15 +183,13 @@ describe("enqueueExternalDbSyncBatch (real DB, isolated schema)", () => {
 // skips the ClickHouse path and there is nothing to assert against.
 describe.skipIf(getEnvVariable("STACK_CLICKHOUSE_URL", "") === "")("recordExternalDbSyncDeletion (real DB)", () => {
   it("writes an EmailOutbox tombstone that removes the row from ClickHouse", async () => {
+    const clickhouse = getClickhouseAdminClient();
     const tenancy = await getSoleTenancyFromProjectBranch("internal", "main");
     const id = randomUUID();
-    let clickhouse: ReturnType<typeof getClickhouseAdminClient> | undefined;
 
     try {
-      clickhouse = getClickhouseAdminClient();
       async function waitForClickhouseCount(expectedCount: number) {
         for (let attempt = 0; attempt < 20; attempt += 1) {
-          await syncExternalDatabases(tenancy);
           const rows = await clickhouse.query({
             query: `
               SELECT count() AS count
@@ -280,7 +278,7 @@ describe.skipIf(getEnvVariable("STACK_CLICKHOUSE_URL", "") === "")("recordExtern
           where: { tenancyId: tenancy.id, id },
         });
       });
-      await clickhouse?.close();
+      await clickhouse.close();
     }
   });
 });

--- a/apps/backend/src/lib/external-db-sync-queue.test.ts
+++ b/apps/backend/src/lib/external-db-sync-queue.test.ts
@@ -248,6 +248,11 @@ describe("recordExternalDbSyncDeletion", () => {
       })).toBeNull();
     } finally {
       await retryTransaction(globalPrismaClient, async (tx) => {
+        await recordExternalDbSyncDeletion(tx, {
+          tableName: "EmailOutbox",
+          tenancyId,
+          emailOutboxId: id,
+        });
         await tx.emailOutbox.deleteMany({
           where: { tenancyId, id },
         });

--- a/apps/backend/src/lib/external-db-sync-queue.test.ts
+++ b/apps/backend/src/lib/external-db-sync-queue.test.ts
@@ -185,58 +185,61 @@ describe.skipIf(getEnvVariable("STACK_CLICKHOUSE_URL", "") === "")("recordExtern
   it("writes an EmailOutbox tombstone that removes the row from ClickHouse", async () => {
     const tenancy = await getSoleTenancyFromProjectBranch("internal", "main");
     const id = randomUUID();
-    const clickhouse = getClickhouseAdminClient();
-    async function waitForClickhouseCount(expectedCount: number) {
-      for (let attempt = 0; attempt < 20; attempt += 1) {
-        const rows = await clickhouse.query({
-          query: `
-            SELECT count() AS count
-            FROM default.email_outboxes
-            WHERE project_id = 'internal' AND branch_id = 'main'
-              AND id = {id:UUID}
-          `,
-          query_params: { id },
-          format: "JSONEachRow",
-        }).then(async result => await result.json<{ count: string }>());
-        if (Number(rows[0]?.count ?? 0) === expectedCount) {
-          return;
-        }
-        await new Promise(resolve => setTimeout(resolve, 250));
-      }
-      throw new Error(`Timed out waiting for ClickHouse count ${expectedCount}`);
-    }
-
-    await retryTransaction(globalPrismaClient, async (tx) => {
-      await tx.emailOutbox.create({
-        data: {
-          id,
-          tenancyId: tenancy.id,
-          tsxSource: `/* external-db-sync-test-${id} */`,
-          themeId: null,
-          isHighPriority: false,
-          to: { type: "custom-emails", emails: ["external-db-sync-test@example.com"] },
-          extraRenderVariables: {},
-          shouldSkipDeliverabilityCheck: true,
-          createdWith: EmailOutboxCreatedWith.PROGRAMMATIC_CALL,
-          scheduledAt: new Date(),
-          isQueued: true,
-          renderedByWorkerId: "00000000-0000-0000-0000-000000000000",
-          startedRenderingAt: new Date(),
-          finishedRenderingAt: new Date(),
-          renderedHtml: "<p>external DB sync test</p>",
-          renderedText: "external DB sync test",
-          renderedSubject: "external DB sync test",
-          renderedIsTransactional: false,
-          startedSendingAt: null,
-          finishedSendingAt: null,
-          sendRetries: 0,
-          nextSendRetryAt: null,
-          isPaused: true,
-        },
-      });
-    });
+    let clickhouse: ReturnType<typeof getClickhouseAdminClient> | undefined;
 
     try {
+      clickhouse = getClickhouseAdminClient();
+      async function waitForClickhouseCount(expectedCount: number) {
+        for (let attempt = 0; attempt < 20; attempt += 1) {
+          await syncExternalDatabases(tenancy);
+          const rows = await clickhouse.query({
+            query: `
+              SELECT count() AS count
+              FROM default.email_outboxes
+              WHERE project_id = 'internal' AND branch_id = 'main'
+                AND id = {id:UUID}
+            `,
+            query_params: { id },
+            format: "JSONEachRow",
+          }).then(async result => await result.json<{ count: string }>());
+          if (Number(rows[0]?.count ?? 0) === expectedCount) {
+            return;
+          }
+          await new Promise(resolve => setTimeout(resolve, 250));
+        }
+        throw new Error(`Timed out waiting for ClickHouse count ${expectedCount}`);
+      }
+
+      await retryTransaction(globalPrismaClient, async (tx) => {
+        await tx.emailOutbox.create({
+          data: {
+            id,
+            tenancyId: tenancy.id,
+            tsxSource: `/* external-db-sync-test-${id} */`,
+            themeId: null,
+            isHighPriority: false,
+            to: { type: "custom-emails", emails: ["external-db-sync-test@example.com"] },
+            extraRenderVariables: {},
+            shouldSkipDeliverabilityCheck: true,
+            createdWith: EmailOutboxCreatedWith.PROGRAMMATIC_CALL,
+            scheduledAt: new Date(),
+            isQueued: true,
+            renderedByWorkerId: "00000000-0000-0000-0000-000000000000",
+            startedRenderingAt: new Date(),
+            finishedRenderingAt: new Date(),
+            renderedHtml: "<p>external DB sync test</p>",
+            renderedText: "external DB sync test",
+            renderedSubject: "external DB sync test",
+            renderedIsTransactional: false,
+            startedSendingAt: null,
+            finishedSendingAt: null,
+            sendRetries: 0,
+            nextSendRetryAt: null,
+            isPaused: true,
+          },
+        });
+      });
+
       await syncExternalDatabases(tenancy);
       await waitForClickhouseCount(1);
 
@@ -251,6 +254,7 @@ describe.skipIf(getEnvVariable("STACK_CLICKHOUSE_URL", "") === "")("recordExtern
         });
       });
 
+      // Read from primary because the tombstone was just committed and replica lag would make this assertion flaky.
       const tombstones = await globalPrismaClient.$queryRaw<{ primaryKey: { tenancyId: string, id: string } }[]>`
         SELECT "primaryKey"
         FROM "DeletedRow"
@@ -266,10 +270,17 @@ describe.skipIf(getEnvVariable("STACK_CLICKHOUSE_URL", "") === "")("recordExtern
       await syncExternalDatabases(tenancy);
       await waitForClickhouseCount(0);
     } finally {
-      await globalPrismaClient.emailOutbox.deleteMany({
-        where: { tenancyId: tenancy.id, id },
+      await retryTransaction(globalPrismaClient, async (tx) => {
+        await recordExternalDbSyncDeletion(tx, {
+          tableName: "EmailOutbox",
+          tenancyId: tenancy.id,
+          emailOutboxId: id,
+        });
+        await tx.emailOutbox.deleteMany({
+          where: { tenancyId: tenancy.id, id },
+        });
       });
-      await clickhouse.close();
+      await clickhouse?.close();
     }
   });
 });

--- a/apps/backend/src/lib/external-db-sync-queue.test.ts
+++ b/apps/backend/src/lib/external-db-sync-queue.test.ts
@@ -7,8 +7,7 @@ import { globalPrismaClient, globalPrismaSchema, retryTransaction, sqlQuoteIdent
 import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { throwErr } from "@hexclave/shared/dist/utils/errors";
 import { enqueueExternalDbSync, enqueueExternalDbSyncBatch } from "./external-db-sync-queue";
-import { getClickhouseAdminClient } from "./clickhouse";
-import { recordExternalDbSyncDeletion, syncExternalDatabases } from "./external-db-sync";
+import { recordExternalDbSyncDeletion } from "./external-db-sync";
 import { getSoleTenancyFromProjectBranch } from "./tenancies";
 
 const DEDUP_PREFIX = "sentinel-sync-key-";
@@ -179,106 +178,80 @@ describe("enqueueExternalDbSyncBatch (real DB, isolated schema)", () => {
   });
 });
 
-// Needs a real ClickHouse: without STACK_CLICKHOUSE_URL, syncExternalDatabases
-// skips the ClickHouse path and there is nothing to assert against.
-describe.skipIf(getEnvVariable("STACK_CLICKHOUSE_URL", "") === "")("recordExternalDbSyncDeletion (real DB)", () => {
-  it("writes an EmailOutbox tombstone that removes the row from ClickHouse", async () => {
-    const tenancy = await getSoleTenancyFromProjectBranch("internal", "main");
+describe("recordExternalDbSyncDeletion", () => {
+  it("writes an EmailOutbox tombstone with the complete primary key in the delete transaction", async () => {
+    const tenancyId = (await getSoleTenancyFromProjectBranch("internal", "main")).id;
     const id = randomUUID();
-    const clickhouse = getClickhouseAdminClient();
+
+    await retryTransaction(globalPrismaClient, async (tx) => {
+      await tx.emailOutbox.create({
+        data: {
+          id,
+          tenancyId,
+          tsxSource: `/* external-db-sync-test-${id} */`,
+          themeId: null,
+          isHighPriority: false,
+          to: { type: "custom-emails", emails: ["external-db-sync-test@example.com"] },
+          extraRenderVariables: {},
+          shouldSkipDeliverabilityCheck: true,
+          createdWith: EmailOutboxCreatedWith.PROGRAMMATIC_CALL,
+          scheduledAt: new Date(),
+          isQueued: true,
+          renderedByWorkerId: "00000000-0000-0000-0000-000000000000",
+          startedRenderingAt: new Date(),
+          finishedRenderingAt: new Date(),
+          renderedHtml: "<p>external DB sync test</p>",
+          renderedText: "external DB sync test",
+          renderedSubject: "external DB sync test",
+          renderedIsTransactional: false,
+          startedSendingAt: null,
+          finishedSendingAt: null,
+          sendRetries: 0,
+          nextSendRetryAt: null,
+          isPaused: true,
+        },
+      });
+    });
 
     try {
-      async function waitForClickhouseCount(expectedCount: number) {
-        for (let attempt = 0; attempt < 20; attempt += 1) {
-          const rows = await clickhouse.query({
-            query: `
-              SELECT count() AS count
-              FROM default.email_outboxes
-              WHERE project_id = 'internal' AND branch_id = 'main'
-                AND id = {id:UUID}
-            `,
-            query_params: { id },
-            format: "JSONEachRow",
-          }).then(async result => await result.json<{ count: string }>());
-          if (Number(rows[0]?.count ?? 0) === expectedCount) {
-            return;
-          }
-          await new Promise(resolve => setTimeout(resolve, 250));
-        }
-        throw new Error(`Timed out waiting for ClickHouse count ${expectedCount}`);
-      }
-
-      await retryTransaction(globalPrismaClient, async (tx) => {
-        await tx.emailOutbox.create({
-          data: {
-            id,
-            tenancyId: tenancy.id,
-            tsxSource: `/* external-db-sync-test-${id} */`,
-            themeId: null,
-            isHighPriority: false,
-            to: { type: "custom-emails", emails: ["external-db-sync-test@example.com"] },
-            extraRenderVariables: {},
-            shouldSkipDeliverabilityCheck: true,
-            createdWith: EmailOutboxCreatedWith.PROGRAMMATIC_CALL,
-            scheduledAt: new Date(),
-            isQueued: true,
-            renderedByWorkerId: "00000000-0000-0000-0000-000000000000",
-            startedRenderingAt: new Date(),
-            finishedRenderingAt: new Date(),
-            renderedHtml: "<p>external DB sync test</p>",
-            renderedText: "external DB sync test",
-            renderedSubject: "external DB sync test",
-            renderedIsTransactional: false,
-            startedSendingAt: null,
-            finishedSendingAt: null,
-            sendRetries: 0,
-            nextSendRetryAt: null,
-            isPaused: true,
-          },
-        });
-      });
-
-      await syncExternalDatabases(tenancy);
-      await waitForClickhouseCount(1);
-
       await retryTransaction(globalPrismaClient, async (tx) => {
         await recordExternalDbSyncDeletion(tx, {
           tableName: "EmailOutbox",
-          tenancyId: tenancy.id,
+          tenancyId,
           emailOutboxId: id,
         });
         await tx.emailOutbox.delete({
-          where: { tenancyId_id: { tenancyId: tenancy.id, id } },
+          where: { tenancyId_id: { tenancyId, id } },
         });
       });
 
       // Read from primary because the tombstone was just committed and replica lag would make this assertion flaky.
-      const tombstones = await globalPrismaClient.$queryRaw<{ primaryKey: { tenancyId: string, id: string } }[]>`
-        SELECT "primaryKey"
+      const tombstones = await globalPrismaClient.$queryRaw<{
+        primaryKey: { tenancyId: string, id: string },
+        shouldUpdateSequenceId: boolean,
+      }[]>`
+        SELECT "primaryKey", "shouldUpdateSequenceId"
         FROM "DeletedRow"
         WHERE "tableName" = 'EmailOutbox'
-          AND "tenancyId" = ${tenancy.id}::uuid
+          AND "tenancyId" = ${tenancyId}::uuid
           AND "primaryKey"->>'id' = ${id}
         ORDER BY "sequenceId" DESC
         LIMIT 1
       `;
       expect(tombstones).toHaveLength(1);
-      expect(tombstones[0]?.primaryKey).toMatchObject({ tenancyId: tenancy.id, id });
-
-      await syncExternalDatabases(tenancy);
-      await waitForClickhouseCount(0);
+      expect(tombstones[0]).toMatchObject({
+        primaryKey: { tenancyId, id },
+        shouldUpdateSequenceId: true,
+      });
+      expect(await globalPrismaClient.emailOutbox.findUnique({
+        where: { tenancyId_id: { tenancyId, id } },
+      })).toBeNull();
     } finally {
       await retryTransaction(globalPrismaClient, async (tx) => {
-        await recordExternalDbSyncDeletion(tx, {
-          tableName: "EmailOutbox",
-          tenancyId: tenancy.id,
-          emailOutboxId: id,
-        });
         await tx.emailOutbox.deleteMany({
-          where: { tenancyId: tenancy.id, id },
+          where: { tenancyId, id },
         });
       });
-      await clickhouse.close();
     }
   });
 });

--- a/apps/backend/src/lib/external-db-sync-queue.test.ts
+++ b/apps/backend/src/lib/external-db-sync-queue.test.ts
@@ -183,9 +183,9 @@ describe("enqueueExternalDbSyncBatch (real DB, isolated schema)", () => {
 // skips the ClickHouse path and there is nothing to assert against.
 describe.skipIf(getEnvVariable("STACK_CLICKHOUSE_URL", "") === "")("recordExternalDbSyncDeletion (real DB)", () => {
   it("writes an EmailOutbox tombstone that removes the row from ClickHouse", async () => {
-    const clickhouse = getClickhouseAdminClient();
     const tenancy = await getSoleTenancyFromProjectBranch("internal", "main");
     const id = randomUUID();
+    const clickhouse = getClickhouseAdminClient();
 
     try {
       async function waitForClickhouseCount(expectedCount: number) {

--- a/apps/backend/src/lib/external-db-sync.ts
+++ b/apps/backend/src/lib/external-db-sync.ts
@@ -38,6 +38,11 @@ type ExternalDbSyncTarget =
     projectUserId: string,
   }
   | {
+    tableName: "EmailOutbox",
+    tenancyId: string,
+    emailOutboxId: string,
+  }
+  | {
     tableName: "ContactChannel",
     tenancyId: string,
     projectUserId: string,
@@ -148,6 +153,35 @@ export async function recordExternalDbSyncDeletion(
       FROM "ProjectUser"
       WHERE "tenancyId" = ${target.tenancyId}::uuid
         AND "projectUserId" = ${target.projectUserId}::uuid
+      FOR UPDATE
+    `);
+
+    return;
+  }
+
+  if (target.tableName === "EmailOutbox") {
+    assertUuid(target.emailOutboxId, "emailOutboxId");
+    await tx.$executeRaw(Prisma.sql`
+      INSERT INTO "DeletedRow" (
+        "id",
+        "tenancyId",
+        "tableName",
+        "primaryKey",
+        "data",
+        "deletedAt",
+        "shouldUpdateSequenceId"
+      )
+      SELECT
+        gen_random_uuid(),
+        "tenancyId",
+        'EmailOutbox',
+        jsonb_build_object('tenancyId', "tenancyId", 'id', "id"),
+        to_jsonb("EmailOutbox".*),
+        NOW(),
+        TRUE
+      FROM "EmailOutbox"
+      WHERE "tenancyId" = ${target.tenancyId}::uuid
+        AND "id" = ${target.emailOutboxId}::uuid
       FOR UPDATE
     `);
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
@@ -5,7 +5,6 @@ import { niceFetch, STACK_BACKEND_BASE_URL, test } from '../../../../helpers';
 import { withPortPrefix } from '../../../../helpers/ports';
 import { Auth, backendContext, InternalApiKey, Project, User, niceBackendFetch } from '../../../backend-helpers';
 import { randomUUID } from 'node:crypto';
-import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import {
   TEST_TIMEOUT,
   TestDbManager,

--- a/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
@@ -1,10 +1,12 @@
-import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+import { HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { wait } from "@hexclave/shared/dist/utils/promises";
 import { afterAll, beforeAll, describe, expect } from 'vitest';
+import { Client } from "pg";
 import { niceFetch, STACK_BACKEND_BASE_URL, test } from '../../../../helpers';
 import { withPortPrefix } from '../../../../helpers/ports';
 import { Auth, backendContext, InternalApiKey, Project, User, niceBackendFetch } from '../../../backend-helpers';
 import { randomUUID } from 'node:crypto';
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import {
   TEST_TIMEOUT,
   TestDbManager,
@@ -97,6 +99,66 @@ async function waitForClickhouseUserDeletion(email: string) {
   }
 
   throw new HexclaveAssertionError(`Timed out waiting for ClickHouse user ${email} to be deleted.`, { response });
+}
+
+async function waitForClickhouseEmailOutboxDeletion(id: string) {
+  await InternalApiKey.createAndSetProjectKeys();
+
+  const timeoutMs = 180_000;
+  const intervalMs = 2_000;
+  const start = performance.now();
+
+  let response;
+  while (performance.now() - start < timeoutMs) {
+    response = await runQueryForCurrentProject({
+      query: "SELECT id FROM email_outboxes WHERE id = {id:UUID}",
+      params: { id },
+    });
+    expect(response.status).toBe(200);
+    if (response.body.result.length === 0) {
+      return response;
+    }
+    await wait(intervalMs);
+  }
+
+  throw new HexclaveAssertionError(`Timed out waiting for ClickHouse email outbox ${id} to be deleted.`, { response });
+}
+
+async function waitForClickhouseEmailOutbox(id: string) {
+  await InternalApiKey.createAndSetProjectKeys();
+
+  const timeoutMs = 180_000;
+  const intervalMs = 2_000;
+  const start = performance.now();
+
+  let response;
+  while (performance.now() - start < timeoutMs) {
+    response = await runQueryForCurrentProject({
+      query: "SELECT id FROM email_outboxes WHERE id = {id:UUID}",
+      params: { id },
+    });
+    expect(response.status).toBe(200);
+    if (response.body.result.length === 1) {
+      return response;
+    }
+    await wait(intervalMs);
+  }
+
+  throw new HexclaveAssertionError(`Timed out waiting for ClickHouse email outbox ${id} to sync.`, { response });
+}
+
+async function withInternalDatabase<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client({
+    connectionString: getEnvVariable("STACK_DATABASE_CONNECTION_STRING", ""),
+    connectionTimeoutMillis: 10_000,
+    query_timeout: 30_000,
+  });
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    await client.end();
+  }
 }
 
 // Run tests sequentially to avoid concurrency issues with shared backend state
@@ -1497,6 +1559,108 @@ describe.sequential('External DB Sync - Basic Tests', () => {
     expect(response!.body.result.length).toBeGreaterThanOrEqual(1);
     const row = response!.body.result[0];
     expect(row.created_with).toBe('programmatic-call');
+  }, TEST_TIMEOUT);
+
+  test('Deleted EmailOutbox is removed from ClickHouse', async ({ expect }) => {
+    const connectionString = await dbManager.createDatabase("email_outbox_delete_test");
+    const project = await createProjectWithExternalDb({
+      main: {
+        type: "postgres",
+        connectionString,
+      },
+    }, {
+      config: {
+        magic_link_enabled: true,
+        email_config: {
+          type: "standard",
+          host: "localhost",
+          port: Number(withPortPrefix("29")),
+          username: "test",
+          password: "test",
+          sender_name: "Test Project",
+          sender_email: "test@example.com",
+        },
+      },
+    });
+
+    const createUserResponse = await niceBackendFetch("/api/v1/users", {
+      method: "POST",
+      accessType: "server",
+      body: {
+        primary_email: backendContext.value.mailbox.emailAddress,
+        primary_email_verified: true,
+      },
+    });
+    expect(createUserResponse.status).toBe(201);
+
+    const sendResponse = await niceBackendFetch("/api/v1/emails/send-email", {
+      method: "POST",
+      accessType: "server",
+      body: {
+        user_ids: [createUserResponse.body.id],
+        html: "<p>ClickHouse deletion test email</p>",
+        subject: "CH Deletion Test Email",
+        notification_category_name: "Transactional",
+      },
+    });
+    expect(sendResponse.status).toBe(200);
+
+    let emailId!: string;
+    await waitForCondition(
+      async () => {
+        const listResponse = await niceBackendFetch("/api/v1/emails/outbox", {
+          method: "GET",
+          accessType: "server",
+        });
+        if (listResponse.status !== 200 || listResponse.body.items.length === 0) return false;
+        emailId = listResponse.body.items[0].id;
+        return true;
+      },
+      { timeoutMs: 30_000, intervalMs: 500, description: "email to appear in outbox" },
+    );
+
+    await InternalApiKey.createAndSetProjectKeys();
+    await waitForClickhouseEmailOutbox(emailId);
+
+    await withInternalDatabase(async (client) => {
+      const tenancy = await client.query<{ id: string }>(
+        `SELECT "id" FROM "Tenancy" WHERE "projectId" = $1 AND "branchId" = 'main' LIMIT 1`,
+        [project.projectId],
+      );
+      const tenancyId = tenancy.rows[0]?.id ?? throwErr(`No main tenancy found for project ${project.projectId}`);
+
+      await client.query("BEGIN");
+      try {
+        await client.query(
+          `
+            INSERT INTO "DeletedRow"
+              ("id", "tenancyId", "tableName", "primaryKey", "data", "deletedAt", "shouldUpdateSequenceId")
+            SELECT
+              gen_random_uuid(),
+              "tenancyId",
+              'EmailOutbox',
+              jsonb_build_object('tenancyId', "tenancyId", 'id', "id"),
+              to_jsonb("EmailOutbox".*),
+              NOW(),
+              TRUE
+            FROM "EmailOutbox"
+            WHERE "tenancyId" = $1::uuid AND "id" = $2::uuid
+            FOR UPDATE
+          `,
+          [tenancyId, emailId],
+        );
+        await client.query(
+          `DELETE FROM "EmailOutbox" WHERE "tenancyId" = $1::uuid AND "id" = $2::uuid`,
+          [tenancyId, emailId],
+        );
+        await client.query("COMMIT");
+      } catch (error) {
+        await client.query("ROLLBACK");
+        throw error;
+      }
+    });
+
+    await waitForClickhouseEmailOutboxDeletion(emailId);
   }, TEST_TIMEOUT);
 
   /**

--- a/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
@@ -1,7 +1,6 @@
 import { HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { wait } from "@hexclave/shared/dist/utils/promises";
 import { afterAll, beforeAll, describe, expect } from 'vitest';
-import { Client } from "pg";
 import { niceFetch, STACK_BACKEND_BASE_URL, test } from '../../../../helpers';
 import { withPortPrefix } from '../../../../helpers/ports';
 import { Auth, backendContext, InternalApiKey, Project, User, niceBackendFetch } from '../../../backend-helpers';
@@ -36,7 +35,9 @@ import {
   waitForSyncedProjectPermissionDeletion,
   waitForCondition,
   waitForSyncedNotificationPreference,
-  waitForTable
+  waitForTable,
+  deleteSyncedRowsWithTombstones,
+  withInternalDatabase,
 } from './external-db-sync-utils';
 
 async function runQueryForCurrentProject(body: { query: string, params?: Record<string, string>, timeout_ms?: number }) {
@@ -101,64 +102,26 @@ async function waitForClickhouseUserDeletion(email: string) {
   throw new HexclaveAssertionError(`Timed out waiting for ClickHouse user ${email} to be deleted.`, { response });
 }
 
-async function waitForClickhouseEmailOutboxDeletion(id: string) {
+async function waitForClickhouseEmailOutbox(id: string, expectedCount: number, deadline: number) {
   await InternalApiKey.createAndSetProjectKeys();
 
-  const timeoutMs = 180_000;
   const intervalMs = 2_000;
-  const start = performance.now();
 
   let response;
-  while (performance.now() - start < timeoutMs) {
+  while (performance.now() < deadline) {
     response = await runQueryForCurrentProject({
       query: "SELECT id FROM email_outboxes WHERE id = {id:UUID}",
       params: { id },
     });
     expect(response.status).toBe(200);
-    if (response.body.result.length === 0) {
+    if (response.body.result.length === expectedCount) {
       return response;
     }
     await wait(intervalMs);
   }
 
-  throw new HexclaveAssertionError(`Timed out waiting for ClickHouse email outbox ${id} to be deleted.`, { response });
-}
-
-async function waitForClickhouseEmailOutbox(id: string) {
-  await InternalApiKey.createAndSetProjectKeys();
-
-  const timeoutMs = 180_000;
-  const intervalMs = 2_000;
-  const start = performance.now();
-
-  let response;
-  while (performance.now() - start < timeoutMs) {
-    response = await runQueryForCurrentProject({
-      query: "SELECT id FROM email_outboxes WHERE id = {id:UUID}",
-      params: { id },
-    });
-    expect(response.status).toBe(200);
-    if (response.body.result.length === 1) {
-      return response;
-    }
-    await wait(intervalMs);
-  }
-
-  throw new HexclaveAssertionError(`Timed out waiting for ClickHouse email outbox ${id} to sync.`, { response });
-}
-
-async function withInternalDatabase<T>(fn: (client: Client) => Promise<T>): Promise<T> {
-  const client = new Client({
-    connectionString: getEnvVariable("STACK_DATABASE_CONNECTION_STRING", ""),
-    connectionTimeoutMillis: 10_000,
-    query_timeout: 30_000,
-  });
-  await client.connect();
-  try {
-    return await fn(client);
-  } finally {
-    await client.end();
-  }
+  const state = expectedCount === 0 ? "to be deleted" : "to sync";
+  throw new HexclaveAssertionError(`Timed out waiting for ClickHouse email outbox ${id} ${state}.`, { response });
 }
 
 // Run tests sequentially to avoid concurrency issues with shared backend state
@@ -1619,9 +1582,12 @@ describe.sequential('External DB Sync - Basic Tests', () => {
       { timeoutMs: 30_000, intervalMs: 500, description: "email to appear in outbox" },
     );
 
+    // Both ClickHouse assertions share this budget so the helper reports a useful failure before TEST_TIMEOUT.
+    const clickhouseDeadline = performance.now() + 180_000;
     await InternalApiKey.createAndSetProjectKeys();
-    await waitForClickhouseEmailOutbox(emailId);
+    await waitForClickhouseEmailOutbox(emailId, 1, clickhouseDeadline);
 
+    // No production endpoint deletes EmailOutbox rows, so e2e cannot drive this over HTTP; the tombstone shape is pinned by the backend unit test.
     await withInternalDatabase(async (client) => {
       const tenancy = await client.query<{ id: string }>(
         `SELECT "id" FROM "Tenancy" WHERE "projectId" = $1 AND "branchId" = 'main' LIMIT 1`,
@@ -1629,38 +1595,14 @@ describe.sequential('External DB Sync - Basic Tests', () => {
       );
       const tenancyId = tenancy.rows[0]?.id ?? throwErr(`No main tenancy found for project ${project.projectId}`);
 
-      await client.query("BEGIN");
-      try {
-        await client.query(
-          `
-            INSERT INTO "DeletedRow"
-              ("id", "tenancyId", "tableName", "primaryKey", "data", "deletedAt", "shouldUpdateSequenceId")
-            SELECT
-              gen_random_uuid(),
-              "tenancyId",
-              'EmailOutbox',
-              jsonb_build_object('tenancyId', "tenancyId", 'id', "id"),
-              to_jsonb("EmailOutbox".*),
-              NOW(),
-              TRUE
-            FROM "EmailOutbox"
-            WHERE "tenancyId" = $1::uuid AND "id" = $2::uuid
-            FOR UPDATE
-          `,
-          [tenancyId, emailId],
-        );
-        await client.query(
-          `DELETE FROM "EmailOutbox" WHERE "tenancyId" = $1::uuid AND "id" = $2::uuid`,
-          [tenancyId, emailId],
-        );
-        await client.query("COMMIT");
-      } catch (error) {
-        await client.query("ROLLBACK");
-        throw error;
-      }
+      await deleteSyncedRowsWithTombstones(client, {
+        table: "EmailOutbox",
+        whereClause: `"tenancyId" = $1::uuid AND "id" = $2::uuid`,
+        values: [tenancyId, emailId],
+      });
     });
 
-    await waitForClickhouseEmailOutboxDeletion(emailId);
+    await waitForClickhouseEmailOutbox(emailId, 0, clickhouseDeadline);
   }, TEST_TIMEOUT);
 
   /**

--- a/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-utils.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-utils.ts
@@ -1,5 +1,7 @@
 import { Client, ClientConfig } from 'pg';
 import { expect } from 'vitest';
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
+import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { niceFetch, STACK_BACKEND_BASE_URL } from '../../../../helpers';
 import { InternalApiKey, Project } from '../../../backend-helpers';
 
@@ -10,6 +12,69 @@ export const POSTGRES_USER = process.env.EXTERNAL_DB_TEST_USER || 'postgres';
 export const POSTGRES_PASSWORD = process.env.EXTERNAL_DB_TEST_PASSWORD || 'PASSWORD-PLACEHOLDER--uqfEC1hmmv';
 export const TEST_TIMEOUT = 240000;
 export const HIGH_VOLUME_TIMEOUT = 600000; // 10 minutes for 1500+ users
+
+function getInternalDatabaseConnectionString(): string {
+  const connectionString = getEnvVariable(
+    "HEXCLAVE_DATABASE_CONNECTION_STRING",
+    getEnvVariable("STACK_DATABASE_CONNECTION_STRING", ""),
+  );
+  if (connectionString === "") {
+    throw new HexclaveAssertionError("E2E tests require a configured internal database connection string");
+  }
+  return connectionString;
+}
+
+export async function withInternalDatabase<T>(fn: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client({
+    connectionString: getInternalDatabaseConnectionString(),
+    connectionTimeoutMillis: 10_000,
+    query_timeout: 30_000,
+  });
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    await client.end();
+  }
+}
+
+const syncedCleanupTableConfig = {
+  EmailOutbox: {
+    primaryKey: `jsonb_build_object('tenancyId', "tenancyId", 'id', "id")`,
+  },
+  ProjectUser: {
+    primaryKey: `jsonb_build_object('tenancyId', "tenancyId", 'projectUserId', "projectUserId")`,
+  },
+} as const;
+
+export async function deleteSyncedRowsWithTombstones(client: Client, options: {
+  table: keyof typeof syncedCleanupTableConfig,
+  whereClause: string,
+  values: unknown[],
+}): Promise<void> {
+  const tableConfig = syncedCleanupTableConfig[options.table];
+  await client.query(
+    `
+      WITH deleted_rows AS (
+        DELETE FROM "${options.table}"
+        WHERE ${options.whereClause}
+        RETURNING *
+      )
+      INSERT INTO "DeletedRow"
+        ("id", "tenancyId", "tableName", "primaryKey", "data", "deletedAt", "shouldUpdateSequenceId")
+      SELECT
+        gen_random_uuid(),
+        "tenancyId",
+        '${options.table}',
+        ${tableConfig.primaryKey},
+        to_jsonb(deleted_rows),
+        now(),
+        true
+      FROM deleted_rows
+    `,
+    options.values,
+  );
+}
 
 // Connection settings to prevent connection leaks
 const CLIENT_CONFIG: Partial<ClientConfig> = {

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/plan-usage.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/plan-usage.test.ts
@@ -54,51 +54,60 @@ async function getProjectUsageContext(client: Client, projectId: string): Promis
   };
 }
 
+const syncedCleanupTableConfig = {
+  EmailOutbox: {
+    primaryKey: `jsonb_build_object('tenancyId', "tenancyId", 'id', "id")`,
+  },
+  ProjectUser: {
+    primaryKey: `jsonb_build_object('tenancyId', "tenancyId", 'projectUserId', "projectUserId")`,
+  },
+} as const;
+
+async function deleteSyncedRowsWithTombstones(client: Client, options: {
+  table: keyof typeof syncedCleanupTableConfig,
+  whereClause: string,
+  values: unknown[],
+}): Promise<void> {
+  const tableConfig = syncedCleanupTableConfig[options.table];
+  await client.query(
+    `
+      WITH deleted_rows AS (
+        DELETE FROM "${options.table}"
+        WHERE ${options.whereClause}
+        RETURNING *
+      )
+      INSERT INTO "DeletedRow"
+        ("id", "tenancyId", "tableName", "primaryKey", "data", "deletedAt", "shouldUpdateSequenceId")
+      SELECT
+        gen_random_uuid(),
+        "tenancyId",
+        '${options.table}',
+        ${tableConfig.primaryKey},
+        to_jsonb(deleted_rows),
+        now(),
+        true
+      FROM deleted_rows
+    `,
+    options.values,
+  );
+}
+
 async function clearSeededUsageRows(client: Client, tenancies: readonly ProjectUsageContext[]): Promise<void> {
   const tenancyIds = tenancies.map((tenancy) => tenancy.tenancyId);
   await client.query("BEGIN");
   try {
     await client.query(`DELETE FROM "SessionReplay" WHERE "tenancyId" = ANY($1::uuid[])`, [tenancyIds]);
     // Deletions of synced tables only reach ClickHouse through DeletedRow.
-    await client.query(
-      `
-        INSERT INTO "DeletedRow"
-          ("id", "tenancyId", "tableName", "primaryKey", "data", "deletedAt", "shouldUpdateSequenceId")
-        SELECT
-          gen_random_uuid(),
-          "tenancyId",
-          'EmailOutbox',
-          jsonb_build_object('tenancyId', "tenancyId", 'id', "id"),
-          to_jsonb("EmailOutbox".*),
-          now(),
-          true
-        FROM "EmailOutbox"
-        WHERE "tenancyId" = ANY($1::uuid[])
-        FOR UPDATE
-      `,
-      [tenancyIds],
-    );
-    await client.query(`DELETE FROM "EmailOutbox" WHERE "tenancyId" = ANY($1::uuid[])`, [tenancyIds]);
-    // Deletions of synced tables only reach ClickHouse through DeletedRow.
-    await client.query(
-      `
-        INSERT INTO "DeletedRow"
-          ("id", "tenancyId", "tableName", "primaryKey", "data", "deletedAt", "shouldUpdateSequenceId")
-        SELECT
-          gen_random_uuid(),
-          "tenancyId",
-          'ProjectUser',
-          jsonb_build_object('tenancyId', "tenancyId", 'projectUserId', "projectUserId"),
-          to_jsonb("ProjectUser".*),
-          now(),
-          true
-        FROM "ProjectUser"
-        WHERE "tenancyId" = ANY($1::uuid[])
-        FOR UPDATE
-      `,
-      [tenancyIds],
-    );
-    await client.query(`DELETE FROM "ProjectUser" WHERE "tenancyId" = ANY($1::uuid[])`, [tenancyIds]);
+    await deleteSyncedRowsWithTombstones(client, {
+      table: "EmailOutbox",
+      whereClause: `"tenancyId" = ANY($1::uuid[])`,
+      values: [tenancyIds],
+    });
+    await deleteSyncedRowsWithTombstones(client, {
+      table: "ProjectUser",
+      whereClause: `"tenancyId" = ANY($1::uuid[])`,
+      values: [tenancyIds],
+    });
     await client.query("COMMIT");
   } catch (error) {
     await client.query("ROLLBACK");
@@ -212,29 +221,11 @@ async function deleteIncidentalEmailRows(client: Client, tenancyIds: readonly st
   await client.query("BEGIN");
   try {
     // Deletions of synced tables only reach ClickHouse through DeletedRow.
-    await client.query(
-      `
-        INSERT INTO "DeletedRow"
-          ("id", "tenancyId", "tableName", "primaryKey", "data", "deletedAt", "shouldUpdateSequenceId")
-        SELECT
-          gen_random_uuid(),
-          "tenancyId",
-          'EmailOutbox',
-          jsonb_build_object('tenancyId', "tenancyId", 'id', "id"),
-          to_jsonb("EmailOutbox".*),
-          now(),
-          true
-        FROM "EmailOutbox"
-        WHERE "tenancyId" = ANY($1::uuid[])
-          AND "renderedSubject" IS DISTINCT FROM $2
-        FOR UPDATE
-      `,
-      [tenancyIds, SEEDED_EMAIL_SUBJECT],
-    );
-    await client.query(
-      `DELETE FROM "EmailOutbox" WHERE "tenancyId" = ANY($1::uuid[]) AND "renderedSubject" IS DISTINCT FROM $2`,
-      [tenancyIds, SEEDED_EMAIL_SUBJECT],
-    );
+    await deleteSyncedRowsWithTombstones(client, {
+      table: "EmailOutbox",
+      whereClause: `"tenancyId" = ANY($1::uuid[]) AND "renderedSubject" IS DISTINCT FROM $2`,
+      values: [tenancyIds, SEEDED_EMAIL_SUBJECT],
+    });
     await client.query("COMMIT");
   } catch (error) {
     await client.query("ROLLBACK");

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/plan-usage.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/plan-usage.test.ts
@@ -56,9 +56,54 @@ async function getProjectUsageContext(client: Client, projectId: string): Promis
 
 async function clearSeededUsageRows(client: Client, tenancies: readonly ProjectUsageContext[]): Promise<void> {
   const tenancyIds = tenancies.map((tenancy) => tenancy.tenancyId);
-  await client.query(`DELETE FROM "SessionReplay" WHERE "tenancyId" = ANY($1::uuid[])`, [tenancyIds]);
-  await client.query(`DELETE FROM "EmailOutbox" WHERE "tenancyId" = ANY($1::uuid[])`, [tenancyIds]);
-  await client.query(`DELETE FROM "ProjectUser" WHERE "tenancyId" = ANY($1::uuid[])`, [tenancyIds]);
+  await client.query("BEGIN");
+  try {
+    await client.query(`DELETE FROM "SessionReplay" WHERE "tenancyId" = ANY($1::uuid[])`, [tenancyIds]);
+    // Deletions of synced tables only reach ClickHouse through DeletedRow.
+    await client.query(
+      `
+        INSERT INTO "DeletedRow"
+          ("id", "tenancyId", "tableName", "primaryKey", "data", "deletedAt", "shouldUpdateSequenceId")
+        SELECT
+          gen_random_uuid(),
+          "tenancyId",
+          'EmailOutbox',
+          jsonb_build_object('tenancyId', "tenancyId", 'id', "id"),
+          to_jsonb("EmailOutbox".*),
+          now(),
+          true
+        FROM "EmailOutbox"
+        WHERE "tenancyId" = ANY($1::uuid[])
+        FOR UPDATE
+      `,
+      [tenancyIds],
+    );
+    await client.query(`DELETE FROM "EmailOutbox" WHERE "tenancyId" = ANY($1::uuid[])`, [tenancyIds]);
+    // Deletions of synced tables only reach ClickHouse through DeletedRow.
+    await client.query(
+      `
+        INSERT INTO "DeletedRow"
+          ("id", "tenancyId", "tableName", "primaryKey", "data", "deletedAt", "shouldUpdateSequenceId")
+        SELECT
+          gen_random_uuid(),
+          "tenancyId",
+          'ProjectUser',
+          jsonb_build_object('tenancyId', "tenancyId", 'projectUserId', "projectUserId"),
+          to_jsonb("ProjectUser".*),
+          now(),
+          true
+        FROM "ProjectUser"
+        WHERE "tenancyId" = ANY($1::uuid[])
+        FOR UPDATE
+      `,
+      [tenancyIds],
+    );
+    await client.query(`DELETE FROM "ProjectUser" WHERE "tenancyId" = ANY($1::uuid[])`, [tenancyIds]);
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  }
 }
 
 async function insertProjectUsers(client: Client, context: ProjectUsageContext, options: {
@@ -164,10 +209,37 @@ async function insertEmailOutboxRow(client: Client, tenancyId: string, startedSe
 // CI shards — locally they settle before seeding). Deleting the non-seeded rows
 // keeps the test measuring exactly the usage it controls.
 async function deleteIncidentalEmailRows(client: Client, tenancyIds: readonly string[]): Promise<void> {
-  await client.query(
-    `DELETE FROM "EmailOutbox" WHERE "tenancyId" = ANY($1::uuid[]) AND "renderedSubject" IS DISTINCT FROM $2`,
-    [tenancyIds, SEEDED_EMAIL_SUBJECT],
-  );
+  await client.query("BEGIN");
+  try {
+    // Deletions of synced tables only reach ClickHouse through DeletedRow.
+    await client.query(
+      `
+        INSERT INTO "DeletedRow"
+          ("id", "tenancyId", "tableName", "primaryKey", "data", "deletedAt", "shouldUpdateSequenceId")
+        SELECT
+          gen_random_uuid(),
+          "tenancyId",
+          'EmailOutbox',
+          jsonb_build_object('tenancyId', "tenancyId", 'id', "id"),
+          to_jsonb("EmailOutbox".*),
+          now(),
+          true
+        FROM "EmailOutbox"
+        WHERE "tenancyId" = ANY($1::uuid[])
+          AND "renderedSubject" IS DISTINCT FROM $2
+        FOR UPDATE
+      `,
+      [tenancyIds, SEEDED_EMAIL_SUBJECT],
+    );
+    await client.query(
+      `DELETE FROM "EmailOutbox" WHERE "tenancyId" = ANY($1::uuid[]) AND "renderedSubject" IS DISTINCT FROM $2`,
+      [tenancyIds, SEEDED_EMAIL_SUBJECT],
+    );
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  }
 }
 
 async function insertSessionReplayRow(client: Client, context: ProjectUsageContext, projectUserId: string, startedAt: Date): Promise<void> {

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/plan-usage.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/plan-usage.test.ts
@@ -2,42 +2,17 @@ import { randomUUID } from "node:crypto";
 import { Client } from "pg";
 import { describe } from "vitest";
 import { ITEM_IDS } from "@hexclave/shared/dist/plans";
-import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { wait } from "@hexclave/shared/dist/utils/promises";
 import { planUsageResponseSchema, type PlanUsageResponse } from "@hexclave/shared/dist/interface/plan-usage";
 import { it } from "../../../../../helpers";
 import { Auth, InternalProjectKeys, Project, backendContext, niceBackendFetch } from "../../../../backend-helpers";
+import { deleteSyncedRowsWithTombstones, withInternalDatabase } from "../external-db-sync-utils";
 
 type ProjectUsageContext = {
   projectId: string,
   tenancyId: string,
 };
-
-function getInternalDatabaseConnectionString(): string {
-  const connectionString = getEnvVariable(
-    "HEXCLAVE_DATABASE_CONNECTION_STRING",
-    getEnvVariable("STACK_DATABASE_CONNECTION_STRING", ""),
-  );
-  if (connectionString === "") {
-    throw new HexclaveAssertionError("Plan usage E2E tests require a configured internal database connection string");
-  }
-  return connectionString;
-}
-
-async function withInternalDatabase<T>(fn: (client: Client) => Promise<T>): Promise<T> {
-  const client = new Client({
-    connectionString: getInternalDatabaseConnectionString(),
-    connectionTimeoutMillis: 10_000,
-    query_timeout: 30_000,
-  });
-  await client.connect();
-  try {
-    return await fn(client);
-  } finally {
-    await client.end();
-  }
-}
 
 async function getMainTenancyId(client: Client, projectId: string): Promise<string> {
   const tenancies = await client.query<{ id: string }>(
@@ -52,44 +27,6 @@ async function getProjectUsageContext(client: Client, projectId: string): Promis
     projectId,
     tenancyId: await getMainTenancyId(client, projectId),
   };
-}
-
-const syncedCleanupTableConfig = {
-  EmailOutbox: {
-    primaryKey: `jsonb_build_object('tenancyId', "tenancyId", 'id', "id")`,
-  },
-  ProjectUser: {
-    primaryKey: `jsonb_build_object('tenancyId', "tenancyId", 'projectUserId', "projectUserId")`,
-  },
-} as const;
-
-async function deleteSyncedRowsWithTombstones(client: Client, options: {
-  table: keyof typeof syncedCleanupTableConfig,
-  whereClause: string,
-  values: unknown[],
-}): Promise<void> {
-  const tableConfig = syncedCleanupTableConfig[options.table];
-  await client.query(
-    `
-      WITH deleted_rows AS (
-        DELETE FROM "${options.table}"
-        WHERE ${options.whereClause}
-        RETURNING *
-      )
-      INSERT INTO "DeletedRow"
-        ("id", "tenancyId", "tableName", "primaryKey", "data", "deletedAt", "shouldUpdateSequenceId")
-      SELECT
-        gen_random_uuid(),
-        "tenancyId",
-        '${options.table}',
-        ${tableConfig.primaryKey},
-        to_jsonb(deleted_rows),
-        now(),
-        true
-      FROM deleted_rows
-    `,
-    options.values,
-  );
 }
 
 async function clearSeededUsageRows(client: Client, tenancies: readonly ProjectUsageContext[]): Promise<void> {


### PR DESCRIPTION
The e2e job's post-suite `verify-data-integrity` step intermittently failed with

```
ClickHouse sync row count mismatch for email_outboxes.
Postgres: 106 rows, ClickHouse: 107 rows.
```

The ClickHouse sync only learns about deletions from `DeletedRow` tombstones (the `email_outboxes` mapping unions them in with `sync_is_deleted = true`), but `recordExternalDbSyncDeletion` had no `EmailOutbox` case at all. So any hard delete of an already-synced outbox row leaves the ClickHouse row behind forever. Two test suites do exactly that in their cleanup, against the seeded `internal` tenancy — hence the count drifting by one whenever a sync happened to run while their rows existed.

Changes:

- `recordExternalDbSyncDeletion` gains an `EmailOutbox` target, writing the tombstone shape the mapping reads (`primaryKey = {tenancyId, id}`), mirroring the existing branches.
- The cleanup paths in `email-queue-step.test.tsx` and `plan-usage.test.ts` record the tombstone in the same transaction as the delete. `plan-usage.test.ts` also deletes `ProjectUser` rows, which sync to the `users` table and had the identical latent bug, so that gets a tombstone too.
- Shared e2e helpers `withInternalDatabase` and `deleteSyncedRowsWithTombstones` in `external-db-sync-utils.ts`, so the tombstone-backed cleanup exists once rather than per test file.

Coverage is split in two:

- A backend unit test pins the tombstone contract itself — one tombstone, `primaryKey` exactly `{tenancyId, id}`, `shouldUpdateSequenceId`, source row gone — deterministically, with no ClickHouse involved.
- An e2e test in `external-db-sync-basics.test.ts` covers the real propagation path end to end: create → present in ClickHouse → tombstone + delete → gone from ClickHouse. It runs against its own per-test project and external database rather than the shared seeded tenancy, so a concurrent writer can't move the sync watermark underneath it.

Reproduced locally before the fix (create → sync → delete → sync left an orphaned ClickHouse row and `verify-data-integrity` failed with `Postgres: 0 rows, ClickHouse: 2 rows`); after the fix the same sequence leaves ClickHouse empty and `verify-data-integrity` reports `All good!`.


Link to Devin session: https://app.devin.ai/sessions/7d17b5e948974a71ba36d68c045bcb1f
Requested by: @N2D4