### PR TITLE
test(payments-perf): sweep the payments benchmark over prefilled data volume

### DIFF
--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
@@ -1,9 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
 import { expect } from "vitest";
 import { it } from "../../../../../helpers";
 import { Auth, Payments, Project, niceBackendFetch } from "../../../../backend-helpers";
 
 const USER_COUNT = 6;
 const ITEM_UPDATES_PER_USER = 10;
+
+// The benchmark can be run against a tenancy that already holds payments data, to see how the
+// measured flows scale with the amount of data Bulldozer keeps in its trees. One prefill unit is one
+// fully-populated customer (a subscription purchase, a one-time purchase, two granted stackable
+// products and ITEM_UPDATES_PER_USER item-quantity changes) written into the same tenancy before any
+// measurement happens. The measured workload stays identical at every level, so the only thing that
+// varies between runs is the volume of pre-existing data.
+const PREFILL_CUSTOMERS = Number(process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL ?? "0");
+if (!Number.isInteger(PREFILL_CUSTOMERS) || PREFILL_CUSTOMERS < 0) {
+  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL must be a non-negative integer, got ${process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL}`);
+}
+// When set, the summary is also written to this path as JSON, so that a sweep over several prefill
+// levels can be aggregated and plotted afterwards.
+const OUTPUT_PATH = process.env.HEXCLAVE_PAYMENTS_PERF_OUTPUT;
 
 type PerfMetric = {
   name: string,
@@ -16,7 +32,8 @@ async function measure<T>(name: string, count: number, fn: () => Promise<T>, met
   const result = await fn();
   const elapsedMs = performance.now() - startedAt;
   metrics.push({ name, count, elapsedMs });
-  console.log(`[bulldozer-payments-e2e-perf] ${name}: ${elapsedMs.toFixed(1)} ms (${count} ops, ${(count / elapsedMs * 1000).toFixed(2)} ops/s)`);
+  const throughput = count === 0 ? "n/a" : `${(count / elapsedMs * 1000).toFixed(2)} ops/s`;
+  console.log(`[bulldozer-payments-e2e-perf] ${name}: ${elapsedMs.toFixed(1)} ms (${count} ops, ${throughput})`);
   return result;
 }
 
@@ -56,7 +73,11 @@ async function listAllTransactions() {
   return transactions;
 }
 
-it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary", { timeout: 240_000 }, async () => {
+// The measured workload alone fits comfortably into the base timeout; prefilling is what can take
+// arbitrarily long, so the budget grows with the requested prefill size.
+const TEST_TIMEOUT_MS = 240_000 + PREFILL_CUSTOMERS * 30_000;
+
+it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary", { timeout: TEST_TIMEOUT_MS }, async () => {
   const metrics: PerfMetric[] = [];
 
   await measure("setup project + payments config", 1, async () => {
@@ -111,6 +132,48 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
         },
       },
     });
+  }, metrics);
+
+  await measure("prefill existing payments data", PREFILL_CUSTOMERS, async () => {
+    for (let i = 0; i < PREFILL_CUSTOMERS; i++) {
+      const { userId } = await Auth.fastSignUp();
+
+      const subscriptionCode = await createPurchaseCode({ customerType: "user", customerId: userId, productId: "perf-sub" });
+      const subscriptionResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
+        accessType: "admin",
+        method: "POST",
+        body: { full_code: subscriptionCode, price_id: "monthly", quantity: 1 },
+      });
+      expect(subscriptionResponse.status).toBe(200);
+
+      const oneTimeCode = await createPurchaseCode({ customerType: "user", customerId: userId, productId: "perf-otp" });
+      const oneTimeResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
+        accessType: "admin",
+        method: "POST",
+        body: { full_code: oneTimeCode, price_id: "single", quantity: 2 },
+      });
+      expect(oneTimeResponse.status).toBe(200);
+
+      for (let grant = 0; grant < 2; grant++) {
+        const grantResponse = await niceBackendFetch(`/api/v1/payments/products/user/${userId}`, {
+          method: "POST",
+          accessType: "server",
+          body: { product_id: "perf-api-grant", quantity: 1 },
+        });
+        expect(grantResponse.status).toBe(200);
+      }
+
+      for (let update = 0; update < ITEM_UPDATES_PER_USER; update++) {
+        const itemId = update % 2 === 0 ? "credits" : "boosts";
+        const updateResponse = await niceBackendFetch(`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
+          method: "POST",
+          accessType: "server",
+          query: { allow_negative: "false" },
+          body: { delta: update + 1, description: `prefill-${i}-${update}` },
+        });
+        expect(updateResponse.status).toBe(200);
+      }
+    }
   }, metrics);
 
   const users = await measure("create users", USER_COUNT, async () => {
@@ -205,14 +268,21 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
   const transactions = await measure("list all transactions with pagination", 1, listAllTransactions, metrics);
   expect(transactions.length).toBeGreaterThanOrEqual(users.length * 4);
 
-  console.log("[bulldozer-payments-e2e-perf] summary", JSON.stringify({
+  const summary = {
+    prefillCustomers: PREFILL_CUSTOMERS,
     users: users.length,
     transactions: transactions.length,
     metrics: metrics.map((metric) => ({
       name: metric.name,
       count: metric.count,
       elapsedMs: Number(metric.elapsedMs.toFixed(1)),
-      opsPerSecond: Number((metric.count / metric.elapsedMs * 1000).toFixed(2)),
+      opsPerSecond: metric.count === 0 ? null : Number((metric.count / metric.elapsedMs * 1000).toFixed(2)),
     })),
-  }));
+  };
+  console.log("[bulldozer-payments-e2e-perf] summary", JSON.stringify(summary));
+
+  if (OUTPUT_PATH != null) {
+    fs.mkdirSync(path.dirname(path.resolve(OUTPUT_PATH)), { recursive: true });
+    fs.writeFileSync(OUTPUT_PATH, JSON.stringify(summary, null, 2));
+  }
 });

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
@@ -11,28 +11,84 @@ const ITEM_UPDATES_PER_USER = 10;
 // The benchmark can be run against a tenancy that already holds payments data, to see how the
 // measured flows scale with the amount of data Bulldozer keeps in its trees. One prefill unit is one
 // fully-populated customer (a subscription purchase, a one-time purchase, two granted stackable
-// products and ITEM_UPDATES_PER_USER item-quantity changes) written into the same tenancy before any
-// measurement happens. The measured workload stays identical at every level, so the only thing that
-// varies between runs is the volume of pre-existing data.
+// products and ITEM_UPDATES_PER_USER item-quantity changes) written into the same tenancy before
+// each measured workload.
 const PREFILL_VALUE = process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL;
-if (PREFILL_VALUE != null && !/^\d+$/.test(PREFILL_VALUE)) {
-  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL must be a non-negative integer, got ${PREFILL_VALUE}`);
+const PREFILL_STAGES_VALUE = process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES;
+if (PREFILL_VALUE != null && PREFILL_STAGES_VALUE != null) {
+  throw new Error("HEXCLAVE_PAYMENTS_PERF_PREFILL and HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES cannot both be set");
 }
-const PREFILL_CUSTOMERS = PREFILL_VALUE == null ? 0 : Number(PREFILL_VALUE);
-if (PREFILL_VALUE != null && !Number.isSafeInteger(PREFILL_CUSTOMERS)) {
-  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL must be a non-negative integer, got ${PREFILL_VALUE}`);
+
+function parseNonNegativeInteger(envName: string, value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${envName} must be a non-negative integer, got ${value}`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${envName} must be a non-negative integer, got ${value}`);
+  }
+  return parsed;
 }
-// When set, the summary is also written to this path as JSON, so that a sweep over several prefill
-// levels can be aggregated and plotted afterwards.
+
+function parsePositiveInteger(envName: string, value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${envName} must be a positive integer, got ${value}`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${envName} must be a positive integer, got ${value}`);
+  }
+  return parsed;
+}
+
+function parsePrefillStages(value: string): number[] {
+  const stages: number[] = [];
+  for (const rawStage of value.split(",")) {
+    const stageValue = rawStage.trim();
+    if (!/^\d+$/.test(stageValue)) {
+      throw new Error(
+        `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES must be a comma-separated list of strictly increasing non-negative integers, offending value ${rawStage}`,
+      );
+    }
+    const stage = Number(stageValue);
+    if (!Number.isSafeInteger(stage)) {
+      throw new Error(
+        `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES must be a comma-separated list of strictly increasing non-negative integers, offending value ${rawStage}`,
+      );
+    }
+    if (stages.length > 0 && stage <= stages[stages.length - 1]) {
+      throw new Error(
+        `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES must be strictly increasing, offending value ${rawStage}`,
+      );
+    }
+    stages.push(stage);
+  }
+  return stages;
+}
+
+const PREFILL_CUSTOMERS = PREFILL_VALUE == null ? 0 : parseNonNegativeInteger("HEXCLAVE_PAYMENTS_PERF_PREFILL", PREFILL_VALUE);
+const PREFILL_STAGES = PREFILL_STAGES_VALUE == null ? [PREFILL_CUSTOMERS] : parsePrefillStages(PREFILL_STAGES_VALUE);
+const PREFILL_CONCURRENCY_VALUE = process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL_CONCURRENCY;
+const PREFILL_CONCURRENCY = PREFILL_CONCURRENCY_VALUE == null
+  ? 8
+  : parsePositiveInteger("HEXCLAVE_PAYMENTS_PERF_PREFILL_CONCURRENCY", PREFILL_CONCURRENCY_VALUE);
 const OUTPUT_PATH = process.env.HEXCLAVE_PAYMENTS_PERF_OUTPUT;
 if (OUTPUT_PATH != null && OUTPUT_PATH.trim() === "") {
   throw new Error(`HEXCLAVE_PAYMENTS_PERF_OUTPUT must be a non-empty path, got ${OUTPUT_PATH}`);
+}
+if (PREFILL_STAGES.length > 1 && OUTPUT_PATH != null && !OUTPUT_PATH.includes("{prefill}")) {
+  throw new Error("HEXCLAVE_PAYMENTS_PERF_OUTPUT must contain the {prefill} placeholder when multiple prefill stages are configured");
 }
 
 type PerfMetric = {
   name: string,
   count: number,
   elapsedMs: number,
+};
+
+type RequestUserAuth = {
+  accessToken: string,
+  refreshToken: string,
 };
 
 async function measure<T>(name: string, count: number, fn: () => Promise<T>, metrics: PerfMetric[]): Promise<T> {
@@ -45,7 +101,7 @@ async function measure<T>(name: string, count: number, fn: () => Promise<T>, met
   return result;
 }
 
-async function createPurchaseCode(options: { customerType: "user", customerId: string, productId: string }) {
+async function createPurchaseCode(options: { customerType: "user", customerId: string, productId: string, userAuth?: RequestUserAuth }) {
   const res = await niceBackendFetch("/api/latest/payments/purchases/create-purchase-url", {
     method: "POST",
     accessType: "server",
@@ -54,6 +110,7 @@ async function createPurchaseCode(options: { customerType: "user", customerId: s
       customer_id: options.customerId,
       product_id: options.productId,
     },
+    userAuth: options.userAuth,
   });
   expect(res.status).toBe(200);
   const codeMatch = (res.body.url as string).match(/\/purchase\/([a-z0-9-_]+)/);
@@ -81,118 +138,166 @@ async function listAllTransactions() {
   return transactions;
 }
 
-// The measured workload alone fits comfortably into the base timeout; prefilling is what can take
-// arbitrarily long, so the budget grows with the requested prefill size.
 const BASE_TEST_TIMEOUT_MS = 240_000;
 const PREFILL_TIMEOUT_MS = 30_000;
 const MAX_NODE_TIMER_MS = 2 ** 31 - 1;
-const MAX_PREFILL_CUSTOMERS = Math.floor((MAX_NODE_TIMER_MS - BASE_TEST_TIMEOUT_MS) / PREFILL_TIMEOUT_MS);
-if (PREFILL_CUSTOMERS > MAX_PREFILL_CUSTOMERS) {
+const MAX_PREFILL_CUSTOMERS = PREFILL_STAGES.reduce((maximum, stage) => Math.max(maximum, stage), 0);
+const MAX_ALLOWED_PREFILL_CUSTOMERS = Math.floor(
+  (MAX_NODE_TIMER_MS - BASE_TEST_TIMEOUT_MS * PREFILL_STAGES.length) / PREFILL_TIMEOUT_MS,
+);
+if (MAX_ALLOWED_PREFILL_CUSTOMERS < 0 || MAX_PREFILL_CUSTOMERS > MAX_ALLOWED_PREFILL_CUSTOMERS) {
+  const prefillVariable = PREFILL_STAGES_VALUE == null
+    ? "HEXCLAVE_PAYMENTS_PERF_PREFILL"
+    : "HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES";
   throw new Error(
-    `HEXCLAVE_PAYMENTS_PERF_PREFILL assumes the derived test timeout stays within Node's maximum timer delay of ${MAX_NODE_TIMER_MS} ms; effective maximum prefill count is ${MAX_PREFILL_CUSTOMERS}, got ${PREFILL_CUSTOMERS}`,
+    `${prefillVariable} assumes the derived test timeout stays within Node's maximum timer delay of ${MAX_NODE_TIMER_MS} ms; effective maximum cumulative prefill count is ${Math.max(0, MAX_ALLOWED_PREFILL_CUSTOMERS)} for ${PREFILL_STAGES.length} stage(s), got ${MAX_PREFILL_CUSTOMERS}`,
   );
 }
-const TEST_TIMEOUT_MS = BASE_TEST_TIMEOUT_MS + PREFILL_CUSTOMERS * PREFILL_TIMEOUT_MS;
+const TEST_TIMEOUT_MS = BASE_TEST_TIMEOUT_MS * PREFILL_STAGES.length
+  + MAX_PREFILL_CUSTOMERS * PREFILL_TIMEOUT_MS;
 
-it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary", { timeout: TEST_TIMEOUT_MS }, async () => {
-  const metrics: PerfMetric[] = [];
+async function prefillOne(index: number): Promise<void> {
+  const { userId, accessToken, refreshToken } = await Auth.fastSignUp();
+  const userAuth = { accessToken, refreshToken };
 
-  await measure("setup project + payments config", 1, async () => {
-    await Project.createAndSwitch();
-    await Payments.setup();
-    await Project.updateConfig({
-      payments: {
-        testMode: true,
-        products: {
-          "perf-sub": {
-            displayName: "Perf Subscription",
-            customerType: "user",
-            serverOnly: false,
-            stackable: true,
-            prices: {
-              monthly: { USD: "10.00", interval: [1, "month"] },
-            },
-            includedItems: {
-              credits: { quantity: 10, repeat: [1, "month"], expires: "when-repeated" },
-              seats: { quantity: 1, expires: "when-purchase-expires" },
-            },
+  const subscriptionCode = await createPurchaseCode({
+    customerType: "user",
+    customerId: userId,
+    productId: "perf-sub",
+    userAuth,
+  });
+  const subscriptionResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
+    accessType: "admin",
+    method: "POST",
+    body: { full_code: subscriptionCode, price_id: "monthly", quantity: 1 },
+    userAuth,
+  });
+  expect(subscriptionResponse.status).toBe(200);
+
+  const oneTimeCode = await createPurchaseCode({
+    customerType: "user",
+    customerId: userId,
+    productId: "perf-otp",
+    userAuth,
+  });
+  const oneTimeResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
+    accessType: "admin",
+    method: "POST",
+    body: { full_code: oneTimeCode, price_id: "single", quantity: 2 },
+    userAuth,
+  });
+  expect(oneTimeResponse.status).toBe(200);
+
+  for (let grant = 0; grant < 2; grant++) {
+    const grantResponse = await niceBackendFetch(urlString`/api/v1/payments/products/user/${userId}`, {
+      method: "POST",
+      accessType: "server",
+      body: { product_id: "perf-api-grant", quantity: 1 },
+      userAuth,
+    });
+    expect(grantResponse.status).toBe(200);
+  }
+
+  for (let update = 0; update < ITEM_UPDATES_PER_USER; update++) {
+    const itemId = update % 2 === 0 ? "credits" : "boosts";
+    const updateResponse = await niceBackendFetch(urlString`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
+      method: "POST",
+      accessType: "server",
+      query: { allow_negative: "false" },
+      body: { delta: update + 1, description: `prefill-${index}-${update}` },
+      userAuth,
+    });
+    expect(updateResponse.status).toBe(200);
+  }
+}
+
+async function prefillCustomersInRange(startIndex: number, count: number): Promise<void> {
+  let nextIndex = 0;
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const offset = nextIndex++;
+      if (offset >= count) return;
+      await prefillOne(startIndex + offset);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(PREFILL_CONCURRENCY, count) }, worker));
+}
+
+async function setupPayments(): Promise<void> {
+  await Project.createAndSwitch();
+  await Payments.setup();
+  await Project.updateConfig({
+    payments: {
+      testMode: true,
+      products: {
+        "perf-sub": {
+          displayName: "Perf Subscription",
+          customerType: "user",
+          serverOnly: false,
+          stackable: true,
+          prices: {
+            monthly: { USD: "10.00", interval: [1, "month"] },
           },
-          "perf-otp": {
-            displayName: "Perf One-Time Purchase",
-            customerType: "user",
-            serverOnly: false,
-            stackable: true,
-            prices: {
-              single: { USD: "5.00" },
-            },
-            includedItems: {
-              credits: { quantity: 5, expires: "never" },
-            },
-          },
-          "perf-api-grant": {
-            displayName: "Perf API Grant",
-            customerType: "user",
-            serverOnly: false,
-            stackable: true,
-            prices: {
-              monthly: { USD: "0.00", interval: [1, "month"] },
-            },
-            includedItems: {
-              credits: { quantity: 3, expires: "when-purchase-expires" },
-            },
+          includedItems: {
+            credits: { quantity: 10, repeat: [1, "month"], expires: "when-repeated" },
+            seats: { quantity: 1, expires: "when-purchase-expires" },
           },
         },
-        items: {
-          credits: { displayName: "Credits", customerType: "user" },
-          seats: { displayName: "Seats", customerType: "user" },
-          boosts: { displayName: "Boosts", customerType: "user" },
+        "perf-otp": {
+          displayName: "Perf One-Time Purchase",
+          customerType: "user",
+          serverOnly: false,
+          stackable: true,
+          prices: {
+            single: { USD: "5.00" },
+          },
+          includedItems: {
+            credits: { quantity: 5, expires: "never" },
+          },
+        },
+        "perf-api-grant": {
+          displayName: "Perf API Grant",
+          customerType: "user",
+          serverOnly: false,
+          stackable: true,
+          prices: {
+            monthly: { USD: "0.00", interval: [1, "month"] },
+          },
+          includedItems: {
+            credits: { quantity: 3, expires: "when-purchase-expires" },
+          },
         },
       },
-    });
-  }, metrics);
+      items: {
+        credits: { displayName: "Credits", customerType: "user" },
+        seats: { displayName: "Seats", customerType: "user" },
+        boosts: { displayName: "Boosts", customerType: "user" },
+      },
+    },
+  });
+}
 
-  await measure("prefill existing payments data", PREFILL_CUSTOMERS, async () => {
-    for (let i = 0; i < PREFILL_CUSTOMERS; i++) {
-      const { userId } = await Auth.fastSignUp();
+type PerfSummary = {
+  prefillCustomers: number,
+  prefillCustomersAdded: number,
+  prefillConcurrency: number,
+  users: number,
+  transactions: number,
+  metrics: Array<{
+    name: string,
+    count: number,
+    elapsedMs: number,
+    opsPerSecond: number | null,
+  }>,
+};
 
-      const subscriptionCode = await createPurchaseCode({ customerType: "user", customerId: userId, productId: "perf-sub" });
-      const subscriptionResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
-        accessType: "admin",
-        method: "POST",
-        body: { full_code: subscriptionCode, price_id: "monthly", quantity: 1 },
-      });
-      expect(subscriptionResponse.status).toBe(200);
-
-      const oneTimeCode = await createPurchaseCode({ customerType: "user", customerId: userId, productId: "perf-otp" });
-      const oneTimeResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
-        accessType: "admin",
-        method: "POST",
-        body: { full_code: oneTimeCode, price_id: "single", quantity: 2 },
-      });
-      expect(oneTimeResponse.status).toBe(200);
-
-      for (let grant = 0; grant < 2; grant++) {
-        const grantResponse = await niceBackendFetch(urlString`/api/v1/payments/products/user/${userId}`, {
-          method: "POST",
-          accessType: "server",
-          body: { product_id: "perf-api-grant", quantity: 1 },
-        });
-        expect(grantResponse.status).toBe(200);
-      }
-
-      for (let update = 0; update < ITEM_UPDATES_PER_USER; update++) {
-        const itemId = update % 2 === 0 ? "credits" : "boosts";
-        const updateResponse = await niceBackendFetch(urlString`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
-          method: "POST",
-          accessType: "server",
-          query: { allow_negative: "false" },
-          body: { delta: update + 1, description: `prefill-${i}-${update}` },
-        });
-        expect(updateResponse.status).toBe(200);
-      }
-    }
-  }, metrics);
-
+async function runMeasuredWorkload(
+  prefillCustomers: number,
+  prefillCustomersAdded: number,
+  prefillConcurrency: number,
+  metricsBeforeWorkload: PerfMetric[],
+): Promise<PerfSummary> {
+  const metrics = metricsBeforeWorkload.map((metric) => ({ ...metric }));
   const users = await measure("create users", USER_COUNT, async () => {
     const createdUsers: string[] = [];
     for (let i = 0; i < USER_COUNT; i++) {
@@ -229,7 +334,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
   await measure("grant stackable subscription products via server API", users.length * 2, async () => {
     for (const userId of users) {
       for (let i = 0; i < 2; i++) {
-        const response = await niceBackendFetch(`/api/v1/payments/products/user/${userId}`, {
+        const response = await niceBackendFetch(urlString`/api/v1/payments/products/user/${userId}`, {
           method: "POST",
           accessType: "server",
           body: {
@@ -246,7 +351,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
     for (const userId of users) {
       for (let i = 0; i < ITEM_UPDATES_PER_USER; i++) {
         const itemId = i % 2 === 0 ? "credits" : "boosts";
-        const response = await niceBackendFetch(`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
+        const response = await niceBackendFetch(urlString`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
           method: "POST",
           accessType: "server",
           query: { allow_negative: "false" },
@@ -262,7 +367,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
 
   await measure("read owned products for all users", users.length, async () => {
     for (const userId of users) {
-      const response = await niceBackendFetch(`/api/v1/payments/products/user/${userId}`, {
+      const response = await niceBackendFetch(urlString`/api/v1/payments/products/user/${userId}`, {
         accessType: "server",
       });
       expect(response.status).toBe(200);
@@ -273,7 +378,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
   await measure("read item quantities for all users", users.length * 3, async () => {
     for (const userId of users) {
       for (const itemId of ["credits", "seats", "boosts"]) {
-        const response = await niceBackendFetch(`/api/latest/payments/items/user/${userId}/${itemId}`, {
+        const response = await niceBackendFetch(urlString`/api/latest/payments/items/user/${userId}/${itemId}`, {
           accessType: "server",
         });
         expect(response.status).toBe(200);
@@ -285,8 +390,10 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
   const transactions = await measure("list all transactions with pagination", 1, listAllTransactions, metrics);
   expect(transactions.length).toBeGreaterThanOrEqual(users.length * 4);
 
-  const summary = {
-    prefillCustomers: PREFILL_CUSTOMERS,
+  const summary: PerfSummary = {
+    prefillCustomers,
+    prefillCustomersAdded,
+    prefillConcurrency,
     users: users.length,
     transactions: transactions.length,
     metrics: metrics.map((metric) => ({
@@ -297,9 +404,38 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
     })),
   };
   console.log("[bulldozer-payments-e2e-perf] summary", JSON.stringify(summary));
+  return summary;
+}
 
-  if (OUTPUT_PATH != null) {
-    fs.mkdirSync(path.dirname(path.resolve(OUTPUT_PATH)), { recursive: true });
-    fs.writeFileSync(OUTPUT_PATH, JSON.stringify(summary, null, 2));
+function writeSummary(summary: PerfSummary, outputPath: string): void {
+  fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+  fs.writeFileSync(outputPath, JSON.stringify(summary, null, 2));
+}
+
+it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary", { timeout: TEST_TIMEOUT_MS }, async () => {
+  const setupMetrics: PerfMetric[] = [];
+  await measure("setup project + payments config", 1, setupPayments, setupMetrics);
+
+  let previousPrefillCustomers = 0;
+  for (const prefillCustomers of PREFILL_STAGES) {
+    const delta = prefillCustomers - previousPrefillCustomers;
+    console.log(`[bulldozer-payments-e2e-perf] prefill stage ${prefillCustomers}: adding ${delta} customers`);
+    const metricsBeforeWorkload = setupMetrics.map((metric) => ({ ...metric }));
+    // Prefill runs before measurements, so bounded concurrency cannot taint the measured workload.
+    await measure(
+      "prefill existing payments data",
+      delta,
+      () => prefillCustomersInRange(previousPrefillCustomers, delta),
+      metricsBeforeWorkload,
+    );
+
+    const summary = await runMeasuredWorkload(prefillCustomers, delta, PREFILL_CONCURRENCY, metricsBeforeWorkload);
+    if (OUTPUT_PATH != null) {
+      const outputPath = PREFILL_STAGES.length > 1
+        ? OUTPUT_PATH.replace(/\{prefill\}/g, String(prefillCustomers))
+        : OUTPUT_PATH;
+      writeSummary(summary, outputPath);
+    }
+    previousPrefillCustomers = prefillCustomers;
   }
 });

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { urlString } from "@hexclave/shared/dist/utils/urls";
 import { expect } from "vitest";
 import { it } from "../../../../../helpers";
 import { Auth, Payments, Project, niceBackendFetch } from "../../../../backend-helpers";
@@ -13,13 +14,20 @@ const ITEM_UPDATES_PER_USER = 10;
 // products and ITEM_UPDATES_PER_USER item-quantity changes) written into the same tenancy before any
 // measurement happens. The measured workload stays identical at every level, so the only thing that
 // varies between runs is the volume of pre-existing data.
-const PREFILL_CUSTOMERS = Number(process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL ?? "0");
-if (!Number.isInteger(PREFILL_CUSTOMERS) || PREFILL_CUSTOMERS < 0) {
-  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL must be a non-negative integer, got ${process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL}`);
+const PREFILL_VALUE = process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL;
+if (PREFILL_VALUE != null && !/^\d+$/.test(PREFILL_VALUE)) {
+  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL must be a non-negative integer, got ${PREFILL_VALUE}`);
+}
+const PREFILL_CUSTOMERS = PREFILL_VALUE == null ? 0 : Number(PREFILL_VALUE);
+if (PREFILL_VALUE != null && !Number.isSafeInteger(PREFILL_CUSTOMERS)) {
+  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL must be a non-negative integer, got ${PREFILL_VALUE}`);
 }
 // When set, the summary is also written to this path as JSON, so that a sweep over several prefill
 // levels can be aggregated and plotted afterwards.
 const OUTPUT_PATH = process.env.HEXCLAVE_PAYMENTS_PERF_OUTPUT;
+if (OUTPUT_PATH != null && OUTPUT_PATH.trim() === "") {
+  throw new Error(`HEXCLAVE_PAYMENTS_PERF_OUTPUT must be a non-empty path, got ${OUTPUT_PATH}`);
+}
 
 type PerfMetric = {
   name: string,
@@ -75,7 +83,16 @@ async function listAllTransactions() {
 
 // The measured workload alone fits comfortably into the base timeout; prefilling is what can take
 // arbitrarily long, so the budget grows with the requested prefill size.
-const TEST_TIMEOUT_MS = 240_000 + PREFILL_CUSTOMERS * 30_000;
+const BASE_TEST_TIMEOUT_MS = 240_000;
+const PREFILL_TIMEOUT_MS = 30_000;
+const MAX_NODE_TIMER_MS = 2 ** 31 - 1;
+const MAX_PREFILL_CUSTOMERS = Math.floor((MAX_NODE_TIMER_MS - BASE_TEST_TIMEOUT_MS) / PREFILL_TIMEOUT_MS);
+if (PREFILL_CUSTOMERS > MAX_PREFILL_CUSTOMERS) {
+  throw new Error(
+    `HEXCLAVE_PAYMENTS_PERF_PREFILL assumes the derived test timeout stays within Node's maximum timer delay of ${MAX_NODE_TIMER_MS} ms; effective maximum prefill count is ${MAX_PREFILL_CUSTOMERS}, got ${PREFILL_CUSTOMERS}`,
+  );
+}
+const TEST_TIMEOUT_MS = BASE_TEST_TIMEOUT_MS + PREFILL_CUSTOMERS * PREFILL_TIMEOUT_MS;
 
 it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary", { timeout: TEST_TIMEOUT_MS }, async () => {
   const metrics: PerfMetric[] = [];
@@ -155,7 +172,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
       expect(oneTimeResponse.status).toBe(200);
 
       for (let grant = 0; grant < 2; grant++) {
-        const grantResponse = await niceBackendFetch(`/api/v1/payments/products/user/${userId}`, {
+        const grantResponse = await niceBackendFetch(urlString`/api/v1/payments/products/user/${userId}`, {
           method: "POST",
           accessType: "server",
           body: { product_id: "perf-api-grant", quantity: 1 },
@@ -165,7 +182,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
 
       for (let update = 0; update < ITEM_UPDATES_PER_USER; update++) {
         const itemId = update % 2 === 0 ? "credits" : "boosts";
-        const updateResponse = await niceBackendFetch(`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
+        const updateResponse = await niceBackendFetch(urlString`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
           method: "POST",
           accessType: "server",
           query: { allow_negative: "false" },

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
@@ -87,9 +87,13 @@ type PerfMetric = {
 };
 
 type RequestUserAuth = {
-  accessToken: string,
-  refreshToken: string,
+  accessToken?: string,
+  refreshToken?: string,
 };
+
+// Prefill requests use server/admin access and explicit customer IDs, so an empty override avoids
+// pinning a 60-second user token while also suppressing the shared ambient auth state.
+const PREFILL_NO_USER_AUTH: RequestUserAuth = {};
 
 async function measure<T>(name: string, count: number, fn: () => Promise<T>, metrics: PerfMetric[]): Promise<T> {
   const startedAt = performance.now();
@@ -157,20 +161,19 @@ const TEST_TIMEOUT_MS = BASE_TEST_TIMEOUT_MS * PREFILL_STAGES.length
   + MAX_PREFILL_CUSTOMERS * PREFILL_TIMEOUT_MS;
 
 async function prefillOne(index: number): Promise<void> {
-  const { userId, accessToken, refreshToken } = await Auth.fastSignUp();
-  const userAuth = { accessToken, refreshToken };
+  const { userId } = await Auth.fastSignUp();
 
   const subscriptionCode = await createPurchaseCode({
     customerType: "user",
     customerId: userId,
     productId: "perf-sub",
-    userAuth,
+    userAuth: PREFILL_NO_USER_AUTH,
   });
   const subscriptionResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
     accessType: "admin",
     method: "POST",
     body: { full_code: subscriptionCode, price_id: "monthly", quantity: 1 },
-    userAuth,
+    userAuth: PREFILL_NO_USER_AUTH,
   });
   expect(subscriptionResponse.status).toBe(200);
 
@@ -178,13 +181,13 @@ async function prefillOne(index: number): Promise<void> {
     customerType: "user",
     customerId: userId,
     productId: "perf-otp",
-    userAuth,
+    userAuth: PREFILL_NO_USER_AUTH,
   });
   const oneTimeResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
     accessType: "admin",
     method: "POST",
     body: { full_code: oneTimeCode, price_id: "single", quantity: 2 },
-    userAuth,
+    userAuth: PREFILL_NO_USER_AUTH,
   });
   expect(oneTimeResponse.status).toBe(200);
 
@@ -193,7 +196,7 @@ async function prefillOne(index: number): Promise<void> {
       method: "POST",
       accessType: "server",
       body: { product_id: "perf-api-grant", quantity: 1 },
-      userAuth,
+      userAuth: PREFILL_NO_USER_AUTH,
     });
     expect(grantResponse.status).toBe(200);
   }
@@ -205,7 +208,7 @@ async function prefillOne(index: number): Promise<void> {
       accessType: "server",
       query: { allow_negative: "false" },
       body: { delta: update + 1, description: `prefill-${index}-${update}` },
-      userAuth,
+      userAuth: PREFILL_NO_USER_AUTH,
     });
     expect(updateResponse.status).toBe(200);
   }
@@ -431,9 +434,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
 
     const summary = await runMeasuredWorkload(prefillCustomers, delta, PREFILL_CONCURRENCY, metricsBeforeWorkload);
     if (OUTPUT_PATH != null) {
-      const outputPath = PREFILL_STAGES.length > 1
-        ? OUTPUT_PATH.replace(/\{prefill\}/g, String(prefillCustomers))
-        : OUTPUT_PATH;
+      const outputPath = OUTPUT_PATH.replace(/\{prefill\}/g, String(prefillCustomers));
       writeSummary(summary, outputPath);
     }
     previousPrefillCustomers = prefillCustomers;


### PR DESCRIPTION
The payments perf benchmark always measured an empty tenancy, so it couldn't tell us how the measured flows scale with the amount of payments data Bulldozer already holds.

One prefill unit is one fully-populated customer: a subscription purchase, a one-time purchase, two granted stackable products and `ITEM_UPDATES_PER_USER` item-quantity changes, all written into the same tenancy before measurement. The measured workload is unchanged and identical at every level, so a sweep isolates the effect of pre-existing data volume.

Three env vars, all opt-in:

- `HEXCLAVE_PAYMENTS_PERF_PREFILL=<n>` — prefill `n` customers, then run the workload once.
- `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES=300,1000,3000` — cumulative sweep in a single run against a single tenancy: top the tenancy up to each stage (writing only the delta), then run the identical workload and emit that stage's summary. Reaching 3000 this way costs 3000 customers of prefill instead of 4300, and rules out cross-run variance between levels. Mutually exclusive with `HEXCLAVE_PAYMENTS_PERF_PREFILL`.
- `HEXCLAVE_PAYMENTS_PERF_PREFILL_CONCURRENCY=<n>` (default 8) — bounded worker pool for prefill only. Prefill happens before any measurement, so concurrency here can't taint the numbers; each customer's own request sequence stays serial. Measured locally: 8.1s/customer serial vs 2.4s/customer at 8 workers, with no further gain at 24, which is what makes the 3000-customer levels feasible.

`HEXCLAVE_PAYMENTS_PERF_OUTPUT=<path>` writes each summary as JSON for aggregation afterwards; `{prefill}` in the path is substituted with the stage's cumulative count, and is required when more than one stage is configured. Summaries carry `prefillCustomers`, `prefillCustomersAdded` and `prefillConcurrency` so a file is self-describing, and prefill itself stays a recorded metric per stage — its ms/customer is the direct read on whether write throughput degrades as the tenancy grows.

Config is validated at parse time and fails loudly: strict decimal integers, strictly increasing stages, positive concurrency, non-blank output path, and a derived timeout that stays inside Node's maximum timer delay.

Defaults are unchanged (`prefill = 0`, no JSON output), so CI's perf step behaves exactly as before.

Link to Devin session: https://app.devin.ai/sessions/2705b83c6dec4720b89cd19f596b819f
Requested by: @N2D4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable payment performance test prefill stages and concurrency.
  * Added support for measuring workloads after each prefill stage.
  * Added formatted JSON output with stage-specific file naming.
* **Bug Fixes**
  * Improved validation for safe configuration values and required output paths.
  * Clarified zero-count throughput results as `n/a`.
  * Enhanced test setup with authenticated payment and purchase flows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to an internal perf harness; no production payments or API behavior is modified, and CI defaults are unchanged.
> 
> **Overview**
> Extends the Bulldozer payments e2e perf benchmark so it can measure the **same** HTTP workload against tenancies that already hold varying amounts of payments tree data, instead of only an empty tenancy.
> 
> **Opt-in env configuration:** `HEXCLAVE_PAYMENTS_PERF_PREFILL` (single count) or `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES` (comma-separated cumulative levels in one run, topping up only the delta per stage); `HEXCLAVE_PAYMENTS_PERF_PREFILL_CONCURRENCY` (default 8) for a bounded prefill worker pool that runs **before** measurements; `HEXCLAVE_PAYMENTS_PERF_OUTPUT` for per-stage JSON summaries with `{prefill}` substitution when multiple stages are used. Parse-time validation covers mutual exclusivity, integer/stage ordering, output path rules, and a derived Vitest timeout capped by Node’s max timer.
> 
> **Harness changes:** setup and the measured workload are split (`setupPayments`, `runMeasuredWorkload`); prefill writes one “full customer” per unit (purchases, grants, item updates) with `PREFILL_NO_USER_AUTH` on `niceBackendFetch`; summaries include prefill metadata and treat zero-count throughput as `null` / log `n/a`. Defaults unchanged (`prefill = 0`, no file output), so CI behavior matches the prior single-pass benchmark.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a8e5428d83e059ee151ffad15916da47e63b9ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->