### PR TITLE
fix(external-db-sync): serialize sequence allocation so the sync watermark can't skip rows

### DIFF
--- a/apps/backend/src/app/api/latest/internal/external-db-sync/sequencer/route.ts
+++ b/apps/backend/src/app/api/latest/internal/external-db-sync/sequencer/route.ts
@@ -1,7 +1,7 @@
 import { getExternalDbSyncFusebox } from "@/lib/external-db-sync-metadata";
 import { enqueueExternalDbSyncBatch } from "@/lib/external-db-sync-queue";
 import { Prisma } from "@/generated/prisma/client";
-import { globalPrismaClient } from "@/prisma-client";
+import { globalPrismaClient, retryTransaction } from "@/prisma-client";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { traceSpan } from "@/utils/telemetry";
 import {
@@ -18,6 +18,95 @@ import { wait } from "@hexclave/shared/dist/utils/promises";
 const DEFAULT_MAX_DURATION_MS = 3 * 60 * 1000;
 const SEQUENCER_BATCH_SIZE_ENV = "STACK_EXTERNAL_DB_SYNC_SEQUENCER_BATCH_SIZE";
 const DEFAULT_BATCH_SIZE = 1000;
+
+/** PostgreSQL advisory-lock namespace for sequence allocation. */
+const SEQUENCE_ALLOCATION_LOCK_CLASS = 178555;
+
+export type SequenceAllocationResult<T> = {
+  locked: boolean,
+  result: T | null,
+};
+
+type EmailOutboxSequenceAllocationScope = {
+  tenancyId: string,
+  id: string,
+};
+
+export type EmailOutboxSequenceAllocation = {
+  tenancyId: string,
+  id: string,
+  sequenceId: bigint,
+};
+
+/**
+ * Runs one set-based sequence allocation while holding the global transaction-scoped lock.
+ * The lock is global because each batch statement can span multiple tenancies.
+ */
+export async function runSequenceAllocationInTransaction<T>(
+  tx: Prisma.TransactionClient,
+  allocation: (tx: Prisma.TransactionClient) => Promise<T>,
+): Promise<SequenceAllocationResult<T>> {
+  const [{ locked }] = await tx.$queryRaw<{ locked: boolean }[]>`
+    SELECT pg_try_advisory_xact_lock(${SEQUENCE_ALLOCATION_LOCK_CLASS}::int) AS locked
+  `;
+  if (!locked) return { locked: false, result: null };
+  return { locked: true, result: await allocation(tx) };
+}
+
+export async function allocateEmailOutboxSequence(
+  tx: Prisma.TransactionClient,
+  batchSize: number,
+  scope?: EmailOutboxSequenceAllocationScope,
+): Promise<EmailOutboxSequenceAllocation[]> {
+  if (scope != null) {
+    return await tx.$queryRaw<EmailOutboxSequenceAllocation[]>`
+      WITH rows_to_update AS (
+        SELECT "tenancyId", "id"
+        FROM "EmailOutbox"
+        WHERE "tenancyId" = ${scope.tenancyId}::uuid
+          AND "id" = ${scope.id}::uuid
+          AND "shouldUpdateSequenceId" = TRUE
+        FOR UPDATE SKIP LOCKED
+      ),
+      updated_rows AS (
+        UPDATE "EmailOutbox" eo
+        SET "sequenceId" = nextval('global_seq_id'),
+            "shouldUpdateSequenceId" = FALSE
+        FROM rows_to_update r
+        WHERE eo."tenancyId" = r."tenancyId"
+          AND eo."id" = r."id"
+        RETURNING eo."tenancyId", eo."id", eo."sequenceId"
+      )
+      SELECT "tenancyId", "id", "sequenceId" FROM updated_rows
+    `;
+  }
+  return await tx.$queryRaw<EmailOutboxSequenceAllocation[]>`
+    WITH rows_to_update AS (
+      SELECT "tenancyId", "id"
+      FROM "EmailOutbox"
+      WHERE "shouldUpdateSequenceId" = TRUE
+      ORDER BY "tenancyId"
+      LIMIT ${batchSize}
+      FOR UPDATE SKIP LOCKED
+    ),
+    updated_rows AS (
+      UPDATE "EmailOutbox" eo
+      SET "sequenceId" = nextval('global_seq_id'),
+          "shouldUpdateSequenceId" = FALSE
+      FROM rows_to_update r
+      WHERE eo."tenancyId" = r."tenancyId"
+        AND eo."id" = r."id"
+      RETURNING eo."tenancyId", eo."id", eo."sequenceId"
+    )
+    SELECT "tenancyId", "id", "sequenceId" FROM updated_rows
+  `;
+}
+
+async function runSequenceAllocation<T>(
+  allocation: (tx: Prisma.TransactionClient) => Promise<T>,
+): Promise<SequenceAllocationResult<T>> {
+  return await retryTransaction(globalPrismaClient, (tx) => runSequenceAllocationInTransaction(tx, allocation));
+}
 
 function parseMaxDurationMs(value: string | undefined): number {
   if (!value) return DEFAULT_MAX_DURATION_MS;
@@ -52,7 +141,9 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
   }, async (span) => {
     let didUpdate = false;
 
-    const projectUserTenants = await globalPrismaClient.$queryRaw<{ tenancyId: string }[]>`
+    // Sequence allocation must commit in allocation order: the sync's `> watermark` filter
+    // permanently skips a lower value if a higher value becomes visible first.
+    const projectUserTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "projectUserId"
         FROM "ProjectUser"
@@ -71,7 +162,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING pu."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `;
+    `)).result ?? [];
 
     span.setAttribute("stack.external-db-sync.project-user-tenants", projectUserTenants.length);
 
@@ -81,7 +172,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const contactChannelTenants = await globalPrismaClient.$queryRaw<{ tenancyId: string }[]>`
+    const contactChannelTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "projectUserId", "id"
         FROM "ContactChannel"
@@ -101,7 +192,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING cc."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `;
+    `)).result ?? [];
 
     span.setAttribute("stack.external-db-sync.contact-channel-tenants", contactChannelTenants.length);
 
@@ -110,7 +201,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const teamTenants = await globalPrismaClient.$queryRaw<{ tenancyId: string, teamId: string }[]>`
+    const teamTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string, teamId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "teamId"
         FROM "Team"
@@ -129,7 +220,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING t."tenancyId", t."teamId"
       )
       SELECT DISTINCT "tenancyId", "teamId" FROM updated_rows
-    `;
+    `)).result ?? [];
 
     span.setAttribute("stack.external-db-sync.team-tenants", teamTenants.length);
 
@@ -158,7 +249,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       `;
     }
 
-    const teamMemberTenants = await globalPrismaClient.$queryRaw<{ tenancyId: string }[]>`
+    const teamMemberTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "projectUserId", "teamId"
         FROM "TeamMember"
@@ -178,7 +269,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING tm."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `;
+    `)).result ?? [];
 
     span.setAttribute("stack.external-db-sync.team-member-tenants", teamMemberTenants.length);
 
@@ -187,7 +278,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const teamPermissionTenants = await globalPrismaClient.$queryRaw<{ tenancyId: string }[]>`
+    const teamPermissionTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "id"
         FROM "TeamMemberDirectPermission"
@@ -205,7 +296,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING tp."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `;
+    `)).result ?? [];
 
     span.setAttribute("stack.external-db-sync.team-permission-tenants", teamPermissionTenants.length);
 
@@ -214,7 +305,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const teamInvitationTenants = await globalPrismaClient.$queryRaw<{ tenancyId: string }[]>`
+    const teamInvitationTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "projectId", "branchId", "id"
         FROM "VerificationCode"
@@ -238,7 +329,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       FROM updated_rows
       JOIN "Tenancy" ON "Tenancy"."projectId" = updated_rows."projectId"
         AND "Tenancy"."branchId" = updated_rows."branchId"
-    `;
+    `)).result ?? [];
 
     span.setAttribute("stack.external-db-sync.team-invitation-tenants", teamInvitationTenants.length);
 
@@ -247,26 +338,9 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const emailOutboxTenants = await globalPrismaClient.$queryRaw<{ tenancyId: string }[]>`
-      WITH rows_to_update AS (
-        SELECT "tenancyId", "id"
-        FROM "EmailOutbox"
-        WHERE "shouldUpdateSequenceId" = TRUE
-        ORDER BY "tenancyId"
-        LIMIT ${batchSize}
-        FOR UPDATE SKIP LOCKED
-      ),
-      updated_rows AS (
-        UPDATE "EmailOutbox" eo
-        SET "sequenceId" = nextval('global_seq_id'),
-            "shouldUpdateSequenceId" = FALSE
-        FROM rows_to_update r
-        WHERE eo."tenancyId" = r."tenancyId"
-          AND eo."id"        = r."id"
-        RETURNING eo."tenancyId"
-      )
-      SELECT DISTINCT "tenancyId" FROM updated_rows
-    `;
+    const emailOutboxRows = (await runSequenceAllocation((tx) => allocateEmailOutboxSequence(tx, batchSize))).result ?? [];
+    const emailOutboxTenants = Array.from(new Set(emailOutboxRows.map(row => row.tenancyId)))
+      .map(tenancyId => ({ tenancyId }));
 
     span.setAttribute("stack.external-db-sync.email-outbox-tenants", emailOutboxTenants.length);
 
@@ -275,7 +349,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const projectPermissionTenants = await globalPrismaClient.$queryRaw<{ tenancyId: string }[]>`
+    const projectPermissionTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "id"
         FROM "ProjectUserDirectPermission"
@@ -293,7 +367,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING pp."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `;
+    `)).result ?? [];
 
     span.setAttribute("stack.external-db-sync.project-permission-tenants", projectPermissionTenants.length);
 
@@ -302,7 +376,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const notificationPreferenceTenants = await globalPrismaClient.$queryRaw<{ tenancyId: string }[]>`
+    const notificationPreferenceTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "id"
         FROM "UserNotificationPreference"
@@ -321,7 +395,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING np."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `;
+    `)).result ?? [];
 
     span.setAttribute("stack.external-db-sync.notification-preference-tenants", notificationPreferenceTenants.length);
 
@@ -330,7 +404,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const refreshTokenTenants = await globalPrismaClient.$queryRaw<{ tenancyId: string }[]>`
+    const refreshTokenTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "id"
         FROM "ProjectUserRefreshToken"
@@ -349,7 +423,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING rt."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `;
+    `)).result ?? [];
 
     span.setAttribute("stack.external-db-sync.refresh-token-tenants", refreshTokenTenants.length);
 
@@ -358,7 +432,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const oauthAccountTenants = await globalPrismaClient.$queryRaw<{ tenancyId: string }[]>`
+    const oauthAccountTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "id"
         FROM "ProjectUserOAuthAccount"
@@ -377,7 +451,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING oa."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `;
+    `)).result ?? [];
 
     span.setAttribute("stack.external-db-sync.oauth-account-tenants", oauthAccountTenants.length);
 
@@ -386,7 +460,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const deletedRowTenants = await globalPrismaClient.$queryRaw<{ tenancyId: string }[]>`
+    const deletedRowTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "id", "tenancyId"
         FROM "DeletedRow"
@@ -404,7 +478,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING dr."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `;
+    `)).result ?? [];
 
     span.setAttribute("stack.external-db-sync.deleted-row-tenants", deletedRowTenants.length);
 

--- a/apps/backend/src/app/api/latest/internal/external-db-sync/sequencer/route.ts
+++ b/apps/backend/src/app/api/latest/internal/external-db-sync/sequencer/route.ts
@@ -1,5 +1,6 @@
 import { getExternalDbSyncFusebox } from "@/lib/external-db-sync-metadata";
 import { enqueueExternalDbSyncBatch } from "@/lib/external-db-sync-queue";
+import { runSequenceAllocationInTransaction } from "@/lib/external-db-sync-sequencing";
 import { Prisma } from "@/generated/prisma/client";
 import { globalPrismaClient, retryTransaction } from "@/prisma-client";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
@@ -11,7 +12,6 @@ import {
   yupString,
   yupTuple,
 } from "@hexclave/shared/dist/schema-fields";
-import { SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY } from "@hexclave/shared/dist/config/db-sync-mappings";
 import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { captureError, HexclaveAssertionError, StatusError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { wait } from "@hexclave/shared/dist/utils/promises";
@@ -20,31 +20,20 @@ const DEFAULT_MAX_DURATION_MS = 3 * 60 * 1000;
 const SEQUENCER_BATCH_SIZE_ENV = "STACK_EXTERNAL_DB_SYNC_SEQUENCER_BATCH_SIZE";
 const DEFAULT_BATCH_SIZE = 1000;
 
-/**
- * Runs one set-based sequence allocation while holding the global transaction-scoped lock.
- *
- * Sequence allocation must commit in allocation order: the sync's `> watermark` filter
- * permanently skips a lower value if a higher value becomes visible first. The lock is global
- * because each batch statement can span multiple tenancies.
- */
-export async function runSequenceAllocationInTransaction<T>(
-  tx: Prisma.TransactionClient,
-  allocation: (tx: Prisma.TransactionClient) => Promise<T>,
-): Promise<T | null> {
-  const lockRows = await tx.$queryRaw<{ locked: boolean }[]>`
-    SELECT pg_try_advisory_xact_lock(${SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY}::int) AS locked
-  `;
-  const locked = lockRows[0]?.locked ?? throwErr(
-    "Sequence allocation advisory lock query must return exactly one row",
-  );
-  if (!locked) return null;
-  return await allocation(tx);
-}
-
 async function runSequenceAllocation<T>(
   allocation: (tx: Prisma.TransactionClient) => Promise<T>,
+  onSkipped: () => void = () => undefined,
 ): Promise<T | null> {
-  return await retryTransaction(globalPrismaClient, (tx) => runSequenceAllocationInTransaction(tx, allocation));
+  // Allocation batches can contain up to 1,000 rows; allow substantial headroom above
+  // the normal sub-second case while keeping the globally locked transaction bounded.
+  return await retryTransaction(
+    globalPrismaClient,
+    (tx) => runSequenceAllocationInTransaction(tx, allocation),
+    { timeout: 30_000 },
+  ).then((result) => {
+    if (result == null) onSkipped();
+    return result;
+  });
 }
 
 function parseMaxDurationMs(value: string | undefined): number {
@@ -80,7 +69,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
   }, async (span) => {
     let didUpdate = false;
 
-    const projectUserTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
+    const projectUserTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "projectUserId"
         FROM "ProjectUser"
@@ -99,7 +88,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING pu."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)) ?? [];
+    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
 
     span.setAttribute("stack.external-db-sync.project-user-tenants", projectUserTenants.length);
 
@@ -109,7 +98,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const contactChannelTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
+    const contactChannelTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "projectUserId", "id"
         FROM "ContactChannel"
@@ -129,7 +118,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING cc."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)) ?? [];
+    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
 
     span.setAttribute("stack.external-db-sync.contact-channel-tenants", contactChannelTenants.length);
 
@@ -138,7 +127,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const teamTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string, teamId: string }[]>`
+    const teamTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string, teamId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "teamId"
         FROM "Team"
@@ -157,7 +146,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING t."tenancyId", t."teamId"
       )
       SELECT DISTINCT "tenancyId", "teamId" FROM updated_rows
-    `)) ?? [];
+    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
 
     span.setAttribute("stack.external-db-sync.team-tenants", teamTenants.length);
 
@@ -186,7 +175,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       `;
     }
 
-    const teamMemberTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
+    const teamMemberTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "projectUserId", "teamId"
         FROM "TeamMember"
@@ -206,7 +195,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING tm."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)) ?? [];
+    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
 
     span.setAttribute("stack.external-db-sync.team-member-tenants", teamMemberTenants.length);
 
@@ -215,7 +204,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const teamPermissionTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
+    const teamPermissionTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "id"
         FROM "TeamMemberDirectPermission"
@@ -233,7 +222,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING tp."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)) ?? [];
+    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
 
     span.setAttribute("stack.external-db-sync.team-permission-tenants", teamPermissionTenants.length);
 
@@ -242,7 +231,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const teamInvitationTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
+    const teamInvitationTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "projectId", "branchId", "id"
         FROM "VerificationCode"
@@ -266,7 +255,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       FROM updated_rows
       JOIN "Tenancy" ON "Tenancy"."projectId" = updated_rows."projectId"
         AND "Tenancy"."branchId" = updated_rows."branchId"
-    `)) ?? [];
+    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
 
     span.setAttribute("stack.external-db-sync.team-invitation-tenants", teamInvitationTenants.length);
 
@@ -275,7 +264,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const emailOutboxTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
+    const emailOutboxTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "id"
         FROM "EmailOutbox"
@@ -294,7 +283,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING eo."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)) ?? [];
+    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
 
     span.setAttribute("stack.external-db-sync.email-outbox-tenants", emailOutboxTenants.length);
 
@@ -303,7 +292,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const projectPermissionTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
+    const projectPermissionTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "id"
         FROM "ProjectUserDirectPermission"
@@ -321,7 +310,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING pp."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)) ?? [];
+    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
 
     span.setAttribute("stack.external-db-sync.project-permission-tenants", projectPermissionTenants.length);
 
@@ -330,7 +319,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const notificationPreferenceTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
+    const notificationPreferenceTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "id"
         FROM "UserNotificationPreference"
@@ -349,7 +338,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING np."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)) ?? [];
+    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
 
     span.setAttribute("stack.external-db-sync.notification-preference-tenants", notificationPreferenceTenants.length);
 
@@ -358,7 +347,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const refreshTokenTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
+    const refreshTokenTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "id"
         FROM "ProjectUserRefreshToken"
@@ -377,7 +366,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING rt."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)) ?? [];
+    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
 
     span.setAttribute("stack.external-db-sync.refresh-token-tenants", refreshTokenTenants.length);
 
@@ -386,7 +375,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const oauthAccountTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
+    const oauthAccountTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "id"
         FROM "ProjectUserOAuthAccount"
@@ -405,7 +394,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING oa."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)) ?? [];
+    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
 
     span.setAttribute("stack.external-db-sync.oauth-account-tenants", oauthAccountTenants.length);
 
@@ -414,7 +403,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const deletedRowTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
+    const deletedRowTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "id", "tenancyId"
         FROM "DeletedRow"
@@ -432,7 +421,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING dr."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)) ?? [];
+    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
 
     span.setAttribute("stack.external-db-sync.deleted-row-tenants", deletedRowTenants.length);
 

--- a/apps/backend/src/app/api/latest/internal/external-db-sync/sequencer/route.ts
+++ b/apps/backend/src/app/api/latest/internal/external-db-sync/sequencer/route.ts
@@ -1,6 +1,7 @@
 import { getExternalDbSyncFusebox } from "@/lib/external-db-sync-metadata";
 import { enqueueExternalDbSyncBatch } from "@/lib/external-db-sync-queue";
 import { runSequenceAllocationInTransaction } from "@/lib/external-db-sync-sequencing";
+import { Span } from "@opentelemetry/api";
 import { Prisma } from "@/generated/prisma/client";
 import { globalPrismaClient, retryTransaction } from "@/prisma-client";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
@@ -22,18 +23,17 @@ const DEFAULT_BATCH_SIZE = 1000;
 
 async function runSequenceAllocation<T>(
   allocation: (tx: Prisma.TransactionClient) => Promise<T>,
-  onSkipped: () => void = () => undefined,
+  span: Span,
 ): Promise<T | null> {
   // Allocation batches can contain up to 1,000 rows; allow substantial headroom above
   // the normal sub-second case while keeping the globally locked transaction bounded.
-  return await retryTransaction(
+  const result = await retryTransaction(
     globalPrismaClient,
     (tx) => runSequenceAllocationInTransaction(tx, allocation),
     { timeout: 30_000 },
-  ).then((result) => {
-    if (result == null) onSkipped();
-    return result;
-  });
+  );
+  if (result == null) span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true);
+  return result;
 }
 
 function parseMaxDurationMs(value: string | undefined): number {
@@ -69,7 +69,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
   }, async (span) => {
     let didUpdate = false;
 
-    const projectUserTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
+    const projectUserTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "projectUserId"
         FROM "ProjectUser"
@@ -88,7 +88,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING pu."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
+    `, span)) ?? [];
 
     span.setAttribute("stack.external-db-sync.project-user-tenants", projectUserTenants.length);
 
@@ -98,7 +98,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const contactChannelTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
+    const contactChannelTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "projectUserId", "id"
         FROM "ContactChannel"
@@ -118,7 +118,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING cc."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
+    `, span)) ?? [];
 
     span.setAttribute("stack.external-db-sync.contact-channel-tenants", contactChannelTenants.length);
 
@@ -127,7 +127,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const teamTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string, teamId: string }[]>`
+    const teamTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string, teamId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "teamId"
         FROM "Team"
@@ -146,7 +146,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING t."tenancyId", t."teamId"
       )
       SELECT DISTINCT "tenancyId", "teamId" FROM updated_rows
-    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
+    `, span)) ?? [];
 
     span.setAttribute("stack.external-db-sync.team-tenants", teamTenants.length);
 
@@ -175,7 +175,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       `;
     }
 
-    const teamMemberTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
+    const teamMemberTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "projectUserId", "teamId"
         FROM "TeamMember"
@@ -195,7 +195,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING tm."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
+    `, span)) ?? [];
 
     span.setAttribute("stack.external-db-sync.team-member-tenants", teamMemberTenants.length);
 
@@ -204,7 +204,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const teamPermissionTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
+    const teamPermissionTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "id"
         FROM "TeamMemberDirectPermission"
@@ -222,7 +222,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING tp."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
+    `, span)) ?? [];
 
     span.setAttribute("stack.external-db-sync.team-permission-tenants", teamPermissionTenants.length);
 
@@ -231,7 +231,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const teamInvitationTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
+    const teamInvitationTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "projectId", "branchId", "id"
         FROM "VerificationCode"
@@ -255,7 +255,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       FROM updated_rows
       JOIN "Tenancy" ON "Tenancy"."projectId" = updated_rows."projectId"
         AND "Tenancy"."branchId" = updated_rows."branchId"
-    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
+    `, span)) ?? [];
 
     span.setAttribute("stack.external-db-sync.team-invitation-tenants", teamInvitationTenants.length);
 
@@ -264,7 +264,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const emailOutboxTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
+    const emailOutboxTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "id"
         FROM "EmailOutbox"
@@ -283,7 +283,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING eo."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
+    `, span)) ?? [];
 
     span.setAttribute("stack.external-db-sync.email-outbox-tenants", emailOutboxTenants.length);
 
@@ -292,7 +292,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const projectPermissionTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
+    const projectPermissionTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "id"
         FROM "ProjectUserDirectPermission"
@@ -310,7 +310,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING pp."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
+    `, span)) ?? [];
 
     span.setAttribute("stack.external-db-sync.project-permission-tenants", projectPermissionTenants.length);
 
@@ -319,7 +319,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const notificationPreferenceTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
+    const notificationPreferenceTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "id"
         FROM "UserNotificationPreference"
@@ -338,7 +338,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING np."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
+    `, span)) ?? [];
 
     span.setAttribute("stack.external-db-sync.notification-preference-tenants", notificationPreferenceTenants.length);
 
@@ -347,7 +347,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const refreshTokenTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
+    const refreshTokenTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "id"
         FROM "ProjectUserRefreshToken"
@@ -366,7 +366,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING rt."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
+    `, span)) ?? [];
 
     span.setAttribute("stack.external-db-sync.refresh-token-tenants", refreshTokenTenants.length);
 
@@ -375,7 +375,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const oauthAccountTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
+    const oauthAccountTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "id"
         FROM "ProjectUserOAuthAccount"
@@ -394,7 +394,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING oa."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
+    `, span)) ?? [];
 
     span.setAttribute("stack.external-db-sync.oauth-account-tenants", oauthAccountTenants.length);
 
@@ -403,7 +403,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const deletedRowTenants = (await runSequenceAllocation((tx) => (tx.$queryRaw<{ tenancyId: string }[]>`
+    const deletedRowTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "id", "tenancyId"
         FROM "DeletedRow"
@@ -421,7 +421,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING dr."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `), () => span.setAttribute("stack.external-db-sync.sequence-allocation-skipped", true))) ?? [];
+    `, span)) ?? [];
 
     span.setAttribute("stack.external-db-sync.deleted-row-tenants", deletedRowTenants.length);
 

--- a/apps/backend/src/app/api/latest/internal/external-db-sync/sequencer/route.ts
+++ b/apps/backend/src/app/api/latest/internal/external-db-sync/sequencer/route.ts
@@ -11,100 +11,39 @@ import {
   yupString,
   yupTuple,
 } from "@hexclave/shared/dist/schema-fields";
+import { SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY } from "@hexclave/shared/dist/config/db-sync-mappings";
 import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
-import { captureError, HexclaveAssertionError, StatusError } from "@hexclave/shared/dist/utils/errors";
+import { captureError, HexclaveAssertionError, StatusError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { wait } from "@hexclave/shared/dist/utils/promises";
 
 const DEFAULT_MAX_DURATION_MS = 3 * 60 * 1000;
 const SEQUENCER_BATCH_SIZE_ENV = "STACK_EXTERNAL_DB_SYNC_SEQUENCER_BATCH_SIZE";
 const DEFAULT_BATCH_SIZE = 1000;
 
-/** PostgreSQL advisory-lock namespace for sequence allocation. */
-const SEQUENCE_ALLOCATION_LOCK_CLASS = 178555;
-
-export type SequenceAllocationResult<T> = {
-  locked: boolean,
-  result: T | null,
-};
-
-type EmailOutboxSequenceAllocationScope = {
-  tenancyId: string,
-  id: string,
-};
-
-export type EmailOutboxSequenceAllocation = {
-  tenancyId: string,
-  id: string,
-  sequenceId: bigint,
-};
-
 /**
  * Runs one set-based sequence allocation while holding the global transaction-scoped lock.
- * The lock is global because each batch statement can span multiple tenancies.
+ *
+ * Sequence allocation must commit in allocation order: the sync's `> watermark` filter
+ * permanently skips a lower value if a higher value becomes visible first. The lock is global
+ * because each batch statement can span multiple tenancies.
  */
 export async function runSequenceAllocationInTransaction<T>(
   tx: Prisma.TransactionClient,
   allocation: (tx: Prisma.TransactionClient) => Promise<T>,
-): Promise<SequenceAllocationResult<T>> {
-  const [{ locked }] = await tx.$queryRaw<{ locked: boolean }[]>`
-    SELECT pg_try_advisory_xact_lock(${SEQUENCE_ALLOCATION_LOCK_CLASS}::int) AS locked
+): Promise<T | null> {
+  const lockRows = await tx.$queryRaw<{ locked: boolean }[]>`
+    SELECT pg_try_advisory_xact_lock(${SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY}::int) AS locked
   `;
-  if (!locked) return { locked: false, result: null };
-  return { locked: true, result: await allocation(tx) };
-}
-
-export async function allocateEmailOutboxSequence(
-  tx: Prisma.TransactionClient,
-  batchSize: number,
-  scope?: EmailOutboxSequenceAllocationScope,
-): Promise<EmailOutboxSequenceAllocation[]> {
-  if (scope != null) {
-    return await tx.$queryRaw<EmailOutboxSequenceAllocation[]>`
-      WITH rows_to_update AS (
-        SELECT "tenancyId", "id"
-        FROM "EmailOutbox"
-        WHERE "tenancyId" = ${scope.tenancyId}::uuid
-          AND "id" = ${scope.id}::uuid
-          AND "shouldUpdateSequenceId" = TRUE
-        FOR UPDATE SKIP LOCKED
-      ),
-      updated_rows AS (
-        UPDATE "EmailOutbox" eo
-        SET "sequenceId" = nextval('global_seq_id'),
-            "shouldUpdateSequenceId" = FALSE
-        FROM rows_to_update r
-        WHERE eo."tenancyId" = r."tenancyId"
-          AND eo."id" = r."id"
-        RETURNING eo."tenancyId", eo."id", eo."sequenceId"
-      )
-      SELECT "tenancyId", "id", "sequenceId" FROM updated_rows
-    `;
-  }
-  return await tx.$queryRaw<EmailOutboxSequenceAllocation[]>`
-    WITH rows_to_update AS (
-      SELECT "tenancyId", "id"
-      FROM "EmailOutbox"
-      WHERE "shouldUpdateSequenceId" = TRUE
-      ORDER BY "tenancyId"
-      LIMIT ${batchSize}
-      FOR UPDATE SKIP LOCKED
-    ),
-    updated_rows AS (
-      UPDATE "EmailOutbox" eo
-      SET "sequenceId" = nextval('global_seq_id'),
-          "shouldUpdateSequenceId" = FALSE
-      FROM rows_to_update r
-      WHERE eo."tenancyId" = r."tenancyId"
-        AND eo."id" = r."id"
-      RETURNING eo."tenancyId", eo."id", eo."sequenceId"
-    )
-    SELECT "tenancyId", "id", "sequenceId" FROM updated_rows
-  `;
+  const locked = lockRows[0]?.locked ?? throwErr(
+    "Sequence allocation advisory lock query must return exactly one row",
+  );
+  if (!locked) return null;
+  return await allocation(tx);
 }
 
 async function runSequenceAllocation<T>(
   allocation: (tx: Prisma.TransactionClient) => Promise<T>,
-): Promise<SequenceAllocationResult<T>> {
+): Promise<T | null> {
   return await retryTransaction(globalPrismaClient, (tx) => runSequenceAllocationInTransaction(tx, allocation));
 }
 
@@ -141,8 +80,6 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
   }, async (span) => {
     let didUpdate = false;
 
-    // Sequence allocation must commit in allocation order: the sync's `> watermark` filter
-    // permanently skips a lower value if a higher value becomes visible first.
     const projectUserTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
       WITH rows_to_update AS (
         SELECT "tenancyId", "projectUserId"
@@ -162,7 +99,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING pu."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)).result ?? [];
+    `)) ?? [];
 
     span.setAttribute("stack.external-db-sync.project-user-tenants", projectUserTenants.length);
 
@@ -192,7 +129,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING cc."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)).result ?? [];
+    `)) ?? [];
 
     span.setAttribute("stack.external-db-sync.contact-channel-tenants", contactChannelTenants.length);
 
@@ -220,7 +157,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING t."tenancyId", t."teamId"
       )
       SELECT DISTINCT "tenancyId", "teamId" FROM updated_rows
-    `)).result ?? [];
+    `)) ?? [];
 
     span.setAttribute("stack.external-db-sync.team-tenants", teamTenants.length);
 
@@ -269,7 +206,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING tm."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)).result ?? [];
+    `)) ?? [];
 
     span.setAttribute("stack.external-db-sync.team-member-tenants", teamMemberTenants.length);
 
@@ -296,7 +233,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING tp."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)).result ?? [];
+    `)) ?? [];
 
     span.setAttribute("stack.external-db-sync.team-permission-tenants", teamPermissionTenants.length);
 
@@ -329,7 +266,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       FROM updated_rows
       JOIN "Tenancy" ON "Tenancy"."projectId" = updated_rows."projectId"
         AND "Tenancy"."branchId" = updated_rows."branchId"
-    `)).result ?? [];
+    `)) ?? [];
 
     span.setAttribute("stack.external-db-sync.team-invitation-tenants", teamInvitationTenants.length);
 
@@ -338,9 +275,26 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
       didUpdate = true;
     }
 
-    const emailOutboxRows = (await runSequenceAllocation((tx) => allocateEmailOutboxSequence(tx, batchSize))).result ?? [];
-    const emailOutboxTenants = Array.from(new Set(emailOutboxRows.map(row => row.tenancyId)))
-      .map(tenancyId => ({ tenancyId }));
+    const emailOutboxTenants = (await runSequenceAllocation((tx) => tx.$queryRaw<{ tenancyId: string }[]>`
+      WITH rows_to_update AS (
+        SELECT "tenancyId", "id"
+        FROM "EmailOutbox"
+        WHERE "shouldUpdateSequenceId" = TRUE
+        ORDER BY "tenancyId"
+        LIMIT ${batchSize}
+        FOR UPDATE SKIP LOCKED
+      ),
+      updated_rows AS (
+        UPDATE "EmailOutbox" eo
+        SET "sequenceId" = nextval('global_seq_id'),
+            "shouldUpdateSequenceId" = FALSE
+        FROM rows_to_update r
+        WHERE eo."tenancyId" = r."tenancyId"
+          AND eo."id"        = r."id"
+        RETURNING eo."tenancyId"
+      )
+      SELECT DISTINCT "tenancyId" FROM updated_rows
+    `)) ?? [];
 
     span.setAttribute("stack.external-db-sync.email-outbox-tenants", emailOutboxTenants.length);
 
@@ -367,7 +321,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING pp."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)).result ?? [];
+    `)) ?? [];
 
     span.setAttribute("stack.external-db-sync.project-permission-tenants", projectPermissionTenants.length);
 
@@ -395,7 +349,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING np."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)).result ?? [];
+    `)) ?? [];
 
     span.setAttribute("stack.external-db-sync.notification-preference-tenants", notificationPreferenceTenants.length);
 
@@ -423,7 +377,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING rt."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)).result ?? [];
+    `)) ?? [];
 
     span.setAttribute("stack.external-db-sync.refresh-token-tenants", refreshTokenTenants.length);
 
@@ -451,7 +405,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING oa."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)).result ?? [];
+    `)) ?? [];
 
     span.setAttribute("stack.external-db-sync.oauth-account-tenants", oauthAccountTenants.length);
 
@@ -478,7 +432,7 @@ async function backfillSequenceIds(batchSize: number): Promise<boolean> {
         RETURNING dr."tenancyId"
       )
       SELECT DISTINCT "tenancyId" FROM updated_rows
-    `)).result ?? [];
+    `)) ?? [];
 
     span.setAttribute("stack.external-db-sync.deleted-row-tenants", deletedRowTenants.length);
 

--- a/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
+++ b/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import { EmailOutboxCreatedWith, Prisma } from "@/generated/prisma/client";
 import { globalPrismaClient, retryTransaction } from "@/prisma-client";
 import { throwErr } from "@hexclave/shared/dist/utils/errors";
+import { wait } from "@hexclave/shared/dist/utils/promises";
 import { runSequenceAllocationInTransaction } from "@/lib/external-db-sync-sequencing";
 import { getSoleTenancyFromProjectBranch } from "./tenancies";
 import { recordExternalDbSyncDeletion } from "./external-db-sync";
@@ -89,6 +90,7 @@ describe("external DB sync sequence visibility", () => {
     let allocationA: bigint | undefined;
     let allocationASkipped: boolean | undefined;
     let testError: unknown;
+    let cleanupError: unknown;
 
     try {
       await createEmailOutbox(tenancyId, rowA.id);
@@ -135,13 +137,31 @@ describe("external DB sync sequence visibility", () => {
       releaseTransactionA();
       await transactionA;
 
-      const transactionB = await retryTransaction(
-        globalPrismaClient,
-        async (tx) => await allocateEmailOutboxSequence(tx, rowB),
-        { timeout: 10_000 },
-      );
+      const sequenceBDeadline = performance.now() + 10_000;
+      let sequenceB: bigint | undefined;
+      while (sequenceB == null && performance.now() < sequenceBDeadline) {
+        sequenceB = await retryTransaction(
+          globalPrismaClient,
+          async (tx) => {
+            const existingRow = await tx.emailOutbox.findUnique({
+              where: { tenancyId_id: { tenancyId, id: rowB.id } },
+              select: { sequenceId: true },
+            });
+            if (existingRow?.sequenceId != null) return existingRow.sequenceId;
+
+            await allocateEmailOutboxSequence(tx, rowB);
+            const allocatedRow = await tx.emailOutbox.findUnique({
+              where: { tenancyId_id: { tenancyId, id: rowB.id } },
+              select: { sequenceId: true },
+            });
+            return allocatedRow?.sequenceId;
+          },
+          { timeout: 10_000 },
+        ) ?? undefined;
+        if (sequenceB == null) await wait(50);
+      }
       rowA.sequenceId = allocationA ?? throwErr(`Sequencer did not update EmailOutbox ${rowA.id}`);
-      rowB.sequenceId = transactionB?.[0]?.sequenceId ?? throwErr(`Sequencer did not update EmailOutbox ${rowB.id}`);
+      rowB.sequenceId = sequenceB ?? throwErr(`Sequencer did not update EmailOutbox ${rowB.id}`);
       expect(rowA.sequenceId).toBeLessThan(rowB.sequenceId);
 
       const visibleRows = await globalPrismaClient.emailOutbox.findMany({
@@ -155,11 +175,9 @@ describe("external DB sync sequence visibility", () => {
       ]);
     } catch (error) {
       testError = error;
-      throw error;
     } finally {
-      releaseTransactionA();
-      let cleanupError: unknown;
       try {
+        releaseTransactionA();
         if (transactionA != null) await transactionA;
 
         await retryTransaction(globalPrismaClient, async (tx) => {
@@ -180,7 +198,8 @@ describe("external DB sync sequence visibility", () => {
       } catch (error) {
         cleanupError = error;
       }
-      if (testError == null && cleanupError != null) throw cleanupError;
     }
+    if (testError != null) throw testError;
+    if (cleanupError != null) throw cleanupError;
   });
 });

--- a/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
+++ b/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
@@ -1,15 +1,14 @@
 import { randomUUID } from "node:crypto";
 import { describe, expect, it } from "vitest";
-import { EmailOutboxCreatedWith } from "@/generated/prisma/client";
+import { EmailOutboxCreatedWith, Prisma } from "@/generated/prisma/client";
 import { globalPrismaClient, retryTransaction } from "@/prisma-client";
 import { throwErr } from "@hexclave/shared/dist/utils/errors";
-import {
-  runSequenceAllocationInTransaction,
-} from "@/app/api/latest/internal/external-db-sync/sequencer/route";
+import { runSequenceAllocationInTransaction } from "@/lib/external-db-sync-sequencing";
 import { getSoleTenancyFromProjectBranch } from "./tenancies";
 import { recordExternalDbSyncDeletion } from "./external-db-sync";
 
 type SequencedRow = {
+  tenancyId: string,
   id: string,
   sequenceId: bigint,
 };
@@ -45,11 +44,39 @@ async function createEmailOutbox(tenancyId: string, id: string): Promise<void> {
   });
 }
 
+async function allocateEmailOutboxSequence(
+  tx: Prisma.TransactionClient,
+  row: { tenancyId: string, id: string },
+): Promise<{ sequenceId: bigint }[] | null> {
+  return await runSequenceAllocationInTransaction(tx, async (lockedTx) =>
+    await lockedTx.$queryRaw<{ sequenceId: bigint }[]>`
+      WITH rows_to_update AS (
+        SELECT "tenancyId", "id"
+        FROM "EmailOutbox"
+        WHERE "tenancyId" = ${row.tenancyId}::uuid
+          AND "id" = ${row.id}::uuid
+          AND "shouldUpdateSequenceId" = TRUE
+        FOR UPDATE SKIP LOCKED
+      ),
+      updated_rows AS (
+        UPDATE "EmailOutbox" eo
+        SET "sequenceId" = nextval('global_seq_id'),
+            "shouldUpdateSequenceId" = FALSE
+        FROM rows_to_update r
+        WHERE eo."tenancyId" = r."tenancyId"
+          AND eo."id" = r."id"
+        RETURNING eo."sequenceId"
+      )
+      SELECT "sequenceId" FROM updated_rows
+    `,
+  );
+}
+
 describe("external DB sync sequence visibility", () => {
   it("requires visible higher sequence IDs to imply visibility of all lower assigned IDs", async () => {
     const tenancyId = (await getSoleTenancyFromProjectBranch("internal", "main")).id;
-    const rowA: SequencedRow = { id: randomUUID(), sequenceId: 0n };
-    const rowB: SequencedRow = { id: randomUUID(), sequenceId: 0n };
+    const rowA: SequencedRow = { tenancyId, id: randomUUID(), sequenceId: 0n };
+    const rowB: SequencedRow = { tenancyId, id: randomUUID(), sequenceId: 0n };
     let releaseTransactionA: () => void = () => undefined;
     let resolveTransactionAAllocated: () => void = () => undefined;
     const transactionAReleased = new Promise<void>((resolve) => {
@@ -61,6 +88,7 @@ describe("external DB sync sequence visibility", () => {
     let transactionA: Promise<void> | undefined;
     let allocationA: bigint | undefined;
     let allocationASkipped: boolean | undefined;
+    let testError: unknown;
 
     try {
       await createEmailOutbox(tenancyId, rowA.id);
@@ -75,34 +103,16 @@ describe("external DB sync sequence visibility", () => {
           WHERE "tenancyId" = ${tenancyId}::uuid
             AND "id" = ${rowA.id}::uuid
         `;
-        const allocation = await runSequenceAllocationInTransaction(tx, async (lockedTx) =>
-          await lockedTx.$queryRaw<{ sequenceId: bigint }[]>`
-            WITH rows_to_update AS (
-              SELECT "tenancyId", "id"
-              FROM "EmailOutbox"
-              WHERE "tenancyId" = ${tenancyId}::uuid
-                AND "id" = ${rowA.id}::uuid
-                AND "shouldUpdateSequenceId" = TRUE
-              FOR UPDATE SKIP LOCKED
-            ),
-            updated_rows AS (
-              UPDATE "EmailOutbox" eo
-              SET "sequenceId" = nextval('global_seq_id'),
-                  "shouldUpdateSequenceId" = FALSE
-              FROM rows_to_update r
-              WHERE eo."tenancyId" = r."tenancyId"
-                AND eo."id" = r."id"
-              RETURNING eo."sequenceId"
-            )
-            SELECT "sequenceId" FROM updated_rows
-          `
-        );
+        const allocation = await allocateEmailOutboxSequence(tx, rowA);
         allocationASkipped = allocation == null;
         allocationA = allocation?.[0]?.sequenceId;
         resolveTransactionAAllocated();
         await transactionAReleased;
       }, { maxWait: 10_000, timeout: 60_000 });
-      await transactionAAllocated;
+      await Promise.race([
+        transactionAAllocated,
+        transactionA.then(() => throwErr("Allocation transaction exited before reaching its gate")),
+      ]);
 
       const transactionBAttempt = await retryTransaction(globalPrismaClient, async (tx) => {
         await tx.$executeRaw`
@@ -111,28 +121,7 @@ describe("external DB sync sequence visibility", () => {
           WHERE "tenancyId" = ${tenancyId}::uuid
             AND "id" = ${rowB.id}::uuid
         `;
-        return await runSequenceAllocationInTransaction(tx, async (lockedTx) =>
-          await lockedTx.$queryRaw<{ sequenceId: bigint }[]>`
-            WITH rows_to_update AS (
-              SELECT "tenancyId", "id"
-              FROM "EmailOutbox"
-              WHERE "tenancyId" = ${tenancyId}::uuid
-                AND "id" = ${rowB.id}::uuid
-                AND "shouldUpdateSequenceId" = TRUE
-              FOR UPDATE SKIP LOCKED
-            ),
-            updated_rows AS (
-              UPDATE "EmailOutbox" eo
-              SET "sequenceId" = nextval('global_seq_id'),
-                  "shouldUpdateSequenceId" = FALSE
-              FROM rows_to_update r
-              WHERE eo."tenancyId" = r."tenancyId"
-                AND eo."id" = r."id"
-              RETURNING eo."sequenceId"
-            )
-            SELECT "sequenceId" FROM updated_rows
-          `
-        );
+        return await allocateEmailOutboxSequence(tx, rowB);
       }, { timeout: 5_000 });
       expect(
         allocationASkipped,
@@ -148,29 +137,7 @@ describe("external DB sync sequence visibility", () => {
 
       const transactionB = await retryTransaction(
         globalPrismaClient,
-        async (tx) =>
-          await runSequenceAllocationInTransaction(tx, async (lockedTx) =>
-            await lockedTx.$queryRaw<{ sequenceId: bigint }[]>`
-            WITH rows_to_update AS (
-              SELECT "tenancyId", "id"
-              FROM "EmailOutbox"
-              WHERE "tenancyId" = ${tenancyId}::uuid
-                AND "id" = ${rowB.id}::uuid
-                AND "shouldUpdateSequenceId" = TRUE
-              FOR UPDATE SKIP LOCKED
-            ),
-            updated_rows AS (
-              UPDATE "EmailOutbox" eo
-              SET "sequenceId" = nextval('global_seq_id'),
-                  "shouldUpdateSequenceId" = FALSE
-              FROM rows_to_update r
-              WHERE eo."tenancyId" = r."tenancyId"
-                AND eo."id" = r."id"
-              RETURNING eo."sequenceId"
-            )
-            SELECT "sequenceId" FROM updated_rows
-            `
-          ),
+        async (tx) => await allocateEmailOutboxSequence(tx, rowB),
         { timeout: 10_000 },
       );
       rowA.sequenceId = allocationA ?? throwErr(`Sequencer did not update EmailOutbox ${rowA.id}`);
@@ -186,25 +153,34 @@ describe("external DB sync sequence visibility", () => {
         { id: rowA.id, sequenceId: rowA.sequenceId },
         { id: rowB.id, sequenceId: rowB.sequenceId },
       ]);
+    } catch (error) {
+      testError = error;
+      throw error;
     } finally {
       releaseTransactionA();
-      if (transactionA != null) await transactionA;
+      let cleanupError: unknown;
+      try {
+        if (transactionA != null) await transactionA;
 
-      await retryTransaction(globalPrismaClient, async (tx) => {
-        await recordExternalDbSyncDeletion(tx, {
-          tableName: "EmailOutbox",
-          tenancyId,
-          emailOutboxId: rowA.id,
+        await retryTransaction(globalPrismaClient, async (tx) => {
+          await recordExternalDbSyncDeletion(tx, {
+            tableName: "EmailOutbox",
+            tenancyId,
+            emailOutboxId: rowA.id,
+          });
+          await recordExternalDbSyncDeletion(tx, {
+            tableName: "EmailOutbox",
+            tenancyId,
+            emailOutboxId: rowB.id,
+          });
+          await tx.emailOutbox.deleteMany({
+            where: { tenancyId, id: { in: [rowA.id, rowB.id] } },
+          });
         });
-        await recordExternalDbSyncDeletion(tx, {
-          tableName: "EmailOutbox",
-          tenancyId,
-          emailOutboxId: rowB.id,
-        });
-        await tx.emailOutbox.deleteMany({
-          where: { tenancyId, id: { in: [rowA.id, rowB.id] } },
-        });
-      });
+      } catch (error) {
+        cleanupError = error;
+      }
+      if (testError == null && cleanupError != null) throw cleanupError;
     }
   });
 });

--- a/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
+++ b/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
@@ -115,7 +115,9 @@ describe("external DB sync sequence visibility", () => {
             "Sequence allocation lock remained unavailable while acquiring row A in the regression test",
           );
         }
-        allocationA = allocation[0]?.sequenceId;
+        allocationA = allocation[0]?.sequenceId ?? throwErr(
+          `Sequence allocation must return row A's sequence ID for EmailOutbox ${rowA.id}`,
+        );
         resolveTransactionAAllocated();
         await transactionAReleased;
       }, { maxWait: 10_000, timeout: 60_000 });

--- a/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
+++ b/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
@@ -88,7 +88,6 @@ describe("external DB sync sequence visibility", () => {
     });
     let transactionA: Promise<void> | undefined;
     let allocationA: bigint | undefined;
-    let allocationASkipped: boolean | undefined;
     let testError: unknown;
     let cleanupError: unknown;
 
@@ -116,7 +115,6 @@ describe("external DB sync sequence visibility", () => {
             "Sequence allocation lock remained unavailable while acquiring row A in the regression test",
           );
         }
-        allocationASkipped = false;
         allocationA = allocation[0]?.sequenceId;
         resolveTransactionAAllocated();
         await transactionAReleased;
@@ -135,10 +133,6 @@ describe("external DB sync sequence visibility", () => {
         `;
         return await allocateEmailOutboxSequence(tx, rowB);
       }, { timeout: 5_000 });
-      expect(
-        allocationASkipped,
-        "The first allocation must acquire the sequence lock",
-      ).toBe(false);
       expect(
         transactionBAttempt,
         "A second allocation must skip while the first allocation transaction is still open",

--- a/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
+++ b/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
@@ -1,21 +1,13 @@
 import { randomUUID } from "node:crypto";
-import { PrismaPg } from "@prisma/adapter-pg";
-import { Pool } from "pg";
 import { describe, expect, it } from "vitest";
-import { EmailOutboxCreatedWith, PrismaClient } from "@/generated/prisma/client";
+import { EmailOutboxCreatedWith } from "@/generated/prisma/client";
 import { globalPrismaClient, retryTransaction } from "@/prisma-client";
-import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { throwErr } from "@hexclave/shared/dist/utils/errors";
 import {
-  allocateEmailOutboxSequence,
   runSequenceAllocationInTransaction,
 } from "@/app/api/latest/internal/external-db-sync/sequencer/route";
-import { getExternalDbSyncFusebox, updateExternalDbSyncFusebox } from "./external-db-sync-metadata";
 import { getSoleTenancyFromProjectBranch } from "./tenancies";
 import { recordExternalDbSyncDeletion } from "./external-db-sync";
-
-const databaseConnectionString = getEnvVariable("STACK_DATABASE_CONNECTION_STRING", "")
-  || throwErr("Missing database connection string for sequence visibility tests");
 
 type SequencedRow = {
   id: string,
@@ -58,12 +50,6 @@ describe("external DB sync sequence visibility", () => {
     const tenancyId = (await getSoleTenancyFromProjectBranch("internal", "main")).id;
     const rowA: SequencedRow = { id: randomUUID(), sequenceId: 0n };
     const rowB: SequencedRow = { id: randomUUID(), sequenceId: 0n };
-    const poolA = new Pool({ connectionString: databaseConnectionString });
-    const poolB = new Pool({ connectionString: databaseConnectionString });
-    const poolReader = new Pool({ connectionString: databaseConnectionString });
-    const clientA = new PrismaClient({ adapter: new PrismaPg(poolA) });
-    const clientB = new PrismaClient({ adapter: new PrismaPg(poolB) });
-    const reader = new PrismaClient({ adapter: new PrismaPg(poolReader) });
     let releaseTransactionA: () => void = () => undefined;
     let resolveTransactionAAllocated: () => void = () => undefined;
     const transactionAReleased = new Promise<void>((resolve) => {
@@ -73,60 +59,125 @@ describe("external DB sync sequence visibility", () => {
       resolveTransactionAAllocated = resolve;
     });
     let transactionA: Promise<void> | undefined;
-    const originalFusebox = await getExternalDbSyncFusebox();
-    await updateExternalDbSyncFusebox({ ...originalFusebox, sequencerEnabled: false });
+    let allocationA: bigint | undefined;
+    let allocationASkipped: boolean | undefined;
 
     try {
       await createEmailOutbox(tenancyId, rowA.id);
       await createEmailOutbox(tenancyId, rowB.id);
+      // This raw interactive transaction is deliberately held open to test visibility before commit.
+      // retryTransaction cannot be used here because its injected failures would make the gate flaky.
       // eslint-disable-next-line no-restricted-syntax
-      transactionA = clientA.$transaction(async (tx) => {
+      transactionA = globalPrismaClient.$transaction(async (tx) => {
         await tx.$executeRaw`
           UPDATE "EmailOutbox"
           SET "shouldUpdateSequenceId" = TRUE
           WHERE "tenancyId" = ${tenancyId}::uuid
             AND "id" = ${rowA.id}::uuid
         `;
-        const allocation = await runSequenceAllocationInTransaction(tx, (lockedTx) =>
-          allocateEmailOutboxSequence(lockedTx, 1, { tenancyId, id: rowA.id })
+        const allocation = await runSequenceAllocationInTransaction(tx, async (lockedTx) =>
+          await lockedTx.$queryRaw<{ sequenceId: bigint }[]>`
+            WITH rows_to_update AS (
+              SELECT "tenancyId", "id"
+              FROM "EmailOutbox"
+              WHERE "tenancyId" = ${tenancyId}::uuid
+                AND "id" = ${rowA.id}::uuid
+                AND "shouldUpdateSequenceId" = TRUE
+              FOR UPDATE SKIP LOCKED
+            ),
+            updated_rows AS (
+              UPDATE "EmailOutbox" eo
+              SET "sequenceId" = nextval('global_seq_id'),
+                  "shouldUpdateSequenceId" = FALSE
+              FROM rows_to_update r
+              WHERE eo."tenancyId" = r."tenancyId"
+                AND eo."id" = r."id"
+              RETURNING eo."sequenceId"
+            )
+            SELECT "sequenceId" FROM updated_rows
+          `
         );
-        expect(allocation.locked).toBe(true);
-        rowA.sequenceId = allocation.result?.[0]?.sequenceId ?? throwErr(`Sequencer did not update EmailOutbox ${rowA.id}`);
+        allocationASkipped = allocation == null;
+        allocationA = allocation?.[0]?.sequenceId;
         resolveTransactionAAllocated();
         await transactionAReleased;
-      });
+      }, { maxWait: 10_000, timeout: 60_000 });
       await transactionAAllocated;
 
-      // eslint-disable-next-line no-restricted-syntax
-      const transactionBAttempt = await clientB.$transaction((tx) =>
-        runSequenceAllocationInTransaction(tx, (lockedTx) =>
-          allocateEmailOutboxSequence(lockedTx, 1, { tenancyId, id: rowB.id })
-        )
-      );
-      expect(
-        transactionBAttempt.locked,
-        "A second allocation must skip while the first allocation transaction is still open",
-      ).toBe(false);
-
-      releaseTransactionA();
-      await transactionA;
-
-      // eslint-disable-next-line no-restricted-syntax
-      const transactionB = await clientB.$transaction(async (tx) => {
+      const transactionBAttempt = await retryTransaction(globalPrismaClient, async (tx) => {
         await tx.$executeRaw`
           UPDATE "EmailOutbox"
           SET "shouldUpdateSequenceId" = TRUE
           WHERE "tenancyId" = ${tenancyId}::uuid
             AND "id" = ${rowB.id}::uuid
         `;
-        return await runSequenceAllocationInTransaction(tx, (lockedTx) =>
-          allocateEmailOutboxSequence(lockedTx, 1, { tenancyId, id: rowB.id })
+        return await runSequenceAllocationInTransaction(tx, async (lockedTx) =>
+          await lockedTx.$queryRaw<{ sequenceId: bigint }[]>`
+            WITH rows_to_update AS (
+              SELECT "tenancyId", "id"
+              FROM "EmailOutbox"
+              WHERE "tenancyId" = ${tenancyId}::uuid
+                AND "id" = ${rowB.id}::uuid
+                AND "shouldUpdateSequenceId" = TRUE
+              FOR UPDATE SKIP LOCKED
+            ),
+            updated_rows AS (
+              UPDATE "EmailOutbox" eo
+              SET "sequenceId" = nextval('global_seq_id'),
+                  "shouldUpdateSequenceId" = FALSE
+              FROM rows_to_update r
+              WHERE eo."tenancyId" = r."tenancyId"
+                AND eo."id" = r."id"
+              RETURNING eo."sequenceId"
+            )
+            SELECT "sequenceId" FROM updated_rows
+          `
         );
-      });
-      expect(transactionB.locked).toBe(true);
-      rowB.sequenceId = transactionB.result?.[0]?.sequenceId ?? throwErr(`Sequencer did not update EmailOutbox ${rowB.id}`);
+      }, { timeout: 5_000 });
+      expect(
+        allocationASkipped,
+        "The first allocation must acquire the sequence lock",
+      ).toBe(false);
+      expect(
+        transactionBAttempt,
+        "A second allocation must skip while the first allocation transaction is still open",
+      ).toBeNull();
 
-      const visibleRows = await reader.emailOutbox.findMany({
+      releaseTransactionA();
+      await transactionA;
+
+      const transactionB = await retryTransaction(
+        globalPrismaClient,
+        async (tx) =>
+          await runSequenceAllocationInTransaction(tx, async (lockedTx) =>
+            await lockedTx.$queryRaw<{ sequenceId: bigint }[]>`
+            WITH rows_to_update AS (
+              SELECT "tenancyId", "id"
+              FROM "EmailOutbox"
+              WHERE "tenancyId" = ${tenancyId}::uuid
+                AND "id" = ${rowB.id}::uuid
+                AND "shouldUpdateSequenceId" = TRUE
+              FOR UPDATE SKIP LOCKED
+            ),
+            updated_rows AS (
+              UPDATE "EmailOutbox" eo
+              SET "sequenceId" = nextval('global_seq_id'),
+                  "shouldUpdateSequenceId" = FALSE
+              FROM rows_to_update r
+              WHERE eo."tenancyId" = r."tenancyId"
+                AND eo."id" = r."id"
+              RETURNING eo."sequenceId"
+            )
+            SELECT "sequenceId" FROM updated_rows
+            `
+          ),
+        { timeout: 10_000 },
+      );
+      rowA.sequenceId = allocationA ?? throwErr(`Sequencer did not update EmailOutbox ${rowA.id}`);
+      rowB.sequenceId = transactionB?.[0]?.sequenceId ?? throwErr(`Sequencer did not update EmailOutbox ${rowB.id}`);
+      expect(rowA.sequenceId).toBeLessThan(rowB.sequenceId);
+
+      const visibleRows = await globalPrismaClient.emailOutbox.findMany({
         where: { tenancyId, id: { in: [rowA.id, rowB.id] }, sequenceId: { not: null } },
         select: { id: true, sequenceId: true },
         orderBy: { sequenceId: "asc" },
@@ -138,32 +189,22 @@ describe("external DB sync sequence visibility", () => {
     } finally {
       releaseTransactionA();
       if (transactionA != null) await transactionA;
-      await clientA.$disconnect();
-      await clientB.$disconnect();
-      await reader.$disconnect();
-      await poolA.end();
-      await poolB.end();
-      await poolReader.end();
 
-      try {
-        await retryTransaction(globalPrismaClient, async (tx) => {
-          await recordExternalDbSyncDeletion(tx, {
-            tableName: "EmailOutbox",
-            tenancyId,
-            emailOutboxId: rowA.id,
-          });
-          await recordExternalDbSyncDeletion(tx, {
-            tableName: "EmailOutbox",
-            tenancyId,
-            emailOutboxId: rowB.id,
-          });
-          await tx.emailOutbox.deleteMany({
-            where: { tenancyId, id: { in: [rowA.id, rowB.id] } },
-          });
+      await retryTransaction(globalPrismaClient, async (tx) => {
+        await recordExternalDbSyncDeletion(tx, {
+          tableName: "EmailOutbox",
+          tenancyId,
+          emailOutboxId: rowA.id,
         });
-      } finally {
-        await updateExternalDbSyncFusebox(originalFusebox);
-      }
+        await recordExternalDbSyncDeletion(tx, {
+          tableName: "EmailOutbox",
+          tenancyId,
+          emailOutboxId: rowB.id,
+        });
+        await tx.emailOutbox.deleteMany({
+          where: { tenancyId, id: { in: [rowA.id, rowB.id] } },
+        });
+      });
     }
   });
 });

--- a/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
+++ b/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
@@ -105,9 +105,19 @@ describe("external DB sync sequence visibility", () => {
           WHERE "tenancyId" = ${tenancyId}::uuid
             AND "id" = ${rowA.id}::uuid
         `;
-        const allocation = await allocateEmailOutboxSequence(tx, rowA);
-        allocationASkipped = allocation == null;
-        allocationA = allocation?.[0]?.sequenceId;
+        const allocationDeadline = performance.now() + 10_000;
+        let allocation: { sequenceId: bigint }[] | null = null;
+        while (allocation == null && performance.now() < allocationDeadline) {
+          allocation = await allocateEmailOutboxSequence(tx, rowA);
+          if (allocation == null) await wait(50);
+        }
+        if (allocation == null) {
+          throwErr(
+            "Sequence allocation lock remained unavailable while acquiring row A in the regression test",
+          );
+        }
+        allocationASkipped = false;
+        allocationA = allocation[0]?.sequenceId;
         resolveTransactionAAllocated();
         await transactionAReleased;
       }, { maxWait: 10_000, timeout: 60_000 });

--- a/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
+++ b/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
@@ -1,10 +1,15 @@
 import { randomUUID } from "node:crypto";
-import { Client } from "pg";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
 import { describe, expect, it } from "vitest";
-import { EmailOutboxCreatedWith } from "@/generated/prisma/client";
+import { EmailOutboxCreatedWith, PrismaClient } from "@/generated/prisma/client";
 import { globalPrismaClient, retryTransaction } from "@/prisma-client";
 import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { throwErr } from "@hexclave/shared/dist/utils/errors";
+import {
+  allocateEmailOutboxSequence,
+  runSequenceAllocationInTransaction,
+} from "@/app/api/latest/internal/external-db-sync/sequencer/route";
 import { getExternalDbSyncFusebox, updateExternalDbSyncFusebox } from "./external-db-sync-metadata";
 import { getSoleTenancyFromProjectBranch } from "./tenancies";
 import { recordExternalDbSyncDeletion } from "./external-db-sync";
@@ -16,38 +21,6 @@ type SequencedRow = {
   id: string,
   sequenceId: bigint,
 };
-
-type VisibleRow = {
-  id: string,
-  sequenceId: string,
-};
-
-async function allocateEmailOutboxSequence(client: Client, tenancyId: string, id: string): Promise<bigint> {
-  const rows = await client.query<{ sequenceId: string }>(
-    `
-      WITH rows_to_update AS (
-        SELECT "tenancyId", "id"
-        FROM "EmailOutbox"
-        WHERE "tenancyId" = $1::uuid
-          AND "id" = $2::uuid
-          AND "shouldUpdateSequenceId" = TRUE
-        FOR UPDATE SKIP LOCKED
-      ),
-      updated_rows AS (
-        UPDATE "EmailOutbox" eo
-        SET "sequenceId" = nextval('global_seq_id'),
-            "shouldUpdateSequenceId" = FALSE
-        FROM rows_to_update r
-        WHERE eo."tenancyId" = r."tenancyId"
-          AND eo."id" = r."id"
-        RETURNING eo."sequenceId"
-      )
-      SELECT "sequenceId" FROM updated_rows
-    `,
-    [tenancyId, id],
-  );
-  return BigInt(rows.rows[0]?.sequenceId ?? throwErr(`Sequencer did not update EmailOutbox ${id}`));
-}
 
 async function createEmailOutbox(tenancyId: string, id: string): Promise<void> {
   await globalPrismaClient.emailOutbox.create({
@@ -70,7 +43,7 @@ async function createEmailOutbox(tenancyId: string, id: string): Promise<void> {
       renderedText: "sequence visibility test",
       renderedSubject: "sequence visibility test",
       renderedIsTransactional: false,
-      shouldUpdateSequenceId: true,
+      shouldUpdateSequenceId: false,
       startedSendingAt: null,
       finishedSendingAt: null,
       sendRetries: 0,
@@ -85,58 +58,94 @@ describe("external DB sync sequence visibility", () => {
     const tenancyId = (await getSoleTenancyFromProjectBranch("internal", "main")).id;
     const rowA: SequencedRow = { id: randomUUID(), sequenceId: 0n };
     const rowB: SequencedRow = { id: randomUUID(), sequenceId: 0n };
-    const transactionA = new Client({ connectionString: databaseConnectionString });
-    const transactionB = new Client({ connectionString: databaseConnectionString });
-    const reader = new Client({ connectionString: databaseConnectionString });
-    let transactionAStarted = false;
+    const poolA = new Pool({ connectionString: databaseConnectionString });
+    const poolB = new Pool({ connectionString: databaseConnectionString });
+    const poolReader = new Pool({ connectionString: databaseConnectionString });
+    const clientA = new PrismaClient({ adapter: new PrismaPg(poolA) });
+    const clientB = new PrismaClient({ adapter: new PrismaPg(poolB) });
+    const reader = new PrismaClient({ adapter: new PrismaPg(poolReader) });
+    let releaseTransactionA: () => void = () => undefined;
+    let resolveTransactionAAllocated: () => void = () => undefined;
+    const transactionAReleased = new Promise<void>((resolve) => {
+      releaseTransactionA = resolve;
+    });
+    const transactionAAllocated = new Promise<void>((resolve) => {
+      resolveTransactionAAllocated = resolve;
+    });
+    let transactionA: Promise<void> | undefined;
     const originalFusebox = await getExternalDbSyncFusebox();
     await updateExternalDbSyncFusebox({ ...originalFusebox, sequencerEnabled: false });
 
     try {
       await createEmailOutbox(tenancyId, rowA.id);
       await createEmailOutbox(tenancyId, rowB.id);
-      await transactionA.connect();
-      await transactionB.connect();
-      await reader.connect();
+      // eslint-disable-next-line no-restricted-syntax
+      transactionA = clientA.$transaction(async (tx) => {
+        await tx.$executeRaw`
+          UPDATE "EmailOutbox"
+          SET "shouldUpdateSequenceId" = TRUE
+          WHERE "tenancyId" = ${tenancyId}::uuid
+            AND "id" = ${rowA.id}::uuid
+        `;
+        const allocation = await runSequenceAllocationInTransaction(tx, (lockedTx) =>
+          allocateEmailOutboxSequence(lockedTx, 1, { tenancyId, id: rowA.id })
+        );
+        expect(allocation.locked).toBe(true);
+        rowA.sequenceId = allocation.result?.[0]?.sequenceId ?? throwErr(`Sequencer did not update EmailOutbox ${rowA.id}`);
+        resolveTransactionAAllocated();
+        await transactionAReleased;
+      });
+      await transactionAAllocated;
 
-      await transactionA.query("BEGIN");
-      transactionAStarted = true;
-      rowA.sequenceId = await allocateEmailOutboxSequence(transactionA, tenancyId, rowA.id);
-
-      await transactionB.query("BEGIN");
-      rowB.sequenceId = await allocateEmailOutboxSequence(transactionB, tenancyId, rowB.id);
-      await transactionB.query("COMMIT");
-
-      const visibleRows = (await reader.query<VisibleRow>(
-        `
-          SELECT "id", "sequenceId"
-          FROM "EmailOutbox"
-          WHERE "tenancyId" = $1::uuid
-            AND "id" = ANY($2::uuid[])
-            AND "sequenceId" IS NOT NULL
-          ORDER BY "sequenceId"
-        `,
-        [tenancyId, [rowA.id, rowB.id]],
-      )).rows;
-
-      expect(visibleRows).toEqual([{ id: rowB.id, sequenceId: rowB.sequenceId.toString() }]);
-
-      const highestVisibleSequenceId = BigInt(visibleRows.at(-1)?.sequenceId ?? throwErr("No visible sequence ID"));
-      const missingLowerRows = [rowA, rowB]
-        .filter(row => row.sequenceId < highestVisibleSequenceId)
-        .filter(row => !visibleRows.some(visibleRow => visibleRow.id === row.id));
-
+      // eslint-disable-next-line no-restricted-syntax
+      const transactionBAttempt = await clientB.$transaction((tx) =>
+        runSequenceAllocationInTransaction(tx, (lockedTx) =>
+          allocateEmailOutboxSequence(lockedTx, 1, { tenancyId, id: rowB.id })
+        )
+      );
       expect(
-        missingLowerRows,
-        `A visible sequence ID ${highestVisibleSequenceId} skipped lower assigned rows: ${JSON.stringify(missingLowerRows.map(row => ({ id: row.id, sequenceId: row.sequenceId.toString() })))}.`,
-      ).toHaveLength(0);
-    } finally {
-      try {
-        if (transactionAStarted) await transactionA.query("ROLLBACK");
-        await transactionB.end();
-        await reader.end();
-        await transactionA.end();
+        transactionBAttempt.locked,
+        "A second allocation must skip while the first allocation transaction is still open",
+      ).toBe(false);
 
+      releaseTransactionA();
+      await transactionA;
+
+      // eslint-disable-next-line no-restricted-syntax
+      const transactionB = await clientB.$transaction(async (tx) => {
+        await tx.$executeRaw`
+          UPDATE "EmailOutbox"
+          SET "shouldUpdateSequenceId" = TRUE
+          WHERE "tenancyId" = ${tenancyId}::uuid
+            AND "id" = ${rowB.id}::uuid
+        `;
+        return await runSequenceAllocationInTransaction(tx, (lockedTx) =>
+          allocateEmailOutboxSequence(lockedTx, 1, { tenancyId, id: rowB.id })
+        );
+      });
+      expect(transactionB.locked).toBe(true);
+      rowB.sequenceId = transactionB.result?.[0]?.sequenceId ?? throwErr(`Sequencer did not update EmailOutbox ${rowB.id}`);
+
+      const visibleRows = await reader.emailOutbox.findMany({
+        where: { tenancyId, id: { in: [rowA.id, rowB.id] }, sequenceId: { not: null } },
+        select: { id: true, sequenceId: true },
+        orderBy: { sequenceId: "asc" },
+      });
+      expect(visibleRows).toEqual([
+        { id: rowA.id, sequenceId: rowA.sequenceId },
+        { id: rowB.id, sequenceId: rowB.sequenceId },
+      ]);
+    } finally {
+      releaseTransactionA();
+      if (transactionA != null) await transactionA;
+      await clientA.$disconnect();
+      await clientB.$disconnect();
+      await reader.$disconnect();
+      await poolA.end();
+      await poolB.end();
+      await poolReader.end();
+
+      try {
         await retryTransaction(globalPrismaClient, async (tx) => {
           await recordExternalDbSyncDeletion(tx, {
             tableName: "EmailOutbox",

--- a/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
+++ b/apps/backend/src/lib/external-db-sync-sequence-visibility.test.ts
@@ -1,0 +1,160 @@
+import { randomUUID } from "node:crypto";
+import { Client } from "pg";
+import { describe, expect, it } from "vitest";
+import { EmailOutboxCreatedWith } from "@/generated/prisma/client";
+import { globalPrismaClient, retryTransaction } from "@/prisma-client";
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
+import { throwErr } from "@hexclave/shared/dist/utils/errors";
+import { getExternalDbSyncFusebox, updateExternalDbSyncFusebox } from "./external-db-sync-metadata";
+import { getSoleTenancyFromProjectBranch } from "./tenancies";
+import { recordExternalDbSyncDeletion } from "./external-db-sync";
+
+const databaseConnectionString = getEnvVariable("STACK_DATABASE_CONNECTION_STRING", "")
+  || throwErr("Missing database connection string for sequence visibility tests");
+
+type SequencedRow = {
+  id: string,
+  sequenceId: bigint,
+};
+
+type VisibleRow = {
+  id: string,
+  sequenceId: string,
+};
+
+async function allocateEmailOutboxSequence(client: Client, tenancyId: string, id: string): Promise<bigint> {
+  const rows = await client.query<{ sequenceId: string }>(
+    `
+      WITH rows_to_update AS (
+        SELECT "tenancyId", "id"
+        FROM "EmailOutbox"
+        WHERE "tenancyId" = $1::uuid
+          AND "id" = $2::uuid
+          AND "shouldUpdateSequenceId" = TRUE
+        FOR UPDATE SKIP LOCKED
+      ),
+      updated_rows AS (
+        UPDATE "EmailOutbox" eo
+        SET "sequenceId" = nextval('global_seq_id'),
+            "shouldUpdateSequenceId" = FALSE
+        FROM rows_to_update r
+        WHERE eo."tenancyId" = r."tenancyId"
+          AND eo."id" = r."id"
+        RETURNING eo."sequenceId"
+      )
+      SELECT "sequenceId" FROM updated_rows
+    `,
+    [tenancyId, id],
+  );
+  return BigInt(rows.rows[0]?.sequenceId ?? throwErr(`Sequencer did not update EmailOutbox ${id}`));
+}
+
+async function createEmailOutbox(tenancyId: string, id: string): Promise<void> {
+  await globalPrismaClient.emailOutbox.create({
+    data: {
+      id,
+      tenancyId,
+      tsxSource: `/* sequence-visibility-test-${id} */`,
+      themeId: null,
+      isHighPriority: false,
+      to: { type: "custom-emails", emails: [`sequence-visibility-${id}@example.com`] },
+      extraRenderVariables: {},
+      shouldSkipDeliverabilityCheck: true,
+      createdWith: EmailOutboxCreatedWith.PROGRAMMATIC_CALL,
+      scheduledAt: new Date(),
+      isQueued: true,
+      renderedByWorkerId: "00000000-0000-0000-0000-000000000000",
+      startedRenderingAt: new Date(),
+      finishedRenderingAt: new Date(),
+      renderedHtml: "<p>sequence visibility test</p>",
+      renderedText: "sequence visibility test",
+      renderedSubject: "sequence visibility test",
+      renderedIsTransactional: false,
+      shouldUpdateSequenceId: true,
+      startedSendingAt: null,
+      finishedSendingAt: null,
+      sendRetries: 0,
+      nextSendRetryAt: null,
+      isPaused: true,
+    },
+  });
+}
+
+describe("external DB sync sequence visibility", () => {
+  it("requires visible higher sequence IDs to imply visibility of all lower assigned IDs", async () => {
+    const tenancyId = (await getSoleTenancyFromProjectBranch("internal", "main")).id;
+    const rowA: SequencedRow = { id: randomUUID(), sequenceId: 0n };
+    const rowB: SequencedRow = { id: randomUUID(), sequenceId: 0n };
+    const transactionA = new Client({ connectionString: databaseConnectionString });
+    const transactionB = new Client({ connectionString: databaseConnectionString });
+    const reader = new Client({ connectionString: databaseConnectionString });
+    let transactionAStarted = false;
+    const originalFusebox = await getExternalDbSyncFusebox();
+    await updateExternalDbSyncFusebox({ ...originalFusebox, sequencerEnabled: false });
+
+    try {
+      await createEmailOutbox(tenancyId, rowA.id);
+      await createEmailOutbox(tenancyId, rowB.id);
+      await transactionA.connect();
+      await transactionB.connect();
+      await reader.connect();
+
+      await transactionA.query("BEGIN");
+      transactionAStarted = true;
+      rowA.sequenceId = await allocateEmailOutboxSequence(transactionA, tenancyId, rowA.id);
+
+      await transactionB.query("BEGIN");
+      rowB.sequenceId = await allocateEmailOutboxSequence(transactionB, tenancyId, rowB.id);
+      await transactionB.query("COMMIT");
+
+      const visibleRows = (await reader.query<VisibleRow>(
+        `
+          SELECT "id", "sequenceId"
+          FROM "EmailOutbox"
+          WHERE "tenancyId" = $1::uuid
+            AND "id" = ANY($2::uuid[])
+            AND "sequenceId" IS NOT NULL
+          ORDER BY "sequenceId"
+        `,
+        [tenancyId, [rowA.id, rowB.id]],
+      )).rows;
+
+      expect(visibleRows).toEqual([{ id: rowB.id, sequenceId: rowB.sequenceId.toString() }]);
+
+      const highestVisibleSequenceId = BigInt(visibleRows.at(-1)?.sequenceId ?? throwErr("No visible sequence ID"));
+      const missingLowerRows = [rowA, rowB]
+        .filter(row => row.sequenceId < highestVisibleSequenceId)
+        .filter(row => !visibleRows.some(visibleRow => visibleRow.id === row.id));
+
+      expect(
+        missingLowerRows,
+        `A visible sequence ID ${highestVisibleSequenceId} skipped lower assigned rows: ${JSON.stringify(missingLowerRows.map(row => ({ id: row.id, sequenceId: row.sequenceId.toString() })))}.`,
+      ).toHaveLength(0);
+    } finally {
+      try {
+        if (transactionAStarted) await transactionA.query("ROLLBACK");
+        await transactionB.end();
+        await reader.end();
+        await transactionA.end();
+
+        await retryTransaction(globalPrismaClient, async (tx) => {
+          await recordExternalDbSyncDeletion(tx, {
+            tableName: "EmailOutbox",
+            tenancyId,
+            emailOutboxId: rowA.id,
+          });
+          await recordExternalDbSyncDeletion(tx, {
+            tableName: "EmailOutbox",
+            tenancyId,
+            emailOutboxId: rowB.id,
+          });
+          await tx.emailOutbox.deleteMany({
+            where: { tenancyId, id: { in: [rowA.id, rowB.id] } },
+          });
+        });
+      } finally {
+        await updateExternalDbSyncFusebox(originalFusebox);
+      }
+    }
+  });
+});

--- a/apps/backend/src/lib/external-db-sync-sequencing.ts
+++ b/apps/backend/src/lib/external-db-sync-sequencing.ts
@@ -1,0 +1,24 @@
+import { Prisma } from "@/generated/prisma/client";
+import { SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY } from "@hexclave/shared/dist/config/db-sync-mappings";
+import { throwErr } from "@hexclave/shared/dist/utils/errors";
+
+/**
+ * Runs one set-based sequence allocation while holding the global transaction-scoped lock.
+ *
+ * Sequence allocation must commit in allocation order: the sync's `> watermark` filter
+ * permanently skips a lower value if a higher value becomes visible first. The lock is global
+ * because each batch statement can span multiple tenancies.
+ */
+export async function runSequenceAllocationInTransaction<T>(
+  tx: Prisma.TransactionClient,
+  allocation: (tx: Prisma.TransactionClient) => Promise<T>,
+): Promise<T | null> {
+  const lockRows = await tx.$queryRaw<{ locked: boolean }[]>`
+    SELECT pg_try_advisory_xact_lock(${SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY}::int) AS locked
+  `;
+  const locked = lockRows[0]?.locked ?? throwErr(
+    "Sequence allocation advisory lock query must return exactly one row",
+  );
+  if (!locked) return null;
+  return await allocation(tx);
+}

--- a/apps/backend/src/lib/external-db-sync.ts
+++ b/apps/backend/src/lib/external-db-sync.ts
@@ -1368,6 +1368,8 @@ async function syncPostgresMapping(
       mappingId,
     );
 
+    // This watermark relies on sequencer allocation committing in sequence order; a visible
+    // higher value must imply that every lower value is already visible to the source reader.
     let maxSeqInBatch = lastSequenceId;
     for (const row of rows) {
       const seqNum = parseSequenceId(row.sequence_id, mappingId);
@@ -1446,6 +1448,8 @@ async function syncClickhouseMapping(
       mappingId,
     );
 
+    // This watermark relies on sequencer allocation committing in sequence order; a visible
+    // higher value must imply that every lower value is already visible to the source reader.
     let maxSeqInBatch = lastSequenceId;
     for (const row of rows) {
       const seqNum = parseSequenceId(row.sync_sequence_id, mappingId);

--- a/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
@@ -190,46 +190,75 @@ async function triggerExternalDbSync(tenancyId: string): Promise<void> {
   expect(response.status).toBe(200);
 }
 
-type FuseboxState = {
-  existed: boolean,
-  sequencerEnabled: boolean,
-  pollerEnabled: boolean,
-};
-
-async function disableAutomaticSequencing(): Promise<FuseboxState> {
-  return await withInternalDatabase(async (client) => {
-    const result = await client.query<{ sequencerEnabled: boolean, pollerEnabled: boolean }>(
-      `SELECT "sequencerEnabled", "pollerEnabled" FROM "ExternalDbSyncMetadata" WHERE "singleton" = 'TRUE'::"BooleanTrue"`,
-    );
-    const existing = result.rows.at(0);
-    await client.query(
-      `
-        INSERT INTO "ExternalDbSyncMetadata" ("singleton", "sequencerEnabled", "pollerEnabled", "createdAt", "updatedAt")
-        VALUES ('TRUE'::"BooleanTrue", false, COALESCE($1, true), now(), now())
-        ON CONFLICT ("singleton")
-        DO UPDATE SET "sequencerEnabled" = false
-      `,
-      [existing?.pollerEnabled ?? null],
-    );
-    return {
-      existed: existing != null,
-      sequencerEnabled: existing?.sequencerEnabled ?? true,
-      pollerEnabled: existing?.pollerEnabled ?? true,
-    };
+async function triggerExternalDbSequencer(): Promise<void> {
+  const cronSecret = getEnvVariable("CRON_SECRET", "") || throwErr("Sequence visibility e2e test requires CRON_SECRET");
+  const url = new URL("/api/latest/internal/external-db-sync/sequencer", STACK_BACKEND_BASE_URL);
+  url.searchParams.set("maxDurationMs", "500");
+  const response = await niceFetch(url, {
+    method: "GET",
+    headers: {
+      authorization: `Bearer ${cronSecret}`,
+    },
   });
+  expect(response.status).toBe(200);
 }
 
-async function restoreFusebox(state: FuseboxState): Promise<void> {
-  await withInternalDatabase(async (client) => {
-    if (state.existed) {
-      await client.query(
-        `UPDATE "ExternalDbSyncMetadata" SET "sequencerEnabled" = $1, "pollerEnabled" = $2 WHERE "singleton" = 'TRUE'::"BooleanTrue"`,
-        [state.sequencerEnabled, state.pollerEnabled],
-      );
-    } else {
-      await client.query(`DELETE FROM "ExternalDbSyncMetadata" WHERE "singleton" = 'TRUE'::"BooleanTrue"`);
-    }
-  });
+async function waitForReplicaEmailOutboxSequence(id: string): Promise<bigint> {
+  const connectionString = getEnvVariable(
+    "STACK_DATABASE_REPLICA_CONNECTION_STRING",
+    getEnvVariable("STACK_DATABASE_CONNECTION_STRING", ""),
+  );
+  if (connectionString === "") {
+    throwErr("Sequence visibility e2e test requires a database replica connection string");
+  }
+  const client = new Client({ connectionString });
+  await client.connect();
+  try {
+    let sequenceId: bigint | undefined;
+    await waitForCondition(
+      async () => {
+        const result = await client.query<{ sequenceId: string | null }>(
+          `SELECT "sequenceId" FROM "EmailOutbox" WHERE "id" = $1`,
+          [id],
+        );
+        const value = result.rows[0]?.sequenceId;
+        if (value == null) return false;
+        sequenceId = BigInt(value);
+        return true;
+      },
+      {
+        timeoutMs: 30_000,
+        intervalMs: 250,
+        description: `EmailOutbox ${id} to become visible on the sync reader`,
+      },
+    );
+    return sequenceId ?? throwErr(`Replica did not return a sequence ID for EmailOutbox ${id}`);
+  } finally {
+    await client.end();
+  }
+}
+
+async function waitForPrimaryEmailOutboxSequence(id: string): Promise<bigint> {
+  let sequenceId: bigint | undefined;
+  await waitForCondition(
+    async () => {
+      await withInternalDatabase(async (client) => {
+        const result = await client.query<{ sequenceId: string | null }>(
+          `SELECT "sequenceId" FROM "EmailOutbox" WHERE "id" = $1`,
+          [id],
+        );
+        const value = result.rows[0]?.sequenceId;
+        if (value != null) sequenceId = BigInt(value);
+      });
+      return sequenceId != null;
+    },
+    {
+      timeoutMs: 30_000,
+      intervalMs: 250,
+      description: `EmailOutbox ${id} to receive a sequence ID`,
+    },
+  );
+  return sequenceId ?? throwErr(`Primary did not return a sequence ID for EmailOutbox ${id}`);
 }
 
 async function waitForExternalEmailOutbox(client: Client, id: string, expectedCount: number): Promise<void> {
@@ -1596,15 +1625,10 @@ describe.sequential('External DB Sync - Basic Tests', () => {
     const transactionA = new Client({
       connectionString: internalDatabaseConnectionString,
     });
-    const transactionB = new Client({
-      connectionString: internalDatabaseConnectionString,
-    });
 
     let tenancyId: string | undefined;
     let transactionAStarted = false;
-    let fuseboxState: FuseboxState | undefined;
     try {
-      fuseboxState = await disableAutomaticSequencing();
       await withInternalDatabase(async (client) => {
         const tenancy = await client.query<{ id: string }>(
           `SELECT "id" FROM "Tenancy" WHERE "projectId" = $1 AND "branchId" = 'main' LIMIT 1`,
@@ -1616,12 +1640,12 @@ describe.sequential('External DB Sync - Basic Tests', () => {
       const testTenancyId = tenancyId ?? throwErr("Test project's tenancy was not initialized");
 
       await transactionA.connect();
-      await transactionB.connect();
       await withInternalDatabase(async (client) => {
         await client.query("BEGIN");
         await allocateEmailOutboxSequence(client, testTenancyId, baselineRow);
         await client.query("COMMIT");
       });
+      await waitForReplicaEmailOutboxSequence(baselineRow);
       await triggerExternalDbSync(testTenancyId);
       await waitForExternalEmailOutbox(externalClient, baselineRow, 1);
 
@@ -1632,18 +1656,31 @@ describe.sequential('External DB Sync - Basic Tests', () => {
 
       await transactionA.query("BEGIN");
       transactionAStarted = true;
+      await transactionA.query("SET LOCAL lock_timeout = '5000ms'");
+      await transactionA.query("SELECT pg_advisory_xact_lock(178555)");
       const sequenceA = await allocateEmailOutboxSequence(transactionA, testTenancyId, rowA);
 
-      await transactionB.query("BEGIN");
-      const sequenceB = await allocateEmailOutboxSequence(transactionB, testTenancyId, rowB);
-      await transactionB.query("COMMIT");
-
-      // T1 has allocated the lower value but is still uncommitted. T2 commits the higher value first.
+      // T1 holds the production allocation lock after assigning A. A real sequencer invocation
+      // runs while T1 is open and must skip rather than commit a higher value first.
+      await triggerExternalDbSequencer();
+      const rowBSequenceBeforeACommit = await withInternalDatabase(async (client) => {
+        const result = await client.query<{ sequenceId: string | null }>(
+          `SELECT "sequenceId" FROM "EmailOutbox" WHERE "id" = $1`,
+          [rowB],
+        );
+        return result.rows[0]?.sequenceId;
+      });
+      if (rowBSequenceBeforeACommit != null) {
+        await waitForReplicaEmailOutboxSequence(rowB);
+      }
       await triggerExternalDbSync(testTenancyId);
-      await waitForExternalEmailOutbox(externalClient, rowB, 1);
 
       await transactionA.query("COMMIT");
       transactionAStarted = false;
+      await triggerExternalDbSequencer();
+      await waitForPrimaryEmailOutboxSequence(rowB);
+      await waitForReplicaEmailOutboxSequence(rowA);
+      await waitForReplicaEmailOutboxSequence(rowB);
       await triggerExternalDbSync(testTenancyId);
 
       await waitForCondition(
@@ -1651,33 +1688,29 @@ describe.sequential('External DB Sync - Basic Tests', () => {
         {
           timeoutMs: 20_000,
           intervalMs: 500,
-          description: `EmailOutbox ${rowA} to reach the external database after the sequence visibility interleaving (A=${sequenceA}, B=${sequenceB})`,
+          description: `EmailOutbox ${rowA} to reach the external database after serialized sequence allocation (A=${sequenceA})`,
         },
       );
+      await waitForExternalEmailOutbox(externalClient, rowB, 1);
     } finally {
-      try {
-        if (transactionAStarted) await transactionA.query("ROLLBACK");
-        await transactionA.end();
-        await transactionB.end();
+      if (transactionAStarted) await transactionA.query("ROLLBACK");
+      await transactionA.end();
 
-        if (tenancyId != null) {
-          await withInternalDatabase(async (client) => {
-            await client.query("BEGIN");
-            try {
-              await deleteSyncedRowsWithTombstones(client, {
-                table: "EmailOutbox",
-                whereClause: `"tenancyId" = $1::uuid AND "id" = ANY($2::uuid[])`,
-                values: [tenancyId, [baselineRow, rowA, rowB]],
-              });
-              await client.query("COMMIT");
-            } catch (error) {
-              await client.query("ROLLBACK");
-              throw error;
-            }
-          });
-        }
-      } finally {
-        if (fuseboxState != null) await restoreFusebox(fuseboxState);
+      if (tenancyId != null) {
+        await withInternalDatabase(async (client) => {
+          await client.query("BEGIN");
+          try {
+            await deleteSyncedRowsWithTombstones(client, {
+              table: "EmailOutbox",
+              whereClause: `"tenancyId" = $1::uuid AND "id" = ANY($2::uuid[])`,
+              values: [tenancyId, [baselineRow, rowA, rowB]],
+            });
+            await client.query("COMMIT");
+          } catch (error) {
+            await client.query("ROLLBACK");
+            throw error;
+          }
+        });
       }
     }
   }, TEST_TIMEOUT);

--- a/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
@@ -39,6 +39,7 @@ import {
   waitForSyncedNotificationPreference,
   waitForTable,
   deleteSyncedRowsWithTombstones,
+  getInternalDatabaseConnectionString,
   withInternalDatabase,
 } from './external-db-sync-utils';
 
@@ -168,7 +169,7 @@ async function insertSequenceVisibilityEmail(client: Client, tenancyId: string, 
       VALUES
         ($1::uuid, $2::uuid, $3, $3, '', false, $4::jsonb, '{}'::jsonb,
          true, 'PROGRAMMATIC_CALL', $5::uuid, $3, $3, '<p>sequence visibility test</p>',
-         $6, true, $3, false, true, null, null, null, true)
+         $6, true, $3, false, true, null, null, null, false)
     `,
     [
       tenancyId,
@@ -206,7 +207,11 @@ async function triggerExternalDbSequencer(): Promise<void> {
   expect(response.status).toBe(200);
 }
 
-async function waitForEmailOutboxSequence(id: string, reader: "primary" | "replica"): Promise<bigint> {
+async function waitForEmailOutboxSequence(
+  id: string,
+  reader: "primary" | "replica",
+  retry?: () => Promise<void>,
+): Promise<bigint> {
   const connectionString = reader === "replica"
     ? getEnvVariable(
       "STACK_DATABASE_REPLICA_CONNECTION_STRING",
@@ -222,6 +227,7 @@ async function waitForEmailOutboxSequence(id: string, reader: "primary" | "repli
   try {
     let sequenceId: bigint | undefined;
     await waitForCondition(async () => {
+      if (retry != null) await retry();
       if (client != null) {
         const result = await client.query<{ sequenceId: string | null }>(
           `SELECT "sequenceId" FROM "EmailOutbox" WHERE "id" = $1`,
@@ -1605,15 +1611,8 @@ describe.sequential('External DB Sync - Basic Tests', () => {
     const rowA = randomUUID();
     const rowB = randomUUID();
     const baselineRow = randomUUID();
-    const internalDatabaseConnectionString = getEnvVariable(
-      "HEXCLAVE_DATABASE_CONNECTION_STRING",
-      getEnvVariable("STACK_DATABASE_CONNECTION_STRING", ""),
-    );
-    if (internalDatabaseConnectionString === "") {
-      throwErr("Sequence visibility e2e test requires an internal database connection string");
-    }
     const transactionA = new Client({
-      connectionString: internalDatabaseConnectionString,
+      connectionString: getInternalDatabaseConnectionString(),
     });
 
     let tenancyId: string | undefined;
@@ -1630,11 +1629,17 @@ describe.sequential('External DB Sync - Basic Tests', () => {
       const testTenancyId = tenancyId ?? throwErr("Test project's tenancy was not initialized");
 
       await transactionA.connect();
-      await withInternalDatabase(async (client) => {
-        await client.query("BEGIN");
-        await allocateEmailOutboxSequence(client, testTenancyId, baselineRow);
-        await client.query("COMMIT");
-      });
+      await transactionA.query("BEGIN");
+      transactionAStarted = true;
+      await transactionA.query("SET LOCAL lock_timeout = '5000ms'");
+      await transactionA.query(`SELECT pg_advisory_xact_lock($1)`, [SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY]);
+      await transactionA.query(
+        `UPDATE "EmailOutbox" SET "shouldUpdateSequenceId" = TRUE WHERE "tenancyId" = $1 AND "id" = $2`,
+        [testTenancyId, baselineRow],
+      );
+      await allocateEmailOutboxSequence(transactionA, testTenancyId, baselineRow);
+      await transactionA.query("COMMIT");
+      transactionAStarted = false;
       await waitForEmailOutboxSequence(baselineRow, "replica");
       await triggerExternalDbSync(testTenancyId);
       await waitForExternalEmailOutbox(externalClient, baselineRow, 1);
@@ -1647,8 +1652,18 @@ describe.sequential('External DB Sync - Basic Tests', () => {
       await transactionA.query("BEGIN");
       transactionAStarted = true;
       await transactionA.query("SET LOCAL lock_timeout = '5000ms'");
-      await transactionA.query(`SELECT pg_advisory_xact_lock(${SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY})`);
+      await transactionA.query(`SELECT pg_advisory_xact_lock($1)`, [SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY]);
+      await transactionA.query(
+        `UPDATE "EmailOutbox" SET "shouldUpdateSequenceId" = TRUE WHERE "tenancyId" = $1 AND "id" = $2`,
+        [testTenancyId, rowA],
+      );
       const sequenceA = await allocateEmailOutboxSequence(transactionA, testTenancyId, rowA);
+      await withInternalDatabase(async (client) => {
+        await client.query(
+          `UPDATE "EmailOutbox" SET "shouldUpdateSequenceId" = TRUE WHERE "tenancyId" = $1 AND "id" = $2`,
+          [testTenancyId, rowB],
+        );
+      });
 
       // T1 holds the production allocation lock after assigning A. A real sequencer invocation
       // runs while T1 is open and must skip rather than commit a higher value first.
@@ -1660,15 +1675,12 @@ describe.sequential('External DB Sync - Basic Tests', () => {
         );
         return result.rows[0]?.sequenceId;
       });
-      if (rowBSequenceBeforeACommit != null) {
-        await waitForEmailOutboxSequence(rowB, "replica");
-      }
+      expect(rowBSequenceBeforeACommit, "Sequencer must skip while another transaction holds the allocation lock").toBeNull();
       await triggerExternalDbSync(testTenancyId);
 
       await transactionA.query("COMMIT");
       transactionAStarted = false;
-      await triggerExternalDbSequencer();
-      const sequenceB = await waitForEmailOutboxSequence(rowB, "primary");
+      const sequenceB = await waitForEmailOutboxSequence(rowB, "primary", triggerExternalDbSequencer);
       await waitForEmailOutboxSequence(rowA, "replica");
       await waitForEmailOutboxSequence(rowB, "replica");
       await triggerExternalDbSync(testTenancyId);

--- a/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
@@ -5,6 +5,8 @@ import { niceFetch, STACK_BACKEND_BASE_URL, test } from '../../../../helpers';
 import { withPortPrefix } from '../../../../helpers/ports';
 import { Auth, backendContext, InternalApiKey, Project, User, niceBackendFetch } from '../../../backend-helpers';
 import { randomUUID } from 'node:crypto';
+import { Client } from 'pg';
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import {
   TEST_TIMEOUT,
   TestDbManager,
@@ -121,6 +123,124 @@ async function waitForClickhouseEmailOutbox(id: string, expectedCount: number, d
 
   const state = expectedCount === 0 ? "to be deleted" : "to sync";
   throw new HexclaveAssertionError(`Timed out waiting for ClickHouse email outbox ${id} ${state}.`, { response });
+}
+
+async function allocateEmailOutboxSequence(client: Client, tenancyId: string, id: string): Promise<bigint> {
+  const rows = await client.query<{ sequenceId: string }>(
+    `
+      WITH rows_to_update AS (
+        SELECT "tenancyId", "id"
+        FROM "EmailOutbox"
+        WHERE "tenancyId" = $1::uuid
+          AND "id" = $2::uuid
+          AND "shouldUpdateSequenceId" = TRUE
+        FOR UPDATE SKIP LOCKED
+      ),
+      updated_rows AS (
+        UPDATE "EmailOutbox" eo
+        SET "sequenceId" = nextval('global_seq_id'),
+            "shouldUpdateSequenceId" = FALSE
+        FROM rows_to_update r
+        WHERE eo."tenancyId" = r."tenancyId"
+          AND eo."id" = r."id"
+        RETURNING eo."sequenceId"
+      )
+      SELECT "sequenceId" FROM updated_rows
+    `,
+    [tenancyId, id],
+  );
+  return BigInt(rows.rows[0]?.sequenceId ?? throwErr(`Sequencer did not update EmailOutbox ${id}`));
+}
+
+async function insertSequenceVisibilityEmail(client: Client, tenancyId: string, id: string, subject: string): Promise<void> {
+  const renderedAt = new Date();
+  await client.query(
+    `
+      INSERT INTO "EmailOutbox"
+        ("tenancyId", "id", "createdAt", "updatedAt", "tsxSource", "isHighPriority", "to", "extraRenderVariables",
+         "shouldSkipDeliverabilityCheck", "createdWith", "renderedByWorkerId", "startedRenderingAt",
+         "finishedRenderingAt", "renderedHtml", "renderedSubject", "renderedIsTransactional",
+         "scheduledAt", "isQueued", "isPaused", "startedSendingAt", "finishedSendingAt", "canHaveDeliveryInfo",
+         "shouldUpdateSequenceId")
+      VALUES
+        ($1::uuid, $2::uuid, $3, $3, '', false, $4::jsonb, '{}'::jsonb,
+         true, 'PROGRAMMATIC_CALL', $5::uuid, $3, $3, '<p>sequence visibility test</p>',
+         $6, true, $3, false, true, null, null, null, true)
+    `,
+    [
+      tenancyId,
+      id,
+      renderedAt,
+      JSON.stringify({ type: "custom-emails", emails: [`sequence-visibility-${id}@example.com`] }),
+      randomUUID(),
+      subject,
+    ],
+  );
+}
+
+async function triggerExternalDbSync(tenancyId: string): Promise<void> {
+  const response = await niceFetch(new URL("/api/latest/internal/external-db-sync/sync-engine", STACK_BACKEND_BASE_URL), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "upstash-signature": "test-bypass",
+    },
+    body: JSON.stringify({ tenancyId }),
+  });
+  expect(response.status).toBe(200);
+}
+
+type FuseboxState = {
+  existed: boolean,
+  sequencerEnabled: boolean,
+  pollerEnabled: boolean,
+};
+
+async function disableAutomaticSequencing(): Promise<FuseboxState> {
+  return await withInternalDatabase(async (client) => {
+    const result = await client.query<{ sequencerEnabled: boolean, pollerEnabled: boolean }>(
+      `SELECT "sequencerEnabled", "pollerEnabled" FROM "ExternalDbSyncMetadata" WHERE "singleton" = 'TRUE'::"BooleanTrue"`,
+    );
+    const existing = result.rows.at(0);
+    await client.query(
+      `
+        INSERT INTO "ExternalDbSyncMetadata" ("singleton", "sequencerEnabled", "pollerEnabled", "createdAt", "updatedAt")
+        VALUES ('TRUE'::"BooleanTrue", false, COALESCE($1, true), now(), now())
+        ON CONFLICT ("singleton")
+        DO UPDATE SET "sequencerEnabled" = false
+      `,
+      [existing?.pollerEnabled ?? null],
+    );
+    return {
+      existed: existing != null,
+      sequencerEnabled: existing?.sequencerEnabled ?? true,
+      pollerEnabled: existing?.pollerEnabled ?? true,
+    };
+  });
+}
+
+async function restoreFusebox(state: FuseboxState): Promise<void> {
+  await withInternalDatabase(async (client) => {
+    if (state.existed) {
+      await client.query(
+        `UPDATE "ExternalDbSyncMetadata" SET "sequencerEnabled" = $1, "pollerEnabled" = $2 WHERE "singleton" = 'TRUE'::"BooleanTrue"`,
+        [state.sequencerEnabled, state.pollerEnabled],
+      );
+    } else {
+      await client.query(`DELETE FROM "ExternalDbSyncMetadata" WHERE "singleton" = 'TRUE'::"BooleanTrue"`);
+    }
+  });
+}
+
+async function waitForExternalEmailOutbox(client: Client, id: string, expectedCount: number): Promise<void> {
+  await waitForCondition(
+    async () => (await client.query(`SELECT "id" FROM "email_outboxes" WHERE "id" = $1`, [id])).rows.length === expectedCount,
+    {
+      timeoutMs: 30_000,
+      intervalMs: 500,
+      description: `EmailOutbox ${id} to have external row count ${expectedCount}`,
+    },
+  );
 }
 
 // Run tests sequentially to avoid concurrency issues with shared backend state
@@ -1451,6 +1571,115 @@ describe.sequential('External DB Sync - Basic Tests', () => {
     expect(row.created_with).toBe('PROGRAMMATIC_CALL');
     expect(row.is_high_priority).toBe(false);
     expect(row.is_paused).toBe(false);
+  }, TEST_TIMEOUT);
+
+  test("Sequence allocation visibility does not permanently skip an EmailOutbox row", async () => {
+    const dbName = "sequence_visibility_race_test";
+    const connectionString = await dbManager.createDatabase(dbName);
+    const project = await createProjectWithExternalDb({
+      main: {
+        type: "postgres",
+        connectionString,
+      },
+    });
+    const externalClient = dbManager.getClient(dbName);
+    const rowA = randomUUID();
+    const rowB = randomUUID();
+    const baselineRow = randomUUID();
+    const internalDatabaseConnectionString = getEnvVariable(
+      "HEXCLAVE_DATABASE_CONNECTION_STRING",
+      getEnvVariable("STACK_DATABASE_CONNECTION_STRING", ""),
+    );
+    if (internalDatabaseConnectionString === "") {
+      throwErr("Sequence visibility e2e test requires an internal database connection string");
+    }
+    const transactionA = new Client({
+      connectionString: internalDatabaseConnectionString,
+    });
+    const transactionB = new Client({
+      connectionString: internalDatabaseConnectionString,
+    });
+
+    let tenancyId: string | undefined;
+    let transactionAStarted = false;
+    let fuseboxState: FuseboxState | undefined;
+    try {
+      fuseboxState = await disableAutomaticSequencing();
+      await withInternalDatabase(async (client) => {
+        const tenancy = await client.query<{ id: string }>(
+          `SELECT "id" FROM "Tenancy" WHERE "projectId" = $1 AND "branchId" = 'main' LIMIT 1`,
+          [project.projectId],
+        );
+        tenancyId = tenancy.rows[0]?.id ?? throwErr("Could not find the test project's main tenancy");
+        await insertSequenceVisibilityEmail(client, tenancyId, baselineRow, "Sequence visibility baseline");
+      });
+      const testTenancyId = tenancyId ?? throwErr("Test project's tenancy was not initialized");
+
+      await transactionA.connect();
+      await transactionB.connect();
+      await withInternalDatabase(async (client) => {
+        await client.query("BEGIN");
+        await allocateEmailOutboxSequence(client, testTenancyId, baselineRow);
+        await client.query("COMMIT");
+      });
+      await triggerExternalDbSync(testTenancyId);
+      await waitForExternalEmailOutbox(externalClient, baselineRow, 1);
+
+      await withInternalDatabase(async (client) => {
+        await insertSequenceVisibilityEmail(client, testTenancyId, rowA, "Sequence visibility row A");
+        await insertSequenceVisibilityEmail(client, testTenancyId, rowB, "Sequence visibility row B");
+      });
+
+      await transactionA.query("BEGIN");
+      transactionAStarted = true;
+      const sequenceA = await allocateEmailOutboxSequence(transactionA, testTenancyId, rowA);
+
+      await transactionB.query("BEGIN");
+      const sequenceB = await allocateEmailOutboxSequence(transactionB, testTenancyId, rowB);
+      await transactionB.query("COMMIT");
+
+      // T1 has allocated the lower value but is still uncommitted. T2 commits the higher value first.
+      await triggerExternalDbSync(testTenancyId);
+      await waitForExternalEmailOutbox(externalClient, rowB, 1);
+
+      await transactionA.query("COMMIT");
+      transactionAStarted = false;
+      await triggerExternalDbSync(testTenancyId);
+
+      await waitForCondition(
+        async () => (await externalClient.query(`SELECT "id" FROM "email_outboxes" WHERE "id" = $1`, [rowA])).rows.length === 1,
+        {
+          timeoutMs: 20_000,
+          intervalMs: 500,
+          description: `EmailOutbox ${rowA} to reach the external database after the sequence visibility interleaving (A=${sequenceA}, B=${sequenceB})`,
+        },
+      );
+    } finally {
+      try {
+        if (transactionAStarted) await transactionA.query("ROLLBACK");
+        await transactionA.end();
+        await transactionB.end();
+
+        if (tenancyId != null) {
+          await withInternalDatabase(async (client) => {
+            await client.query("BEGIN");
+            try {
+              await deleteSyncedRowsWithTombstones(client, {
+                table: "EmailOutbox",
+                whereClause: `"tenancyId" = $1::uuid AND "id" = ANY($2::uuid[])`,
+                values: [tenancyId, [baselineRow, rowA, rowB]],
+              });
+              await client.query("COMMIT");
+            } catch (error) {
+              await client.query("ROLLBACK");
+              throw error;
+            }
+          });
+        }
+      } finally {
+        if (fuseboxState != null) await restoreFusebox(fuseboxState);
+      }
+    }
   }, TEST_TIMEOUT);
 
   /**

--- a/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-basics.test.ts
@@ -1,5 +1,6 @@
 import { HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { wait } from "@hexclave/shared/dist/utils/promises";
+import { SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY } from "@hexclave/shared/dist/config/db-sync-mappings";
 import { afterAll, beforeAll, describe, expect } from 'vitest';
 import { niceFetch, STACK_BACKEND_BASE_URL, test } from '../../../../helpers';
 import { withPortPrefix } from '../../../../helpers/ports';
@@ -126,6 +127,8 @@ async function waitForClickhouseEmailOutbox(id: string, expectedCount: number, d
 }
 
 async function allocateEmailOutboxSequence(client: Client, tenancyId: string, id: string): Promise<bigint> {
+  // This mirrors the sequencer's EmailOutbox statement. Its SQL shape is pinned by the
+  // backend sequence-visibility test; this e2e test only drives the real external sync path.
   const rows = await client.query<{ sequenceId: string }>(
     `
       WITH rows_to_update AS (
@@ -203,69 +206,56 @@ async function triggerExternalDbSequencer(): Promise<void> {
   expect(response.status).toBe(200);
 }
 
-async function waitForReplicaEmailOutboxSequence(id: string): Promise<bigint> {
-  const connectionString = getEnvVariable(
-    "STACK_DATABASE_REPLICA_CONNECTION_STRING",
-    getEnvVariable("STACK_DATABASE_CONNECTION_STRING", ""),
-  );
-  if (connectionString === "") {
+async function waitForEmailOutboxSequence(id: string, reader: "primary" | "replica"): Promise<bigint> {
+  const connectionString = reader === "replica"
+    ? getEnvVariable(
+      "STACK_DATABASE_REPLICA_CONNECTION_STRING",
+      // Match prisma-client.tsx: use the primary when no replica is configured.
+      getEnvVariable("STACK_DATABASE_CONNECTION_STRING", ""),
+    )
+    : null;
+  if (reader === "replica" && connectionString === "") {
     throwErr("Sequence visibility e2e test requires a database replica connection string");
   }
-  const client = new Client({ connectionString });
-  await client.connect();
+  const client = connectionString == null ? null : new Client({ connectionString });
+  if (client != null) await client.connect();
   try {
     let sequenceId: bigint | undefined;
-    await waitForCondition(
-      async () => {
-        const result = await client.query<{ sequenceId: string | null }>(
-          `SELECT "sequenceId" FROM "EmailOutbox" WHERE "id" = $1`,
-          [id],
-        );
-        const value = result.rows[0]?.sequenceId;
-        if (value == null) return false;
-        sequenceId = BigInt(value);
-        return true;
-      },
-      {
-        timeoutMs: 30_000,
-        intervalMs: 250,
-        description: `EmailOutbox ${id} to become visible on the sync reader`,
-      },
-    );
-    return sequenceId ?? throwErr(`Replica did not return a sequence ID for EmailOutbox ${id}`);
-  } finally {
-    await client.end();
-  }
-}
-
-async function waitForPrimaryEmailOutboxSequence(id: string): Promise<bigint> {
-  let sequenceId: bigint | undefined;
-  await waitForCondition(
-    async () => {
-      await withInternalDatabase(async (client) => {
+    await waitForCondition(async () => {
+      if (client != null) {
         const result = await client.query<{ sequenceId: string | null }>(
           `SELECT "sequenceId" FROM "EmailOutbox" WHERE "id" = $1`,
           [id],
         );
         const value = result.rows[0]?.sequenceId;
         if (value != null) sequenceId = BigInt(value);
-      });
+      } else {
+        await withInternalDatabase(async (primaryClient) => {
+          const result = await primaryClient.query<{ sequenceId: string | null }>(
+            `SELECT "sequenceId" FROM "EmailOutbox" WHERE "id" = $1`,
+            [id],
+          );
+          const value = result.rows[0]?.sequenceId;
+          if (value != null) sequenceId = BigInt(value);
+        });
+      }
       return sequenceId != null;
-    },
-    {
-      timeoutMs: 30_000,
+    }, {
+      timeoutMs: 15_000,
       intervalMs: 250,
-      description: `EmailOutbox ${id} to receive a sequence ID`,
-    },
-  );
-  return sequenceId ?? throwErr(`Primary did not return a sequence ID for EmailOutbox ${id}`);
+      description: `EmailOutbox ${id} to receive a sequence ID on the ${reader} sync reader`,
+    });
+    return sequenceId ?? throwErr(`The ${reader} sync reader did not return a sequence ID for EmailOutbox ${id}`);
+  } finally {
+    if (client != null) await client.end();
+  }
 }
 
 async function waitForExternalEmailOutbox(client: Client, id: string, expectedCount: number): Promise<void> {
   await waitForCondition(
     async () => (await client.query(`SELECT "id" FROM "email_outboxes" WHERE "id" = $1`, [id])).rows.length === expectedCount,
     {
-      timeoutMs: 30_000,
+      timeoutMs: 20_000,
       intervalMs: 500,
       description: `EmailOutbox ${id} to have external row count ${expectedCount}`,
     },
@@ -1645,7 +1635,7 @@ describe.sequential('External DB Sync - Basic Tests', () => {
         await allocateEmailOutboxSequence(client, testTenancyId, baselineRow);
         await client.query("COMMIT");
       });
-      await waitForReplicaEmailOutboxSequence(baselineRow);
+      await waitForEmailOutboxSequence(baselineRow, "replica");
       await triggerExternalDbSync(testTenancyId);
       await waitForExternalEmailOutbox(externalClient, baselineRow, 1);
 
@@ -1657,7 +1647,7 @@ describe.sequential('External DB Sync - Basic Tests', () => {
       await transactionA.query("BEGIN");
       transactionAStarted = true;
       await transactionA.query("SET LOCAL lock_timeout = '5000ms'");
-      await transactionA.query("SELECT pg_advisory_xact_lock(178555)");
+      await transactionA.query(`SELECT pg_advisory_xact_lock(${SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY})`);
       const sequenceA = await allocateEmailOutboxSequence(transactionA, testTenancyId, rowA);
 
       // T1 holds the production allocation lock after assigning A. A real sequencer invocation
@@ -1671,27 +1661,29 @@ describe.sequential('External DB Sync - Basic Tests', () => {
         return result.rows[0]?.sequenceId;
       });
       if (rowBSequenceBeforeACommit != null) {
-        await waitForReplicaEmailOutboxSequence(rowB);
+        await waitForEmailOutboxSequence(rowB, "replica");
       }
       await triggerExternalDbSync(testTenancyId);
 
       await transactionA.query("COMMIT");
       transactionAStarted = false;
       await triggerExternalDbSequencer();
-      await waitForPrimaryEmailOutboxSequence(rowB);
-      await waitForReplicaEmailOutboxSequence(rowA);
-      await waitForReplicaEmailOutboxSequence(rowB);
+      const sequenceB = await waitForEmailOutboxSequence(rowB, "primary");
+      await waitForEmailOutboxSequence(rowA, "replica");
+      await waitForEmailOutboxSequence(rowB, "replica");
       await triggerExternalDbSync(testTenancyId);
 
-      await waitForCondition(
-        async () => (await externalClient.query(`SELECT "id" FROM "email_outboxes" WHERE "id" = $1`, [rowA])).rows.length === 1,
-        {
-          timeoutMs: 20_000,
-          intervalMs: 500,
-          description: `EmailOutbox ${rowA} to reach the external database after serialized sequence allocation (A=${sequenceA})`,
-        },
-      );
+      expect(sequenceA).toBeLessThan(sequenceB);
       await waitForExternalEmailOutbox(externalClient, rowB, 1);
+      await waitForExternalEmailOutbox(externalClient, rowA, 1);
+      const externalRows = await externalClient.query<{ id: string }>(
+        `SELECT "id"
+         FROM "email_outboxes"
+         WHERE "id" = ANY($1::uuid[])
+         ORDER BY "id"`,
+        [[rowA, rowB]],
+      );
+      expect(externalRows.rows.map(row => row.id)).toEqual([rowA, rowB].sort());
     } finally {
       if (transactionAStarted) await transactionA.query("ROLLBACK");
       await transactionA.end();

--- a/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-utils.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/external-db-sync-utils.ts
@@ -13,7 +13,7 @@ export const POSTGRES_PASSWORD = process.env.EXTERNAL_DB_TEST_PASSWORD || 'PASSW
 export const TEST_TIMEOUT = 240000;
 export const HIGH_VOLUME_TIMEOUT = 600000; // 10 minutes for 1500+ users
 
-function getInternalDatabaseConnectionString(): string {
+export function getInternalDatabaseConnectionString(): string {
   const connectionString = getEnvVariable(
     "HEXCLAVE_DATABASE_CONNECTION_STRING",
     getEnvVariable("STACK_DATABASE_CONNECTION_STRING", ""),

--- a/packages/shared/src/config/db-sync-mappings.ts
+++ b/packages/shared/src/config/db-sync-mappings.ts
@@ -1,3 +1,9 @@
+/**
+ * PostgreSQL advisory-lock key shared by sequence allocation and its regression tests.
+ * Both the sequencer and the sequence-visibility regression test take this lock.
+ */
+export const SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY = 178555;
+
 export const DEFAULT_DB_SYNC_MAPPINGS = {
   "users": {
     sourceTables: { "ProjectUser": "ProjectUser" },


### PR DESCRIPTION
Follow-up to #1951, where a CI-only failure of that PR's first regression test turned out not to be the test's fault.

The sync advances a per-(tenancy, mapping) watermark to the highest `sequenceId` in the batch it just pushed, and every later fetch filters `"sync_sequence_id" > $2::bigint`. That is only sound if visibility is monotonic in `sequenceId` — if a reader can see value N, it must also see every lower value. Nothing enforced that:

- `nextval('global_seq_id')` is non-transactional, so a transaction can allocate a value and commit *after* another transaction that allocated a higher one.
- The sequencer cron runs every minute and each invocation loops for up to three minutes (`apps/backend/vercel.json`), so up to three invocations overlap by design — that's what the `FOR UPDATE SKIP LOCKED` in each allocation statement is for.

So a row can become visible *after* the watermark has already moved past its sequence value, and the `>` filter then excludes it on every subsequent sync. The row never reaches the external database or ClickHouse again until something updates it and it earns a fresh, higher value. This is a silent data-loss path, not a test-only artifact; it's the same class of drift as the `email_outboxes` count mismatch in #1951, and it's why that PR's ClickHouse assertion had to run against its own project instead of the shared seeded tenancy.

Fix: allocation is the only place that assigns sequence values, so enforce the invariant there. Each per-table allocation now runs in a transaction that first takes a global transaction-scoped advisory lock, which makes commit order equal allocation order. It's a `pg_try_advisory_xact_lock`, so a sequencer invocation that loses the race skips that allocation for the iteration instead of blocking — no work is lost, the rows still carry `shouldUpdateSequenceId = TRUE` and the loop comes back 50ms later. Queue writes stay outside the locked transaction.

The lock is global rather than per tenancy because the batch statements deliberately span tenancies (`ORDER BY "tenancyId" LIMIT batchSize`); the tradeoff is that allocation throughput becomes one set-based batch of up to `batchSize` rows at a time, which is why those statements stay set-based.

Coverage, both of which fail without the production change:

- A backend test drives two concurrent transactions through the production lock wrapper and asserts the second allocation cannot proceed while the first is still open, then that both values are visible in allocation order.
- An e2e test proves the consequence end to end against a real per-test external database: it holds the allocation lock after assigning the lower value, runs a real sequencer invocation and a real sync in that window, and asserts the lower-valued row still reaches the external table afterwards. Before the fix that row never arrived (`Timeout waiting for EmailOutbox ... to reach the external database`, A=35707 lost while B=35718 synced).

The invariant is documented at the lock wrapper and pointed at from both places where the watermark is advanced, since changing either side alone breaks the other.


Link to Devin session: https://app.devin.ai/sessions/7d17b5e948974a71ba36d68c045bcb1f
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core external-db-sync sequencing and locking; incorrect behavior would cause silent sync gaps, though losers skip non-blockingly and coverage targets the race explicitly.
> 
> **Overview**
> Fixes a **silent data-loss path** in external DB / ClickHouse sync: overlapping sequencer work could commit `global_seq_id` assignments out of order, so the sync watermark (`sequence_id > last`) could advance past a row that was not yet visible to readers.
> 
> **Production change:** Each per-table `nextval` batch in the external-db-sync sequencer now runs inside `retryTransaction` behind `runSequenceAllocationInTransaction`, which takes a **global** transaction-scoped `pg_try_advisory_xact_lock` (`SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY` in shared config). Winners allocate and commit in order; losers return `null` for that iteration (rows stay `shouldUpdateSequenceId = TRUE` and retry on the next loop). Sync enqueue calls remain outside the locked transaction.
> 
> **Docs / tests:** Watermark advancement in `external-db-sync.ts` is annotated to depend on this ordering. A backend test exercises concurrent allocations through the production lock wrapper; an e2e test holds the lock, runs the real sequencer + sync, and asserts both `EmailOutbox` rows still reach the external Postgres table.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adde088df1b92271f5ca27a3c7e73ad4b55fe470. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serializes external DB sequence allocation under a global advisory lock so `sequenceId` visibility is monotonic. Previously, overlapping runs could commit a higher `sequenceId` before a lower one, letting the `> last` sync watermark skip a row; now allocations commit in order and losing attempts skip and retry.

- Adds `runSequenceAllocationInTransaction` (uses `pg_try_advisory_xact_lock`) and a `runSequenceAllocation` wrapper around `retryTransaction` (30s). Losing attempts return null and set span attr `stack.external-db-sync.sequence-allocation-skipped`.
- Applies the locked, set-based allocation to all sequenced tables in the sequencer route; queue writes remain outside the lock. Documents the ordering requirement in both Postgres and ClickHouse sync paths.
- Exports `SEQUENCE_ALLOCATION_ADVISORY_LOCK_KEY` from `@hexclave/shared` for production and tests.
- Tests: backend regression test holds a transaction to prove skip-while-locked and commit-order visibility, and asserts the allocated row is returned; e2e test drives the real sequencer + sync (with replica reader) and verifies both `EmailOutbox` rows reach the external DB in order.
- Operational impact: global serialization reduces concurrent allocation to one batch at a time but keeps set-based throughput. No schema or API changes.

<sup>Written for commit 127e4aa69961d915a7456976204cd3f4939eea89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external database synchronization during concurrent sequence allocation.
  * Prevented blocked allocations from delaying later records while preserving ordering and eventual synchronization.
  * Ensured lower sequence values are visible before higher values are processed.

* **Tests**
  * Added integration and end-to-end coverage for allocation contention, ordering, skipped work, and external visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->