### PR TITLE
feat(bulldozer): add buffered Piledriver backend

### DIFF
--- a/apps/bulldozer-js/src/databases/bulldozer/index.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.ts
@@ -900,6 +900,7 @@ export type BulldozerDatabase = {
   collectPiledriverGarbage(cutoffTimestampMillis: number, maxObjects?: number): Promise<PiledriverGarbageCollectionResult>,
   close(): Promise<void>,
   applyRemainingMigrations(): Promise<{ seq: DatabaseSeq }>,
+  debugWriteLockStats?(): { heldMs: number, waitMs: number, acquisitions: number },
 };
 
 type BulldozerDatabaseRootSerialized = {
@@ -920,16 +921,24 @@ export function declareBulldozerDatabase(piledriverDatabase: PiledriverDatabase,
   const tablesState = createTablesStateFromMigrations(options.migrations);
   let currentOperation: Promise<unknown> | null = null;
   let closePromise: Promise<void> | null = null;
+  let writeLockHeldMs = 0;
+  let writeLockWaitMs = 0;
+  let writeLockAcquisitions = 0;
 
   const withWriteLock = async <T>(operation: () => Promise<T>): Promise<T> => {
+    const waitStartedAt = performance.now();
     while (currentOperation !== null) {
       await currentOperation.catch(() => {});
     }
+    writeLockWaitMs += performance.now() - waitStartedAt;
+    writeLockAcquisitions++;
     const operationPromise = Promise.resolve().then(operation);
     currentOperation = operationPromise;
+    const heldStartedAt = performance.now();
     try {
       return await operationPromise;
     } finally {
+      writeLockHeldMs += performance.now() - heldStartedAt;
       if (currentOperation === operationPromise) currentOperation = null;
     }
   };
@@ -1025,6 +1034,7 @@ export function declareBulldozerDatabase(piledriverDatabase: PiledriverDatabase,
         closePromise,
       };
     },
+    debugWriteLockStats: () => ({ heldMs: writeLockHeldMs, waitMs: writeLockWaitMs, acquisitions: writeLockAcquisitions }),
     listTables: () => Object.entries(tablesState.tables).map(([tableId, tableState]) => ({
       tableId,
       inputTableIds: { ...tableState.inputTableIds },

--- a/apps/bulldozer-js/src/databases/bulldozer/index.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.ts
@@ -930,6 +930,7 @@ export function declareBulldozerDatabase(piledriverDatabase: PiledriverDatabase,
     while (currentOperation !== null) {
       await currentOperation.catch(() => {});
     }
+    // This includes acquisition overhead; it is meaningful as contention wait only when another operation held the lock.
     writeLockWaitMs += performance.now() - waitStartedAt;
     writeLockAcquisitions++;
     const operationPromise = Promise.resolve().then(operation);

--- a/apps/bulldozer-js/src/databases/bulldozer/index.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.ts
@@ -900,7 +900,7 @@ export type BulldozerDatabase = {
   collectPiledriverGarbage(cutoffTimestampMillis: number, maxObjects?: number): Promise<PiledriverGarbageCollectionResult>,
   close(): Promise<void>,
   applyRemainingMigrations(): Promise<{ seq: DatabaseSeq }>,
-  debugWriteLockStats?(): { heldMs: number, waitMs: number, acquisitions: number },
+  debugWriteLockStats(): { heldMs: number, waitMs: number, acquisitions: number },
 };
 
 type BulldozerDatabaseRootSerialized = {

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
@@ -4,7 +4,13 @@ import { declareBufferedPiledriverDatabase } from "./buffered.js";
 import type { PiledriverDatabase } from "../index.js";
 
 const key = (value: string) => new TextEncoder().encode(value).buffer;
-const delay = (milliseconds: number) => new Promise(resolve => setTimeout(resolve, milliseconds));
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(resolvePromise => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+};
 
 function countingDatabase() {
   const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
@@ -39,13 +45,13 @@ describe("BufferedPiledriverDatabase", () => {
     const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 20 });
     const rootKey = key("coalesce");
 
-    const first = db.setRootObject(rootKey, "first");
-    const second = db.setRootObject(rootKey, "second");
-    const third = db.setRootObject(rootKey, "third");
-    await Promise.all([first, second, third]);
-    await delay(30);
+    const first = await db.setRootObject(rootKey, "first");
+    await db.waitUntilDurable(first.seq);
+    const second = await db.setRootObject(rootKey, "second");
+    const third = await db.setRootObject(rootKey, "third");
+    await db.waitUntilDurable(third.seq);
 
-    expect(getWrites()).toBe(1);
+    expect(getWrites()).toBe(2);
     await expect(counted.getRootObject(rootKey)).resolves.toMatchObject({ object: "third" });
   });
 
@@ -55,9 +61,55 @@ describe("BufferedPiledriverDatabase", () => {
     await counted.setRootObject(rootKey, "value");
     const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 50 });
 
-    await db.deleteRootObject(rootKey);
+    const { seq } = await db.deleteRootObject(rootKey);
 
     await expect(db.getRootObject(rootKey)).rejects.toThrow("Root object not found");
+    await db.waitUntilDurable(seq);
+    await expect(counted.getRootObject(rootKey)).rejects.toThrow("Root object not found");
+  });
+
+  it("waits for every member of a combined sequence", async () => {
+    const gate = deferred<void>();
+    const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
+    let writes = 0;
+    const delayed: PiledriverDatabase = {
+      ...wrapped,
+      async setRootObject(rootKey, value) {
+        writes++;
+        if (writes === 1) await gate.promise;
+        return await wrapped.setRootObject(rootKey, value);
+      },
+    };
+    const db = declareBufferedPiledriverDatabase(delayed, { throttleMs: 50 });
+    const firstKey = key("combined-first");
+    const secondKey = key("combined-second");
+    const first = await db.setRootObject(firstKey, "first");
+    await Promise.resolve();
+    const second = await db.setRootObject(secondKey, "second");
+    const combined = db.combineSeqs(second.seq, first.seq);
+    gate.resolve();
+
+    await db.waitUntilDurable(combined);
+
+    await expect(wrapped.getRootObject(firstKey)).resolves.toMatchObject({ object: "first" });
+    await expect(wrapped.getRootObject(secondKey)).resolves.toMatchObject({ object: "second" });
+  });
+
+  it("rejects a durability waiter once without retrying a failed write", async () => {
+    const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
+    let attempts = 0;
+    const failing: PiledriverDatabase = {
+      ...wrapped,
+      async setRootObject() {
+        attempts++;
+        throw new Error("write failed");
+      },
+    };
+    const db = declareBufferedPiledriverDatabase(failing, { throttleMs: 0 });
+    const { seq } = await db.setRootObject(key("failure"), "value");
+
+    await expect(db.waitUntilDurable(seq)).rejects.toThrow("write failed");
+    expect(attempts).toBe(1);
   });
 
   it("waits for the scheduled flush before durable completion", async () => {

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
@@ -68,6 +68,30 @@ describe("BufferedPiledriverDatabase", () => {
     await expect(counted.getRootObject(rootKey)).rejects.toThrow("Root object not found");
   });
 
+  it("keeps all in-flight writes visible while the flush is blocked", async () => {
+    const gate = deferred<void>();
+    const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
+    const delayed: PiledriverDatabase = {
+      ...wrapped,
+      async setRootObject(rootKey, value) {
+        if (value === "first") await gate.promise;
+        return await wrapped.setRootObject(rootKey, value);
+      },
+    };
+    const db = declareBufferedPiledriverDatabase(delayed, { throttleMs: 50 });
+    const firstKey = key("in-flight-first");
+    const secondKey = key("in-flight-second");
+
+    const first = await db.setRootObject(firstKey, "first");
+    const second = await db.setRootObject(secondKey, "second");
+    await Promise.resolve();
+
+    await expect(db.getRootObject(secondKey)).resolves.toMatchObject({ object: "second" });
+    gate.resolve();
+    await db.waitUntilDurable(first.seq);
+    await db.waitUntilDurable(second.seq);
+  });
+
   it("waits for every member of a combined sequence", async () => {
     const gate = deferred<void>();
     const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
@@ -129,6 +153,18 @@ describe("BufferedPiledriverDatabase", () => {
 
     await expect(db.waitUntilDurable(seq)).rejects.toThrow("write failed");
     expect(attempts).toBe(1);
+    await expect(db.getRootObject(key("failure"))).resolves.toMatchObject({ object: "value" });
+  });
+
+  it("wraps sequences returned by fallthrough reads", async () => {
+    const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
+    const rootKey = key("fallthrough");
+    await wrapped.setRootObject(rootKey, "value");
+    const db = declareBufferedPiledriverDatabase(wrapped);
+
+    const { seq } = await db.getRootObject(rootKey);
+    await db.waitUntilDurable(seq);
+    await db.waitUntilDurable(db.combineSeqs(seq));
   });
 
   it("waits for the scheduled flush before durable completion", async () => {

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
@@ -105,7 +105,6 @@ describe("BufferedPiledriverDatabase", () => {
   });
 
   it("never has more than one underlying write in flight", async () => {
-    const gate = deferred<void>();
     const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
     let inFlight = 0;
     let maxInFlight = 0;
@@ -115,7 +114,7 @@ describe("BufferedPiledriverDatabase", () => {
         inFlight++;
         maxInFlight = Math.max(maxInFlight, inFlight);
         try {
-          await gate.promise;
+          await Promise.resolve();
           return await wrapped.setRootObject(rootKey, value);
         } finally {
           inFlight--;
@@ -123,12 +122,12 @@ describe("BufferedPiledriverDatabase", () => {
       },
     };
     const db = declareBufferedPiledriverDatabase(observed);
-    const writes = await Promise.all(["one", "two", "three"].map(async value => await db.setRootObject(key(value), value)));
-
-    await Promise.resolve();
-    expect(maxInFlight).toBe(1);
-    gate.resolve();
+    const values = ["one", "two", "three"];
+    const writes = await Promise.all(values.map(async value => await db.setRootObject(key(value), value)));
     await Promise.all(writes.map(async ({ seq }) => await db.waitUntilDurable(seq)));
+
+    expect(maxInFlight).toBe(1);
+    for (const value of values) await expect(wrapped.getRootObject(key(value))).resolves.toMatchObject({ object: value });
   });
 
   it("waits for every member of a combined sequence", async () => {

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
@@ -95,6 +95,25 @@ describe("BufferedPiledriverDatabase", () => {
     await expect(wrapped.getRootObject(secondKey)).resolves.toMatchObject({ object: "second" });
   });
 
+  it("rejects combined sequences from another buffered database synchronously", async () => {
+    const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
+    const first = declareBufferedPiledriverDatabase(wrapped, { throttleMs: 50 });
+    const second = declareBufferedPiledriverDatabase(wrapped, { throttleMs: 50 });
+    const { seq } = await first.setRootObject(key("foreign"), "value");
+
+    expect(() => second.combineSeqs(seq)).toThrow("does not belong to this database");
+  });
+
+  it("waits for a single-member combined sequence", async () => {
+    const { wrapped, counted } = countingDatabase();
+    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 20 });
+    const { seq } = await db.setRootObject(key("single-combined"), "value");
+
+    await db.waitUntilDurable(db.combineSeqs(seq));
+
+    await expect(wrapped.getRootObject(key("single-combined"))).resolves.toMatchObject({ object: "value" });
+  });
+
   it("rejects a durability waiter once without retrying a failed write", async () => {
     const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
     let attempts = 0;

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { declareInMemoryPiledriverDatabase } from "./in-memory.js";
+import { declareBufferedPiledriverDatabase } from "./buffered.js";
+import type { PiledriverDatabase } from "../index.js";
+
+const key = (value: string) => new TextEncoder().encode(value).buffer;
+const delay = (milliseconds: number) => new Promise(resolve => setTimeout(resolve, milliseconds));
+
+function countingDatabase() {
+  const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
+  let writes = 0;
+  const counted: PiledriverDatabase = {
+    ...wrapped,
+    async setRootObject(rootKey, value) {
+      writes++;
+      return await wrapped.setRootObject(rootKey, value);
+    },
+    async deleteRootObject(rootKey) {
+      writes++;
+      return await wrapped.deleteRootObject(rootKey);
+    },
+  };
+  return { wrapped, counted, getWrites: () => writes };
+}
+
+describe("BufferedPiledriverDatabase", () => {
+  it("reads pending writes immediately", async () => {
+    const { counted } = countingDatabase();
+    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 50 });
+    const rootKey = key("read-your-writes");
+
+    await db.setRootObject(rootKey, "value");
+
+    await expect(db.getRootObject(rootKey)).resolves.toMatchObject({ object: "value" });
+  });
+
+  it("coalesces writes to one key within the throttle window", async () => {
+    const { counted, getWrites } = countingDatabase();
+    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 20 });
+    const rootKey = key("coalesce");
+
+    const first = db.setRootObject(rootKey, "first");
+    const second = db.setRootObject(rootKey, "second");
+    const third = db.setRootObject(rootKey, "third");
+    await Promise.all([first, second, third]);
+    await delay(30);
+
+    expect(getWrites()).toBe(1);
+    await expect(counted.getRootObject(rootKey)).resolves.toMatchObject({ object: "third" });
+  });
+
+  it("reads pending deletions as missing roots", async () => {
+    const { counted } = countingDatabase();
+    const rootKey = key("delete");
+    await counted.setRootObject(rootKey, "value");
+    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 50 });
+
+    await db.deleteRootObject(rootKey);
+
+    await expect(db.getRootObject(rootKey)).rejects.toThrow("Root object not found");
+  });
+
+  it("waits for the scheduled flush before durable completion", async () => {
+    const { wrapped, counted } = countingDatabase();
+    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 20 });
+    const rootKey = key("durable");
+
+    const { seq } = await db.setRootObject(rootKey, "value");
+    await db.waitUntilDurable(seq);
+
+    await expect(wrapped.getRootObject(rootKey)).resolves.toMatchObject({ object: "value" });
+  });
+
+  it("flushes on close", async () => {
+    const { wrapped, counted } = countingDatabase();
+    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 50 });
+    const rootKey = key("close");
+
+    await db.setRootObject(rootKey, "value");
+    await db.close();
+
+    await expect(wrapped.getRootObject(rootKey)).resolves.toMatchObject({ object: "value" });
+    await db.close();
+  });
+
+  it("supports an immediate throttle window", async () => {
+    const { wrapped, counted } = countingDatabase();
+    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 0 });
+    const rootKey = key("zero");
+
+    const { seq } = await db.setRootObject(rootKey, "value");
+    await db.waitUntilDurable(seq);
+
+    await expect(wrapped.getRootObject(rootKey)).resolves.toMatchObject({ object: "value" });
+  });
+
+  it("rejects invalid throttle windows", () => {
+    const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
+
+    expect(() => declareBufferedPiledriverDatabase(wrapped, { throttleMs: -1 })).toThrow("throttleMs");
+    expect(() => declareBufferedPiledriverDatabase(wrapped, { throttleMs: Number.NaN })).toThrow("throttleMs");
+    expect(() => declareBufferedPiledriverDatabase(wrapped, { throttleMs: Number.POSITIVE_INFINITY })).toThrow("throttleMs");
+  });
+});

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
@@ -82,14 +82,15 @@ describe("BufferedPiledriverDatabase", () => {
     const firstKey = key("in-flight-first");
     const secondKey = key("in-flight-second");
 
-    const first = await db.setRootObject(firstKey, "first");
-    const second = await db.setRootObject(secondKey, "second");
+    const first = db.setRootObject(firstKey, "first");
+    const second = db.setRootObject(secondKey, "second");
     await Promise.resolve();
 
+    await expect(db.getRootObject(firstKey)).resolves.toMatchObject({ object: "first" });
     await expect(db.getRootObject(secondKey)).resolves.toMatchObject({ object: "second" });
     gate.resolve();
-    await db.waitUntilDurable(first.seq);
-    await db.waitUntilDurable(second.seq);
+    await db.waitUntilDurable((await first).seq);
+    await db.waitUntilDurable((await second).seq);
   });
 
   it("waits for every member of a combined sequence", async () => {
@@ -159,12 +160,21 @@ describe("BufferedPiledriverDatabase", () => {
   it("wraps sequences returned by fallthrough reads", async () => {
     const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
     const rootKey = key("fallthrough");
-    await wrapped.setRootObject(rootKey, "value");
-    const db = declareBufferedPiledriverDatabase(wrapped);
+    const { seq: wrappedSeq } = await wrapped.setRootObject(rootKey, "value");
+    const durableSeqs: PiledriverDatabase["initialSeq"][] = [];
+    const observed: PiledriverDatabase = {
+      ...wrapped,
+      async waitUntilDurable(seq) {
+        durableSeqs.push(seq);
+        await wrapped.waitUntilDurable(seq);
+      },
+    };
+    const db = declareBufferedPiledriverDatabase(observed);
 
     const { seq } = await db.getRootObject(rootKey);
     await db.waitUntilDurable(seq);
     await db.waitUntilDurable(db.combineSeqs(seq));
+    expect(durableSeqs).toEqual([wrappedSeq, wrappedSeq]);
   });
 
   it("waits for the scheduled flush before durable completion", async () => {

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
@@ -32,7 +32,7 @@ function countingDatabase() {
 describe("BufferedPiledriverDatabase", () => {
   it("reads pending writes immediately", async () => {
     const { counted } = countingDatabase();
-    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 50 });
+    const db = declareBufferedPiledriverDatabase(counted);
     const rootKey = key("read-your-writes");
 
     await db.setRootObject(rootKey, "value");
@@ -40,26 +40,37 @@ describe("BufferedPiledriverDatabase", () => {
     await expect(db.getRootObject(rootKey)).resolves.toMatchObject({ object: "value" });
   });
 
-  it("coalesces writes to one key within the throttle window", async () => {
-    const { counted, getWrites } = countingDatabase();
-    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 20 });
+  it("coalesces writes to one key while an underlying write is in flight", async () => {
+    const gate = deferred<void>();
+    const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
+    let writes = 0;
+    const delayed: PiledriverDatabase = {
+      ...wrapped,
+      async setRootObject(rootKey, value) {
+        writes++;
+        if (writes === 1) await gate.promise;
+        return await wrapped.setRootObject(rootKey, value);
+      },
+    };
+    const db = declareBufferedPiledriverDatabase(delayed);
     const rootKey = key("coalesce");
 
-    const first = await db.setRootObject(rootKey, "first");
-    await db.waitUntilDurable(first.seq);
-    const second = await db.setRootObject(rootKey, "second");
+    await db.setRootObject(rootKey, "first");
+    await Promise.resolve();
+    await db.setRootObject(rootKey, "second");
     const third = await db.setRootObject(rootKey, "third");
+    gate.resolve();
     await db.waitUntilDurable(third.seq);
 
-    expect(getWrites()).toBe(2);
-    await expect(counted.getRootObject(rootKey)).resolves.toMatchObject({ object: "third" });
+    expect(writes).toBe(2);
+    await expect(wrapped.getRootObject(rootKey)).resolves.toMatchObject({ object: "third" });
   });
 
   it("reads pending deletions as missing roots", async () => {
     const { counted } = countingDatabase();
     const rootKey = key("delete");
     await counted.setRootObject(rootKey, "value");
-    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 50 });
+    const db = declareBufferedPiledriverDatabase(counted);
 
     const { seq } = await db.deleteRootObject(rootKey);
 
@@ -78,7 +89,7 @@ describe("BufferedPiledriverDatabase", () => {
         return await wrapped.setRootObject(rootKey, value);
       },
     };
-    const db = declareBufferedPiledriverDatabase(delayed, { throttleMs: 50 });
+    const db = declareBufferedPiledriverDatabase(delayed);
     const firstKey = key("in-flight-first");
     const secondKey = key("in-flight-second");
 
@@ -93,6 +104,33 @@ describe("BufferedPiledriverDatabase", () => {
     await db.waitUntilDurable((await second).seq);
   });
 
+  it("never has more than one underlying write in flight", async () => {
+    const gate = deferred<void>();
+    const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const observed: PiledriverDatabase = {
+      ...wrapped,
+      async setRootObject(rootKey, value) {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        try {
+          await gate.promise;
+          return await wrapped.setRootObject(rootKey, value);
+        } finally {
+          inFlight--;
+        }
+      },
+    };
+    const db = declareBufferedPiledriverDatabase(observed);
+    const writes = await Promise.all(["one", "two", "three"].map(async value => await db.setRootObject(key(value), value)));
+
+    await Promise.resolve();
+    expect(maxInFlight).toBe(1);
+    gate.resolve();
+    await Promise.all(writes.map(async ({ seq }) => await db.waitUntilDurable(seq)));
+  });
+
   it("waits for every member of a combined sequence", async () => {
     const gate = deferred<void>();
     const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
@@ -105,7 +143,7 @@ describe("BufferedPiledriverDatabase", () => {
         return await wrapped.setRootObject(rootKey, value);
       },
     };
-    const db = declareBufferedPiledriverDatabase(delayed, { throttleMs: 50 });
+    const db = declareBufferedPiledriverDatabase(delayed);
     const firstKey = key("combined-first");
     const secondKey = key("combined-second");
     const first = await db.setRootObject(firstKey, "first");
@@ -122,8 +160,8 @@ describe("BufferedPiledriverDatabase", () => {
 
   it("rejects combined sequences from another buffered database synchronously", async () => {
     const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
-    const first = declareBufferedPiledriverDatabase(wrapped, { throttleMs: 50 });
-    const second = declareBufferedPiledriverDatabase(wrapped, { throttleMs: 50 });
+    const first = declareBufferedPiledriverDatabase(wrapped);
+    const second = declareBufferedPiledriverDatabase(wrapped);
     const { seq } = await first.setRootObject(key("foreign"), "value");
 
     expect(() => second.combineSeqs(seq)).toThrow("does not belong to this database");
@@ -131,7 +169,7 @@ describe("BufferedPiledriverDatabase", () => {
 
   it("waits for a single-member combined sequence", async () => {
     const { wrapped, counted } = countingDatabase();
-    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 20 });
+    const db = declareBufferedPiledriverDatabase(counted);
     const { seq } = await db.setRootObject(key("single-combined"), "value");
 
     await db.waitUntilDurable(db.combineSeqs(seq));
@@ -139,22 +177,25 @@ describe("BufferedPiledriverDatabase", () => {
     await expect(wrapped.getRootObject(key("single-combined"))).resolves.toMatchObject({ object: "value" });
   });
 
-  it("rejects a durability waiter once without retrying a failed write", async () => {
+  it("rejects a failed entry without blocking later entries", async () => {
     const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
     let attempts = 0;
     const failing: PiledriverDatabase = {
       ...wrapped,
-      async setRootObject() {
+      async setRootObject(rootKey, value) {
         attempts++;
-        throw new Error("write failed");
+        if (value === "failure") throw new Error("write failed");
+        return await wrapped.setRootObject(rootKey, value);
       },
     };
-    const db = declareBufferedPiledriverDatabase(failing, { throttleMs: 0 });
-    const { seq } = await db.setRootObject(key("failure"), "value");
+    const db = declareBufferedPiledriverDatabase(failing);
+    const failed = await db.setRootObject(key("failure"), "failure");
+    const succeeded = await db.setRootObject(key("success"), "success");
 
-    await expect(db.waitUntilDurable(seq)).rejects.toThrow("write failed");
-    expect(attempts).toBe(1);
-    await expect(db.getRootObject(key("failure"))).resolves.toMatchObject({ object: "value" });
+    await expect(db.waitUntilDurable(failed.seq)).rejects.toThrow("write failed");
+    await expect(db.waitUntilDurable(succeeded.seq)).resolves.toBeUndefined();
+    expect(attempts).toBe(2);
+    await expect(db.getRootObject(key("failure"))).resolves.toMatchObject({ object: "failure" });
   });
 
   it("wraps sequences returned by fallthrough reads", async () => {
@@ -177,9 +218,9 @@ describe("BufferedPiledriverDatabase", () => {
     expect(durableSeqs).toEqual([wrappedSeq, wrappedSeq]);
   });
 
-  it("waits for the scheduled flush before durable completion", async () => {
+  it("waits for the drain before durable completion", async () => {
     const { wrapped, counted } = countingDatabase();
-    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 20 });
+    const db = declareBufferedPiledriverDatabase(counted);
     const rootKey = key("durable");
 
     const { seq } = await db.setRootObject(rootKey, "value");
@@ -190,7 +231,7 @@ describe("BufferedPiledriverDatabase", () => {
 
   it("flushes on close", async () => {
     const { wrapped, counted } = countingDatabase();
-    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 50 });
+    const db = declareBufferedPiledriverDatabase(counted);
     const rootKey = key("close");
 
     await db.setRootObject(rootKey, "value");
@@ -198,25 +239,5 @@ describe("BufferedPiledriverDatabase", () => {
 
     await expect(wrapped.getRootObject(rootKey)).resolves.toMatchObject({ object: "value" });
     await db.close();
-  });
-
-  it("supports an immediate throttle window", async () => {
-    const { wrapped, counted } = countingDatabase();
-    const db = declareBufferedPiledriverDatabase(counted, { throttleMs: 0 });
-    const rootKey = key("zero");
-
-    const { seq } = await db.setRootObject(rootKey, "value");
-    await db.waitUntilDurable(seq);
-
-    await expect(wrapped.getRootObject(rootKey)).resolves.toMatchObject({ object: "value" });
-  });
-
-  it("rejects invalid throttle windows", () => {
-    const wrapped = declareInMemoryPiledriverDatabase(crypto.randomUUID());
-
-    expect(() => declareBufferedPiledriverDatabase(wrapped, { throttleMs: -1 })).toThrow("throttleMs");
-    expect(() => declareBufferedPiledriverDatabase(wrapped, { throttleMs: Number.NaN })).toThrow("throttleMs");
-    expect(() => declareBufferedPiledriverDatabase(wrapped, { throttleMs: Number.POSITIVE_INFINITY })).toThrow("throttleMs");
-    expect(() => declareBufferedPiledriverDatabase(wrapped, { throttleMs: 2 ** 31 })).toThrow("throttleMs");
   });
 });

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.test.ts
@@ -207,5 +207,6 @@ describe("BufferedPiledriverDatabase", () => {
     expect(() => declareBufferedPiledriverDatabase(wrapped, { throttleMs: -1 })).toThrow("throttleMs");
     expect(() => declareBufferedPiledriverDatabase(wrapped, { throttleMs: Number.NaN })).toThrow("throttleMs");
     expect(() => declareBufferedPiledriverDatabase(wrapped, { throttleMs: Number.POSITIVE_INFINITY })).toThrow("throttleMs");
+    expect(() => declareBufferedPiledriverDatabase(wrapped, { throttleMs: 2 ** 31 })).toThrow("throttleMs");
   });
 });

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
@@ -1,4 +1,4 @@
-import { captureError } from "@hexclave/shared/dist/utils/errors";
+import { captureError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { encodeBase64 } from "@hexclave/shared/dist/utils/bytes";
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 import { DatabaseSeq } from "../../index.js";
@@ -42,19 +42,19 @@ export function declareBufferedPiledriverDatabase(wrapped: PiledriverDatabase): 
 
   const drain = async () => {
     while (pending.size > 0) {
-      const entry = pending.entries().next().value as [string, PendingEntry];
-      pending.delete(entry[0]);
-      inFlight.set(entry[0], entry[1]);
+      const entry = pending.values().next().value ?? throwErr("Buffered Piledriver drain expected a pending entry");
+      pending.delete(entry.id);
+      inFlight.set(entry.id, entry);
       try {
-        const result = entry[1].state.type === "delete"
-          ? await wrapped.deleteRootObject(entry[1].key)
-          : await wrapped.setRootObject(entry[1].key, entry[1].state.value);
-        for (const record of entry[1].records) record.resolve(result.seq);
-        if (inFlight.get(entry[0]) === entry[1] && !pending.has(entry[0])) inFlight.delete(entry[0]);
+        const result = entry.state.type === "delete"
+          ? await wrapped.deleteRootObject(entry.key)
+          : await wrapped.setRootObject(entry.key, entry.state.value);
+        for (const record of entry.records) record.resolve(result.seq);
+        if (inFlight.get(entry.id) === entry && !pending.has(entry.id)) inFlight.delete(entry.id);
       } catch (error) {
         // The caller was already told this write succeeded, so rolling back a failed flush could expose stale data
         // without anyone noticing; keep the failed value visible and report the anomaly instead.
-        for (const record of entry[1].records) record.reject(error);
+        for (const record of entry.records) record.reject(error);
         captureError("bulldozer-js:piledriver-buffered-flush", error);
       }
     }
@@ -101,14 +101,14 @@ export function declareBufferedPiledriverDatabase(wrapped: PiledriverDatabase): 
   const write = (key: ArrayBuffer, state: PendingEntry["state"]) => {
     if (isClosing) throw new Error("Buffered Piledriver database is closing and cannot accept writes");
     const pendingKey = getPendingKey(key);
+    const { seq, record } = createSeq();
     const entry = pending.get(pendingKey.id) ?? {
       id: pendingKey.id,
       key: pendingKey.key,
       state,
-      latestSeq: initialSeq,
+      latestSeq: seq,
       records: [],
     };
-    const { seq, record } = createSeq();
     entry.state = state;
     entry.latestSeq = seq;
     entry.records.push(record);

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
@@ -1,13 +1,13 @@
 import { captureError } from "@hexclave/shared/dist/utils/errors";
 import { encodeBase64 } from "@hexclave/shared/dist/utils/bytes";
+import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 import { DatabaseSeq } from "../../index.js";
 import { PiledriverDatabase, PiledriverObject } from "../index.js";
 
-type BufferedPiledriverSeq = DatabaseSeq;
 type PendingEntry = {
   key: ArrayBuffer,
-  value: PiledriverObject | undefined,
-  deleted: boolean,
+  state: { type: "set", value: PiledriverObject } | { type: "delete" },
+  latestSeq: DatabaseSeq,
   records: SeqRecord[],
 };
 type SeqRecord = {
@@ -16,11 +16,10 @@ type SeqRecord = {
   reject: (error: unknown) => void,
 };
 
-const cloneKey = (key: ArrayBuffer) => key.slice(0);
-const pendingValue = (entry: PendingEntry): PiledriverObject => {
-  if (entry.value === undefined) throw new Error("Buffered Piledriver pending value is missing");
-  return entry.value;
-};
+const getPendingKey = (key: ArrayBuffer) => ({
+  id: encodeBase64(new Uint8Array(key)),
+  key: key.slice(0),
+});
 
 export function declareBufferedPiledriverDatabase(
   wrapped: PiledriverDatabase,
@@ -30,7 +29,7 @@ export function declareBufferedPiledriverDatabase(
   if (!Number.isFinite(throttleMs) || throttleMs < 0) throw new Error("throttleMs must be a non-negative finite number");
 
   const dbId = `buffered-piledriver-${crypto.randomUUID()}`;
-  const initialSeq = [dbId, "initial"] as unknown as BufferedPiledriverSeq;
+  const initialSeq = [dbId, "initial"] as unknown as DatabaseSeq;
   const seqRecords = new WeakMap<object, SeqRecord>();
   const pending = new Map<string, PendingEntry>();
   let flushPromise: Promise<DatabaseSeq> | null = null;
@@ -49,7 +48,7 @@ export function declareBufferedPiledriverDatabase(
 
   const flushPending = (): Promise<DatabaseSeq> => {
     if (flushPromise !== null) return flushPromise;
-    if (pending.size === 0) return Promise.resolve(initialSeq);
+    if (pending.size === 0) return Promise.resolve(wrapped.initialSeq);
 
     const batch = [...pending.values()];
     pending.clear();
@@ -57,18 +56,16 @@ export function declareBufferedPiledriverDatabase(
       let combinedSeq = wrapped.initialSeq;
       try {
         for (const entry of batch) {
-          const result = entry.deleted
+          const result = entry.state.type === "delete"
             ? await wrapped.deleteRootObject(entry.key)
-            : await wrapped.setRootObject(entry.key, pendingValue(entry));
+            : await wrapped.setRootObject(entry.key, entry.state.value);
           combinedSeq = wrapped.combineSeqs(combinedSeq, result.seq);
         }
         for (const entry of batch) for (const record of entry.records) record.resolve(combinedSeq);
         return combinedSeq;
       } catch (error) {
-        for (const entry of batch) {
-          const current = pending.get(encodeBase64(new Uint8Array(entry.key)));
-          if (current === undefined) pending.set(encodeBase64(new Uint8Array(entry.key)), entry);
-        }
+        // The caller was already told this write succeeded, so swallowing a background failure could lose data without
+        // anyone noticing.
         for (const entry of batch) for (const record of entry.records) record.reject(error);
         throw error;
       } finally {
@@ -77,20 +74,24 @@ export function declareBufferedPiledriverDatabase(
         if (pending.size > 0) scheduleFlush();
       }
     })();
-    flushPromise.catch(error => captureError("bulldozer-js:piledriver-buffered-flush", error));
     return flushPromise;
   };
+
+  const startBackgroundFlush = () => runAsynchronously(flushPending(), {
+    noErrorLogging: true,
+    onError: error => captureError("bulldozer-js:piledriver-buffered-flush", error),
+  });
 
   const scheduleFlush = () => {
     if (flushPromise !== null || pending.size === 0 || flushTimer !== null) return;
     const delay = lastFlushAt === -Infinity ? 0 : Math.max(0, throttleMs - (performance.now() - lastFlushAt));
     if (delay === 0) {
-      void Promise.resolve().then(() => flushPending().catch(() => {})).catch(() => {});
+      queueMicrotask(startBackgroundFlush);
       return;
     }
     flushTimer = setTimeout(() => {
       flushTimer = null;
-      void flushPending().catch(() => {});
+      startBackgroundFlush();
     }, delay);
     if ("unref" in flushTimer) flushTimer.unref();
   };
@@ -106,8 +107,8 @@ export function declareBufferedPiledriverDatabase(
     }
   };
 
-  const createSeq = (entry: PendingEntry) => {
-    const seq = [dbId, crypto.randomUUID()] as unknown as BufferedPiledriverSeq;
+  const createSeq = () => {
+    const seq = [dbId, crypto.randomUUID()] as unknown as DatabaseSeq;
     let resolve!: (value: DatabaseSeq) => void;
     let reject!: (error: unknown) => void;
     const flush = new Promise<DatabaseSeq>((resolvePromise, rejectPromise) => {
@@ -115,22 +116,41 @@ export function declareBufferedPiledriverDatabase(
       reject = rejectPromise;
     });
     const record = { flush, resolve, reject };
-    entry.records.push(record);
     seqRecords.set(seq, record);
+    return { seq, record };
+  };
+
+  const write = (key: ArrayBuffer, state: PendingEntry["state"]) => {
+    if (isClosing) throw new Error("Buffered Piledriver database is closing and cannot accept writes");
+    const pendingKey = getPendingKey(key);
+    const entry = pending.get(pendingKey.id) ?? {
+      key: pendingKey.key,
+      state,
+      latestSeq: initialSeq,
+      records: [],
+    };
+    const { seq, record } = createSeq();
+    entry.state = state;
+    entry.latestSeq = seq;
+    entry.records.push(record);
+    pending.set(pendingKey.id, entry);
+    scheduleFlush();
     return seq;
   };
 
-  const keyString = (key: ArrayBuffer) => encodeBase64(new Uint8Array(key));
-  const write = (key: ArrayBuffer, value: PiledriverObject | undefined, deleted: boolean) => {
-    if (isClosing) throw new Error("Buffered Piledriver database is closing and cannot accept writes");
-    const keyCopy = cloneKey(key);
-    const stringKey = keyString(keyCopy);
-    const entry = pending.get(stringKey) ?? { key: keyCopy, value, deleted, records: [] };
-    entry.value = value;
-    entry.deleted = deleted;
-    pending.set(stringKey, entry);
-    const seq = createSeq(entry);
-    scheduleFlush();
+  const createCombinedSeq = (seqs: DatabaseSeq[]) => {
+    if (seqs.length === 0) return initialSeq;
+    const { seq, record } = createSeq();
+    runAsynchronously(async () => {
+      const underlyingSeqs = await Promise.all(seqs.map(memberSeq => {
+        const memberRecord = getRecord(memberSeq);
+        return memberRecord === null ? Promise.resolve(wrapped.initialSeq) : memberRecord.flush;
+      }));
+      record.resolve(wrapped.combineSeqs(...underlyingSeqs));
+    }, {
+      noErrorLogging: true,
+      onError: error => record.reject(error),
+    });
     return seq;
   };
 
@@ -146,18 +166,20 @@ export function declareBufferedPiledriverDatabase(
       return { backend: "piledriver-buffered", wrapped, pendingBufferSize: pending.size };
     },
     async getRootObject(key) {
-      const entry = pending.get(keyString(key));
+      const entry = pending.get(getPendingKey(key).id);
       if (entry !== undefined) {
-        if (entry.deleted) throw new Error("Root object not found");
-        return { object: pendingValue(entry), seq: initialSeq };
+        if (entry.state.type === "delete") throw new Error("Root object not found");
+        // Pending reads return the original object without serialization, so callers must preserve the same immutability
+        // expectations as with the in-memory Piledriver backend.
+        return { object: entry.state.value, seq: entry.latestSeq };
       }
       return await wrapped.getRootObject(key);
     },
     async setRootObject(key, value) {
-      return { seq: write(key, value, false) };
+      return { seq: write(key, { type: "set", value }) };
     },
     async deleteRootObject(key) {
-      return { seq: write(key, undefined, true) };
+      return { seq: write(key, { type: "delete" }) };
     },
     getGarbageCollectionProcessStartedAtMillis() {
       return wrapped.getGarbageCollectionProcessStartedAtMillis();
@@ -177,7 +199,7 @@ export function declareBufferedPiledriverDatabase(
       return await wrapped.debugLowLevelSnapshot();
     },
     combineSeqs(...seqs) {
-      return seqs.length === 0 ? initialSeq : seqs[seqs.length - 1];
+      return createCombinedSeq(seqs);
     },
     waitUntilAvailable: async () => {},
     waitUntilDurable: async seq => await waitUntil(seq, underlyingSeq => wrapped.waitUntilDurable(underlyingSeq)),

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
@@ -32,6 +32,7 @@ export function declareBufferedPiledriverDatabase(
   const initialSeq = [dbId, "initial"] as unknown as DatabaseSeq;
   const seqRecords = new WeakMap<object, SeqRecord>();
   const pending = new Map<string, PendingEntry>();
+  const inFlight = new Map<string, PendingEntry>();
   let flushPromise: Promise<DatabaseSeq> | null = null;
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
   let lastFlushAt = -Infinity;
@@ -52,20 +53,23 @@ export function declareBufferedPiledriverDatabase(
 
     const batch = [...pending.values()];
     pending.clear();
+    for (const entry of batch) inFlight.set(encodeBase64(new Uint8Array(entry.key)), entry);
     flushPromise = (async () => {
       let combinedSeq = wrapped.initialSeq;
       try {
         for (const entry of batch) {
+          const entryId = encodeBase64(new Uint8Array(entry.key));
           const result = entry.state.type === "delete"
             ? await wrapped.deleteRootObject(entry.key)
             : await wrapped.setRootObject(entry.key, entry.state.value);
           combinedSeq = wrapped.combineSeqs(combinedSeq, result.seq);
+          if (inFlight.get(entryId) === entry && !pending.has(entryId)) inFlight.delete(entryId);
         }
         for (const entry of batch) for (const record of entry.records) record.resolve(combinedSeq);
         return combinedSeq;
       } catch (error) {
-        // The caller was already told this write succeeded, so swallowing a background failure could lose data without
-        // anyone noticing.
+        // The caller was already told this write succeeded, so rolling back a failed flush could expose stale data
+        // without anyone noticing; keep the failed value visible and report the anomaly instead.
         for (const entry of batch) for (const record of entry.records) record.reject(error);
         throw error;
       } finally {
@@ -123,6 +127,12 @@ export function declareBufferedPiledriverDatabase(
     return { seq, record };
   };
 
+  const createResolvedSeq = (underlyingSeq: DatabaseSeq) => {
+    const { seq, record } = createSeq();
+    record.resolve(underlyingSeq);
+    return seq;
+  };
+
   const write = (key: ArrayBuffer, state: PendingEntry["state"]) => {
     if (isClosing) throw new Error("Buffered Piledriver database is closing and cannot accept writes");
     const pendingKey = getPendingKey(key);
@@ -173,14 +183,16 @@ export function declareBufferedPiledriverDatabase(
       return { backend: "piledriver-buffered", wrapped, pendingBufferSize: pending.size };
     },
     async getRootObject(key) {
-      const entry = pending.get(getPendingKey(key).id);
+      const pendingKey = getPendingKey(key);
+      const entry = pending.get(pendingKey.id) ?? inFlight.get(pendingKey.id);
       if (entry !== undefined) {
         if (entry.state.type === "delete") throw new Error("Root object not found");
         // Pending reads return the original object without serialization, so callers must preserve the same immutability
         // expectations as with the in-memory Piledriver backend.
         return { object: entry.state.value, seq: entry.latestSeq };
       }
-      return await wrapped.getRootObject(key);
+      const result = await wrapped.getRootObject(key);
+      return { object: result.object, seq: createResolvedSeq(result.seq) };
     },
     async setRootObject(key, value) {
       return { seq: write(key, { type: "set", value }) };

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
@@ -1,0 +1,200 @@
+import { captureError } from "@hexclave/shared/dist/utils/errors";
+import { encodeBase64 } from "@hexclave/shared/dist/utils/bytes";
+import { DatabaseSeq } from "../../index.js";
+import { PiledriverDatabase, PiledriverObject } from "../index.js";
+
+type BufferedPiledriverSeq = DatabaseSeq;
+type PendingEntry = {
+  key: ArrayBuffer,
+  value: PiledriverObject | undefined,
+  deleted: boolean,
+  records: SeqRecord[],
+};
+type SeqRecord = {
+  flush: Promise<DatabaseSeq>,
+  resolve: (seq: DatabaseSeq) => void,
+  reject: (error: unknown) => void,
+};
+
+const cloneKey = (key: ArrayBuffer) => key.slice(0);
+const pendingValue = (entry: PendingEntry): PiledriverObject => {
+  if (entry.value === undefined) throw new Error("Buffered Piledriver pending value is missing");
+  return entry.value;
+};
+
+export function declareBufferedPiledriverDatabase(
+  wrapped: PiledriverDatabase,
+  options: { throttleMs?: number } = {},
+): PiledriverDatabase {
+  const throttleMs = options.throttleMs ?? 200;
+  if (!Number.isFinite(throttleMs) || throttleMs < 0) throw new Error("throttleMs must be a non-negative finite number");
+
+  const dbId = `buffered-piledriver-${crypto.randomUUID()}`;
+  const initialSeq = [dbId, "initial"] as unknown as BufferedPiledriverSeq;
+  const seqRecords = new WeakMap<object, SeqRecord>();
+  const pending = new Map<string, PendingEntry>();
+  let flushPromise: Promise<DatabaseSeq> | null = null;
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+  let lastFlushAt = -Infinity;
+  let closePromise: Promise<void> | null = null;
+  let isClosing = false;
+
+  const getRecord = (seq: DatabaseSeq) => {
+    if (seq === initialSeq) return null;
+    if (!Array.isArray(seq) || seq[0] !== dbId) throw new Error("Buffered Piledriver sequence does not belong to this database");
+    const record = seqRecords.get(seq);
+    if (record === undefined) throw new Error("Unknown buffered Piledriver sequence");
+    return record;
+  };
+
+  const flushPending = (): Promise<DatabaseSeq> => {
+    if (flushPromise !== null) return flushPromise;
+    if (pending.size === 0) return Promise.resolve(initialSeq);
+
+    const batch = [...pending.values()];
+    pending.clear();
+    flushPromise = (async () => {
+      let combinedSeq = wrapped.initialSeq;
+      try {
+        for (const entry of batch) {
+          const result = entry.deleted
+            ? await wrapped.deleteRootObject(entry.key)
+            : await wrapped.setRootObject(entry.key, pendingValue(entry));
+          combinedSeq = wrapped.combineSeqs(combinedSeq, result.seq);
+        }
+        for (const entry of batch) for (const record of entry.records) record.resolve(combinedSeq);
+        return combinedSeq;
+      } catch (error) {
+        for (const entry of batch) {
+          const current = pending.get(encodeBase64(new Uint8Array(entry.key)));
+          if (current === undefined) pending.set(encodeBase64(new Uint8Array(entry.key)), entry);
+        }
+        for (const entry of batch) for (const record of entry.records) record.reject(error);
+        throw error;
+      } finally {
+        lastFlushAt = performance.now();
+        flushPromise = null;
+        if (pending.size > 0) scheduleFlush();
+      }
+    })();
+    flushPromise.catch(error => captureError("bulldozer-js:piledriver-buffered-flush", error));
+    return flushPromise;
+  };
+
+  const scheduleFlush = () => {
+    if (flushPromise !== null || pending.size === 0 || flushTimer !== null) return;
+    const delay = lastFlushAt === -Infinity ? 0 : Math.max(0, throttleMs - (performance.now() - lastFlushAt));
+    if (delay === 0) {
+      void Promise.resolve().then(() => flushPending().catch(() => {})).catch(() => {});
+      return;
+    }
+    flushTimer = setTimeout(() => {
+      flushTimer = null;
+      void flushPending().catch(() => {});
+    }, delay);
+    if ("unref" in flushTimer) flushTimer.unref();
+  };
+
+  const flushImmediately = async () => {
+    while (pending.size > 0 || flushPromise !== null) {
+      if (flushTimer !== null) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      if (flushPromise !== null) await flushPromise;
+      else await flushPending();
+    }
+  };
+
+  const createSeq = (entry: PendingEntry) => {
+    const seq = [dbId, crypto.randomUUID()] as unknown as BufferedPiledriverSeq;
+    let resolve!: (value: DatabaseSeq) => void;
+    let reject!: (error: unknown) => void;
+    const flush = new Promise<DatabaseSeq>((resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    });
+    const record = { flush, resolve, reject };
+    entry.records.push(record);
+    seqRecords.set(seq, record);
+    return seq;
+  };
+
+  const keyString = (key: ArrayBuffer) => encodeBase64(new Uint8Array(key));
+  const write = (key: ArrayBuffer, value: PiledriverObject | undefined, deleted: boolean) => {
+    if (isClosing) throw new Error("Buffered Piledriver database is closing and cannot accept writes");
+    const keyCopy = cloneKey(key);
+    const stringKey = keyString(keyCopy);
+    const entry = pending.get(stringKey) ?? { key: keyCopy, value, deleted, records: [] };
+    entry.value = value;
+    entry.deleted = deleted;
+    pending.set(stringKey, entry);
+    const seq = createSeq(entry);
+    scheduleFlush();
+    return seq;
+  };
+
+  const waitUntil = async (seq: DatabaseSeq, wait: (underlyingSeq: DatabaseSeq) => Promise<void>) => {
+    const record = getRecord(seq);
+    if (record === null) return await wait(wrapped.initialSeq);
+    const underlyingSeq = await record.flush;
+    await wait(underlyingSeq);
+  };
+
+  return {
+    getDebugInfo() {
+      return { backend: "piledriver-buffered", wrapped, pendingBufferSize: pending.size };
+    },
+    async getRootObject(key) {
+      const entry = pending.get(keyString(key));
+      if (entry !== undefined) {
+        if (entry.deleted) throw new Error("Root object not found");
+        return { object: pendingValue(entry), seq: initialSeq };
+      }
+      return await wrapped.getRootObject(key);
+    },
+    async setRootObject(key, value) {
+      return { seq: write(key, value, false) };
+    },
+    async deleteRootObject(key) {
+      return { seq: write(key, undefined, true) };
+    },
+    getGarbageCollectionProcessStartedAtMillis() {
+      return wrapped.getGarbageCollectionProcessStartedAtMillis();
+    },
+    async collectGarbage(cutoffTimestampMillis, maxObjects) {
+      await flushImmediately();
+      return await wrapped.collectGarbage(cutoffTimestampMillis, maxObjects);
+    },
+    async debugSnapshot() {
+      await flushImmediately();
+      if (wrapped.debugSnapshot === undefined) return { roots: [], heap: [] };
+      return await wrapped.debugSnapshot();
+    },
+    async debugLowLevelSnapshot() {
+      await flushImmediately();
+      if (wrapped.debugLowLevelSnapshot === undefined) return { stores: {}, dumps: {} };
+      return await wrapped.debugLowLevelSnapshot();
+    },
+    combineSeqs(...seqs) {
+      return seqs.length === 0 ? initialSeq : seqs[seqs.length - 1];
+    },
+    waitUntilAvailable: async () => {},
+    waitUntilDurable: async seq => await waitUntil(seq, underlyingSeq => wrapped.waitUntilDurable(underlyingSeq)),
+    waitUntilReplicated: async seq => await waitUntil(seq, underlyingSeq => wrapped.waitUntilReplicated(underlyingSeq)),
+    async close() {
+      if (closePromise === null) {
+        isClosing = true;
+        closePromise = (async () => {
+          try {
+            await flushImmediately();
+          } finally {
+            await wrapped.close();
+          }
+        })();
+      }
+      await closePromise;
+    },
+    initialSeq,
+  };
+}

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
@@ -5,6 +5,7 @@ import { DatabaseSeq } from "../../index.js";
 import { PiledriverDatabase, PiledriverObject } from "../index.js";
 
 type PendingEntry = {
+  id: string,
   key: ArrayBuffer,
   state: { type: "set", value: PiledriverObject } | { type: "delete" },
   latestSeq: DatabaseSeq,
@@ -26,7 +27,9 @@ export function declareBufferedPiledriverDatabase(
   options: { throttleMs?: number } = {},
 ): PiledriverDatabase {
   const throttleMs = options.throttleMs ?? 200;
-  if (!Number.isFinite(throttleMs) || throttleMs < 0) throw new Error("throttleMs must be a non-negative finite number");
+  if (!Number.isFinite(throttleMs) || throttleMs < 0 || throttleMs > 2 ** 31 - 1) {
+    throw new Error("throttleMs must be a non-negative finite number no greater than 2^31 - 1");
+  }
 
   const dbId = `buffered-piledriver-${crypto.randomUUID()}`;
   const initialSeq = [dbId, "initial"] as unknown as DatabaseSeq;
@@ -53,17 +56,16 @@ export function declareBufferedPiledriverDatabase(
 
     const batch = [...pending.values()];
     pending.clear();
-    for (const entry of batch) inFlight.set(encodeBase64(new Uint8Array(entry.key)), entry);
+    for (const entry of batch) inFlight.set(entry.id, entry);
     flushPromise = (async () => {
       let combinedSeq = wrapped.initialSeq;
       try {
         for (const entry of batch) {
-          const entryId = encodeBase64(new Uint8Array(entry.key));
           const result = entry.state.type === "delete"
             ? await wrapped.deleteRootObject(entry.key)
             : await wrapped.setRootObject(entry.key, entry.state.value);
           combinedSeq = wrapped.combineSeqs(combinedSeq, result.seq);
-          if (inFlight.get(entryId) === entry && !pending.has(entryId)) inFlight.delete(entryId);
+          if (inFlight.get(entry.id) === entry && !pending.has(entry.id)) inFlight.delete(entry.id);
         }
         for (const entry of batch) for (const record of entry.records) record.resolve(combinedSeq);
         return combinedSeq;
@@ -97,7 +99,7 @@ export function declareBufferedPiledriverDatabase(
       flushTimer = null;
       startBackgroundFlush();
     }, delay);
-    if ("unref" in flushTimer) flushTimer.unref();
+    // This timer carries accepted writes toward durability, so it must keep the process alive until it fires.
   };
 
   const flushImmediately = async () => {
@@ -137,6 +139,7 @@ export function declareBufferedPiledriverDatabase(
     if (isClosing) throw new Error("Buffered Piledriver database is closing and cannot accept writes");
     const pendingKey = getPendingKey(key);
     const entry = pending.get(pendingKey.id) ?? {
+      id: pendingKey.id,
       key: pendingKey.key,
       state,
       latestSeq: initialSeq,
@@ -180,7 +183,7 @@ export function declareBufferedPiledriverDatabase(
 
   return {
     getDebugInfo() {
-      return { backend: "piledriver-buffered", wrapped, pendingBufferSize: pending.size };
+      return { backend: "piledriver-buffered", wrapped, pendingBufferSize: pending.size, inFlightBufferSize: inFlight.size };
     },
     async getRootObject(key) {
       const pendingKey = getPendingKey(key);

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
@@ -22,23 +22,13 @@ const getPendingKey = (key: ArrayBuffer) => ({
   key: key.slice(0),
 });
 
-export function declareBufferedPiledriverDatabase(
-  wrapped: PiledriverDatabase,
-  options: { throttleMs?: number } = {},
-): PiledriverDatabase {
-  const throttleMs = options.throttleMs ?? 200;
-  if (!Number.isFinite(throttleMs) || throttleMs < 0 || throttleMs > 2 ** 31 - 1) {
-    throw new Error("throttleMs must be a non-negative finite number no greater than 2^31 - 1");
-  }
-
+export function declareBufferedPiledriverDatabase(wrapped: PiledriverDatabase): PiledriverDatabase {
   const dbId = `buffered-piledriver-${crypto.randomUUID()}`;
   const initialSeq = [dbId, "initial"] as unknown as DatabaseSeq;
   const seqRecords = new WeakMap<object, SeqRecord>();
   const pending = new Map<string, PendingEntry>();
   const inFlight = new Map<string, PendingEntry>();
-  let flushPromise: Promise<DatabaseSeq> | null = null;
-  let flushTimer: ReturnType<typeof setTimeout> | null = null;
-  let lastFlushAt = -Infinity;
+  let drainPromise: Promise<void> | null = null;
   let closePromise: Promise<void> | null = null;
   let isClosing = false;
 
@@ -50,66 +40,39 @@ export function declareBufferedPiledriverDatabase(
     return record;
   };
 
-  const flushPending = (): Promise<DatabaseSeq> => {
-    if (flushPromise !== null) return flushPromise;
-    if (pending.size === 0) return Promise.resolve(wrapped.initialSeq);
-
-    const batch = [...pending.values()];
-    pending.clear();
-    for (const entry of batch) inFlight.set(entry.id, entry);
-    flushPromise = (async () => {
-      let combinedSeq = wrapped.initialSeq;
+  const drain = async () => {
+    while (pending.size > 0) {
+      const entry = pending.entries().next().value as [string, PendingEntry];
+      pending.delete(entry[0]);
+      inFlight.set(entry[0], entry[1]);
       try {
-        for (const entry of batch) {
-          const result = entry.state.type === "delete"
-            ? await wrapped.deleteRootObject(entry.key)
-            : await wrapped.setRootObject(entry.key, entry.state.value);
-          combinedSeq = wrapped.combineSeqs(combinedSeq, result.seq);
-          if (inFlight.get(entry.id) === entry && !pending.has(entry.id)) inFlight.delete(entry.id);
-        }
-        for (const entry of batch) for (const record of entry.records) record.resolve(combinedSeq);
-        return combinedSeq;
+        const result = entry[1].state.type === "delete"
+          ? await wrapped.deleteRootObject(entry[1].key)
+          : await wrapped.setRootObject(entry[1].key, entry[1].state.value);
+        for (const record of entry[1].records) record.resolve(result.seq);
+        if (inFlight.get(entry[0]) === entry[1] && !pending.has(entry[0])) inFlight.delete(entry[0]);
       } catch (error) {
         // The caller was already told this write succeeded, so rolling back a failed flush could expose stale data
         // without anyone noticing; keep the failed value visible and report the anomaly instead.
-        for (const entry of batch) for (const record of entry.records) record.reject(error);
-        throw error;
-      } finally {
-        lastFlushAt = performance.now();
-        flushPromise = null;
-        if (pending.size > 0) scheduleFlush();
+        for (const record of entry[1].records) record.reject(error);
+        captureError("bulldozer-js:piledriver-buffered-flush", error);
       }
-    })();
-    return flushPromise;
-  };
-
-  const startBackgroundFlush = () => runAsynchronously(flushPending(), {
-    noErrorLogging: true,
-    onError: error => captureError("bulldozer-js:piledriver-buffered-flush", error),
-  });
-
-  const scheduleFlush = () => {
-    if (flushPromise !== null || pending.size === 0 || flushTimer !== null) return;
-    const delay = lastFlushAt === -Infinity ? 0 : Math.max(0, throttleMs - (performance.now() - lastFlushAt));
-    if (delay === 0) {
-      queueMicrotask(startBackgroundFlush);
-      return;
     }
-    flushTimer = setTimeout(() => {
-      flushTimer = null;
-      startBackgroundFlush();
-    }, delay);
-    // This timer carries accepted writes toward durability, so it must keep the process alive until it fires.
   };
 
-  const flushImmediately = async () => {
-    while (pending.size > 0 || flushPromise !== null) {
-      if (flushTimer !== null) {
-        clearTimeout(flushTimer);
-        flushTimer = null;
-      }
-      if (flushPromise !== null) await flushPromise;
-      else await flushPending();
+  const ensureDrain = () => {
+    if (drainPromise === null) {
+      drainPromise = drain().finally(() => {
+        drainPromise = null;
+        if (pending.size > 0) ensureDrain();
+      });
+    }
+  };
+
+  const drainBeforeOperation = async () => {
+    while (drainPromise !== null || pending.size > 0) {
+      if (drainPromise !== null) await drainPromise;
+      else ensureDrain();
     }
   };
 
@@ -150,7 +113,7 @@ export function declareBufferedPiledriverDatabase(
     entry.latestSeq = seq;
     entry.records.push(record);
     pending.set(pendingKey.id, entry);
-    scheduleFlush();
+    ensureDrain();
     return seq;
   };
 
@@ -207,16 +170,16 @@ export function declareBufferedPiledriverDatabase(
       return wrapped.getGarbageCollectionProcessStartedAtMillis();
     },
     async collectGarbage(cutoffTimestampMillis, maxObjects) {
-      await flushImmediately();
+      await drainBeforeOperation();
       return await wrapped.collectGarbage(cutoffTimestampMillis, maxObjects);
     },
     async debugSnapshot() {
-      await flushImmediately();
+      await drainBeforeOperation();
       if (wrapped.debugSnapshot === undefined) return { roots: [], heap: [] };
       return await wrapped.debugSnapshot();
     },
     async debugLowLevelSnapshot() {
-      await flushImmediately();
+      await drainBeforeOperation();
       if (wrapped.debugLowLevelSnapshot === undefined) return { stores: {}, dumps: {} };
       return await wrapped.debugLowLevelSnapshot();
     },
@@ -231,7 +194,7 @@ export function declareBufferedPiledriverDatabase(
         isClosing = true;
         closePromise = (async () => {
           try {
-            await flushImmediately();
+            await drainBeforeOperation();
           } finally {
             await wrapped.close();
           }

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/buffered.ts
@@ -116,6 +116,9 @@ export function declareBufferedPiledriverDatabase(
       reject = rejectPromise;
     });
     const record = { flush, resolve, reject };
+    // Background flush failures are already reported through captureError, and real awaiters still observe the rejection.
+    // This handler only prevents an unobserved record rejection from becoming an unhandled process rejection.
+    record.flush.catch(() => undefined);
     seqRecords.set(seq, record);
     return { seq, record };
   };
@@ -140,10 +143,14 @@ export function declareBufferedPiledriverDatabase(
 
   const createCombinedSeq = (seqs: DatabaseSeq[]) => {
     if (seqs.length === 0) return initialSeq;
+    const memberRecords = seqs.map(memberSeq => ({
+      memberSeq,
+      record: getRecord(memberSeq),
+    }));
+    if (memberRecords.length === 1) return memberRecords[0].memberSeq;
     const { seq, record } = createSeq();
     runAsynchronously(async () => {
-      const underlyingSeqs = await Promise.all(seqs.map(memberSeq => {
-        const memberRecord = getRecord(memberSeq);
+      const underlyingSeqs = await Promise.all(memberRecords.map(({ record: memberRecord }) => {
         return memberRecord === null ? Promise.resolve(wrapped.initialSeq) : memberRecord.flush;
       }));
       record.resolve(wrapped.combineSeqs(...underlyingSeqs));

--- a/apps/bulldozer-js/src/payments/schema/performance.test.ts
+++ b/apps/bulldozer-js/src/payments/schema/performance.test.ts
@@ -231,9 +231,10 @@ describe("payments schema performance", () => {
       }
     }, () => db);
 
-    // Same totals of work as above, but issued CONCURRENCY-at-a-time. Rows live in their own
-    // "concurrent-" namespace so they cannot collide with the serial phases' rows or affect the
-    // transaction count asserted at the end.
+    // The same three operations, issued CONCURRENCY-at-a-time with each batch fully awaited before
+    // the next. This exercises write-lock contention that serial phases cannot show; rows use their
+    // own "concurrent-" namespace so they cannot collide with serial rows or affect the transaction
+    // count asserted at the end.
     await measure(metrics, "write subscriptions (concurrent)", CONCURRENT_SUBSCRIPTION_BATCHES * CONCURRENCY, async () => {
       await inConcurrentBatches(CONCURRENT_SUBSCRIPTION_BATCHES, async (batchIndex, slotIndex) => {
         const i = batchIndex * CONCURRENCY + slotIndex;

--- a/apps/bulldozer-js/src/payments/schema/performance.test.ts
+++ b/apps/bulldozer-js/src/payments/schema/performance.test.ts
@@ -29,6 +29,13 @@ type Snapshot = Awaited<ReturnType<ReturnType<typeof declareBulldozerDatabase>["
 
 const USER_COUNT = 6;
 const ITEM_UPDATES_PER_USER = 10;
+// The concurrent phases issue CONCURRENCY writes at once and only then wait for all of them. This is
+// the shape a real request burst has, and unlike the serial phases it actually puts the Bulldozer
+// write lock under contention, so lockWaitMs becomes meaningful instead of pinned near zero.
+const CONCURRENCY = 10;
+const CONCURRENT_SUBSCRIPTION_BATCHES = 6;
+const CONCURRENT_PURCHASE_BATCHES = 6;
+const CONCURRENT_ITEM_UPDATE_BATCHES = 60;
 const prefillUserCountValue = process.env.BULLDOZER_PAYMENTS_PERF_PREFILL_USERS ?? "200";
 if (!/^\d+$/.test(prefillUserCountValue)) throw new Error("BULLDOZER_PAYMENTS_PERF_PREFILL_USERS must be a non-negative integer");
 const PREFILL_USER_COUNT = Number(prefillUserCountValue);
@@ -113,6 +120,13 @@ const rows = async (snapshot: Snapshot, tableId: string, groupKey: PiledriverObj
   return result;
 };
 const emptyLockStats = (): LockStats => ({ heldMs: 0, waitMs: 0, acquisitions: 0 });
+// Runs `batchCount` batches of CONCURRENCY writes; each batch is issued concurrently and fully
+// awaited before the next one starts, so concurrency stays bounded at CONCURRENCY.
+const inConcurrentBatches = async (batchCount: number, write: (batchIndex: number, slotIndex: number) => Promise<unknown>) => {
+  for (let batchIndex = 0; batchIndex < batchCount; batchIndex++) {
+    await Promise.all(Array.from({ length: CONCURRENCY }, async (_unused, slotIndex) => await write(batchIndex, slotIndex)));
+  }
+};
 const measure = async <T>(
   metrics: Metric[],
   name: string,
@@ -191,28 +205,57 @@ describe("payments schema performance", () => {
       }
     }, () => db);
 
+    // The measured write phases replicate, because that is what an HTTP handler waits for before it
+    // can respond; plain withSnapshot only waits for availability and so understates response time.
     await measure(metrics, "write subscriptions", USER_COUNT, async () => {
       for (let i = 0; i < USER_COUNT; i++) {
-        await db.withSnapshot(async snapshot => await snapshot.setOrDeleteRow({ tableId: schema.subscriptions, rowIdentifier: `sub-${i}`, newRowData: subscription(i) as unknown as PiledriverObject }));
+        await db.withSnapshotReplicated(async snapshot => await snapshot.setOrDeleteRow({ tableId: schema.subscriptions, rowIdentifier: `sub-${i}`, newRowData: subscription(i) as unknown as PiledriverObject }));
       }
     }, () => db);
 
     await measure(metrics, "write one-time purchases", USER_COUNT, async () => {
       for (let i = 0; i < USER_COUNT; i++) {
-        await db.withSnapshot(async snapshot => await snapshot.setOrDeleteRow({ tableId: schema.oneTimePurchases, rowIdentifier: `otp-${i}`, newRowData: oneTimePurchase(i) as unknown as PiledriverObject }));
+        await db.withSnapshotReplicated(async snapshot => await snapshot.setOrDeleteRow({ tableId: schema.oneTimePurchases, rowIdentifier: `otp-${i}`, newRowData: oneTimePurchase(i) as unknown as PiledriverObject }));
       }
     }, () => db);
 
     await measure(metrics, "write manual item quantity changes", USER_COUNT * ITEM_UPDATES_PER_USER, async () => {
       for (let userIndex = 0; userIndex < USER_COUNT; userIndex++) {
         for (let updateIndex = 0; updateIndex < ITEM_UPDATES_PER_USER; updateIndex++) {
-          await db.withSnapshot(async snapshot => await snapshot.setOrDeleteRow({
+          await db.withSnapshotReplicated(async snapshot => await snapshot.setOrDeleteRow({
             tableId: schema.manualItemQuantityChanges,
             rowIdentifier: `miqc-${userIndex}-${updateIndex}`,
             newRowData: manualItemQuantityChange(userIndex, updateIndex),
           }));
         }
       }
+    }, () => db);
+
+    // Same totals of work as above, but issued CONCURRENCY-at-a-time. Rows live in their own
+    // "concurrent-" namespace so they cannot collide with the serial phases' rows or affect the
+    // transaction count asserted at the end.
+    await measure(metrics, "write subscriptions (concurrent)", CONCURRENT_SUBSCRIPTION_BATCHES * CONCURRENCY, async () => {
+      await inConcurrentBatches(CONCURRENT_SUBSCRIPTION_BATCHES, async (batchIndex, slotIndex) => {
+        const i = batchIndex * CONCURRENCY + slotIndex;
+        await db.withSnapshotReplicated(async snapshot => await snapshot.setOrDeleteRow({ tableId: schema.subscriptions, rowIdentifier: `concurrent-sub-${i}`, newRowData: subscription(i, "concurrent-") as unknown as PiledriverObject }));
+      });
+    }, () => db);
+
+    await measure(metrics, "write one-time purchases (concurrent)", CONCURRENT_PURCHASE_BATCHES * CONCURRENCY, async () => {
+      await inConcurrentBatches(CONCURRENT_PURCHASE_BATCHES, async (batchIndex, slotIndex) => {
+        const i = batchIndex * CONCURRENCY + slotIndex;
+        await db.withSnapshotReplicated(async snapshot => await snapshot.setOrDeleteRow({ tableId: schema.oneTimePurchases, rowIdentifier: `concurrent-otp-${i}`, newRowData: oneTimePurchase(i, "concurrent-") as unknown as PiledriverObject }));
+      });
+    }, () => db);
+
+    await measure(metrics, "write manual item quantity changes (concurrent)", CONCURRENT_ITEM_UPDATE_BATCHES * CONCURRENCY, async () => {
+      await inConcurrentBatches(CONCURRENT_ITEM_UPDATE_BATCHES, async (batchIndex, slotIndex) => {
+        await db.withSnapshotReplicated(async snapshot => await snapshot.setOrDeleteRow({
+          tableId: schema.manualItemQuantityChanges,
+          rowIdentifier: `concurrent-miqc-${slotIndex}-${batchIndex}`,
+          newRowData: manualItemQuantityChange(slotIndex, batchIndex, "concurrent-"),
+        }));
+      });
     }, () => db);
 
     const { snapshot } = await db.getSnapshot();

--- a/apps/bulldozer-js/src/payments/schema/performance.test.ts
+++ b/apps/bulldozer-js/src/payments/schema/performance.test.ts
@@ -4,6 +4,7 @@ import { declareInstantAvailabilityLowLevelDatabase } from "../../databases/low-
 import { declareLmdbLowLevelDatabase } from "../../databases/low-level/implementations/lmdb.js";
 import { declareBulldozerDatabase } from "../../databases/bulldozer/index.js";
 import { declareBasePiledriverDatabase } from "../../databases/piledriver/implementations/base.js";
+import { declareBufferedPiledriverDatabase } from "../../databases/piledriver/implementations/buffered.js";
 import { declareInMemoryPiledriverDatabase } from "../../databases/piledriver/implementations/in-memory.js";
 import type { PiledriverObject } from "../../databases/piledriver/index.js";
 import { createPaymentsSchema } from "./index.js";
@@ -12,7 +13,18 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-type Metric = { name: string, count: number, elapsedMs: number, opsPerSecond: number };
+type LockStats = { heldMs: number, waitMs: number, acquisitions: number };
+type Metric = {
+  name: string,
+  count: number,
+  elapsedMs: number,
+  opsPerSecond: number,
+  lockHeldMs: number,
+  lockWaitMs: number,
+  lockAcquisitions: number,
+  lockOccupancy: number,
+};
+type LockStatsDatabase = { debugWriteLockStats?(): LockStats };
 type Snapshot = Awaited<ReturnType<ReturnType<typeof declareBulldozerDatabase>["getSnapshot"]>>["snapshot"];
 
 const USER_COUNT = 6;
@@ -29,6 +41,10 @@ const MONTH_MS = 2_592_000_000;
 const tempPaths: string[] = [];
 const databases: Array<ReturnType<typeof declareBulldozerDatabase>> = [];
 const perfBackend = process.env.BULLDOZER_PAYMENTS_PERF_BACKEND ?? "lmdb-instant";
+const bufferThrottleMsValue = process.env.BULLDOZER_PAYMENTS_PERF_BUFFER_THROTTLE_MS ?? "200";
+if (!/^\d+$/.test(bufferThrottleMsValue)) throw new Error("BULLDOZER_PAYMENTS_PERF_BUFFER_THROTTLE_MS must be a non-negative integer");
+const BUFFER_THROTTLE_MS = Number(bufferThrottleMsValue);
+if (!Number.isSafeInteger(BUFFER_THROTTLE_MS)) throw new Error("BULLDOZER_PAYMENTS_PERF_BUFFER_THROTTLE_MS must be a non-negative integer");
 
 const product = (includedItems: ProductSnapshot["includedItems"]): ProductSnapshot => ({
   displayName: "Perf Product",
@@ -96,23 +112,47 @@ const rows = async (snapshot: Snapshot, tableId: string, groupKey: PiledriverObj
   for await (const row of snapshot.listRowsInGroup({ tableId, groupKey, range: {} })) result.push(row);
   return result;
 };
-const measure = async <T>(metrics: Metric[], name: string, count: number, operation: () => Promise<T>) => {
+const emptyLockStats = (): LockStats => ({ heldMs: 0, waitMs: 0, acquisitions: 0 });
+const measure = async <T>(
+  metrics: Metric[],
+  name: string,
+  count: number,
+  operation: () => Promise<T>,
+  db?: LockStatsDatabase | (() => LockStatsDatabase | undefined),
+) => {
+  const getLockStats = () => (typeof db === "function" ? db() : db)?.debugWriteLockStats?.() ?? emptyLockStats();
+  const before = getLockStats();
   const start = performance.now();
   const value = await operation();
   const elapsedMs = performance.now() - start;
   const opsPerSecond = count / elapsedMs * 1_000;
-  metrics.push({ name, count, elapsedMs, opsPerSecond });
+  const after = getLockStats();
+  const lockHeldMs = after.heldMs - before.heldMs;
+  const lockWaitMs = after.waitMs - before.waitMs;
+  const lockAcquisitions = after.acquisitions - before.acquisitions;
+  const lockOccupancy = elapsedMs === 0 ? 0 : lockHeldMs / elapsedMs;
+  metrics.push({ name, count, elapsedMs, opsPerSecond, lockHeldMs, lockWaitMs, lockAcquisitions, lockOccupancy });
   process.stdout.write(`\n[bulldozer-payments-schema-perf-js] ${name}: ${elapsedMs.toFixed(1)} ms (${count} ops, ${opsPerSecond.toFixed(2)} ops/s)\n`);
   return value;
 };
 const newPiledriverDb = () => {
   if (perfBackend === "piledriver-in-memory") return declareInMemoryPiledriverDatabase(crypto.randomUUID());
+  if (perfBackend === "buffered-piledriver-in-memory") {
+    return declareBufferedPiledriverDatabase(declareInMemoryPiledriverDatabase(crypto.randomUUID()), { throttleMs: BUFFER_THROTTLE_MS });
+  }
   if (perfBackend === "lmdb" || perfBackend === "lmdb-instant") {
     const path = mkdtempSync(join(tmpdir(), "bulldozer-payments-schema-perf-"));
     tempPaths.push(path);
     const lmdb = declareLmdbLowLevelDatabase({ path, dbId: crypto.randomUUID() });
     const lowLevel = perfBackend === "lmdb-instant" ? declareInstantAvailabilityLowLevelDatabase(lmdb) : lmdb;
     return declareBasePiledriverDatabase(lowLevel);
+  }
+  if (perfBackend === "buffered-lmdb-instant" || perfBackend === "buffered-lmdb") {
+    const path = mkdtempSync(join(tmpdir(), "bulldozer-payments-schema-perf-"));
+    tempPaths.push(path);
+    const lmdb = declareLmdbLowLevelDatabase({ path, dbId: crypto.randomUUID() });
+    const lowLevel = perfBackend === "buffered-lmdb-instant" ? declareInstantAvailabilityLowLevelDatabase(lmdb) : lmdb;
+    return declareBufferedPiledriverDatabase(declareBasePiledriverDatabase(lowLevel), { throttleMs: BUFFER_THROTTLE_MS });
   }
   return declareBasePiledriverDatabase(declareInMemoryLowLevelDatabase(crypto.randomUUID()));
 };
@@ -128,8 +168,13 @@ describe("payments schema performance", () => {
   it("runs the comparable schema workload", { timeout: 600_000 }, async () => {
     const metrics: Metric[] = [];
     let initialized!: Awaited<ReturnType<typeof newPaymentsDb>>;
+    let initializedDb: ReturnType<typeof declareBulldozerDatabase> | undefined;
 
-    initialized = await measure(metrics, "initialize schema", 1, newPaymentsDb);
+    initialized = await measure(metrics, "initialize schema", 1, async () => {
+      const result = await newPaymentsDb();
+      initializedDb = result.db;
+      return result;
+    }, () => initializedDb);
     const { db, schema } = initialized;
 
     await measure(metrics, "prefill baseline rows", PREFILL_SOURCE_FACT_COUNT, async () => {
@@ -144,19 +189,19 @@ describe("payments schema performance", () => {
           }));
         }
       }
-    });
+    }, () => db);
 
     await measure(metrics, "write subscriptions", USER_COUNT, async () => {
       for (let i = 0; i < USER_COUNT; i++) {
         await db.withSnapshot(async snapshot => await snapshot.setOrDeleteRow({ tableId: schema.subscriptions, rowIdentifier: `sub-${i}`, newRowData: subscription(i) as unknown as PiledriverObject }));
       }
-    });
+    }, () => db);
 
     await measure(metrics, "write one-time purchases", USER_COUNT, async () => {
       for (let i = 0; i < USER_COUNT; i++) {
         await db.withSnapshot(async snapshot => await snapshot.setOrDeleteRow({ tableId: schema.oneTimePurchases, rowIdentifier: `otp-${i}`, newRowData: oneTimePurchase(i) as unknown as PiledriverObject }));
       }
-    });
+    }, () => db);
 
     await measure(metrics, "write manual item quantity changes", USER_COUNT * ITEM_UPDATES_PER_USER, async () => {
       for (let userIndex = 0; userIndex < USER_COUNT; userIndex++) {
@@ -168,22 +213,22 @@ describe("payments schema performance", () => {
           }));
         }
       }
-    });
+    }, () => db);
 
     const { snapshot } = await db.getSnapshot();
     await measure(metrics, "read owned products", USER_COUNT, async () => {
       for (let i = 0; i < USER_COUNT; i++) await rows(snapshot, schema.ownedProducts, customerGroup(i));
-    });
+    }, () => db);
     await measure(metrics, "read item quantities", USER_COUNT * 3, async () => {
       for (let i = 0; i < USER_COUNT; i++) {
         for (const _itemId of ["credits", "coins", "seats"]) await rows(snapshot, schema.itemQuantities, customerGroup(i));
       }
-    });
+    }, () => db);
     const transactionRows = await measure(metrics, "read transactions", USER_COUNT, async () => {
       let count = 0;
       for (let i = 0; i < USER_COUNT; i++) count += (await rows(snapshot, schema.transactions, customerGroup(i))).length;
       return count;
-    });
+    }, () => db);
 
     expect(transactionRows).toBe(USER_COUNT * (2 + ITEM_UPDATES_PER_USER));
     const summary = { engine: "bulldozer-js", backend: perfBackend, users: USER_COUNT, prefillUsers: PREFILL_USER_COUNT, prefillSourceFacts: PREFILL_SOURCE_FACT_COUNT, transactions: transactionRows, metrics };
@@ -225,12 +270,12 @@ describe("transactions listing performance", () => {
     const metrics: Metric[] = [];
     const { db, schema } = await newPaymentsDb();
 
-    await measure(metrics, "fill tenancy (small)", SMALL_TXN_COUNT, async () => await fillTenancy(db, schema, 0, SMALL_TXN_COUNT));
-    const smallFirstPage = await measure(metrics, "first page @ small total", PAGE_SIZE, async () => await readFirstPage((await db.getSnapshot()).snapshot, schema));
+    await measure(metrics, "fill tenancy (small)", SMALL_TXN_COUNT, async () => await fillTenancy(db, schema, 0, SMALL_TXN_COUNT), () => db);
+    const smallFirstPage = await measure(metrics, "first page @ small total", PAGE_SIZE, async () => await readFirstPage((await db.getSnapshot()).snapshot, schema), () => db);
     const smallPageMs = metrics.at(-1)!.elapsedMs;
 
-    await measure(metrics, "fill tenancy (grow to large)", LARGE_TXN_COUNT - SMALL_TXN_COUNT, async () => await fillTenancy(db, schema, SMALL_TXN_COUNT, LARGE_TXN_COUNT));
-    const largeFirstPage = await measure(metrics, "first page @ large total", PAGE_SIZE, async () => await readFirstPage((await db.getSnapshot()).snapshot, schema));
+    await measure(metrics, "fill tenancy (grow to large)", LARGE_TXN_COUNT - SMALL_TXN_COUNT, async () => await fillTenancy(db, schema, SMALL_TXN_COUNT, LARGE_TXN_COUNT), () => db);
+    const largeFirstPage = await measure(metrics, "first page @ large total", PAGE_SIZE, async () => await readFirstPage((await db.getSnapshot()).snapshot, schema), () => db);
     const largePageMs = metrics.at(-1)!.elapsedMs;
 
     // A page is always ~PAGE_SIZE rows regardless of how big the tenancy got.

--- a/apps/bulldozer-js/src/payments/schema/performance.test.ts
+++ b/apps/bulldozer-js/src/payments/schema/performance.test.ts
@@ -48,10 +48,6 @@ const MONTH_MS = 2_592_000_000;
 const tempPaths: string[] = [];
 const databases: Array<ReturnType<typeof declareBulldozerDatabase>> = [];
 const perfBackend = process.env.BULLDOZER_PAYMENTS_PERF_BACKEND ?? "lmdb-instant";
-const bufferThrottleMsValue = process.env.BULLDOZER_PAYMENTS_PERF_BUFFER_THROTTLE_MS ?? "200";
-if (!/^\d+$/.test(bufferThrottleMsValue)) throw new Error("BULLDOZER_PAYMENTS_PERF_BUFFER_THROTTLE_MS must be a non-negative integer");
-const BUFFER_THROTTLE_MS = Number(bufferThrottleMsValue);
-if (!Number.isSafeInteger(BUFFER_THROTTLE_MS)) throw new Error("BULLDOZER_PAYMENTS_PERF_BUFFER_THROTTLE_MS must be a non-negative integer");
 
 const product = (includedItems: ProductSnapshot["includedItems"]): ProductSnapshot => ({
   displayName: "Perf Product",
@@ -152,7 +148,7 @@ const measure = async <T>(
 const newPiledriverDb = () => {
   if (perfBackend === "piledriver-in-memory") return declareInMemoryPiledriverDatabase(crypto.randomUUID());
   if (perfBackend === "buffered-piledriver-in-memory") {
-    return declareBufferedPiledriverDatabase(declareInMemoryPiledriverDatabase(crypto.randomUUID()), { throttleMs: BUFFER_THROTTLE_MS });
+    return declareBufferedPiledriverDatabase(declareInMemoryPiledriverDatabase(crypto.randomUUID()));
   }
   if (perfBackend === "lmdb" || perfBackend === "lmdb-instant") {
     const path = mkdtempSync(join(tmpdir(), "bulldozer-payments-schema-perf-"));
@@ -166,7 +162,7 @@ const newPiledriverDb = () => {
     tempPaths.push(path);
     const lmdb = declareLmdbLowLevelDatabase({ path, dbId: crypto.randomUUID() });
     const lowLevel = perfBackend === "buffered-lmdb-instant" ? declareInstantAvailabilityLowLevelDatabase(lmdb) : lmdb;
-    return declareBufferedPiledriverDatabase(declareBasePiledriverDatabase(lowLevel), { throttleMs: BUFFER_THROTTLE_MS });
+    return declareBufferedPiledriverDatabase(declareBasePiledriverDatabase(lowLevel));
   }
   return declareBasePiledriverDatabase(declareInMemoryLowLevelDatabase(crypto.randomUUID()));
 };

--- a/apps/bulldozer-js/src/payments/schema/performance.test.ts
+++ b/apps/bulldozer-js/src/payments/schema/performance.test.ts
@@ -205,6 +205,12 @@ describe("payments schema performance", () => {
       }
     }, () => db);
 
+    // The first replicated write after prefill pays one-off costs (LMDB store growth, the first GC
+    // pass over the prefilled heap). Left unwarmed those all land on whichever phase happens to run
+    // first, which reads as a backend difference rather than the startup artifact it is. The
+    // "warmup-" namespace keeps this row out of the transaction count asserted at the end.
+    await db.withSnapshotReplicated(async snapshot => await snapshot.setOrDeleteRow({ tableId: schema.subscriptions, rowIdentifier: "warmup-sub-0", newRowData: subscription(0, "warmup-") as unknown as PiledriverObject }));
+
     // The measured write phases replicate, because that is what an HTTP handler waits for before it
     // can respond; plain withSnapshot only waits for availability and so understates response time.
     await measure(metrics, "write subscriptions", USER_COUNT, async () => {


### PR DESCRIPTION
`declareBufferedPiledriverDatabase(wrapped, { throttleMs = 200 })` decorates any `PiledriverDatabase` with instant availability plus a throttled, coalescing write path — the Piledriver-level analogue of `declareInstantAvailabilityLowLevelDatabase`, but far smaller because roots are a keyed last-writer-wins map rather than a KV range store.

Contract: availability is instant, durability/replication cost up to `throttleMs` plus the underlying database.

```
setRootObject(k, v)  -> buffers v under k, mints a seq, returns immediately
getRootObject(k)     -> pending value (or pending-delete miss) before falling through to wrapped
waitUntilAvailable   -> resolves immediately
waitUntilDurable(s)  -> awaits the flush carrying s, then wrapped.waitUntilDurable(underlyingSeq)
```

Flushing is leading-edge: an isolated write goes out at once, writes arriving inside the window coalesce per key into one trailing flush. A failed background flush is reported via `captureError` and rejects the affected durability waiters — the caller was already told the write succeeded, so it must not be swallowed — and is not retried.

`collectGarbage` and the debug snapshots flush first: the base backend derives heap-object liveness from the roots it can see in its own storage, so a root still sitting in the buffer would get its heap objects collected as unreachable. `close()` flushes too.

Also adds write-lock accounting to `declareBulldozerDatabase` (`debugWriteLockStats()` returning cumulative held/wait ms and acquisitions), and three perf-test backends — `buffered-piledriver-in-memory`, `buffered-lmdb-instant`, `buffered-lmdb` — with `BULLDOZER_PAYMENTS_PERF_BUFFER_THROTTLE_MS`. The payments perf test now records per-phase `lockHeldMs`/`lockWaitMs`/`lockOccupancy`, since the interesting effect of buffering is the write lock's occupancy (the throughput ceiling), not per-call latency.


Link to Devin session: https://app.devin.ai/sessions/85ec1d1a4d974380a1aa2ef9371c1a29
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New persistence layer changes durability timing and coalescing behavior for all root writes when the buffer is enabled; incorrect flush/GC ordering could affect data visibility or GC safety.
> 
> **Overview**
> Adds **`declareBufferedPiledriverDatabase`**, a decorator around any `PiledriverDatabase` that returns immediately on root writes while **coalescing and throttling** flushes to the wrapped store (default **200ms**). Reads see pending sets/deletes; **`waitUntilDurable`** waits for the flush that carries each seq; failed background flushes are surfaced to durability waiters and are **not** retried. **GC**, debug snapshots, and **close** force a full flush so buffered roots are not invisible to heap liveness.
> 
> **`declareBulldozerDatabase`** gains **`debugWriteLockStats()`** (cumulative write-lock held/wait time and acquisition count).
> 
> Payments schema perf tests add buffered backends (`buffered-piledriver-in-memory`, `buffered-lmdb-instant`, `buffered-lmdb`) and per-phase **lock occupancy** metrics via `BULLDOZER_PAYMENTS_PERF_BUFFER_THROTTLE_MS`. Vitest coverage exercises read-your-writes, coalescing, combined seqs, and flush-on-close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d978a774a6e4856dfcc7ba8e7d86eab16883b037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes root writes instantly readable by adding a buffered Piledriver backend that flushes in a serialized, coalescing background writer. Previously reads only saw durable state; now reads see pending sets/deletes immediately while durability/replication complete after the background flush.

- Introduces declareBufferedPiledriverDatabase(wrapped): read-your-writes for roots; one underlying write in flight; same-key writes coalesce; isolated writes flush immediately.
- Seqs and waits: set/delete mint buffered seqs; waitUntilDurable/waitUntilReplicated await the flush carrying that seq and then the wrapped DB; combineSeqs waits all members, rejects foreign buffered seqs, and wraps fall‑through read seqs; waitUntilAvailable resolves immediately.
- Safety: on flush failure, only affected waiters reject (no retry) and buffered values remain readable; collectGarbage, debug snapshots, and close() flush first.
- Adds declareBulldozerDatabase().debugWriteLockStats() with cumulative heldMs, waitMs, and acquisitions.

**Rollout**
- New perf backends: `buffered-piledriver-in-memory`, `buffered-lmdb-instant`, `buffered-lmdb`.
- Perf tests: measured write phases use withSnapshotReplicated, add bounded‑concurrency write phases, warm the first replicated write, and report per‑phase lock stats and lock occupancy.
- No migration required.

<sup>Written for commit 6b54c0219eba6b73bb97f0bb6be9620986aacaf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added buffered database writes with coalescing, throttling, asynchronous flushing, and read-your-writes behavior.
  - Added write-lock metrics for wait time, held time, and acquisition count.
  - Improved handling for durability waits, snapshots, maintenance operations, failures, and database closure.

- **Tests**
  - Expanded coverage for buffered writes, deletions, flushing, throttling, persistence failures, and durability scenarios.
  - Enhanced performance measurements with configurable buffering and lock metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->