### PR TITLE
feat(bulldozer): enable buffered Piledriver by default

### DIFF
--- a/apps/bulldozer-js/src/index.ts
+++ b/apps/bulldozer-js/src/index.ts
@@ -17,6 +17,7 @@ import { declareInstantAvailabilityLowLevelDatabase } from "./databases/low-leve
 import { declareLmdbLowLevelDatabase, getLmdbDiagnostics } from "./databases/low-level/implementations/lmdb.js";
 import type { LowLevelDatabase } from "./databases/low-level/index.js";
 import { declareBasePiledriverDatabase } from "./databases/piledriver/implementations/base.js";
+import { declareBufferedPiledriverDatabase } from "./databases/piledriver/implementations/buffered.js";
 import type { PiledriverObject } from "./databases/piledriver/index.js";
 import "./load-env.js";
 import { shouldSuppressPeriodicBulldozerLogs } from "./logging.js";
@@ -76,10 +77,16 @@ function createLowLevelDatabase(): LowLevelDatabase {
   }));
 }
 
+const basePiledriver = declareBasePiledriverDatabase(createLowLevelDatabase(), {
+  disableHeapReadCache: process.env.HEXCLAVE_BULLDOZER_JS_DISABLE_PILEDRIVER_HEAP_READ_CACHE === "1",
+});
+// Buffering keeps availability instant while durability/replication waits for the wrapped root write;
+// it is worthwhile for write-lock occupancy and throughput, not per-call latency.
+const piledriver = process.env.HEXCLAVE_BULLDOZER_JS_DISABLE_BUFFERED_PILEDRIVER === "1"
+  ? basePiledriver
+  : declareBufferedPiledriverDatabase(basePiledriver);
 const bulldozerDb = declareBulldozerDatabase(
-  declareBasePiledriverDatabase(createLowLevelDatabase(), {
-    disableHeapReadCache: process.env.HEXCLAVE_BULLDOZER_JS_DISABLE_PILEDRIVER_HEAP_READ_CACHE === "1",
-  }),
+  piledriver,
   { migrations: schema.migrations },
 );
 (globalThis as any).bulldozerDb = bulldozerDb;

--- a/apps/bulldozer-js/src/index.ts
+++ b/apps/bulldozer-js/src/index.ts
@@ -82,9 +82,8 @@ const basePiledriver = declareBasePiledriverDatabase(createLowLevelDatabase(), {
 });
 // Buffering keeps availability instant while durability/replication waits for the wrapped root write;
 // it is worthwhile for write-lock occupancy and throughput, not per-call latency.
-const piledriver = process.env.HEXCLAVE_BULLDOZER_JS_DISABLE_BUFFERED_PILEDRIVER === "1"
-  ? basePiledriver
-  : declareBufferedPiledriverDatabase(basePiledriver);
+const bufferedPiledriverEnabled = process.env.HEXCLAVE_BULLDOZER_JS_DISABLE_BUFFERED_PILEDRIVER !== "1";
+const piledriver = bufferedPiledriverEnabled ? declareBufferedPiledriverDatabase(basePiledriver) : basePiledriver;
 const bulldozerDb = declareBulldozerDatabase(
   piledriver,
   { migrations: schema.migrations },
@@ -1161,6 +1160,7 @@ const startupFields = {
   usingTmpLmdb: process.env.HEXCLAVE_BULLDOZER_JS_USE_TMP_LMDB === "1",
   lmdbCompression: process.env.HEXCLAVE_BULLDOZER_JS_LMDB_COMPRESSION === "1",
   disableHeapReadCache: process.env.HEXCLAVE_BULLDOZER_JS_DISABLE_PILEDRIVER_HEAP_READ_CACHE === "1",
+  bufferedPiledriverEnabled,
   gcExposed: globalThis.gc !== undefined,
   heapGcUsageThreshold: HEAP_GC_USAGE_THRESHOLD,
   heapGcMaxPasses: HEAP_GC_MAX_PASSES,


### PR DESCRIPTION
Wraps the server's base Piledriver database in `declareBufferedPiledriverDatabase` (#1954). The low-level stack is unchanged — still instant-availability over LMDB.

```
before: bulldozer -> base piledriver             -> instant-availability -> lmdb
after:  bulldozer -> buffered -> base piledriver -> instant-availability -> lmdb
```

Availability stays instant; durability/replication now completes after the buffered root write reaches the base database. Since at most one underlying root write runs at a time and same-key writes coalesce, a burst collapses into roughly one write per key per underlying round trip. That is a throughput change, not a latency one: on the payments perf workload it cuts write-lock held time ~17-21x while serial replicated latency stays at parity with the unbuffered path.

Set `HEXCLAVE_BULLDOZER_JS_DISABLE_BUFFERED_PILEDRIVER=1` to go back to the unbuffered wiring without a revert.

Request paths already wait for replication (`withSnapshotReplicated`), `/internal/wait-until-durable` still goes through `waitUntilCurrentStateDurable()`, and shutdown's `close()` drains the buffer, so nothing relies on availability implying durability.

Link to Devin session: https://app.devin.ai/sessions/85ec1d1a4d974380a1aa2ef9371c1a29
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core persistence wiring for all Bulldozer-js deployments; durability semantics now depend on buffer flush, though existing replication/drain paths are intended to preserve correctness.
> 
> **Overview**
> **Bulldozer-js** now wires the storage stack through **`declareBufferedPiledriverDatabase`** on top of the existing base Piledriver → instant-availability → LMDB chain, instead of connecting Bulldozer directly to base Piledriver.
> 
> Reads still see instant availability; durability and replication complete when buffered root writes flush to the base layer, with same-key writes coalescing under load to cut write-lock occupancy and improve throughput. Set **`HEXCLAVE_BULLDOZER_JS_DISABLE_BUFFERED_PILEDRIVER=1`** to restore the previous unbuffered wiring without reverting the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36568b3af3bc0a53a2dd048a86a961ceed85a95d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable buffered Piledriver by default to cut write-lock time and boost throughput while keeping instant availability. Previously writes hit the base Piledriver; now they go through a buffer, and durability/replication completes when the buffered root write flushes to the base store.

**Review and rollout**
- Wiring-only change; `lmdb` and instant-availability layers are unchanged; no schema or API changes.
- Request paths already wait for replication; shutdown drains the buffer; `/internal/wait-until-durable` is unchanged.
- Startup diagnostics now report `bufferedPiledriverEnabled` to verify rollout.
- To revert to unbuffered behavior, set `HEXCLAVE_BULLDOZER_JS_DISABLE_BUFFERED_PILEDRIVER=1`. Expect ~17–21x lower write-lock occupancy on perf workloads with no per-call or serial replicated latency regression.

<sup>Written for commit 06dc14e378418f4070f4f43cc51f1856d803f30a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved database performance by enabling buffered data processing by default.
  * Added an option to disable buffered processing through configuration.
  * Added configurable caching for database heap reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->