### PR TITLE
fix(piledriver): keep heap cycle detection proportional to in-flight serialization

### DIFF
--- a/apps/bulldozer-js/src/databases/piledriver/implementations/base.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/base.ts
@@ -141,15 +141,16 @@ function countPiledriverInlineNodes(obj: PiledriverObject, path: Set<object> = n
       if (obj === null) return { ...emptyPiledriverInlineNodeCounts(), primitiveNodes: 1 };
       if (isPiledriverHeapObjectSymbol in obj) return { ...emptyPiledriverInlineNodeCounts(), heapReferenceNodes: 1 };
       if (path.has(obj)) throw new Error("Piledriver objects must not contain cycles");
-      const childPath = new Set(path).add(obj);
+      path.add(obj);
       const counts = emptyPiledriverInlineNodeCounts();
       if (Array.isArray(obj)) {
         counts.arrayNodes++;
-        for (const item of obj) addPiledriverInlineNodeCounts(counts, countPiledriverInlineNodes(item, childPath));
+        for (const item of obj) addPiledriverInlineNodeCounts(counts, countPiledriverInlineNodes(item, path));
       } else {
         counts.objectNodes++;
-        for (const value of Object.values(obj)) addPiledriverInlineNodeCounts(counts, countPiledriverInlineNodes(value, childPath));
+        for (const value of Object.values(obj)) addPiledriverInlineNodeCounts(counts, countPiledriverInlineNodes(value, path));
       }
+      path.delete(obj);
       return counts;
     }
     default: {
@@ -311,6 +312,8 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
     }
 
     const promise = (async () => {
+      // Keep this copy: pending heap references resolve concurrently, so sibling branches cannot
+      // share a mutable path set.
       const childHeapPath = new Set(heapPath).add(heapObj);
       return await traceSpanHot("bulldozer-js.piledriver.heap.serializeAndInsert", async () => {
         const heapObjectGetStartedAt = performance.now();
@@ -355,7 +358,10 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
       result = await promise;
     } catch (error) {
       // Don't leave a poisoned rejected promise in the cache; a later retry may succeed.
-      if (heapKeysAndSeqByHeapObjects.get(heapObj) === promise) heapKeysAndSeqByHeapObjects.delete(heapObj);
+      if (heapKeysAndSeqByHeapObjects.get(heapObj) === promise) {
+        heapKeysAndSeqByHeapObjects.delete(heapObj);
+        heapSerializationDependencies.delete(heapObj);
+      }
       if (heapSerializationEntryByHeapObjects.get(heapObj)?.promise === promise) heapSerializationEntryByHeapObjects.delete(heapObj);
       throw error;
     } finally {
@@ -636,10 +642,6 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
       if (unpublished.length > 0) await startHeapObjectPublication(unpublished);
       const publicationSeqs = await Promise.all(batch.createdObjects.map(entry =>
         entry.publicationPromise ?? throwErr("Piledriver heap serialization entry has no publication promise")));
-      for (const { heapObj } of batch.createdObjects) {
-        const entry = heapSerializationEntryByHeapObjects.get(heapObj);
-        if (entry?.batch === batch && entry.publicationStatus === "published") heapSerializationEntryByHeapObjects.delete(heapObj);
-      }
       return combineSeqsDeduped(publicationSeqs);
     } catch (error) {
       abortHeapSerializationBatch(batch);
@@ -662,6 +664,9 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
       stack.push({ entry: current.entry, expanded: true });
       for (const dependency of heapSerializationDependencies.get(current.entry.heapObj) ?? []) {
         const dependencyEntry = heapSerializationEntryByHeapObjects.get(dependency);
+        // Edges are pruned when their owner publishes, so the graph only spans objects still in
+        // flight. An individual edge can outlive its target's entry when the target publishes
+        // first; that target is already durable and needs no further publication ordering.
         if (dependencyEntry !== undefined && !visited.has(dependencyEntry.heapObj)) {
           stack.push({ entry: dependencyEntry, expanded: false });
         }
@@ -689,12 +694,22 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
         for (const entry of claimedEntries) {
           entry.publicationStatus = "published";
           entry.publicationSeq = seq;
+          if (heapSerializationEntryByHeapObjects.get(entry.heapObj) !== entry) continue;
+          // Once an object is published, its outgoing edges are immutable and no longer needed for
+          // publication ordering or cycle detection, so prune them with the entry.
+          heapSerializationEntryByHeapObjects.delete(entry.heapObj);
+          heapSerializationDependencies.delete(entry.heapObj);
         }
         return seq;
       } catch (error) {
         for (const entry of claimedEntries) {
           entry.publicationStatus = "failed";
           entry.publicationError = error;
+          if (heapSerializationEntryByHeapObjects.get(entry.heapObj) === entry) {
+            // Publication failure is terminal for this entry, so nothing will publish through its
+            // edges; if abort drops it, a fresh serialization registers fresh edges.
+            heapSerializationDependencies.delete(entry.heapObj);
+          }
         }
         throw error;
       }
@@ -715,8 +730,11 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
     for (const { heapObj, promise } of batch.createdObjects) {
       if (heapKeysAndSeqByHeapObjects.get(heapObj) === promise) heapKeysAndSeqByHeapObjects.delete(heapObj);
       const entry = heapSerializationEntryByHeapObjects.get(heapObj);
-      if (entry?.batch === batch && entry.publicationStatus !== "publishing" && entry.publicationStatus !== "published") {
+      // Objects still publishing keep their entry because concurrent publications resolve through
+      // it; everything else is either durable or gone, so nothing needs its dependency edges.
+      if (entry?.batch === batch && entry.publicationStatus !== "publishing") {
         heapSerializationEntryByHeapObjects.delete(heapObj);
+        heapSerializationDependencies.delete(heapObj);
       }
     }
   };


### PR DESCRIPTION
`heapSerializationDependencies` was never pruned, while the `heapSerializationEntryByHeapObjects` entry it mirrors is dropped once an object publishes. Since it's keyed weakly by heap object, edges survived as long as the object did, and a live in-memory tree keeps its whole node spine alive — so the eager reachability walk in `addHeapSerializationDependency` grew with everything ever serialized in-process instead of with the current batch. Each mutation's topmost edge walked the live subtree under the root and allocated a `visited` set that size, making a backfill of `m` rows into a tree of `n` rows about `O(m·n)`.

The edges are now pruned wherever the serialization entry is pruned (published, aborted, failed), so the graph spans only objects still in flight. Nothing else needs them: publication ordering already skips edge targets without a live entry, and a published object can't join a new cycle — heap objects are immutable, and serializing one required serializing everything it references, so all its descendants are published too. Cycles within a single walk are still caught by the `heapPath` checks, and cross-walk cycles by the (now much smaller) reachability walk.

Dependency-walk node visits per 1000 writes while backfilling to 100k rows, and wall time for the same window:

| rows | visits before | visits after | ms before | ms after |
| ---: | ---: | ---: | ---: | ---: |
| 1k | 30,107 | 20,026 | 1228 | 1341 |
| 10k | 591,915 | 49,139 | 2498 | 2170 |
| 50k | 3,092,267 | 52,293 | 3084 | 2491 |
| 100k | 6,216,456 | 65,278 | 4541 | 3079 |

Also drops the ancestor-set copy in `countPiledriverInlineNodes` (it's synchronous, so one mutable set with add/delete works, as in `serializePiledriverObject`) and notes why the sibling copy in `getHeapKeyAndSeq` has to stay: pending heap references resolve concurrently there.


Link to Devin session: https://app.devin.ai/sessions/c89dbc7a8b634d1694510353365de5a8
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes heap serialization publication/cycle-detection bookkeeping in the Piledriver DB path; logic is intended to be equivalent but errors here could affect durability ordering or cycle detection during writes.
> 
> **Overview**
> Fixes **heap serialization** cost during large backfills by pruning `heapSerializationDependencies` whenever a heap serialization entry is dropped (after publish, on batch abort, or on failed serialize). Previously those edges lived as long as heap objects stayed in memory, so `addHeapSerializationDependency`’s reachability walk and publication ordering could scale with **everything ever serialized** in-process (~O(m·n) for tree backfills) instead of only **in-flight** work.
> 
> `countPiledriverInlineNodes` now reuses one mutable ancestor `Set` (add/delete) instead of cloning it per recursive step, matching the synchronous `serializePiledriverObject` walk. Comments clarify why `getHeapKeyAndSeq` still copies `heapPath` for concurrent sibling heap resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 815b1ead0bc719cc9a7cb15b3dde9f97753645c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Piledriver heap dependency graphs to in-flight objects so cycle detection and publication ordering scale with the current batch. Previously edges persisted with live heap objects; now entries and edges are pruned on publish, abort, or failure to bound the reachability walk.

- On publish success, if the entry is still current, delete it from `heapSerializationEntryByHeapObjects` and prune its outgoing edges in `heapSerializationDependencies`.
- On publish failure, mark failed and, if the entry is still current, prune its dependency edges; retries register fresh edges.
- On batch abort, delete non-publishing entries and their edges; keep publishing entries so concurrent publications can resolve.
- On promise rejection during cache fetch, evict `heapKeysAndSeqByHeapObjects` and `heapSerializationDependencies`, and delete the serialization entry if its promise matches.
- Reachability walk skips edges whose target no longer has a live entry; published targets are durable.
- Reuse one mutable ancestor Set in `countPiledriverInlineNodes`; `getHeapKeyAndSeq` keeps a sibling copy due to concurrent heap reference resolution.
- No external API changes.

<sup>Written for commit c4d2e280430e435ec685eecab05f2f988f218d6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when processing deeply nested data.
  - Improved recovery after failed, completed, cancelled, or interrupted serialization operations.
  - Prevented outdated processing state from affecting subsequent operations.
  - Improved handling of data published concurrently.
  - Strengthened validation when publishing serialized data.
  - Improved consistency when serialized data is processed in batches.
  - Reduced the risk of incomplete or inconsistent results during concurrent processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->