### PR TITLE
[Fix]: Refund Creation Retry Should Look the Same as Original Attempt

### DIFF
--- a/apps/backend/src/app/api/latest/internal/payments/transactions/refund/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/payments/transactions/refund/route.tsx
@@ -1,9 +1,9 @@
-import { createHash, randomUUID } from "node:crypto";
+import { createHash } from "node:crypto";
 import { Prisma } from "@/generated/prisma/client";
 import { fetchBulldozerServerJson } from "@/lib/bulldozer-server-client";
 import { bulldozerWriteOneTimePurchase, bulldozerWriteSubscription, persistRefundManualTransaction } from "@/lib/payments/bulldozer-dual-write";
 import { ensureFreePlanForBillingTeam } from "@/lib/payments/ensure-free-plan";
-import { REFUND_TXN_PREFIX } from "@/lib/payments/refund-txn-id";
+import { makeRefundTxnId } from "@/lib/payments/refund-txn-id";
 import { resolveSelectedPriceFromProduct } from "@/app/api/latest/internal/payments/transactions/transaction-builder";
 import { ONE_TIME_PURCHASE_PRODUCT_GRANT_ENTRY_INDEX, SUBSCRIPTION_START_PRODUCT_GRANT_ENTRY_INDEX } from "@/lib/payments/transaction-entry-indexes";
 import type { ManualTransactionRow, TransactionEntryData } from "@/lib/payments/schema/types";
@@ -63,10 +63,6 @@ function getTotalUsdStripeUnits(options: {
 
 // ── Refund row construction ────────────────────────────────────────────────
 
-function makeRefundTxnId(sourceTxnId: string): string {
-  return `${REFUND_TXN_PREFIX}${sourceTxnId}:${randomUUID()}`;
-}
-
 /**
  * Derive a deterministic Stripe idempotency key from the tenancy, source
  * transaction, refund amount, and the cumulative amount already refunded
@@ -74,6 +70,10 @@ function makeRefundTxnId(sourceTxnId: string): string {
  * three identical inputs and dedupes at Stripe. Two intentional partials of
  * the same amount get distinct keys because `priorRefundedStripeUnits`
  * advances after the first one commits.
+ *
+ * Deliberately does NOT include `endAction` — changing this fingerprint would
+ * break in-flight Stripe retries. Refund-row idempotency across Prisma /
+ * Bulldozer dual-write retries is handled by `makeRefundTxnId` instead.
  */
 function makeStripeIdempotencyKey(args: {
   tenancyId: string,
@@ -429,13 +429,18 @@ export const POST = createSmartRouteHandler({
 //    row. The Stripe idempotency key is derived from
 //    `(tenancyId, sourceTxnId, amountStripeUnits, priorRefundedStripeUnits)`
 //    — *not* from `refundTxnId` — so:
-//      - Stripe-success → DB-fail → caller retries: `prior` is unchanged
-//        (no row committed), the key matches, Stripe dedupes, and the
-//        second attempt's bulldozer write recovers the state. Self-heals.
-//      - DB-success → response lost → caller retries: `prior` now includes
-//        the just-committed amount, so a fresh key is generated and Stripe
-//        issues a second real refund. This is the open hole — no
-//        out-of-band reconciliation today. Tracked alongside (1).
+//      - Stripe-success → both-stores-fail → caller retries: `prior` is
+//        unchanged (no Bulldozer row), the Stripe key matches, Stripe
+//        dedupes, and the second attempt's dual-write recovers. Self-heals.
+//      - Stripe-success → Prisma-ok / Bulldozer-fail → caller retries with
+//        the same payload: `makeRefundTxnId` reuses the same `txnId`
+//        (fingerprint includes Bulldozer prior, which did not advance), so
+//        Prisma upserts and Bulldozer setRows converge. Self-heals.
+//      - Both stores succeed → response lost → caller retries: `prior` now
+//        includes the just-committed amount, so a fresh Stripe key and a
+//        fresh refund txn id are generated and Stripe issues a second real
+//        refund. This is the open hole — no out-of-band reconciliation
+//        today. Tracked alongside (1).
 async function handleSubscriptionRefund(options: {
   prisma: Awaited<ReturnType<typeof getPrismaClientForTenancy>>,
   tenancy: Tenancy,
@@ -612,7 +617,17 @@ async function handleSubscriptionRefund(options: {
     throw new KnownErrors.SchemaError("This subscription's product has already been revoked.");
   }
 
-  const refundTxnId = makeRefundTxnId(sourceTxnId);
+  // amountStripeUnits / prior.refundedStripeUnits are already integer cents:
+  // the handler entrypoint ran moneyAmountToStripeUnits, and prior is summed
+  // the same way in bulldozer. makeRefundTxnId asserts that invariant
+  // (HexclaveAssertionError → sanitized 500 if violated).
+  const refundTxnId = makeRefundTxnId(
+    tenancy.id,
+    sourceTxnId,
+    options.amountStripeUnits,
+    prior.refundedStripeUnits,
+    options.endAction ?? "none",
+  );
 
   // ── Stripe side ───────────────────────────────────────────────────────
   if (options.amountStripeUnits > 0 && !isTestMode) {
@@ -879,7 +894,17 @@ async function handleOneTimePurchaseRefund(options: {
     throw new KnownErrors.SchemaError("This purchase's product has already been revoked.");
   }
 
-  const refundTxnId = makeRefundTxnId(sourceTxnId);
+  // amountStripeUnits / prior.refundedStripeUnits are already integer cents:
+  // the handler entrypoint ran moneyAmountToStripeUnits, and prior is summed
+  // the same way in bulldozer. makeRefundTxnId asserts that invariant
+  // (HexclaveAssertionError → sanitized 500 if violated).
+  const refundTxnId = makeRefundTxnId(
+    tenancy.id,
+    sourceTxnId,
+    options.amountStripeUnits,
+    prior.refundedStripeUnits,
+    options.endNow ? "now" : "none",
+  );
 
   // ── Stripe side ───────────────────────────────────────────────────────
   if (options.amountStripeUnits > 0 && !isTestMode) {

--- a/apps/backend/src/lib/payments/bulldozer-dual-write.persist-refund.test.ts
+++ b/apps/backend/src/lib/payments/bulldozer-dual-write.persist-refund.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { ManualTransactionRow } from "@/lib/payments/schema/types";
+
+const { fetchBulldozerServerJsonMock } = vi.hoisted(() => ({
+  fetchBulldozerServerJsonMock: vi.fn(),
+}));
+
+vi.mock("@/lib/bulldozer-server-client", () => ({
+  fetchBulldozerServerJson: fetchBulldozerServerJsonMock,
+  bulldozerCustomerPath: () => {
+    throw new Error("unused in persistRefundManualTransaction tests");
+  },
+}));
+
+import { persistRefundManualTransaction } from "./bulldozer-dual-write";
+
+type StoredPrismaRow = {
+  tenancyId: string,
+  txnId: string,
+  type: string,
+  customerId: string,
+  customerType: string,
+  paymentProvider: string | null,
+  effectiveAt: Date,
+  createdAt: Date,
+  entries: unknown,
+};
+
+/**
+ * In-memory stand-in for Prisma's ManualTransaction upsert. Models the
+ * Prisma-ok / Bulldozer-fail retry: the first create sticks, and a later
+ * conflict with `update: {}` must leave that row untouched.
+ */
+function createInMemoryManualTransactionStore() {
+  const rows = new Map<string, StoredPrismaRow>();
+  const upsertCalls: Array<{ create: StoredPrismaRow, update: Record<string, unknown> }> = [];
+
+  return {
+    upsertCalls,
+    rows,
+    client: {
+      manualTransaction: {
+        upsert: async (args: {
+          where: { tenancyId_txnId: { tenancyId: string, txnId: string } },
+          create: StoredPrismaRow,
+          update: Record<string, unknown>,
+        }) => {
+          upsertCalls.push({ create: args.create, update: args.update });
+          const key = `${args.where.tenancyId_txnId.tenancyId}\0${args.where.tenancyId_txnId.txnId}`;
+          const existing = rows.get(key);
+          if (existing == null) {
+            rows.set(key, { ...args.create });
+            return { ...args.create };
+          }
+          // Mirror Prisma: apply only keys present on `update`. Empty update
+          // leaves the canonical first row intact.
+          const next = { ...existing, ...args.update };
+          rows.set(key, next);
+          return { ...next };
+        },
+      },
+    },
+  };
+}
+
+function refundRow(overrides: Partial<ManualTransactionRow> = {}): ManualTransactionRow {
+  return {
+    txnId: "refund:otp:purchase-1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    tenancyId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    effectiveAtMillis: 1_000,
+    createdAtMillis: 1_000,
+    type: "refund",
+    customerType: "user",
+    customerId: "user-1",
+    paymentProvider: "stripe",
+    entries: [{
+      type: "money-transfer",
+      customerType: "user",
+      customerId: "user-1",
+      chargedAmount: { USD: "2.39" },
+    }],
+    ...overrides,
+  };
+}
+
+describe("persistRefundManualTransaction", () => {
+  beforeEach(() => {
+    fetchBulldozerServerJsonMock.mockReset();
+    fetchBulldozerServerJsonMock.mockResolvedValue({ success: true });
+  });
+
+  test("first write creates the Prisma row and posts that same payload to Bulldozer", async () => {
+    const store = createInMemoryManualTransactionStore();
+    const first = refundRow();
+
+    await persistRefundManualTransaction(store.client, first);
+
+    expect(store.upsertCalls).toHaveLength(1);
+    expect(store.upsertCalls[0].update).toEqual({});
+    expect(fetchBulldozerServerJsonMock).toHaveBeenCalledTimes(1);
+    const body = fetchBulldozerServerJsonMock.mock.calls[0][0].body as { rowData: ManualTransactionRow };
+    expect(body.rowData.txnId).toBe(first.txnId);
+    expect(body.rowData.effectiveAtMillis).toBe(1_000);
+    expect(body.rowData.entries).toEqual(first.entries);
+  });
+
+  test("same-txnId retry keeps the first Prisma row and dual-writes that canonical row (not retry-time values)", async () => {
+    // Reproduces the Prisma-ok / Bulldozer-fail → retry path: first attempt
+    // landed in Postgres; second attempt recomputes nowMillis / entries.
+    const store = createInMemoryManualTransactionStore();
+    const first = refundRow({
+      effectiveAtMillis: 1_000,
+      createdAtMillis: 1_000,
+      entries: [{
+        type: "money-transfer",
+        customerType: "user",
+        customerId: "user-1",
+        chargedAmount: { USD: "2.39" },
+      }],
+    });
+    const retry = refundRow({
+      effectiveAtMillis: 9_999,
+      createdAtMillis: 9_999,
+      entries: [{
+        type: "money-transfer",
+        customerType: "user",
+        customerId: "user-1",
+        chargedAmount: { USD: "2.39" },
+      }, {
+        // Retry-time recomputation could add expiry entries if grants moved;
+        // those must not replace the first ledger snapshot under the same id.
+        type: "item-quantity-expire",
+        customerType: "user",
+        customerId: "user-1",
+        adjustedTransactionId: "otp:purchase-1",
+        adjustedEntryIndex: 1,
+        itemId: "credits",
+        quantity: 10,
+      }],
+    });
+
+    await persistRefundManualTransaction(store.client, first);
+    fetchBulldozerServerJsonMock.mockClear();
+
+    await persistRefundManualTransaction(store.client, retry);
+
+    expect(store.upsertCalls).toHaveLength(2);
+    expect(store.upsertCalls[1].update).toEqual({});
+
+    const key = `${first.tenancyId}\0${first.txnId}`;
+    const persisted = store.rows.get(key);
+    expect(persisted).toBeDefined();
+    expect(persisted?.effectiveAt.getTime()).toBe(1_000);
+    expect(persisted?.createdAt.getTime()).toBe(1_000);
+    expect(persisted?.entries).toEqual(first.entries);
+
+    expect(fetchBulldozerServerJsonMock).toHaveBeenCalledTimes(1);
+    const body = fetchBulldozerServerJsonMock.mock.calls[0][0].body as { rowData: ManualTransactionRow };
+    // Critically: Bulldozer receives the canonical first row, not `retry`.
+    expect(body.rowData.effectiveAtMillis).toBe(1_000);
+    expect(body.rowData.createdAtMillis).toBe(1_000);
+    expect(body.rowData.entries).toEqual(first.entries);
+    expect(body.rowData.entries).not.toEqual(retry.entries);
+  });
+
+  test("Bulldozer failure after Prisma create leaves the canonical row for a later retry", async () => {
+    const store = createInMemoryManualTransactionStore();
+    const first = refundRow({ effectiveAtMillis: 1_000, createdAtMillis: 1_000 });
+    const retry = refundRow({ effectiveAtMillis: 5_000, createdAtMillis: 5_000 });
+
+    fetchBulldozerServerJsonMock.mockRejectedValueOnce(new Error("bulldozer unavailable"));
+    await expect(persistRefundManualTransaction(store.client, first)).rejects.toThrow("bulldozer unavailable");
+
+    fetchBulldozerServerJsonMock.mockResolvedValueOnce({ success: true });
+    await persistRefundManualTransaction(store.client, retry);
+
+    const key = `${first.tenancyId}\0${first.txnId}`;
+    expect(store.rows.get(key)?.effectiveAt.getTime()).toBe(1_000);
+    const body = fetchBulldozerServerJsonMock.mock.calls[1][0].body as { rowData: ManualTransactionRow };
+    expect(body.rowData.effectiveAtMillis).toBe(1_000);
+  });
+});

--- a/apps/backend/src/lib/payments/bulldozer-dual-write.ts
+++ b/apps/backend/src/lib/payments/bulldozer-dual-write.ts
@@ -350,17 +350,34 @@ export async function bulldozerWriteManualTransaction(
  * Upsert is the retry path for a *reused* `txnId` (see `makeRefundTxnId`):
  * same-payload retries after Prisma-ok / Bulldozer-fail converge on one row.
  * A freshly minted random id would create a second Prisma row instead.
+ *
+ * On conflict the first persisted row is immutable — `update: {}` keeps
+ * effectiveAt / entries / createdAt from the original attempt. We then
+ * dual-write *that* persisted row to Bulldozer (not the newly computed
+ * retry payload), so a late retry cannot shift ledger timestamps or
+ * recompute revocation/expiry entries under the same txnId.
  */
 export async function persistRefundManualTransaction(
   prisma: { manualTransaction: { upsert: (args: {
     where: { tenancyId_txnId: { tenancyId: string, txnId: string } },
     create: ReturnType<typeof manualTransactionToPrismaRow>,
-    update: Omit<ReturnType<typeof manualTransactionToPrismaRow>, "tenancyId" | "txnId" | "createdAt">,
-  }) => Promise<unknown> } },
+    // Empty on purpose: conflict = keep the canonical first row.
+    update: Record<string, never>,
+  }) => Promise<{
+    tenancyId: string,
+    txnId: string,
+    type: string,
+    customerId: string,
+    customerType: string,
+    paymentProvider: string | null,
+    effectiveAt: Date,
+    createdAt: Date,
+    entries: unknown,
+  }> } },
   refundRow: ManualTransactionRow,
 ): Promise<void> {
   const refundPrismaRow = manualTransactionToPrismaRow(refundRow);
-  await prisma.manualTransaction.upsert({
+  const persisted = await prisma.manualTransaction.upsert({
     where: {
       tenancyId_txnId: {
         tenancyId: refundPrismaRow.tenancyId,
@@ -368,17 +385,12 @@ export async function persistRefundManualTransaction(
       },
     },
     create: refundPrismaRow,
-    update: {
-      type: refundPrismaRow.type,
-      customerId: refundPrismaRow.customerId,
-      customerType: refundPrismaRow.customerType,
-      paymentProvider: refundPrismaRow.paymentProvider,
-      effectiveAt: refundPrismaRow.effectiveAt,
-      // Preserve original create time on conflict (same-txnId retry).
-      entries: refundPrismaRow.entries,
-    },
+    update: {},
   });
-  await bulldozerWriteManualTransaction(refundRow.txnId, refundRow);
+  await bulldozerWriteManualTransaction(
+    persisted.txnId,
+    prismaManualTransactionToBulldozerRow(persisted),
+  );
 }
 
 // ── Batch dual-write executors (backfill only) ────────────────────────

--- a/apps/backend/src/lib/payments/bulldozer-dual-write.ts
+++ b/apps/backend/src/lib/payments/bulldozer-dual-write.ts
@@ -346,6 +346,10 @@ export async function bulldozerWriteManualTransaction(
 /**
  * Prisma-then-Bulldozer dual-write for a refund manual transaction. Shared by
  * the subscription and OTP refund handlers so field updates stay in sync.
+ *
+ * Upsert is the retry path for a *reused* `txnId` (see `makeRefundTxnId`):
+ * same-payload retries after Prisma-ok / Bulldozer-fail converge on one row.
+ * A freshly minted random id would create a second Prisma row instead.
  */
 export async function persistRefundManualTransaction(
   prisma: { manualTransaction: { upsert: (args: {
@@ -370,7 +374,7 @@ export async function persistRefundManualTransaction(
       customerType: refundPrismaRow.customerType,
       paymentProvider: refundPrismaRow.paymentProvider,
       effectiveAt: refundPrismaRow.effectiveAt,
-      // Preserve original create time on conflict (idempotent re-refund / retry).
+      // Preserve original create time on conflict (same-txnId retry).
       entries: refundPrismaRow.entries,
     },
   });

--- a/apps/backend/src/lib/payments/refund-txn-id.ts
+++ b/apps/backend/src/lib/payments/refund-txn-id.ts
@@ -1,3 +1,8 @@
+import { createHash } from "node:crypto";
+import { moneyAmountToStripeUnits } from "@hexclave/shared/dist/utils/currencies";
+import { SUPPORTED_CURRENCIES, type MoneyAmount } from "@hexclave/shared/dist/utils/currency-constants";
+import { HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
+
 export const REFUND_TXN_PREFIX = "refund:";
 
 /**
@@ -13,10 +18,19 @@ export const REFUND_SOURCE_TXN_PREFIXES = [
   "otp:",
 ] as const;
 
+export type RefundEndActionFingerprint = "now" | "at-period-end" | "none";
+
 /**
- * Parse a refund txnId of shape `refund:<sourceTxnId>:<uuid>`. The sourceTxnId
- * itself may contain colons (e.g. `sub-start:abc`), so we strip the leading
- * `refund:` and the trailing `:<uuid>`. Returns null for non-refund ids.
+ * Parse a refund txnId of shape `refund:<sourceTxnId>:<suffix>`.
+ *
+ * The trailing `<suffix>` used to be a random UUID; new refunds use a
+ * deterministic sha256 hex prefix (see `makeRefundTxnId`). The field is still
+ * named `uuid` so callers (and the duplicate parser in bulldozer-js) stay in
+ * sync without a rename — treat it as an opaque suffix.
+ *
+ * The sourceTxnId itself may contain colons (e.g. `sub-start:abc`), so we
+ * strip the leading `refund:` and the trailing `:<suffix>`. Returns null for
+ * non-refund ids.
  */
 export function parseRefundTxnId(txnId: string): { sourceTxnId: string, uuid: string } | null {
   if (!txnId.startsWith(REFUND_TXN_PREFIX)) return null;
@@ -27,6 +41,58 @@ export function parseRefundTxnId(txnId: string): { sourceTxnId: string, uuid: st
   const uuid = rest.slice(lastColon + 1);
   if (sourceTxnId.length === 0 || uuid.length === 0) return null;
   return { sourceTxnId, uuid };
+}
+
+/**
+ * Stripe-unit amounts in the fingerprint must be whole non-negative cents.
+ *
+ * Callers are responsible for converting dollar strings via
+ * `moneyAmountToStripeUnits` *before* invoking `makeRefundTxnId`. Hitting this
+ * with a float / NaN / negative is a platform bug (HexclaveAssertionError →
+ * sanitized 500), not a client SchemaError — never pass raw `amount_usd`.
+ */
+function requireNonNegativeStripeUnits(value: number, label: string): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new HexclaveAssertionError(
+      `${label} must be a non-negative safe integer (stripe units / cents) before makeRefundTxnId; got ${JSON.stringify(value)}. Callers must run moneyAmountToStripeUnits first.`,
+      { label, value },
+    );
+  }
+  return value;
+}
+
+/**
+ * Build a retry-stable refund txn id: `refund:<sourceTxnId>:<hash>`.
+ *
+ * The hash fingerprints the same inputs a same-payload retry would see
+ * (including Bulldozer's prior refunded amount, which does not advance until
+ * the Bulldozer write succeeds). That way a Prisma-ok / Bulldozer-fail retry
+ * reuses the same `txnId` and the Prisma upsert + Bulldozer setRow converge.
+ *
+ * Intentional second refunds (different amount, or same amount after prior
+ * advanced) get a different id. `endAction` is required so two amount=0
+ * lifecycle-only refunds (schedule cancel vs end now) do not collide.
+ *
+ * Historical rows keep UUID suffixes; this function only affects new writes.
+ *
+ * `amountStripeUnits` / `priorRefundedStripeUnits` must already be integer
+ * cents (e.g. `"2.50"` → 250). The refund route converts via
+ * `moneyAmountToStripeUnits` at the handler entrypoint; prior is summed the
+ * same way in bulldozer's `readPriorRefundSummary`.
+ */
+export function makeRefundTxnId(
+  tenancyId: string,
+  sourceTxnId: string,
+  amountStripeUnits: number,
+  priorRefundedStripeUnits: number,
+  endAction: RefundEndActionFingerprint,
+): string {
+  const amount = requireNonNegativeStripeUnits(amountStripeUnits, "amountStripeUnits");
+  const prior = requireNonNegativeStripeUnits(priorRefundedStripeUnits, "priorRefundedStripeUnits");
+  // Integers stringify unambiguously ("250", never "2.50" or "2.5e2").
+  const fingerprint = `${tenancyId}:${sourceTxnId}:${amount}:${prior}:${endAction}`;
+  const suffix = createHash("sha256").update(fingerprint).digest("hex").slice(0, 32);
+  return `${REFUND_TXN_PREFIX}${sourceTxnId}:${suffix}`;
 }
 
 import.meta.vitest?.describe("parseRefundTxnId", (test) => {
@@ -44,9 +110,85 @@ import.meta.vitest?.describe("parseRefundTxnId", (test) => {
       uuid: "550e8400-e29b-41d4-a716-446655440000",
     });
   });
+  test("parses a deterministic hash suffix", ({ expect }) => {
+    const id = makeRefundTxnId("t1", "otp:abc", 100, 0, "none");
+    const parsed = parseRefundTxnId(id);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.sourceTxnId).toBe("otp:abc");
+    expect(parsed?.uuid).toMatch(/^[0-9a-f]{32}$/);
+  });
   test("returns null for non-refund txn ids", ({ expect }) => {
     expect(parseRefundTxnId("sub-start:abc")).toBeNull();
     expect(parseRefundTxnId("otp:abc")).toBeNull();
+  });
+});
+
+import.meta.vitest?.describe("makeRefundTxnId", (test) => {
+  test("same fingerprint yields the same id", ({ expect }) => {
+    expect(makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 500, 0, "none"))
+      .toBe(makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 500, 0, "none"));
+  });
+
+  test("shape is refund:<sourceTxnId>:<32-hex>", ({ expect }) => {
+    const id = makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 500, 0, "none");
+    expect(id).toMatch(/^refund:sub-start:sub-abc:[0-9a-f]{32}$/);
+  });
+
+  test("dollar cents like 2.50 / 2.39 are distinct once converted to stripe units", ({ expect }) => {
+    // Route converts "2.50" → 250 and "2.39" → 239 before calling us.
+    const id250 = makeRefundTxnId("t1", "otp:p1", 250, 0, "none");
+    const id239 = makeRefundTxnId("t1", "otp:p1", 239, 0, "none");
+    expect(id250).not.toBe(id239);
+    expect(id250).toBe(makeRefundTxnId("t1", "otp:p1", 250, 0, "none"));
+  });
+
+  test("rejects non-integer stripe units as HexclaveAssertionError (platform bug → 500)", ({ expect }) => {
+    expect(() => makeRefundTxnId("t1", "otp:p1", 2.5, 0, "none")).toThrow(HexclaveAssertionError);
+    expect(() => makeRefundTxnId("t1", "otp:p1", 250, 1.5, "none")).toThrow(HexclaveAssertionError);
+    expect(() => makeRefundTxnId("t1", "otp:p1", NaN, 0, "none")).toThrow(HexclaveAssertionError);
+    expect(() => makeRefundTxnId("t1", "otp:p1", -1, 0, "none")).toThrow(HexclaveAssertionError);
+  });
+
+  test("moneyAmountToStripeUnits output is always accepted by makeRefundTxnId (call-site invariant)", ({ expect }) => {
+    // Attests the refund-route contract: convert amount_usd first, then fingerprint.
+    // If this fails, the handler is passing dollars/floats into makeRefundTxnId.
+    const USD = SUPPORTED_CURRENCIES.find((c) => c.code === "USD") ?? throwErr("USD missing");
+    for (const amountUsd of ["2.39", "2.50", "2.5", "0", "0.01", "50.00"] as MoneyAmount[]) {
+      const cents = moneyAmountToStripeUnits(amountUsd, USD);
+      expect(Number.isSafeInteger(cents)).toBe(true);
+      expect(cents).toBeGreaterThanOrEqual(0);
+      expect(() => makeRefundTxnId("t1", "otp:p1", cents, 0, "none")).not.toThrow();
+    }
+    expect(moneyAmountToStripeUnits("2.39" as MoneyAmount, USD)).toBe(239);
+    expect(moneyAmountToStripeUnits("2.50" as MoneyAmount, USD)).toBe(250);
+    expect(moneyAmountToStripeUnits("2.5" as MoneyAmount, USD)).toBe(250);
+  });
+
+  test("different prior yields a different id", ({ expect }) => {
+    expect(makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 500, 0, "none"))
+      .not.toBe(makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 500, 100, "none"));
+  });
+
+  test("different amount yields a different id", ({ expect }) => {
+    expect(makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 500, 0, "none"))
+      .not.toBe(makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 501, 0, "none"));
+  });
+
+  test("different endAction yields a different id", ({ expect }) => {
+    expect(makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 500, 0, "none"))
+      .not.toBe(makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 500, 0, "now"));
+    expect(makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 500, 0, "now"))
+      .not.toBe(makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 500, 0, "at-period-end"));
+  });
+
+  test("different tenancy yields a different id", ({ expect }) => {
+    expect(makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 500, 0, "none"))
+      .not.toBe(makeRefundTxnId("tenancy-2", "sub-start:sub-abc", 500, 0, "none"));
+  });
+
+  test("different source yields a different id", ({ expect }) => {
+    expect(makeRefundTxnId("tenancy-1", "sub-start:sub-abc", 500, 0, "none"))
+      .not.toBe(makeRefundTxnId("tenancy-1", "otp:purchase-1", 500, 0, "none"));
   });
 });
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/transactions-refund.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/transactions-refund.test.ts
@@ -327,20 +327,38 @@ it("refunds a live-mode OTP fully (money + end_action='now'), surfaces refund ro
 it("supports multiple partial refunds capped at remaining amount", async () => {
   const { purchaseTransaction } = await createLiveModeOneTimePurchaseTransaction();
 
-  // Partial $20.00 refund — succeeds.
+  // Two intentional partials of the *same* dollar amount must get distinct
+  // refund txn ids — prior advances after the first commit, so the
+  // deterministic fingerprint changes. (A same-payload *retry* before prior
+  // advances would reuse the id; that is covered by unit tests on
+  // makeRefundTxnId.)
   const refund1 = await niceBackendFetch("/api/latest/internal/payments/transactions/refund", {
     accessType: "admin",
     method: "POST",
     body: {
       type: "one-time-purchase",
       id: purchaseTransaction.id,
-      amount_usd: "20.00",
+      amount_usd: "10.00",
     },
   });
   expect(refund1.status).toBe(200);
+  expect(refund1.body.refund_transaction_id).toMatch(/^refund:otp:/);
 
-  // Partial $30.00 refund — succeeds (total now $50.00).
   const refund2 = await niceBackendFetch("/api/latest/internal/payments/transactions/refund", {
+    accessType: "admin",
+    method: "POST",
+    body: {
+      type: "one-time-purchase",
+      id: purchaseTransaction.id,
+      amount_usd: "10.00",
+    },
+  });
+  expect(refund2.status).toBe(200);
+  expect(refund2.body.refund_transaction_id).toMatch(/^refund:otp:/);
+  expect(refund2.body.refund_transaction_id).not.toBe(refund1.body.refund_transaction_id);
+
+  // Remaining is $30.00 — a $30.00 refund should succeed and exhaust the cap.
+  const refund3 = await niceBackendFetch("/api/latest/internal/payments/transactions/refund", {
     accessType: "admin",
     method: "POST",
     body: {
@@ -349,10 +367,12 @@ it("supports multiple partial refunds capped at remaining amount", async () => {
       amount_usd: "30.00",
     },
   });
-  expect(refund2.status).toBe(200);
+  expect(refund3.status).toBe(200);
+  expect(refund3.body.refund_transaction_id).not.toBe(refund1.body.refund_transaction_id);
+  expect(refund3.body.refund_transaction_id).not.toBe(refund2.body.refund_transaction_id);
 
-  // Third $0.01 refund — exceeds remaining ($0).
-  const refund3 = await niceBackendFetch("/api/latest/internal/payments/transactions/refund", {
+  // Fourth $0.01 refund — exceeds remaining ($0).
+  const refund4 = await niceBackendFetch("/api/latest/internal/payments/transactions/refund", {
     accessType: "admin",
     method: "POST",
     body: {
@@ -361,9 +381,85 @@ it("supports multiple partial refunds capped at remaining amount", async () => {
       amount_usd: "0.01",
     },
   });
-  expect(refund3.status).toBe(400);
-  expect(refund3.body.code).toBe("SCHEMA_ERROR");
-  expect(refund3.body.error).toMatch(/cannot exceed the remaining refundable amount/);
+  expect(refund4.status).toBe(400);
+  expect(refund4.body.code).toBe("SCHEMA_ERROR");
+  expect(refund4.body.error).toMatch(/cannot exceed the remaining refundable amount/);
+});
+
+it("refunds fractional dollar amounts (2.39 then 2.50) with distinct txn ids", async () => {
+  // moneyAmountToStripeUnits turns these into integer cents (239 / 250)
+  // before makeRefundTxnId fingerprints them — so fractional USD must work
+  // end-to-end and must not collide with each other.
+  const { purchaseTransaction } = await createLiveModeOneTimePurchaseTransaction();
+
+  const refund239 = await niceBackendFetch("/api/latest/internal/payments/transactions/refund", {
+    accessType: "admin",
+    method: "POST",
+    body: {
+      type: "one-time-purchase",
+      id: purchaseTransaction.id,
+      amount_usd: "2.39",
+    },
+  });
+  expect(refund239.status).toBe(200);
+  expect(refund239.body.refund_transaction_id).toMatch(/^refund:otp:.+:[0-9a-f]{32}$/);
+
+  const refund250 = await niceBackendFetch("/api/latest/internal/payments/transactions/refund", {
+    accessType: "admin",
+    method: "POST",
+    body: {
+      type: "one-time-purchase",
+      id: purchaseTransaction.id,
+      amount_usd: "2.50",
+    },
+  });
+  expect(refund250.status).toBe(200);
+  expect(refund250.body.refund_transaction_id).toMatch(/^refund:otp:.+:[0-9a-f]{32}$/);
+  expect(refund250.body.refund_transaction_id).not.toBe(refund239.body.refund_transaction_id);
+
+  // Also accept the shorter "2.5" form (same cents as "2.50") as a later
+  // partial once prior has advanced — distinct from the first 2.50 because
+  // priorRefundedStripeUnits changed.
+  const refund25Again = await niceBackendFetch("/api/latest/internal/payments/transactions/refund", {
+    accessType: "admin",
+    method: "POST",
+    body: {
+      type: "one-time-purchase",
+      id: purchaseTransaction.id,
+      amount_usd: "2.5",
+    },
+  });
+  expect(refund25Again.status).toBe(200);
+  expect(refund25Again.body.refund_transaction_id).not.toBe(refund250.body.refund_transaction_id);
+});
+
+it("rejects a full-amount money refund replay once the cap is exhausted", async () => {
+  const { purchaseTransaction } = await createLiveModeOneTimePurchaseTransaction();
+
+  const refund1 = await niceBackendFetch("/api/latest/internal/payments/transactions/refund", {
+    accessType: "admin",
+    method: "POST",
+    body: {
+      type: "one-time-purchase",
+      id: purchaseTransaction.id,
+      amount_usd: "50.00",
+    },
+  });
+  expect(refund1.status).toBe(200);
+  expect(refund1.body.refund_transaction_id).toMatch(/^refund:otp:.+:[0-9a-f]{32}$/);
+
+  const refund2 = await niceBackendFetch("/api/latest/internal/payments/transactions/refund", {
+    accessType: "admin",
+    method: "POST",
+    body: {
+      type: "one-time-purchase",
+      id: purchaseTransaction.id,
+      amount_usd: "50.00",
+    },
+  });
+  expect(refund2.status).toBe(400);
+  expect(refund2.body.code).toBe("SCHEMA_ERROR");
+  expect(refund2.body.error).toMatch(/cannot exceed the remaining refundable amount/);
 });
 
 it("rejects ending product access twice on the same OTP (productRevoked short-circuit)", async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes refund creation and retry paths idempotent across Prisma and Bulldozer. Previously each attempt used a random UUID and retries could produce duplicate rows or drift in ledger fields; now same‑payload retries reuse a deterministic `refund:<source>:<hash>` and Bulldozer receives the canonical first row.

- Add `makeRefundTxnId(tenancyId, sourceTxnId, amountStripeUnits, priorRefundedStripeUnits, endAction)`; includes integer cents and `endAction` (“now”/“none”/“at-period-end”). `parseRefundTxnId` continues to parse both UUID and 32‑hex suffixes.
- Refund route converts dollars to cents before fingerprinting and asserts non‑negative integers; Stripe idempotency key remains based on `(tenancy, source, amount cents, prior cents)` only (does not include `endAction`).
- `persistRefundManualTransaction` now upserts with `update: {}` to preserve the original row on conflict and then dual‑writes that persisted row to Bulldozer, preventing retry-time changes to `effectiveAt`, `createdAt`, or `entries`.
- Tests: unit coverage for `makeRefundTxnId` invariants and parsing; new dual‑write retry tests; E2E ensures partials advance ids, fractional USD amounts don’t collide, and cap enforcement rejects replays after exhaustion.

<sup>Written for commit a08b04df0b2f3dd9bab1a4b9a9b2ac92bcaa288f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refund processing reliability during retries, reducing the risk of duplicate refunds.
  * Refund requests now consistently track transactions across subscription and one-time purchases.
  * Prevented refunds from exceeding the remaining refundable amount.
  * Improved handling and validation of fractional refund amounts.
  * Preserved consistent refund transaction details when requests are retried or recovery is required.
* **Tests**
  * Expanded coverage for partial refunds, full refunds, repeated requests, refund limits, fractional amounts, and retry recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->