### PR TITLE
Build server Docker images natively per platform instead of under QEMU

### DIFF
--- a/.github/workflows/docker-server-build-push.yaml
+++ b/.github/workflows/docker-server-build-push.yaml
@@ -30,6 +30,7 @@ jobs:
             arch: arm64
             runner: ubicloud-standard-8-arm
             timeout: 45
+    # Both matrix legs compute the same value, so whichever leg writes this output last is equivalent.
     outputs:
       should_push: ${{ steps.push-condition.outputs.should_push }}
     steps:
@@ -74,7 +75,6 @@ jobs:
         with:
           context: .
           file: ./docker/server/Dockerfile
-          push: ${{ steps.push-condition.outputs.should_push }}
           platforms: ${{ matrix.platform }}
           outputs: ${{ steps.push-condition.outputs.should_push == 'true' && format('type=image,name={0}/server,push-by-digest=true,name-canonical=true,push=true', secrets.DOCKER_REPO) || '' }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -83,7 +83,7 @@ jobs:
         if: steps.push-condition.outputs.should_push == 'true'
         run: |
           mkdir -p digest
-          printf '%s\n' '${{ steps.build-platform-image.outputs.digest }}' > "digest/${{ matrix.arch }}"
+          printf '%s\n' '${{ steps.build-platform.outputs.digest }}' > "digest/${{ matrix.arch }}"
 
       - name: Upload image digest
         if: steps.push-condition.outputs.should_push == 'true'
@@ -96,7 +96,7 @@ jobs:
     if: needs.build-server.result == 'success' && needs.build-server.outputs.should_push == 'true'
     needs: build-server
     name: Merge and tag server images
-    runs-on: ubicloud-standard-2
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Docker meta
@@ -137,8 +137,17 @@ jobs:
           sources=()
           while IFS= read -r digest_file; do
             digest="$(cat "$digest_file")"
+            if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+              echo "Invalid or empty image digest in $digest_file: '$digest'" >&2
+              exit 1
+            fi
             sources+=("${IMAGE}@${digest}")
-          done < <(find digests -type f -maxdepth 1 -print | sort)
+          done < <(find digests -maxdepth 1 -type f -print | sort)
+
+          if [ "${#sources[@]}" -ne 2 ]; then
+            echo "Expected 2 platform image digests, found ${#sources[@]}" >&2
+            exit 1
+          fi
 
           while IFS= read -r tag; do
             [ -n "$tag" ] || continue

--- a/.github/workflows/docker-server-build-push.yaml
+++ b/.github/workflows/docker-server-build-push.yaml
@@ -6,17 +6,32 @@ on:
       - main
       - dev
 
-# Grouped per ref (not per sha) on purpose: this pushes the moving `dev`/`latest` image tags, so runs
-# must stay serialized, otherwise a slower run for an older commit can overwrite a newer commit's tag.
+# Grouped per ref (not per sha) on purpose: this publishes the moving `dev`/`latest` image tags after
+# the platform digests are merged, so runs must stay serialized or an older run could overwrite a
+# newer commit's tag.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/dev' }}
 
 jobs:
   build-server:
-    timeout-minutes: 90
-    name: Docker Build and Push Server
-    runs-on: ubicloud-standard-8
+    name: Docker Build Server (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            arch: amd64
+            runner: ubicloud-standard-8
+            timeout: 30
+          - platform: linux/arm64
+            arch: arm64
+            runner: ubicloud-standard-8-arm
+            timeout: 45
+    outputs:
+      should_push: ${{ steps.push-condition.outputs.should_push }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -31,9 +46,6 @@ jobs:
             type=ref,event=branch,enable=${{ github.ref != 'refs/heads/main' }}
             type=sha,prefix=
             type=match,pattern=\d.\d.\d
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
@@ -54,12 +66,81 @@ jobs:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and push
+      # QEMU emulation of the turbo/Next build can hang for the arm64 leg. Build each platform
+      # natively and push only an untagged digest; the merge job below owns moving release tags.
+      - name: Build platform image
+        id: build-platform
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: ./docker/server/Dockerfile
           push: ${{ steps.push-condition.outputs.should_push }}
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
+          outputs: ${{ steps.push-condition.outputs.should_push == 'true' && format('type=image,name={0}/server,push-by-digest=true,name-canonical=true,push=true', secrets.DOCKER_REPO) || '' }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Export image digest
+        if: steps.push-condition.outputs.should_push == 'true'
+        run: |
+          mkdir -p digest
+          printf '%s\n' '${{ steps.build-platform-image.outputs.digest }}' > "digest/${{ matrix.arch }}"
+
+      - name: Upload image digest
+        if: steps.push-condition.outputs.should_push == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: server-digest-${{ matrix.arch }}
+          path: digest/${{ matrix.arch }}
+
+  merge:
+    if: needs.build-server.result == 'success' && needs.build-server.outputs.should_push == 'true'
+    needs: build-server
+    name: Merge and tag server images
+    runs-on: ubicloud-standard-2
+    timeout-minutes: 10
+    steps:
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
+        with:
+          images: ${{ secrets.DOCKER_REPO }}/server
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch,enable=${{ github.ref != 'refs/heads/main' }}
+            type=sha,prefix=
+            type=match,pattern=\d.\d.\d
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Download image digests
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: server-digest-*
+          merge-multiple: true
+          path: digests
+
+      # Platform jobs cannot safely race on release tags. Assemble their immutable digests here,
+      # preserving the metadata action's existing tag rules while publishing one multi-platform tag.
+      - name: Merge platform images and publish tags
+        env:
+          IMAGE: ${{ secrets.DOCKER_REPO }}/server
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          sources=()
+          while IFS= read -r digest_file; do
+            digest="$(cat "$digest_file")"
+            sources+=("${IMAGE}@${digest}")
+          done < <(find digests -type f -maxdepth 1 -print | sort)
+
+          while IFS= read -r tag; do
+            [ -n "$tag" ] || continue
+            docker buildx imagetools create --tag "$tag" "${sources[@]}"
+          done <<< "$TAGS"


### PR DESCRIPTION
## Why

The last two `main` runs of this workflow never published `latest`: both hung in the QEMU-emulated `linux/arm64` leg of `pnpm turbo run docker-build` and were killed by the 90-minute job timeout ([run 31757295680](https://github.com/hexclave/hexclave/actions/runs/31757295680), and the earlier run for the fix's merge commit). In the stalled logs the arm64 step stops emitting output entirely — no OOM, no error — while the amd64 leg of the same step finishes in ~73s, and a `dev` build of a neighbouring commit ran the same emulated step in 8.5 min. So it's an intermittent emulation hang, not legitimate build time. Consequence: `stackauth/server:latest` has been stuck on the Aug 12 build, so the self-hosted key-stability fix (#1950) never reached customers.

## What

Split the single multi-platform job into a matrix that builds each platform on a native runner (`ubicloud-standard-8` for amd64, `ubicloud-standard-8-arm` for arm64) and drop the QEMU setup step.

Because two jobs must not race on the same moving tags, the platform jobs push **untagged, by digest** and a final `merge` job assembles the manifest:

```
build (amd64) ─┐  push-by-digest → server@sha256:…
build (arm64) ─┴─→ merge: docker buildx imagetools create --tag <each meta tag> server@amd64digest server@arm64digest
```

Tag semantics are unchanged — the `merge` job reuses the identical `docker/metadata-action` rules (`latest` on `main` only, branch tag off `main`, unprefixed sha, `\d.\d.\d`), so it emits one `--tag` per generated tag against one multi-platform manifest. Push gating is unchanged too: non-push events build both platforms with an empty `outputs:` (no registry credentials needed) and skip `merge` entirely. Per-ref concurrency is kept, with its comment updated to say the tag move now happens in `merge`.

The merge script refuses to assemble a manifest from anything that isn't exactly two `sha256:<64 hex>` digests rather than silently creating a malformed reference.

No caching in this PR, and no changes to the Dockerfile or application code.

## Testing

Workflow-only change, so it can only be exercised by running on a branch: YAML parses, `git diff --check` clean, and every `steps.*`/`needs.*` reference and the tag loop were checked by hand (`actionlint` isn't installed here). The arm64 runner label is Ubicloud's documented native arm64 8-vCPU Ubuntu 24.04 alias; this repo hasn't used it before, so the first `dev` run is the real proof that the label resolves.


Link to Devin session: https://app.devin.ai/sessions/a9ac9b0a226a4043ba1d627d46fee263
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release publishing for `stackauth/server` images; wrong merge logic or digest handling could break or mis-tag production Docker images, though tag rules and push gating are preserved.
> 
> **Overview**
> Replaces the single QEMU-based multi-platform Docker build with a **matrix** that builds `linux/amd64` and `linux/arm64` on native runners (`ubicloud-standard-8` / `ubicloud-standard-8-arm`), removing QEMU setup. Platform jobs no longer push release tags directly; on push events they **push by digest only** and upload digests as artifacts.
> 
> A new **`merge` job** downloads both digests, validates exactly two `sha256:` references, and runs `docker buildx imagetools create` to publish the same metadata tags (`latest`, branch, sha, semver) as one multi-platform manifest. Per-ref concurrency comments are updated to reflect that tag moves happen in merge. Non-push runs still build both platforms without registry push and skip merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd42720f37e8d00c163719a89a013fcb8e74b00e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds server Docker images natively per platform instead of via QEMU, preventing intermittent arm64 hangs that were blocking `latest` and `dev` tag publication. Previously one job built a multi-arch image under emulation and pushed tags; now each platform builds on a native runner and pushes by digest, then a merge job assembles the multi-arch manifest and tags.

- Runs a matrix: `linux/amd64` on `ubicloud-standard-8` (30 min timeout) and `linux/arm64` on `ubicloud-standard-8-arm` (45 min).
- Removes `docker/setup-qemu-action`; keeps `docker/setup-buildx-action` and `docker/login-action`.
- Each platform uses `docker/build-push-action` to push an untagged digest (`push-by-digest=true`); digests are exchanged via `actions/upload-artifact`/`actions/download-artifact`.
- A `merge` job validates exactly two `sha256:<64 hex>` digests and runs `docker buildx imagetools create` to publish one multi-arch manifest per tag from `docker/metadata-action` (tag rules unchanged: `latest` on `main`, branch tag off `main`, unprefixed SHA, `\d.\d.\d`).
- Concurrency remains per ref; tag movement happens only in `merge`. Non-push events build both platforms without pushing and skip `merge`.
- No changes to Dockerfiles, application code, or caching.

<sup>Written for commit fd42720f37e8d00c163719a89a013fcb8e74b00e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image builds for both amd64 and arm64 platforms.
  * Added validation to ensure platform digests are correctly formatted and complete.
  * Improved image publishing reliability by combining platform-specific builds into multi-platform images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->