### PR TITLE
Fix Piledriver GC reference-count invariant on non-instant low-level backends

### DIFF
--- a/apps/bulldozer-js/src/databases/piledriver/gc.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/gc.ts
@@ -459,6 +459,9 @@ export function declarePiledriverGarbageCollector(options: {
     if (!Number.isSafeInteger(delta) || delta === 0) throw new Error("Piledriver GC reference-count delta must be a non-zero safe integer");
     let compareAndSetAttempts = 0;
     let compareAndSetConflicts = 0;
+    // get carries no requiresSeq, so on non-instant backends an unbarriered read can make a
+    // freshly created tracked object look legacy-immortal; its matching decrement then goes negative.
+    await options.lowLevelDb.waitUntilAvailable(requiresSeq);
     while (true) {
       const existing = await metadataStore.get(key);
       if (existing.buffer === null) {
@@ -559,6 +562,9 @@ export function declarePiledriverGarbageCollector(options: {
       eligibleAtMillis: number,
     }> = [];
     const metadataSequences: DatabaseSeq[] = [requiresSeq];
+    // get carries no requiresSeq, so on non-instant backends an unbarriered read can make a
+    // freshly created tracked object look legacy-immortal; its matching decrement then goes negative.
+    await options.lowLevelDb.waitUntilAvailable(requiresSeq);
     while (pending.length > 0) {
       const reads = await Promise.all(
         pending.map(async delta => ({
@@ -734,9 +740,10 @@ export function declarePiledriverGarbageCollector(options: {
     return await replaceMetadata(key, existingBuffer, replacement, options.lowLevelDb.initialSeq);
   };
 
-  const advanceDeletion = async (key: ArrayBuffer, expectedIndex: number) => {
+  const advanceDeletion = async (key: ArrayBuffer, expectedIndex: number, requiresSeq: DatabaseSeq) => {
     let compareAndSetConflicts = 0;
     while (true) {
+      await options.lowLevelDb.waitUntilAvailable(requiresSeq);
       const existing = await metadataStore.get(key);
       if (existing.buffer === null) throw new Error("Piledriver GC deletion metadata disappeared");
       const metadata = parseReferenceMetadata(existing.buffer);
@@ -844,6 +851,7 @@ export function declarePiledriverGarbageCollector(options: {
           queueIndex = 0;
           if (!initialCandidateScanComplete) {
             const candidateIndexReadStartedAt = performance.now();
+            await options.lowLevelDb.waitUntilAvailable(latestMutationSeq);
             const page = await candidateStore.listEntries({ startAfter: candidateCursor, limit: GC_SCAN_PAGE_SIZE });
             candidateIndexReadMillis += performance.now() - candidateIndexReadStartedAt;
             candidateIndexPagesRead++;
@@ -868,6 +876,7 @@ export function declarePiledriverGarbageCollector(options: {
           }
           if (queue.length === 0 && initialCandidateScanComplete && !metadataRepairPassComplete) {
             const metadataRepairStartedAt = performance.now();
+            await options.lowLevelDb.waitUntilAvailable(latestMutationSeq);
             const stateRead = await stateStore.get(gcStateKey);
             if (stateRead.buffer === null) throw new Error("Piledriver GC state disappeared during candidate repair");
             const state = parseGarbageCollectionState(stateRead.buffer);
@@ -885,6 +894,7 @@ export function declarePiledriverGarbageCollector(options: {
               if (metadata.generation !== readyGeneration() || metadata.referenceCount !== 0) continue;
               const eligibleAtMillis = metadata.lastDereferencedAtMillis ?? metadata.createdAtMillis;
               const expectedCandidateKey = candidateKey(key, eligibleAtMillis);
+              await options.lowLevelDb.waitUntilAvailable(latestMutationSeq);
               const existingCandidate = await candidateStore.get(expectedCandidateKey);
               if (existingCandidate.buffer === null) {
                 recordMutation((await candidateStore.setAll(
@@ -922,6 +932,7 @@ export function declarePiledriverGarbageCollector(options: {
         queuedKeys.delete(encodeBase64(new Uint8Array(key)));
         maxCascadeDepth = Math.max(maxCascadeDepth, candidate.cascadeDepth);
         examinedCandidates++;
+        await options.lowLevelDb.waitUntilAvailable(latestMutationSeq);
         let metadataRead = await metadataStore.get(key);
         if (metadataRead.buffer === null) {
           recordMutation((await candidateStore.deleteAll(
@@ -972,6 +983,7 @@ export function declarePiledriverGarbageCollector(options: {
           continue;
         }
 
+        await options.lowLevelDb.waitUntilAvailable(latestMutationSeq);
         let heapRead = await options.heapDump.get(key);
         let references: ArrayBuffer[];
         if (metadata.deletion === null) {
@@ -984,6 +996,7 @@ export function declarePiledriverGarbageCollector(options: {
             continue;
           }
           recordMutation(claimSeq);
+          await options.lowLevelDb.waitUntilAvailable(latestMutationSeq);
           metadataRead = await metadataStore.get(key);
           if (metadataRead.buffer === null) throw new Error("Piledriver GC deletion claim disappeared");
           metadata = parseReferenceMetadata(metadataRead.buffer);
@@ -1004,7 +1017,7 @@ export function declarePiledriverGarbageCollector(options: {
         for (let referenceIndex = deletion.nextReferenceIndex; referenceIndex < deletion.totalReferences; referenceIndex++) {
           // Persist progress first. A crash between this write and the decrement can leak one
           // reference, but can never undercount and delete live data when the job is resumed.
-          const progress = await advanceDeletion(key, referenceIndex);
+          const progress = await advanceDeletion(key, referenceIndex, latestMutationSeq);
           recordMutation(progress.seq);
           deletionProgressCompareAndSetConflicts += progress.compareAndSetConflicts;
           metadata = progress.metadata;

--- a/apps/bulldozer-js/src/databases/piledriver/gc.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/gc.ts
@@ -443,6 +443,13 @@ export function declarePiledriverGarbageCollector(options: {
     return options.lowLevelDb.combineSeqs(...unique);
   };
 
+  // get carries no requiresSeq, so on non-instant backends an unbarriered read can make a
+  // freshly created tracked object look legacy-immortal; its matching decrement then goes negative.
+  const readReferenceMetadata = async (key: ArrayBuffer, requiresSeq: DatabaseSeq) => {
+    await options.lowLevelDb.waitUntilAvailable(requiresSeq);
+    return await metadataStore.get(key);
+  };
+
   const changeReferenceCount = async (
     key: ArrayBuffer,
     delta: number,
@@ -459,11 +466,8 @@ export function declarePiledriverGarbageCollector(options: {
     if (!Number.isSafeInteger(delta) || delta === 0) throw new Error("Piledriver GC reference-count delta must be a non-zero safe integer");
     let compareAndSetAttempts = 0;
     let compareAndSetConflicts = 0;
-    // get carries no requiresSeq, so on non-instant backends an unbarriered read can make a
-    // freshly created tracked object look legacy-immortal; its matching decrement then goes negative.
-    await options.lowLevelDb.waitUntilAvailable(requiresSeq);
     while (true) {
-      const existing = await metadataStore.get(key);
+      const existing = await readReferenceMetadata(key, requiresSeq);
       if (existing.buffer === null) {
         // No metadata means the object predates this GC generation. Legacy objects are
         // intentionally immortal, including when newly tracked objects reference them.
@@ -562,14 +566,11 @@ export function declarePiledriverGarbageCollector(options: {
       eligibleAtMillis: number,
     }> = [];
     const metadataSequences: DatabaseSeq[] = [requiresSeq];
-    // get carries no requiresSeq, so on non-instant backends an unbarriered read can make a
-    // freshly created tracked object look legacy-immortal; its matching decrement then goes negative.
-    await options.lowLevelDb.waitUntilAvailable(requiresSeq);
     while (pending.length > 0) {
       const reads = await Promise.all(
         pending.map(async delta => ({
           ...delta,
-          existing: await metadataStore.get(delta.key),
+          existing: await readReferenceMetadata(delta.key, requiresSeq),
         })),
       );
       const retry: typeof pending = [];
@@ -742,8 +743,8 @@ export function declarePiledriverGarbageCollector(options: {
 
   const advanceDeletion = async (key: ArrayBuffer, expectedIndex: number, requiresSeq: DatabaseSeq) => {
     let compareAndSetConflicts = 0;
+    await options.lowLevelDb.waitUntilAvailable(requiresSeq);
     while (true) {
-      await options.lowLevelDb.waitUntilAvailable(requiresSeq);
       const existing = await metadataStore.get(key);
       if (existing.buffer === null) throw new Error("Piledriver GC deletion metadata disappeared");
       const metadata = parseReferenceMetadata(existing.buffer);
@@ -851,7 +852,6 @@ export function declarePiledriverGarbageCollector(options: {
           queueIndex = 0;
           if (!initialCandidateScanComplete) {
             const candidateIndexReadStartedAt = performance.now();
-            await options.lowLevelDb.waitUntilAvailable(latestMutationSeq);
             const page = await candidateStore.listEntries({ startAfter: candidateCursor, limit: GC_SCAN_PAGE_SIZE });
             candidateIndexReadMillis += performance.now() - candidateIndexReadStartedAt;
             candidateIndexPagesRead++;
@@ -876,7 +876,6 @@ export function declarePiledriverGarbageCollector(options: {
           }
           if (queue.length === 0 && initialCandidateScanComplete && !metadataRepairPassComplete) {
             const metadataRepairStartedAt = performance.now();
-            await options.lowLevelDb.waitUntilAvailable(latestMutationSeq);
             const stateRead = await stateStore.get(gcStateKey);
             if (stateRead.buffer === null) throw new Error("Piledriver GC state disappeared during candidate repair");
             const state = parseGarbageCollectionState(stateRead.buffer);
@@ -894,7 +893,6 @@ export function declarePiledriverGarbageCollector(options: {
               if (metadata.generation !== readyGeneration() || metadata.referenceCount !== 0) continue;
               const eligibleAtMillis = metadata.lastDereferencedAtMillis ?? metadata.createdAtMillis;
               const expectedCandidateKey = candidateKey(key, eligibleAtMillis);
-              await options.lowLevelDb.waitUntilAvailable(latestMutationSeq);
               const existingCandidate = await candidateStore.get(expectedCandidateKey);
               if (existingCandidate.buffer === null) {
                 recordMutation((await candidateStore.setAll(
@@ -932,7 +930,6 @@ export function declarePiledriverGarbageCollector(options: {
         queuedKeys.delete(encodeBase64(new Uint8Array(key)));
         maxCascadeDepth = Math.max(maxCascadeDepth, candidate.cascadeDepth);
         examinedCandidates++;
-        await options.lowLevelDb.waitUntilAvailable(latestMutationSeq);
         let metadataRead = await metadataStore.get(key);
         if (metadataRead.buffer === null) {
           recordMutation((await candidateStore.deleteAll(
@@ -983,7 +980,6 @@ export function declarePiledriverGarbageCollector(options: {
           continue;
         }
 
-        await options.lowLevelDb.waitUntilAvailable(latestMutationSeq);
         let heapRead = await options.heapDump.get(key);
         let references: ArrayBuffer[];
         if (metadata.deletion === null) {
@@ -996,8 +992,7 @@ export function declarePiledriverGarbageCollector(options: {
             continue;
           }
           recordMutation(claimSeq);
-          await options.lowLevelDb.waitUntilAvailable(latestMutationSeq);
-          metadataRead = await metadataStore.get(key);
+          metadataRead = await readReferenceMetadata(key, latestMutationSeq);
           if (metadataRead.buffer === null) throw new Error("Piledriver GC deletion claim disappeared");
           metadata = parseReferenceMetadata(metadataRead.buffer);
         } else {

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/base.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/base.ts
@@ -208,6 +208,21 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
   });
   const rootMutationByKey = new Map<string, Promise<unknown>>();
   const rootWriteSeqByKey = new Map<string, DatabaseSeq>();
+  const readPreviousRoot = async (key: ArrayBuffer) => {
+    const keyBase64 = encodeBase64(new Uint8Array(key));
+    const previousRootWriteSeq = rootWriteSeqByKey.get(keyBase64);
+    // rootStore.get carries no requiresSeq. Awaiting this process's prior write prevents raw
+    // LMDB from returning an older root; concurrent writers in another process are out of scope.
+    if (previousRootWriteSeq !== undefined) {
+      try {
+        await lowLevelDb.waitUntilAvailable(previousRootWriteSeq);
+      } catch (error) {
+        if (rootWriteSeqByKey.get(keyBase64) === previousRootWriteSeq) rootWriteSeqByKey.delete(keyBase64);
+        throw error;
+      }
+    }
+    return { keyBase64, previousRoot: await rootStore.get(key) };
+  };
   const withRootMutationLock = async <T>(key: ArrayBuffer, operation: () => Promise<T>) => {
     const keyBase64 = encodeBase64(new Uint8Array(key));
     const previous = rootMutationByKey.get(keyBase64) ?? Promise.resolve();
@@ -762,12 +777,7 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
     async setRootObject(key, value): Promise<{ seq: DatabaseSeq }> {
       return await traceSpan("bulldozer-js.piledriver.setRootObject", async () => await withRootMutationLock(key, async () => {
         await garbageCollector.initialize();
-        const keyBase64 = encodeBase64(new Uint8Array(key));
-        const previousRootWriteSeq = rootWriteSeqByKey.get(keyBase64);
-        // rootStore.get carries no requiresSeq. Awaiting this process's prior write prevents raw
-        // LMDB from returning an older root; concurrent writers in another process are out of scope.
-        if (previousRootWriteSeq !== undefined) await lowLevelDb.waitUntilAvailable(previousRootWriteSeq);
-        const previousRoot = await rootStore.get(key);
+        const { keyBase64, previousRoot } = await readPreviousRoot(key);
         const timingStats = emptyPiledriverSerializationTimingStats();
         const startedAt = performance.now();
         const serializeStartedAt = performance.now();
@@ -865,12 +875,7 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
     async deleteRootObject(key): Promise<{ seq: DatabaseSeq }> {
       return await traceSpan("bulldozer-js.piledriver.deleteRootObject", async () => await withRootMutationLock(key, async () => {
         await garbageCollector.initialize();
-        const keyBase64 = encodeBase64(new Uint8Array(key));
-        const previousRootWriteSeq = rootWriteSeqByKey.get(keyBase64);
-        // rootStore.get carries no requiresSeq. Awaiting this process's prior write prevents raw
-        // LMDB from returning an older root; concurrent writers in another process are out of scope.
-        if (previousRootWriteSeq !== undefined) await lowLevelDb.waitUntilAvailable(previousRootWriteSeq);
-        const previousRoot = await rootStore.get(key);
+        const { keyBase64, previousRoot } = await readPreviousRoot(key);
         const deleted = await rootStore.deleteAll([key]);
         rootWriteSeqByKey.set(keyBase64, deleted.seq);
         if (previousRoot.buffer === null) return deleted;

--- a/apps/bulldozer-js/src/databases/piledriver/implementations/base.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/implementations/base.ts
@@ -207,6 +207,7 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
     processStartedAtMillis,
   });
   const rootMutationByKey = new Map<string, Promise<unknown>>();
+  const rootWriteSeqByKey = new Map<string, DatabaseSeq>();
   const withRootMutationLock = async <T>(key: ArrayBuffer, operation: () => Promise<T>) => {
     const keyBase64 = encodeBase64(new Uint8Array(key));
     const previous = rootMutationByKey.get(keyBase64) ?? Promise.resolve();
@@ -761,6 +762,11 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
     async setRootObject(key, value): Promise<{ seq: DatabaseSeq }> {
       return await traceSpan("bulldozer-js.piledriver.setRootObject", async () => await withRootMutationLock(key, async () => {
         await garbageCollector.initialize();
+        const keyBase64 = encodeBase64(new Uint8Array(key));
+        const previousRootWriteSeq = rootWriteSeqByKey.get(keyBase64);
+        // rootStore.get carries no requiresSeq. Awaiting this process's prior write prevents raw
+        // LMDB from returning an older root; concurrent writers in another process are out of scope.
+        if (previousRootWriteSeq !== undefined) await lowLevelDb.waitUntilAvailable(previousRootWriteSeq);
         const previousRoot = await rootStore.get(key);
         const timingStats = emptyPiledriverSerializationTimingStats();
         const startedAt = performance.now();
@@ -786,6 +792,7 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
         const heapReferenceVisibilityMs = performance.now() - visibilityStartedAt;
         const rootStoreSetAllStartedAt = performance.now();
         const { seq: rootSeq } = await rootStore.setAll([{ key, value: buffer }], { requiresSeq: references.seq });
+        rootWriteSeqByKey.set(keyBase64, rootSeq);
         const dereferenced = previousRoot.buffer === null
           ? { seq: rootSeq }
           : await garbageCollector.afterSerializedObjectBecameInvisible(
@@ -858,8 +865,14 @@ export function declareBasePiledriverDatabase(lowLevelDb: LowLevelDatabase, opti
     async deleteRootObject(key): Promise<{ seq: DatabaseSeq }> {
       return await traceSpan("bulldozer-js.piledriver.deleteRootObject", async () => await withRootMutationLock(key, async () => {
         await garbageCollector.initialize();
+        const keyBase64 = encodeBase64(new Uint8Array(key));
+        const previousRootWriteSeq = rootWriteSeqByKey.get(keyBase64);
+        // rootStore.get carries no requiresSeq. Awaiting this process's prior write prevents raw
+        // LMDB from returning an older root; concurrent writers in another process are out of scope.
+        if (previousRootWriteSeq !== undefined) await lowLevelDb.waitUntilAvailable(previousRootWriteSeq);
         const previousRoot = await rootStore.get(key);
         const deleted = await rootStore.deleteAll([key]);
+        rootWriteSeqByKey.set(keyBase64, deleted.seq);
         if (previousRoot.buffer === null) return deleted;
         const dereferenced = await garbageCollector.afterSerializedObjectBecameInvisible(
           previousRoot.buffer,

--- a/apps/bulldozer-js/src/databases/piledriver/raw-lmdb.test.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/raw-lmdb.test.ts
@@ -1,0 +1,171 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, afterEach, describe, it } from "vitest";
+import { encodeBase64 } from "@hexclave/shared/dist/utils/bytes";
+import type { DatabaseSeq } from "../index.js";
+import type { LowLevelDatabase, LowLevelKvStore } from "../low-level/index.js";
+import { declareLmdbLowLevelDatabase } from "../low-level/implementations/lmdb.js";
+import { asHeapObject, isPiledriverHeapObjectSymbol } from "./index.js";
+import { declareBasePiledriverDatabase } from "./implementations/base.js";
+
+const tempPaths: string[] = [];
+
+type PendingWrite = {
+  seq: DatabaseSeq,
+  buffer: ArrayBuffer | null,
+  resolved: boolean,
+};
+
+function wrapDelayedStoreVisibility(lowLevel: LowLevelDatabase, storeId: string): LowLevelDatabase {
+  return {
+    ...lowLevel,
+    declareKvStore(id) {
+      const store = lowLevel.declareKvStore(id);
+      if (id !== storeId) return store;
+      const availableBuffers = new Map<string, ArrayBuffer | null>();
+      const pendingWrites = new Map<string, PendingWrite[]>();
+      const availabilityPromises = new Map<string, Promise<void>>();
+      const keyId = (key: ArrayBuffer) => encodeBase64(new Uint8Array(key));
+      const seqId = (seq: DatabaseSeq) => JSON.stringify(seq);
+      const clone = (buffer: ArrayBuffer | null) => buffer === null ? null : buffer.slice(0);
+      const flushAvailableWrites = (key: string) => {
+        const writes = pendingWrites.get(key);
+        if (writes === undefined) return;
+        while (writes[0]?.resolved === true) {
+          const write = writes.shift();
+          if (write === undefined) throw new Error("Pending low-level visibility write disappeared");
+          availableBuffers.set(key, clone(write.buffer));
+        }
+        if (writes.length === 0) pendingWrites.delete(key);
+      };
+      const trackAvailability = (seq: DatabaseSeq, writes: PendingWrite[]) => {
+        const id = seqId(seq);
+        let availability = availabilityPromises.get(id);
+        if (availability === undefined) {
+          availability = lowLevel.waitUntilAvailable(seq).then(() => {
+            for (const write of writes) write.resolved = true;
+            for (const [key] of pendingWrites) flushAvailableWrites(key);
+          });
+          availabilityPromises.set(id, availability);
+        }
+      };
+      const getAvailable = async (key: ArrayBuffer) => {
+        const id = keyId(key);
+        flushAvailableWrites(id);
+        const pending = pendingWrites.get(id);
+        if (pending !== undefined && pending.length > 0) {
+          return { buffer: clone(availableBuffers.get(id) ?? null), seq: lowLevel.initialSeq };
+        }
+        const existing = await store.get(key);
+        const buffer = clone(existing.buffer);
+        availableBuffers.set(id, buffer);
+        return { buffer, seq: existing.seq };
+      };
+      const wrapped: LowLevelKvStore = {
+        ...store,
+        get: getAvailable,
+        async setAll(entries, options) {
+          const previous = await Promise.all(entries.map(async ({ key }) => ({ key, existing: await getAvailable(key) })));
+          const result = await store.setAll(entries, options);
+          for (const [{ key, existing }, entry] of previous.map((value, index) => [value, entries[index]] as const)) {
+            const id = keyId(key);
+            const writes = pendingWrites.get(id) ?? [];
+            if (writes.length === 0 && !availableBuffers.has(id)) availableBuffers.set(id, existing.buffer);
+            writes.push({ seq: result.seq, buffer: entry.value.slice(0), resolved: false });
+            pendingWrites.set(id, writes);
+            trackAvailability(result.seq, writes);
+          }
+          return result;
+        },
+        async deleteAll(keys, options) {
+          const previous = await Promise.all(keys.map(async key => ({ key, existing: await getAvailable(key) })));
+          const result = await store.deleteAll(keys, options);
+          for (const { key, existing } of previous) {
+            const id = keyId(key);
+            const writes = pendingWrites.get(id) ?? [];
+            if (writes.length === 0 && !availableBuffers.has(id)) availableBuffers.set(id, existing.buffer);
+            writes.push({ seq: result.seq, buffer: null, resolved: false });
+            pendingWrites.set(id, writes);
+            trackAvailability(result.seq, writes);
+          }
+          return result;
+        },
+      };
+      return wrapped;
+    },
+  };
+}
+
+async function expectRootChildren(
+  database: ReturnType<typeof declareBasePiledriverDatabase>,
+  rootKey: ArrayBuffer,
+  expected: unknown[],
+) {
+  const { object } = await database.getRootObject(rootKey);
+  if (typeof object !== "object" || object === null || Array.isArray(object) || !("children" in object) || !Array.isArray(object.children)) {
+    throw new Error("Expected root object with a children array");
+  }
+  const children = await Promise.all(object.children.map(async child => {
+    if (typeof child === "object" && child !== null && !Array.isArray(child) && isPiledriverHeapObjectSymbol in child) return await child.get();
+    return child;
+  }));
+  expect(children).toEqual(expected);
+}
+
+async function withDatabase(storeId: string, test: (database: ReturnType<typeof declareBasePiledriverDatabase>, lowLevel: LowLevelDatabase) => Promise<void>) {
+  const path = await mkdtemp(join(tmpdir(), "piledriver-raw-lmdb-"));
+  tempPaths.push(path);
+  const lowLevel = wrapDelayedStoreVisibility(declareLmdbLowLevelDatabase({ path }), storeId);
+  try {
+    await test(declareBasePiledriverDatabase(lowLevel), lowLevel);
+  } finally {
+    await lowLevel.close();
+  }
+}
+
+async function countNonZeroReferenceMetadata(lowLevel: LowLevelDatabase) {
+  const { entries } = await lowLevel.declareKvStore("piledriver-gc-reference-metadata-v3").listEntries();
+  return entries.filter(({ value }) => {
+    const parsed: unknown = JSON.parse(new TextDecoder().decode(value));
+    return typeof parsed === "object"
+      && parsed !== null
+      && "referenceCount" in parsed
+      && typeof parsed.referenceCount === "number"
+      && parsed.referenceCount !== 0;
+  }).length;
+}
+
+describe("Piledriver over raw LMDB", () => {
+  it("preserves heap references when metadata visibility is delayed", { timeout: 30_000 }, async () => {
+    await withDatabase("piledriver-gc-reference-metadata-v3", async (database, lowLevel) => {
+      const rootKey = new TextEncoder().encode("metadata-root").buffer;
+      const firstWrite = await database.setRootObject(rootKey, { children: [asHeapObject({ value: "first" })] });
+      await lowLevel.waitUntilAvailable(firstWrite.seq);
+      const secondWrite = await database.setRootObject(rootKey, { children: [asHeapObject({ value: "second" })] });
+      await database.waitUntilAvailable(secondWrite.seq);
+      await expectRootChildren(database, rootKey, [{ value: "second" }]);
+    });
+  });
+
+  it("does not leak heap references when the first root write is still pending", { timeout: 30_000 }, async () => {
+    await withDatabase("root", async (database, lowLevel) => {
+      const rootKey = new TextEncoder().encode("root-first-write").buffer;
+      const firstChildren = [asHeapObject({ value: "first-1" }), asHeapObject({ value: "first-2" })];
+      const secondChildren = [asHeapObject({ value: "second-1" }), asHeapObject({ value: "second-2" }), asHeapObject({ value: "second-3" })];
+      const firstWrite = await database.setRootObject(rootKey, { children: firstChildren });
+      const secondWrite = await database.setRootObject(rootKey, { children: secondChildren });
+      await database.waitUntilAvailable(secondWrite.seq);
+      await expectRootChildren(database, rootKey, [{ value: "second-1" }, { value: "second-2" }, { value: "second-3" }]);
+      expect(await countNonZeroReferenceMetadata(lowLevel)).toBe(secondChildren.length);
+      await lowLevel.waitUntilAvailable(firstWrite.seq);
+    });
+  });
+});
+
+afterEach(async () => {
+  while (tempPaths.length > 0) {
+    const path = tempPaths.pop();
+    if (path !== undefined) await rm(path, { recursive: true, force: true });
+  }
+});

--- a/apps/bulldozer-js/src/databases/piledriver/raw-lmdb.test.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/raw-lmdb.test.ts
@@ -25,6 +25,7 @@ function wrapDelayedStoreVisibility(lowLevel: LowLevelDatabase, storeId: string)
       if (id !== storeId) return store;
       const availableBuffers = new Map<string, ArrayBuffer | null>();
       const pendingWrites = new Map<string, PendingWrite[]>();
+      const pendingWritesBySeq = new Map<string, PendingWrite[]>();
       const availabilityPromises = new Map<string, Promise<void>>();
       const keyId = (key: ArrayBuffer) => encodeBase64(new Uint8Array(key));
       const seqId = (seq: DatabaseSeq) => JSON.stringify(seq);
@@ -39,12 +40,14 @@ function wrapDelayedStoreVisibility(lowLevel: LowLevelDatabase, storeId: string)
         }
         if (writes.length === 0) pendingWrites.delete(key);
       };
-      const trackAvailability = (seq: DatabaseSeq, writes: PendingWrite[]) => {
+      const trackAvailability = (seq: DatabaseSeq) => {
         const id = seqId(seq);
         let availability = availabilityPromises.get(id);
         if (availability === undefined) {
           availability = lowLevel.waitUntilAvailable(seq).then(() => {
+            const writes = pendingWritesBySeq.get(id) ?? [];
             for (const write of writes) write.resolved = true;
+            pendingWritesBySeq.delete(id);
             for (const [key] of pendingWrites) flushAvailableWrites(key);
           });
           availabilityPromises.set(id, availability);
@@ -72,10 +75,14 @@ function wrapDelayedStoreVisibility(lowLevel: LowLevelDatabase, storeId: string)
             const id = keyId(key);
             const writes = pendingWrites.get(id) ?? [];
             if (writes.length === 0 && !availableBuffers.has(id)) availableBuffers.set(id, existing.buffer);
-            writes.push({ seq: result.seq, buffer: entry.value.slice(0), resolved: false });
+            const write = { seq: result.seq, buffer: entry.value.slice(0), resolved: false };
+            writes.push(write);
             pendingWrites.set(id, writes);
-            trackAvailability(result.seq, writes);
+            const seqWrites = pendingWritesBySeq.get(seqId(result.seq)) ?? [];
+            seqWrites.push(write);
+            pendingWritesBySeq.set(seqId(result.seq), seqWrites);
           }
+          trackAvailability(result.seq);
           return result;
         },
         async deleteAll(keys, options) {
@@ -85,10 +92,14 @@ function wrapDelayedStoreVisibility(lowLevel: LowLevelDatabase, storeId: string)
             const id = keyId(key);
             const writes = pendingWrites.get(id) ?? [];
             if (writes.length === 0 && !availableBuffers.has(id)) availableBuffers.set(id, existing.buffer);
-            writes.push({ seq: result.seq, buffer: null, resolved: false });
+            const write = { seq: result.seq, buffer: null, resolved: false };
+            writes.push(write);
             pendingWrites.set(id, writes);
-            trackAvailability(result.seq, writes);
+            const seqWrites = pendingWritesBySeq.get(seqId(result.seq)) ?? [];
+            seqWrites.push(write);
+            pendingWritesBySeq.set(seqId(result.seq), seqWrites);
           }
+          trackAvailability(result.seq);
           return result;
         },
       };

--- a/apps/bulldozer-js/src/databases/piledriver/raw-lmdb.test.ts
+++ b/apps/bulldozer-js/src/databases/piledriver/raw-lmdb.test.ts
@@ -161,6 +161,18 @@ describe("Piledriver over raw LMDB", () => {
       await lowLevel.waitUntilAvailable(firstWrite.seq);
     });
   });
+
+  it("dereferences heap references when deleting a pending root write", { timeout: 30_000 }, async () => {
+    await withDatabase("root", async (database, lowLevel) => {
+      const rootKey = new TextEncoder().encode("root-delete-pending").buffer;
+      const firstChildren = [asHeapObject({ value: "first-1" }), asHeapObject({ value: "first-2" })];
+      const firstWrite = await database.setRootObject(rootKey, { children: firstChildren });
+      const deleteWrite = await database.deleteRootObject(rootKey);
+      await database.waitUntilAvailable(deleteWrite.seq);
+      expect(await countNonZeroReferenceMetadata(lowLevel)).toBe(0);
+      await lowLevel.waitUntilAvailable(firstWrite.seq);
+    });
+  });
 });
 
 afterEach(async () => {


### PR DESCRIPTION
Base Piledriver over a raw (non-instant) LMDB low-level database threw `Piledriver GC reference count would become invalid for heap object ...` on the second root write.

**Invariant that was violated:** `LowLevelKvStore.get` takes no `requiresSeq` — it returns whatever is available to this client *now*, so a caller whose read decides a subsequent write must first await availability of the writes it causally depends on. The GC reference-delta code read `piledriver-gc-reference-metadata-v3` without that barrier. On raw LMDB writes are queued and only become readable once committed, so the creation metadata written by `recordHeapObjectCreations` read back as `null`, the positive edge delta was silently skipped as "legacy immortal" (the intended behaviour for pre-GC objects), and the matching decrement for the replaced root then drove that object's count from 0 to -1 and tripped the guard. The instant-availability wrapper hid this by serving pending writes from its in-memory overlay.

**Fix:** await availability of the `requiresSeq` that is already passed in before reading reference metadata whose value decides the next write — `changeReferenceCount`, `changeSerializedReferenceDeltas`, the metadata re-read after a deletion claim, and `advanceDeletion`'s progress read. The guard itself is unchanged. `setRootObject` / `deleteRootObject` additionally await this process's previous root write before reading the previous root, which closes the remaining case where nothing else barriers it (`previousRoot === null`, i.e. the first write for a key) and would otherwise skip the decrement of the preceding root and leak its heap children; if that recorded write turns out to have failed, its entry is dropped so a retry isn't permanently blocked. Cross-process writers are out of scope, as before.

**Regression test** (`piledriver/raw-lmdb.test.ts`, real LMDB, no instant wrapper, with a wrapper that makes one store's writes readable only once their seq is available, so the race is deterministic): a root updated twice with heap children while GC metadata visibility lags — reproduces the negative decrement — plus a first root write still pending when the next write reads the previous root, and the same for a delete, both asserting via the GC metadata that superseded children are dereferenced rather than leaked. Each fails deterministically without its corresponding barrier and passes with it.

Also verified: the `lmdb`, `buffered-lmdb` and `lmdb-instant` payments performance workloads, the piledriver + bulldozer suites, typecheck and lint.


Link to Devin session: https://app.devin.ai/sessions/23f84d331b074a369a36b4d12f350fd5
Requested by: @N2D4