### PR TITLE
feat(bulldozer-js): opt-in IO delay for the in-memory low-level backend

### DIFF
--- a/apps/bulldozer-js/src/databases/low-level/implementations/delayed.test.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/delayed.test.ts
@@ -65,14 +65,14 @@ function createConcurrencyTrackingDatabase(): { database: LowLevelDatabase, getM
   };
 }
 
-// Records whether `close()` was reached before the wrapped write it was racing against had finished,
-// which a wrapper that closes without draining its writer queue would do.
-function createCloseOrderTrackingDatabase(): { database: LowLevelDatabase, wasClosedBeforeWriteFinished: () => boolean } {
+// Records whether `close()` was reached while a mutation the wrapper had accepted had not reached the
+// wrapped database yet, which is what a wrapper that closes without draining its in-flight work does.
+function createCloseOrderTrackingDatabase(): { database: LowLevelDatabase, wasClosedBeforeMutationFinished: () => boolean } {
   const inner = declareInMemoryLowLevelDatabase(crypto.randomUUID());
-  let writeFinished = false;
-  let closedBeforeWriteFinished = false;
+  let finishedMutations = 0;
+  let closedAfterMutations = 0;
   return {
-    wasClosedBeforeWriteFinished: () => closedBeforeWriteFinished,
+    wasClosedBeforeMutationFinished: () => closedAfterMutations < finishedMutations,
     database: {
       ...inner,
       declareKvStore(id) {
@@ -82,13 +82,19 @@ function createCloseOrderTrackingDatabase(): { database: LowLevelDatabase, wasCl
           async setAll(entries, options) {
             await new Promise<void>(resolve => setImmediate(resolve));
             const result = await store.setAll(entries, options);
-            writeFinished = true;
+            finishedMutations++;
+            return result;
+          },
+          async compareAndSetAll(entries, options) {
+            await new Promise<void>(resolve => setImmediate(resolve));
+            const result = await store.compareAndSetAll(entries, options);
+            finishedMutations++;
             return result;
           },
         };
       },
       async close() {
-        if (!writeFinished) closedBeforeWriteFinished = true;
+        closedAfterMutations = finishedMutations;
         await inner.close();
       },
     },
@@ -179,7 +185,9 @@ describe("delayed low-level database", () => {
 
   it("makes compare-and-set pay the write delay only when it writes", async () => {
     const readDelayMs = 10;
-    const writeDelayMs = 40;
+    // Deliberately far apart: the "didn't write, so didn't pay the service time" assertion compares
+    // against this bound, and a tight one would fail whenever CI stalls the event loop for a few ms.
+    const writeDelayMs = 200;
     const database = createDelayedDatabase({ readDelayMs, writeDelayMs });
     const store = database.declareKvStore("store");
     await store.setAll([{ key: buffer("a"), value: buffer("1") }]);
@@ -206,7 +214,7 @@ describe("delayed low-level database", () => {
   });
 
   it("keeps the writer usable after a write fails", async () => {
-    const writeDelayMs = 20;
+    const writeDelayMs = 50;
     const database = declareDelayedLowLevelDatabase(createFailingFirstWriteDatabase(), { readDelayMs: 0, writeDelayMs });
     const store = database.declareKvStore("store");
 
@@ -228,7 +236,7 @@ describe("delayed low-level database", () => {
 
   it("waits for queued writes before closing the wrapped database", async () => {
     const writeDelayMs = 50;
-    const { database: wrapped, wasClosedBeforeWriteFinished } = createCloseOrderTrackingDatabase();
+    const { database: wrapped, wasClosedBeforeMutationFinished } = createCloseOrderTrackingDatabase();
     const database = declareDelayedLowLevelDatabase(wrapped, { readDelayMs: 0, writeDelayMs });
     const store = database.declareKvStore("store");
 
@@ -236,8 +244,25 @@ describe("delayed low-level database", () => {
     const beforeCloseMs = performance.now();
     await database.close();
     expect(performance.now() - beforeCloseMs).toBeGreaterThanOrEqual(writeDelayMs);
-    expect(wasClosedBeforeWriteFinished()).toBe(false);
+    expect(wasClosedBeforeMutationFinished()).toBe(false);
     await pendingWrite;
+  });
+
+  it("waits for a compare-and-set that is still paying its read delay before closing", async () => {
+    // A compare-and-set sleeps off its read delay before it ever reaches the writer queue, so it is
+    // invisible to a `close()` that only drains that queue.
+    const readDelayMs = 50;
+    const { database: wrapped, wasClosedBeforeMutationFinished } = createCloseOrderTrackingDatabase();
+    const database = declareDelayedLowLevelDatabase(wrapped, { readDelayMs, writeDelayMs: 10 });
+    const store = database.declareKvStore("store");
+    await store.setAll([{ key: buffer("a"), value: buffer("1") }]);
+
+    const pendingCompareAndSet = store.compareAndSetAll([{ key: buffer("a"), compare: buffer("1"), value: buffer("2") }]);
+    await database.close();
+    // Awaited only after `close()` returned: the ordering question is whether the compare-and-set had
+    // already reached the wrapped database by then, so it must be settled before asserting.
+    expect((await pendingCompareAndSet).results.map(result => result.wasSet)).toEqual([true]);
+    expect(wasClosedBeforeMutationFinished()).toBe(false);
   });
 
   it("reports delay counters in debug info", async () => {

--- a/apps/bulldozer-js/src/databases/low-level/implementations/delayed.test.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/delayed.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { declareDelayedLowLevelDatabase } from "./delayed.js";
+import { declareInMemoryLowLevelDatabase } from "./in-memory.js";
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+const buffer = (value: string) => textEncoder.encode(value).buffer;
+const text = (value: ArrayBuffer | null) => value === null ? null : textDecoder.decode(value);
+
+function createDelayedDatabase(options: { readDelayMs: number, writeDelayMs: number }) {
+  return declareDelayedLowLevelDatabase(declareInMemoryLowLevelDatabase(crypto.randomUUID()), options);
+}
+
+describe("delayed low-level database", () => {
+  it("rejects invalid delays", () => {
+    const inMemory = declareInMemoryLowLevelDatabase(crypto.randomUUID());
+    expect(() => declareDelayedLowLevelDatabase(inMemory, { readDelayMs: -1, writeDelayMs: 0 })).toThrow("readDelayMs must be a non-negative finite number");
+    expect(() => declareDelayedLowLevelDatabase(inMemory, { readDelayMs: 0, writeDelayMs: Number.POSITIVE_INFINITY })).toThrow("writeDelayMs must be a non-negative finite number");
+  });
+
+  it("behaves like the wrapped database", async () => {
+    const database = createDelayedDatabase({ readDelayMs: 0, writeDelayMs: 0 });
+    const store = database.declareKvStore("store");
+
+    expect(text((await store.get(buffer("a"))).buffer)).toBe(null);
+    await store.setAll([{ key: buffer("a"), value: buffer("1") }, { key: buffer("b"), value: buffer("2") }]);
+    expect(text((await store.get(buffer("a"))).buffer)).toBe("1");
+
+    const listed = await store.listEntries();
+    expect(listed.entries.map(entry => [text(entry.key), text(entry.value)])).toEqual([["a", "1"], ["b", "2"]]);
+    expect(listed.hasMore).toBe(false);
+
+    const compareAndSet = await store.compareAndSetAll([
+      { key: buffer("a"), compare: buffer("1"), value: buffer("3") },
+      { key: buffer("b"), compare: buffer("wrong"), value: buffer("4") },
+    ]);
+    expect(compareAndSet.results.map(result => result.wasSet)).toEqual([true, false]);
+    expect(text((await store.get(buffer("a"))).buffer)).toBe("3");
+    expect(text((await store.get(buffer("b"))).buffer)).toBe("2");
+
+    await store.deleteAll([buffer("a")]);
+    expect(text((await store.get(buffer("a"))).buffer)).toBe(null);
+
+    const dump = database.declareKvDump("dump");
+    const inserted = await dump.insertAll([buffer("x")], { requiresSeq: database.initialSeq });
+    expect(inserted.keys).toHaveLength(1);
+    expect(text((await dump.get(inserted.keys[0])).buffer)).toBe("x");
+  });
+
+  it("delays every read by at least the read delay, in parallel", async () => {
+    const readDelayMs = 20;
+    const database = createDelayedDatabase({ readDelayMs, writeDelayMs: 0 });
+    const store = database.declareKvStore("store");
+    await store.setAll([{ key: buffer("a"), value: buffer("1") }]);
+
+    const beforeSingleMs = performance.now();
+    await store.get(buffer("a"));
+    expect(performance.now() - beforeSingleMs).toBeGreaterThanOrEqual(readDelayMs);
+
+    const beforeListMs = performance.now();
+    await store.listEntries();
+    expect(performance.now() - beforeListMs).toBeGreaterThanOrEqual(readDelayMs);
+
+    // Reads are independent, so eight concurrent ones should still cost roughly one delay rather
+    // than eight of them.
+    const beforeConcurrentMs = performance.now();
+    await Promise.all(Array.from({ length: 8 }, async () => await store.get(buffer("a"))));
+    const concurrentElapsedMs = performance.now() - beforeConcurrentMs;
+    expect(concurrentElapsedMs).toBeGreaterThanOrEqual(readDelayMs);
+    expect(concurrentElapsedMs).toBeLessThan(readDelayMs * 4);
+  });
+
+  it("serializes writes through the emulated single-writer device", async () => {
+    const writeDelayMs = 10;
+    const writeCount = 5;
+    const database = createDelayedDatabase({ readDelayMs: 0, writeDelayMs });
+    const store = database.declareKvStore("store");
+
+    const beforeMs = performance.now();
+    await Promise.all(Array.from({ length: writeCount }, async (_, index) => await store.setAll([{ key: buffer(`k${index}`), value: buffer(`v${index}`) }])));
+    expect(performance.now() - beforeMs).toBeGreaterThanOrEqual(writeDelayMs * writeCount);
+
+    const listed = await store.listEntries();
+    expect(listed.entries).toHaveLength(writeCount);
+  });
+
+  it("reports delay counters in debug info", async () => {
+    const database = createDelayedDatabase({ readDelayMs: 1, writeDelayMs: 1 });
+    const store = database.declareKvStore("store");
+    await store.setAll([{ key: buffer("a"), value: buffer("1") }]);
+    await store.get(buffer("a"));
+
+    const debugInfo = database.getDebugInfo();
+    expect(debugInfo.backend).toBe("delayed");
+    expect(debugInfo.readOperations).toBe(1);
+    expect(debugInfo.writeOperations).toBe(1);
+    expect(debugInfo.delayedReadMs).toBeGreaterThan(0);
+    expect(debugInfo.delayedWriteMs).toBeGreaterThan(0);
+  });
+});

--- a/apps/bulldozer-js/src/databases/low-level/implementations/delayed.test.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/delayed.test.ts
@@ -65,6 +65,36 @@ function createConcurrencyTrackingDatabase(): { database: LowLevelDatabase, getM
   };
 }
 
+// Records whether `close()` was reached before the wrapped write it was racing against had finished,
+// which a wrapper that closes without draining its writer queue would do.
+function createCloseOrderTrackingDatabase(): { database: LowLevelDatabase, wasClosedBeforeWriteFinished: () => boolean } {
+  const inner = declareInMemoryLowLevelDatabase(crypto.randomUUID());
+  let writeFinished = false;
+  let closedBeforeWriteFinished = false;
+  return {
+    wasClosedBeforeWriteFinished: () => closedBeforeWriteFinished,
+    database: {
+      ...inner,
+      declareKvStore(id) {
+        const store = inner.declareKvStore(id);
+        return {
+          ...store,
+          async setAll(entries, options) {
+            await new Promise<void>(resolve => setImmediate(resolve));
+            const result = await store.setAll(entries, options);
+            writeFinished = true;
+            return result;
+          },
+        };
+      },
+      async close() {
+        if (!writeFinished) closedBeforeWriteFinished = true;
+        await inner.close();
+      },
+    },
+  };
+}
+
 describe("delayed low-level database", () => {
   it("rejects invalid delays", () => {
     const inMemory = declareInMemoryLowLevelDatabase(crypto.randomUUID());
@@ -180,27 +210,33 @@ describe("delayed low-level database", () => {
     const database = declareDelayedLowLevelDatabase(createFailingFirstWriteDatabase(), { readDelayMs: 0, writeDelayMs });
     const store = database.declareKvStore("store");
 
-    await expect(store.setAll([{ key: buffer("a"), value: buffer("1") }])).rejects.toThrow("simulated write failure");
-
-    // The failed write must neither leave the emulated device permanently occupied nor have consumed
-    // service time for a write that never happened.
+    // Both writes are queued before either is awaited, so the timing covers the failed write's own
+    // slot: a regression that paid the service delay before rejecting would push the second write
+    // past two intervals instead of one. The failed write must also neither leave the emulated device
+    // permanently occupied nor count as a write that happened.
     const beforeMs = performance.now();
-    await store.setAll([{ key: buffer("b"), value: buffer("2") }]);
+    const failedWrite = store.setAll([{ key: buffer("a"), value: buffer("1") }]);
+    const succeedingWrite = store.setAll([{ key: buffer("b"), value: buffer("2") }]);
+    await expect(failedWrite).rejects.toThrow("simulated write failure");
+    await succeedingWrite;
     const elapsedMs = performance.now() - beforeMs;
     expect(elapsedMs).toBeGreaterThanOrEqual(writeDelayMs);
-    expect(elapsedMs).toBeLessThan(writeDelayMs * 3);
+    expect(elapsedMs).toBeLessThan(writeDelayMs * 2);
+    expect(database.getDebugInfo().writeOperations).toBe(1);
     expect(text((await store.get(buffer("b"))).buffer)).toBe("2");
   });
 
   it("waits for queued writes before closing the wrapped database", async () => {
     const writeDelayMs = 50;
-    const database = createDelayedDatabase({ readDelayMs: 0, writeDelayMs });
+    const { database: wrapped, wasClosedBeforeWriteFinished } = createCloseOrderTrackingDatabase();
+    const database = declareDelayedLowLevelDatabase(wrapped, { readDelayMs: 0, writeDelayMs });
     const store = database.declareKvStore("store");
 
     const pendingWrite = store.setAll([{ key: buffer("a"), value: buffer("1") }]);
     const beforeCloseMs = performance.now();
     await database.close();
     expect(performance.now() - beforeCloseMs).toBeGreaterThanOrEqual(writeDelayMs);
+    expect(wasClosedBeforeWriteFinished()).toBe(false);
     await pendingWrite;
   });
 

--- a/apps/bulldozer-js/src/databases/low-level/implementations/delayed.test.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/delayed.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { LowLevelDatabase } from "../index.js";
 import { declareDelayedLowLevelDatabase } from "./delayed.js";
 import { declareInMemoryLowLevelDatabase } from "./in-memory.js";
 
@@ -9,6 +10,59 @@ const text = (value: ArrayBuffer | null) => value === null ? null : textDecoder.
 
 function createDelayedDatabase(options: { readDelayMs: number, writeDelayMs: number }) {
   return declareDelayedLowLevelDatabase(declareInMemoryLowLevelDatabase(crypto.randomUUID()), options);
+}
+
+// An in-memory database whose very first `setAll` rejects, to check that a failed write doesn't take
+// the emulated write device down with it.
+function createFailingFirstWriteDatabase(): LowLevelDatabase {
+  const inner = declareInMemoryLowLevelDatabase(crypto.randomUUID());
+  let shouldFail = true;
+  return {
+    ...inner,
+    declareKvStore(id) {
+      const store = inner.declareKvStore(id);
+      return {
+        ...store,
+        async setAll(entries, options) {
+          if (shouldFail) {
+            shouldFail = false;
+            throw new Error("simulated write failure");
+          }
+          return await store.setAll(entries, options);
+        },
+      };
+    },
+  };
+}
+
+// Tracks how many wrapped `setAll` calls are ever in flight at the same time; the yield in the
+// middle gives an unserialized wrapper every chance to overlap them.
+function createConcurrencyTrackingDatabase(): { database: LowLevelDatabase, getMaxConcurrentWrites: () => number } {
+  const inner = declareInMemoryLowLevelDatabase(crypto.randomUUID());
+  let concurrentWrites = 0;
+  let maxConcurrentWrites = 0;
+  return {
+    getMaxConcurrentWrites: () => maxConcurrentWrites,
+    database: {
+      ...inner,
+      declareKvStore(id) {
+        const store = inner.declareKvStore(id);
+        return {
+          ...store,
+          async setAll(entries, options) {
+            concurrentWrites++;
+            maxConcurrentWrites = Math.max(maxConcurrentWrites, concurrentWrites);
+            await new Promise<void>(resolve => setImmediate(resolve));
+            try {
+              return await store.setAll(entries, options);
+            } finally {
+              concurrentWrites--;
+            }
+          },
+        };
+      },
+    },
+  };
 }
 
 describe("delayed low-level database", () => {
@@ -82,6 +136,72 @@ describe("delayed low-level database", () => {
 
     const listed = await store.listEntries();
     expect(listed.entries).toHaveLength(writeCount);
+  });
+
+  it("runs the wrapped write itself inside its writer slot", async () => {
+    const { database: wrapped, getMaxConcurrentWrites } = createConcurrencyTrackingDatabase();
+    const database = declareDelayedLowLevelDatabase(wrapped, { readDelayMs: 0, writeDelayMs: 5 });
+    const store = database.declareKvStore("store");
+
+    await Promise.all(Array.from({ length: 5 }, async (_, index) => await store.setAll([{ key: buffer(`k${index}`), value: buffer(`v${index}`) }])));
+    expect(getMaxConcurrentWrites()).toBe(1);
+  });
+
+  it("makes compare-and-set pay the write delay only when it writes", async () => {
+    const readDelayMs = 10;
+    const writeDelayMs = 40;
+    const database = createDelayedDatabase({ readDelayMs, writeDelayMs });
+    const store = database.declareKvStore("store");
+    await store.setAll([{ key: buffer("a"), value: buffer("1") }]);
+    const afterSetup = database.getDebugInfo();
+
+    const beforeFailedMs = performance.now();
+    const failed = await store.compareAndSetAll([{ key: buffer("a"), compare: buffer("wrong"), value: buffer("2") }]);
+    const failedElapsedMs = performance.now() - beforeFailedMs;
+    expect(failed.results.map(result => result.wasSet)).toEqual([false]);
+    expect(failedElapsedMs).toBeGreaterThanOrEqual(readDelayMs);
+    expect(failedElapsedMs).toBeLessThan(writeDelayMs);
+    const afterFailed = database.getDebugInfo();
+    expect(afterFailed.readOperations).toBe(afterSetup.readOperations + 1);
+    expect(afterFailed.writeOperations).toBe(afterSetup.writeOperations);
+
+    const beforeSucceededMs = performance.now();
+    const succeeded = await store.compareAndSetAll([{ key: buffer("a"), compare: buffer("1"), value: buffer("2") }]);
+    expect(succeeded.results.map(result => result.wasSet)).toEqual([true]);
+    expect(performance.now() - beforeSucceededMs).toBeGreaterThanOrEqual(readDelayMs + writeDelayMs);
+    const afterSucceeded = database.getDebugInfo();
+    expect(afterSucceeded.readOperations).toBe(afterFailed.readOperations + 1);
+    expect(afterSucceeded.writeOperations).toBe(afterFailed.writeOperations + 1);
+    expect(text((await store.get(buffer("a"))).buffer)).toBe("2");
+  });
+
+  it("keeps the writer usable after a write fails", async () => {
+    const writeDelayMs = 20;
+    const database = declareDelayedLowLevelDatabase(createFailingFirstWriteDatabase(), { readDelayMs: 0, writeDelayMs });
+    const store = database.declareKvStore("store");
+
+    await expect(store.setAll([{ key: buffer("a"), value: buffer("1") }])).rejects.toThrow("simulated write failure");
+
+    // The failed write must neither leave the emulated device permanently occupied nor have consumed
+    // service time for a write that never happened.
+    const beforeMs = performance.now();
+    await store.setAll([{ key: buffer("b"), value: buffer("2") }]);
+    const elapsedMs = performance.now() - beforeMs;
+    expect(elapsedMs).toBeGreaterThanOrEqual(writeDelayMs);
+    expect(elapsedMs).toBeLessThan(writeDelayMs * 3);
+    expect(text((await store.get(buffer("b"))).buffer)).toBe("2");
+  });
+
+  it("waits for queued writes before closing the wrapped database", async () => {
+    const writeDelayMs = 50;
+    const database = createDelayedDatabase({ readDelayMs: 0, writeDelayMs });
+    const store = database.declareKvStore("store");
+
+    const pendingWrite = store.setAll([{ key: buffer("a"), value: buffer("1") }]);
+    const beforeCloseMs = performance.now();
+    await database.close();
+    expect(performance.now() - beforeCloseMs).toBeGreaterThanOrEqual(writeDelayMs);
+    await pendingWrite;
   });
 
   it("reports delay counters in debug info", async () => {

--- a/apps/bulldozer-js/src/databases/low-level/implementations/delayed.test.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/delayed.test.ts
@@ -265,6 +265,51 @@ describe("delayed low-level database", () => {
     expect(wasClosedBeforeMutationFinished()).toBe(false);
   });
 
+  it("waits for a pending sequence waiter before closing the wrapped backend", async () => {
+    // Sequence waiters pay no delay, but they are pending against the wrapped backend, so closing it
+    // underneath them would leave them waiting on a closed database.
+    const inner = declareInMemoryLowLevelDatabase(crypto.randomUUID());
+    let releaseDurable = (): void => {};
+    let durableFinished = false;
+    let closedAfterDurableFinished = false;
+    const wrapped: LowLevelDatabase = {
+      ...inner,
+      async waitUntilDurable() {
+        await new Promise<void>(resolve => {
+          releaseDurable = resolve;
+        });
+        durableFinished = true;
+      },
+      async close() {
+        closedAfterDurableFinished = durableFinished;
+        await inner.close();
+      },
+    };
+    const database = declareDelayedLowLevelDatabase(wrapped, { readDelayMs: 0, writeDelayMs: 0 });
+
+    const pendingDurable = database.waitUntilDurable(database.initialSeq);
+    // Two turns: one for the wrapper to reach the wrapped waiter, one for `close()` to get past its
+    // synchronous part and prove that it does not resolve while the waiter is still pending.
+    await new Promise<void>(resolve => setImmediate(resolve));
+    const pendingClose = database.close();
+    await new Promise<void>(resolve => setImmediate(resolve));
+
+    releaseDurable();
+    await pendingDurable;
+    await pendingClose;
+    expect(closedAfterDurableFinished).toBe(true);
+  });
+
+  it("rejects operations that start after close has begun", async () => {
+    const database = createDelayedDatabase({ readDelayMs: 5, writeDelayMs: 5 });
+    const store = database.declareKvStore("store");
+    await store.setAll([{ key: buffer("a"), value: buffer("1") }]);
+
+    const pendingClose = database.close();
+    await expect(store.get(buffer("a"))).rejects.toThrow("cannot accept new operations");
+    await pendingClose;
+  });
+
   it("reports delay counters in debug info", async () => {
     const database = createDelayedDatabase({ readDelayMs: 1, writeDelayMs: 1 });
     const store = database.declareKvStore("store");

--- a/apps/bulldozer-js/src/databases/low-level/implementations/delayed.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/delayed.ts
@@ -58,8 +58,15 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
   // knows about operations that already reached it.
   let inFlightOperations = 0;
   let idleWaiters: (() => void)[] = [];
+  // Set synchronously by `close()` before it awaits anything, so that the drain below terminates:
+  // without it, an operation that starts while the drain is yielding would be handed a backend that
+  // is about to close (or, if the drain kept waiting for it, could keep `close()` alive forever).
+  let isClosing = false;
 
   const trackInFlight = async <T>(operation: () => Promise<T>): Promise<T> => {
+    // Async function bodies run synchronously up to their first await, so this check and the counter
+    // below cannot interleave with `close()` setting the flag.
+    if (isClosing) throw new Error("This delayed low-level database is closing or already closed, so it cannot accept new operations");
     inFlightOperations++;
     try {
       return await operation();
@@ -126,7 +133,7 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
       return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.deleteAll", attributes: { ...attributes, "bulldozer.low_level.key_count": keys.length } }, async () => await trackInFlight(async () => await withWriteDelay(async () => await wrappedStore.deleteAll(keys, deleteOptions))));
     },
     async debugEntries() {
-      return await wrappedStore.debugEntries?.() ?? [];
+      return await trackInFlight(async () => await wrappedStore.debugEntries?.() ?? []);
     },
   });
 
@@ -174,22 +181,26 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
         },
       };
     },
+    // The sequence waiters do no IO of their own, so they pay no delay — but they do hold a reference
+    // into the wrapped backend for as long as they are pending, so they are tracked like everything
+    // else and `close()` waits for them.
     async waitUntilAvailable(seq: DatabaseSeq) {
-      await wrapped.waitUntilAvailable(seq);
+      await trackInFlight(async () => await wrapped.waitUntilAvailable(seq));
     },
     async waitUntilDurable(seq: DatabaseSeq) {
-      await wrapped.waitUntilDurable(seq);
+      await trackInFlight(async () => await wrapped.waitUntilDurable(seq));
     },
     async waitUntilReplicated(seq: DatabaseSeq) {
-      await wrapped.waitUntilReplicated(seq);
+      await trackInFlight(async () => await wrapped.waitUntilReplicated(seq));
     },
     combineSeqs(...seqs) {
       return wrapped.combineSeqs(...seqs);
     },
     async close() {
+      isClosing = true;
       // Anything still in flight would otherwise run against an already-closed backend, so drain
       // until nothing is left: an operation woken up by the drain can enqueue further work behind the
-      // writer queue (a buffered flush resuming, say), which is why one pass is not enough.
+      // writer queue, which is why one pass is not enough.
       while (inFlightOperations > 0) {
         await new Promise<void>(resolve => idleWaiters.push(resolve));
         await writerQueueTail;
@@ -198,7 +209,7 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
       await wrapped.close();
     },
     async debugSnapshot() {
-      return await wrapped.debugSnapshot?.() ?? { stores: {}, dumps: {} };
+      return await trackInFlight(async () => await wrapped.debugSnapshot?.() ?? { stores: {}, dumps: {} });
     },
     initialSeq: wrapped.initialSeq,
   };

--- a/apps/bulldozer-js/src/databases/low-level/implementations/delayed.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/delayed.ts
@@ -52,6 +52,26 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
   // something to await. The chained promise is always resolved, never rejected, so a failing write
   // does not poison the queue for the writes behind it.
   let writerQueueTail: Promise<void> = Promise.resolve();
+  // Number of operations that have entered this wrapper and not returned yet, including the ones that
+  // are only sleeping off a delay and have not touched the wrapped backend at all yet (a
+  // compare-and-set in its read phase, say). `close()` needs those too: the writer queue alone only
+  // knows about operations that already reached it.
+  let inFlightOperations = 0;
+  let idleWaiters: (() => void)[] = [];
+
+  const trackInFlight = async <T>(operation: () => Promise<T>): Promise<T> => {
+    inFlightOperations++;
+    try {
+      return await operation();
+    } finally {
+      inFlightOperations--;
+      if (inFlightOperations === 0) {
+        const waiters = idleWaiters;
+        idleWaiters = [];
+        for (const waiter of waiters) waiter();
+      }
+    }
+  };
 
   const payReadDelay = async (deadlineMs: number): Promise<void> => {
     readOperations++;
@@ -97,13 +117,13 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
   // (`setAll`/`compareAndSetAll` vs. `insertAll`), which is why those are added by the callers below.
   const declareSharedMethods = (wrappedStore: LowLevelKvStore | LowLevelKvDump) => ({
     async get(key: ArrayBuffer) {
-      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.get", attributes }, async () => await withReadDelay(async () => await wrappedStore.get(key)));
+      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.get", attributes }, async () => await trackInFlight(async () => await withReadDelay(async () => await wrappedStore.get(key))));
     },
     async listEntries(listOptions?: { startAfter?: ArrayBuffer, limit?: number }) {
-      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.listEntries", attributes }, async () => await withReadDelay(async () => await wrappedStore.listEntries(listOptions)));
+      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.listEntries", attributes }, async () => await trackInFlight(async () => await withReadDelay(async () => await wrappedStore.listEntries(listOptions))));
     },
     async deleteAll(keys: ArrayBuffer[], deleteOptions?: { requiresSeq?: DatabaseSeq }) {
-      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.deleteAll", attributes: { ...attributes, "bulldozer.low_level.key_count": keys.length } }, async () => await withWriteDelay(async () => await wrappedStore.deleteAll(keys, deleteOptions)));
+      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.deleteAll", attributes: { ...attributes, "bulldozer.low_level.key_count": keys.length } }, async () => await trackInFlight(async () => await withWriteDelay(async () => await wrappedStore.deleteAll(keys, deleteOptions))));
     },
     async debugEntries() {
       return await wrappedStore.debugEntries?.() ?? [];
@@ -129,10 +149,10 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
       return {
         ...declareSharedMethods(wrappedStore),
         async setAll(entries, setOptions) {
-          return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.setAll", attributes: { ...attributes, "bulldozer.low_level.entry_count": entries.length } }, async () => await withWriteDelay(async () => await wrappedStore.setAll(entries, setOptions)));
+          return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.setAll", attributes: { ...attributes, "bulldozer.low_level.entry_count": entries.length } }, async () => await trackInFlight(async () => await withWriteDelay(async () => await wrappedStore.setAll(entries, setOptions))));
         },
         async compareAndSetAll(entries, compareAndSetOptions) {
-          return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.compareAndSetAll", attributes: { ...attributes, "bulldozer.low_level.entry_count": entries.length } }, async () => {
+          return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.compareAndSetAll", attributes: { ...attributes, "bulldozer.low_level.entry_count": entries.length } }, async () => await trackInFlight(async () => {
             // A compare-and-set first reads the current values (always) and then writes the matching
             // ones (only if any matched), so it pays the read latency up front and the writer's
             // service time only when it actually mutated something.
@@ -141,7 +161,7 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
               async () => await wrappedStore.compareAndSetAll(entries, compareAndSetOptions),
               result => result.results.some(entryResult => entryResult.wasSet),
             );
-          });
+          }));
         },
       };
     },
@@ -150,7 +170,7 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
       return {
         ...declareSharedMethods(wrappedDump),
         async insertAll(values, insertOptions) {
-          return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.insertAll", attributes: { ...attributes, "bulldozer.low_level.value_count": values.length } }, async () => await withWriteDelay(async () => await wrappedDump.insertAll(values, insertOptions)));
+          return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.insertAll", attributes: { ...attributes, "bulldozer.low_level.value_count": values.length } }, async () => await trackInFlight(async () => await withWriteDelay(async () => await wrappedDump.insertAll(values, insertOptions))));
         },
       };
     },
@@ -167,8 +187,13 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
       return wrapped.combineSeqs(...seqs);
     },
     async close() {
-      // Writes that are still queued behind the emulated device would otherwise run against an
-      // already-closed backend.
+      // Anything still in flight would otherwise run against an already-closed backend, so drain
+      // until nothing is left: an operation woken up by the drain can enqueue further work behind the
+      // writer queue (a buffered flush resuming, say), which is why one pass is not enough.
+      while (inFlightOperations > 0) {
+        await new Promise<void>(resolve => idleWaiters.push(resolve));
+        await writerQueueTail;
+      }
       await writerQueueTail;
       await wrapped.close();
     },

--- a/apps/bulldozer-js/src/databases/low-level/implementations/delayed.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/delayed.ts
@@ -46,57 +46,64 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
   let writeOperations = 0;
   let delayedReadMs = 0;
   let delayedWriteMs = 0;
-  // The emulated write device's timeline: the point (on the `performance.now` clock) at which it
-  // finishes everything queued so far. A new write starts once the device is free, so queueing delay
-  // falls out of the model instead of having to be simulated separately.
-  let writeDeviceFreeAtMs = 0;
+  // Tail of the emulated write device's queue: a promise that settles once everything currently
+  // queued has been serviced. Each write chains onto it, which is what makes writes actually run
+  // one at a time (as opposed to only their completion times being staggered) and gives `close()`
+  // something to await. The chained promise is always resolved, never rejected, so a failing write
+  // does not poison the queue for the writes behind it.
+  let writerQueueTail: Promise<void> = Promise.resolve();
 
-  const withReadDelay = async <T>(operation: () => Promise<T>): Promise<T> => {
-    const deadlineMs = performance.now() + readDelayMs;
-    const result = await operation();
+  const payReadDelay = async (deadlineMs: number): Promise<void> => {
     readOperations++;
     const beforeSleepMs = performance.now();
     await sleepUntil(deadlineMs);
     delayedReadMs += performance.now() - beforeSleepMs;
-    return result;
   };
 
-  const withWriteDelay = async <T>(operation: () => Promise<T>): Promise<T> => {
-    const startMs = Math.max(performance.now(), writeDeviceFreeAtMs);
-    writeDeviceFreeAtMs = startMs + writeDelayMs;
-    const deadlineMs = writeDeviceFreeAtMs;
+  const withReadDelay = async <T>(operation: () => Promise<T>): Promise<T> => {
+    const deadlineMs = performance.now() + readDelayMs;
     const result = await operation();
-    writeOperations++;
-    const beforeSleepMs = performance.now();
-    await sleepUntil(deadlineMs);
-    delayedWriteMs += performance.now() - beforeSleepMs;
+    await payReadDelay(deadlineMs);
     return result;
   };
 
-  const declareStoreOrDump = (wrappedStore: LowLevelKvStore & LowLevelKvDump): LowLevelKvStore & LowLevelKvDump => ({
-    async get(key) {
+  /**
+   * Runs `operation` in its own slot on the emulated single writer: nothing else in this wrapper
+   * writes while it runs, and the slot is only released once the device's service time has elapsed.
+   * `shouldPayWriteDelay` lets compare-and-set skip the service time when it didn't actually write.
+   */
+  const withWriteDelay = async <T>(operation: () => Promise<T>, shouldPayWriteDelay: (result: T) => boolean = () => true): Promise<T> => {
+    const previousQueueTail = writerQueueTail;
+    let releaseNextWrite = (): void => {};
+    writerQueueTail = new Promise<void>(resolve => {
+      releaseNextWrite = resolve;
+    });
+    await previousQueueTail;
+    try {
+      const deadlineMs = performance.now() + writeDelayMs;
+      const result = await operation();
+      if (!shouldPayWriteDelay(result)) return result;
+      writeOperations++;
+      const beforeSleepMs = performance.now();
+      await sleepUntil(deadlineMs);
+      delayedWriteMs += performance.now() - beforeSleepMs;
+      return result;
+    } finally {
+      releaseNextWrite();
+    }
+  };
+
+  // The methods a KV store and a KV dump have in common; the two differ only in how they write
+  // (`setAll`/`compareAndSetAll` vs. `insertAll`), which is why those are added by the callers below.
+  const declareSharedMethods = (wrappedStore: LowLevelKvStore | LowLevelKvDump) => ({
+    async get(key: ArrayBuffer) {
       return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.get", attributes }, async () => await withReadDelay(async () => await wrappedStore.get(key)));
     },
-    async listEntries(listOptions) {
+    async listEntries(listOptions?: { startAfter?: ArrayBuffer, limit?: number }) {
       return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.listEntries", attributes }, async () => await withReadDelay(async () => await wrappedStore.listEntries(listOptions)));
     },
-    async setAll(entries, setOptions) {
-      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.setAll", attributes: { ...attributes, "bulldozer.low_level.entry_count": entries.length } }, async () => await withWriteDelay(async () => await wrappedStore.setAll(entries, setOptions)));
-    },
-    async deleteAll(keys, deleteOptions) {
+    async deleteAll(keys: ArrayBuffer[], deleteOptions?: { requiresSeq?: DatabaseSeq }) {
       return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.deleteAll", attributes: { ...attributes, "bulldozer.low_level.key_count": keys.length } }, async () => await withWriteDelay(async () => await wrappedStore.deleteAll(keys, deleteOptions)));
-    },
-    async insertAll(values, insertOptions) {
-      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.insertAll", attributes: { ...attributes, "bulldozer.low_level.value_count": values.length } }, async () => await withWriteDelay(async () => await wrappedStore.insertAll(values, insertOptions)));
-    },
-    async compareAndSetAll(entries, compareAndSetOptions) {
-      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.compareAndSetAll", attributes: { ...attributes, "bulldozer.low_level.entry_count": entries.length } }, async () => {
-        // A compare-and-set reads the current values and then writes the matching ones, so it pays
-        // both delays rather than being classified as one or the other.
-        const result = await withReadDelay(async () => await wrappedStore.compareAndSetAll(entries, compareAndSetOptions));
-        if (result.results.some(entryResult => entryResult.wasSet)) await withWriteDelay(async () => {});
-        return result;
-      });
     },
     async debugEntries() {
       return await wrappedStore.debugEntries?.() ?? [];
@@ -117,11 +124,35 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
         delayedWriteMs,
       };
     },
-    declareKvStore(id) {
-      return declareStoreOrDump(wrapped.declareKvStore(id) as LowLevelKvStore & LowLevelKvDump);
+    declareKvStore(id): LowLevelKvStore {
+      const wrappedStore = wrapped.declareKvStore(id);
+      return {
+        ...declareSharedMethods(wrappedStore),
+        async setAll(entries, setOptions) {
+          return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.setAll", attributes: { ...attributes, "bulldozer.low_level.entry_count": entries.length } }, async () => await withWriteDelay(async () => await wrappedStore.setAll(entries, setOptions)));
+        },
+        async compareAndSetAll(entries, compareAndSetOptions) {
+          return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.compareAndSetAll", attributes: { ...attributes, "bulldozer.low_level.entry_count": entries.length } }, async () => {
+            // A compare-and-set first reads the current values (always) and then writes the matching
+            // ones (only if any matched), so it pays the read latency up front and the writer's
+            // service time only when it actually mutated something.
+            await payReadDelay(performance.now() + readDelayMs);
+            return await withWriteDelay(
+              async () => await wrappedStore.compareAndSetAll(entries, compareAndSetOptions),
+              result => result.results.some(entryResult => entryResult.wasSet),
+            );
+          });
+        },
+      };
     },
-    declareKvDump(id) {
-      return declareStoreOrDump(wrapped.declareKvDump(id) as LowLevelKvStore & LowLevelKvDump);
+    declareKvDump(id): LowLevelKvDump {
+      const wrappedDump = wrapped.declareKvDump(id);
+      return {
+        ...declareSharedMethods(wrappedDump),
+        async insertAll(values, insertOptions) {
+          return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.insertAll", attributes: { ...attributes, "bulldozer.low_level.value_count": values.length } }, async () => await withWriteDelay(async () => await wrappedDump.insertAll(values, insertOptions)));
+        },
+      };
     },
     async waitUntilAvailable(seq: DatabaseSeq) {
       await wrapped.waitUntilAvailable(seq);
@@ -136,6 +167,9 @@ export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, option
       return wrapped.combineSeqs(...seqs);
     },
     async close() {
+      // Writes that are still queued behind the emulated device would otherwise run against an
+      // already-closed backend.
+      await writerQueueTail;
       await wrapped.close();
     },
     async debugSnapshot() {

--- a/apps/bulldozer-js/src/databases/low-level/implementations/delayed.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/delayed.ts
@@ -1,0 +1,146 @@
+import { traceSpanHot } from "../../../otel.js";
+import { DatabaseSeq } from "../../index.js";
+import { LowLevelDatabase, LowLevelKvDump, LowLevelKvStore } from "../index.js";
+
+/**
+ * Emulates the IO cost of a real storage engine on top of a backend that has none (in practice the
+ * in-memory one). This exists for benchmarks that want to split "how much of a flow's cost is the
+ * amount of IO Piledriver issues" from "how much is everything else", which the in-memory backend
+ * alone cannot answer because it makes IO free.
+ *
+ * The two delays model the two shapes LMDB's IO has:
+ *  - reads are memory-mapped and independent, so `readDelayMs` is a plain per-operation latency and
+ *    concurrent reads all pay it in parallel;
+ *  - writes go through a single writer, so `writeDelayMs` is the service time of one emulated device
+ *    that serializes: a burst of N writes takes N * writeDelayMs, exactly like a queue in front of a
+ *    real commit path, rather than N writes each finishing after writeDelayMs.
+ */
+export type DelayedLowLevelDatabaseOptions = {
+  readDelayMs: number,
+  writeDelayMs: number,
+};
+
+// setTimeout only has millisecond resolution, but the interesting delays here are tens of
+// microseconds. Sleep the whole-millisecond part on a timer and yield through the macrotask queue
+// for the remainder: that keeps the event loop free (unlike a busy-wait) while still landing within
+// a few tens of microseconds of the deadline.
+async function sleepUntil(deadlineMs: number): Promise<void> {
+  while (true) {
+    const remainingMs = deadlineMs - performance.now();
+    if (remainingMs <= 0) return;
+    if (remainingMs >= 2) {
+      await new Promise<void>(resolve => setTimeout(resolve, remainingMs - 1));
+    } else {
+      await new Promise<void>(resolve => setImmediate(resolve));
+    }
+  }
+}
+
+export function declareDelayedLowLevelDatabase(wrapped: LowLevelDatabase, options: DelayedLowLevelDatabaseOptions): LowLevelDatabase {
+  const { readDelayMs, writeDelayMs } = options;
+  if (!Number.isFinite(readDelayMs) || readDelayMs < 0) throw new Error("readDelayMs must be a non-negative finite number");
+  if (!Number.isFinite(writeDelayMs) || writeDelayMs < 0) throw new Error("writeDelayMs must be a non-negative finite number");
+
+  const attributes = { "bulldozer.low_level.backend": "delayed" };
+  let readOperations = 0;
+  let writeOperations = 0;
+  let delayedReadMs = 0;
+  let delayedWriteMs = 0;
+  // The emulated write device's timeline: the point (on the `performance.now` clock) at which it
+  // finishes everything queued so far. A new write starts once the device is free, so queueing delay
+  // falls out of the model instead of having to be simulated separately.
+  let writeDeviceFreeAtMs = 0;
+
+  const withReadDelay = async <T>(operation: () => Promise<T>): Promise<T> => {
+    const deadlineMs = performance.now() + readDelayMs;
+    const result = await operation();
+    readOperations++;
+    const beforeSleepMs = performance.now();
+    await sleepUntil(deadlineMs);
+    delayedReadMs += performance.now() - beforeSleepMs;
+    return result;
+  };
+
+  const withWriteDelay = async <T>(operation: () => Promise<T>): Promise<T> => {
+    const startMs = Math.max(performance.now(), writeDeviceFreeAtMs);
+    writeDeviceFreeAtMs = startMs + writeDelayMs;
+    const deadlineMs = writeDeviceFreeAtMs;
+    const result = await operation();
+    writeOperations++;
+    const beforeSleepMs = performance.now();
+    await sleepUntil(deadlineMs);
+    delayedWriteMs += performance.now() - beforeSleepMs;
+    return result;
+  };
+
+  const declareStoreOrDump = (wrappedStore: LowLevelKvStore & LowLevelKvDump): LowLevelKvStore & LowLevelKvDump => ({
+    async get(key) {
+      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.get", attributes }, async () => await withReadDelay(async () => await wrappedStore.get(key)));
+    },
+    async listEntries(listOptions) {
+      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.listEntries", attributes }, async () => await withReadDelay(async () => await wrappedStore.listEntries(listOptions)));
+    },
+    async setAll(entries, setOptions) {
+      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.setAll", attributes: { ...attributes, "bulldozer.low_level.entry_count": entries.length } }, async () => await withWriteDelay(async () => await wrappedStore.setAll(entries, setOptions)));
+    },
+    async deleteAll(keys, deleteOptions) {
+      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.deleteAll", attributes: { ...attributes, "bulldozer.low_level.key_count": keys.length } }, async () => await withWriteDelay(async () => await wrappedStore.deleteAll(keys, deleteOptions)));
+    },
+    async insertAll(values, insertOptions) {
+      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.insertAll", attributes: { ...attributes, "bulldozer.low_level.value_count": values.length } }, async () => await withWriteDelay(async () => await wrappedStore.insertAll(values, insertOptions)));
+    },
+    async compareAndSetAll(entries, compareAndSetOptions) {
+      return await traceSpanHot({ description: "bulldozer-js.low-level.delayed.compareAndSetAll", attributes: { ...attributes, "bulldozer.low_level.entry_count": entries.length } }, async () => {
+        // A compare-and-set reads the current values and then writes the matching ones, so it pays
+        // both delays rather than being classified as one or the other.
+        const result = await withReadDelay(async () => await wrappedStore.compareAndSetAll(entries, compareAndSetOptions));
+        if (result.results.some(entryResult => entryResult.wasSet)) await withWriteDelay(async () => {});
+        return result;
+      });
+    },
+    async debugEntries() {
+      return await wrappedStore.debugEntries?.() ?? [];
+    },
+  });
+
+  return {
+    getDebugInfo() {
+      return {
+        backend: "delayed",
+        constructorArguments: { wrapped, options },
+        wrapped,
+        readDelayMs,
+        writeDelayMs,
+        readOperations,
+        writeOperations,
+        delayedReadMs,
+        delayedWriteMs,
+      };
+    },
+    declareKvStore(id) {
+      return declareStoreOrDump(wrapped.declareKvStore(id) as LowLevelKvStore & LowLevelKvDump);
+    },
+    declareKvDump(id) {
+      return declareStoreOrDump(wrapped.declareKvDump(id) as LowLevelKvStore & LowLevelKvDump);
+    },
+    async waitUntilAvailable(seq: DatabaseSeq) {
+      await wrapped.waitUntilAvailable(seq);
+    },
+    async waitUntilDurable(seq: DatabaseSeq) {
+      await wrapped.waitUntilDurable(seq);
+    },
+    async waitUntilReplicated(seq: DatabaseSeq) {
+      await wrapped.waitUntilReplicated(seq);
+    },
+    combineSeqs(...seqs) {
+      return wrapped.combineSeqs(...seqs);
+    },
+    async close() {
+      await wrapped.close();
+    },
+    async debugSnapshot() {
+      return await wrapped.debugSnapshot?.() ?? { stores: {}, dumps: {} };
+    },
+    initialSeq: wrapped.initialSeq,
+  };
+}

--- a/apps/bulldozer-js/src/index.ts
+++ b/apps/bulldozer-js/src/index.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { getHeapStatistics } from "node:v8";
 import { isBulldozerRequestAuthorized } from "./auth.js";
 import { declareBulldozerDatabase, type BulldozerDatabase } from "./databases/bulldozer/index.js";
+import { declareDelayedLowLevelDatabase } from "./databases/low-level/implementations/delayed.js";
 import { declareInMemoryLowLevelDatabase } from "./databases/low-level/implementations/in-memory.js";
 import { declareInstantAvailabilityLowLevelDatabase } from "./databases/low-level/implementations/instant-availability.js";
 import { declareLmdbLowLevelDatabase, getLmdbDiagnostics } from "./databases/low-level/implementations/lmdb.js";
@@ -63,7 +64,16 @@ function readOptionalNonNegativeNumberEnv(name: string): number | undefined {
 
 function createLowLevelDatabase(): LowLevelDatabase {
   if (process.env.HEXCLAVE_BULLDOZER_JS_LOW_LEVEL_BACKEND === "in-memory") {
-    return declareInMemoryLowLevelDatabase(crypto.randomUUID());
+    const inMemory = declareInMemoryLowLevelDatabase(crypto.randomUUID());
+    // Opt-in only: with both delays unset the in-memory backend stays exactly as fast as before, so
+    // this is purely additive for benchmarks that want in-memory semantics with LMDB-like IO cost.
+    const readDelayMs = readOptionalNonNegativeNumberEnv("HEXCLAVE_BULLDOZER_JS_IN_MEMORY_READ_DELAY_MS");
+    const writeDelayMs = readOptionalNonNegativeNumberEnv("HEXCLAVE_BULLDOZER_JS_IN_MEMORY_WRITE_DELAY_MS");
+    if (readDelayMs === undefined && writeDelayMs === undefined) return inMemory;
+    return declareDelayedLowLevelDatabase(inMemory, {
+      readDelayMs: readDelayMs ?? 0,
+      writeDelayMs: writeDelayMs ?? 0,
+    });
   }
 
   const lmdbPath = defaultLmdbPath();
@@ -1157,6 +1167,8 @@ const startupFields = {
   nodeVersion: process.version,
   sentryEnvironment: resolveBulldozerSentryEnvironment(),
   lowLevelBackend: process.env.HEXCLAVE_BULLDOZER_JS_LOW_LEVEL_BACKEND ?? "lmdb",
+  inMemoryReadDelayMs: readOptionalNonNegativeNumberEnv("HEXCLAVE_BULLDOZER_JS_IN_MEMORY_READ_DELAY_MS"),
+  inMemoryWriteDelayMs: readOptionalNonNegativeNumberEnv("HEXCLAVE_BULLDOZER_JS_IN_MEMORY_WRITE_DELAY_MS"),
   usingTmpLmdb: process.env.HEXCLAVE_BULLDOZER_JS_USE_TMP_LMDB === "1",
   lmdbCompression: process.env.HEXCLAVE_BULLDOZER_JS_LMDB_COMPRESSION === "1",
   disableHeapReadCache: process.env.HEXCLAVE_BULLDOZER_JS_DISABLE_PILEDRIVER_HEAP_READ_CACHE === "1",

--- a/apps/bulldozer-js/src/index.ts
+++ b/apps/bulldozer-js/src/index.ts
@@ -62,13 +62,19 @@ function readOptionalNonNegativeNumberEnv(name: string): number | undefined {
   return parsed;
 }
 
+const lowLevelBackend = process.env.HEXCLAVE_BULLDOZER_JS_LOW_LEVEL_BACKEND ?? "lmdb";
+// Only read (and therefore only validate) the emulated IO delays on the backend that has them, so a
+// malformed value can't take down the default LMDB backend over a setting it ignores. Opt-in: with
+// both unset the in-memory backend stays exactly as fast as before.
+const inMemoryDelays = lowLevelBackend === "in-memory" ? {
+  readDelayMs: readOptionalNonNegativeNumberEnv("HEXCLAVE_BULLDOZER_JS_IN_MEMORY_READ_DELAY_MS"),
+  writeDelayMs: readOptionalNonNegativeNumberEnv("HEXCLAVE_BULLDOZER_JS_IN_MEMORY_WRITE_DELAY_MS"),
+} : null;
+
 function createLowLevelDatabase(): LowLevelDatabase {
-  if (process.env.HEXCLAVE_BULLDOZER_JS_LOW_LEVEL_BACKEND === "in-memory") {
+  if (inMemoryDelays !== null) {
     const inMemory = declareInMemoryLowLevelDatabase(crypto.randomUUID());
-    // Opt-in only: with both delays unset the in-memory backend stays exactly as fast as before, so
-    // this is purely additive for benchmarks that want in-memory semantics with LMDB-like IO cost.
-    const readDelayMs = readOptionalNonNegativeNumberEnv("HEXCLAVE_BULLDOZER_JS_IN_MEMORY_READ_DELAY_MS");
-    const writeDelayMs = readOptionalNonNegativeNumberEnv("HEXCLAVE_BULLDOZER_JS_IN_MEMORY_WRITE_DELAY_MS");
+    const { readDelayMs, writeDelayMs } = inMemoryDelays;
     if (readDelayMs === undefined && writeDelayMs === undefined) return inMemory;
     return declareDelayedLowLevelDatabase(inMemory, {
       readDelayMs: readDelayMs ?? 0,
@@ -1166,9 +1172,9 @@ const startupFields = {
   pid: process.pid,
   nodeVersion: process.version,
   sentryEnvironment: resolveBulldozerSentryEnvironment(),
-  lowLevelBackend: process.env.HEXCLAVE_BULLDOZER_JS_LOW_LEVEL_BACKEND ?? "lmdb",
-  inMemoryReadDelayMs: readOptionalNonNegativeNumberEnv("HEXCLAVE_BULLDOZER_JS_IN_MEMORY_READ_DELAY_MS"),
-  inMemoryWriteDelayMs: readOptionalNonNegativeNumberEnv("HEXCLAVE_BULLDOZER_JS_IN_MEMORY_WRITE_DELAY_MS"),
+  lowLevelBackend,
+  inMemoryReadDelayMs: inMemoryDelays?.readDelayMs,
+  inMemoryWriteDelayMs: inMemoryDelays?.writeDelayMs,
   usingTmpLmdb: process.env.HEXCLAVE_BULLDOZER_JS_USE_TMP_LMDB === "1",
   lmdbCompression: process.env.HEXCLAVE_BULLDOZER_JS_LMDB_COMPRESSION === "1",
   disableHeapReadCache: process.env.HEXCLAVE_BULLDOZER_JS_DISABLE_PILEDRIVER_HEAP_READ_CACHE === "1",

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { urlString } from "@hexclave/shared/dist/utils/urls";
 import { expect } from "vitest";
 import { it } from "../../../../../helpers";
-import { Auth, Payments, Project, niceBackendFetch } from "../../../../backend-helpers";
+import { Auth, Payments, Project, backendContext, niceBackendFetch } from "../../../../backend-helpers";
 
 const USER_COUNT = 6;
 const ITEM_UPDATES_PER_USER = 10;
@@ -19,23 +19,20 @@ if (PREFILL_VALUE != null && PREFILL_STAGES_VALUE != null) {
   throw new Error("HEXCLAVE_PAYMENTS_PERF_PREFILL and HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES cannot both be set");
 }
 
-function parseNonNegativeInteger(envName: string, value: string): number {
-  if (!/^\d+$/.test(value)) {
-    throw new Error(`${envName} must be a non-negative integer, got ${value}`);
-  }
+// Single source of truth for "this env var holds a count": digits only (so no signs, exponents or
+// whitespace-with-a-number sneaking through `Number()`) and within the safe integer range. Callers
+// add whatever extra constraint they need on top of the returned number.
+function parseNonNegativeInteger(envName: string, value: string, expectation = "a non-negative integer"): number {
   const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed)) {
-    throw new Error(`${envName} must be a non-negative integer, got ${value}`);
+  if (!/^\d+$/.test(value) || !Number.isSafeInteger(parsed)) {
+    throw new Error(`${envName} must be ${expectation}, got ${value}`);
   }
   return parsed;
 }
 
 function parsePositiveInteger(envName: string, value: string): number {
-  if (!/^\d+$/.test(value)) {
-    throw new Error(`${envName} must be a positive integer, got ${value}`);
-  }
-  const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+  const parsed = parseNonNegativeInteger(envName, value, "a positive integer");
+  if (parsed <= 0) {
     throw new Error(`${envName} must be a positive integer, got ${value}`);
   }
   return parsed;
@@ -44,18 +41,11 @@ function parsePositiveInteger(envName: string, value: string): number {
 function parsePrefillStages(value: string): number[] {
   const stages: number[] = [];
   for (const rawStage of value.split(",")) {
-    const stageValue = rawStage.trim();
-    if (!/^\d+$/.test(stageValue)) {
-      throw new Error(
-        `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES must be a comma-separated list of strictly increasing non-negative integers, offending value ${rawStage}`,
-      );
-    }
-    const stage = Number(stageValue);
-    if (!Number.isSafeInteger(stage)) {
-      throw new Error(
-        `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES must be a comma-separated list of strictly increasing non-negative integers, offending value ${rawStage}`,
-      );
-    }
+    const stage = parseNonNegativeInteger(
+      "HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES",
+      rawStage.trim(),
+      "a comma-separated list of strictly increasing non-negative integers",
+    );
     if (stages.length > 0 && stage <= stages[stages.length - 1]) {
       throw new Error(
         `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES must be strictly increasing, offending value ${rawStage}`,
@@ -94,15 +84,6 @@ type PerfMetric = {
   elapsedMs: number,
 };
 
-type RequestUserAuth = {
-  accessToken?: string,
-  refreshToken?: string,
-};
-
-// Prefill requests use server/admin access and explicit customer IDs, so an empty override avoids
-// pinning a 60-second user token while also suppressing the shared ambient auth state.
-const PREFILL_NO_USER_AUTH: RequestUserAuth = {};
-
 async function measure<T>(name: string, count: number, fn: () => Promise<T>, metrics: PerfMetric[]): Promise<T> {
   const startedAt = performance.now();
   const result = await fn();
@@ -113,7 +94,7 @@ async function measure<T>(name: string, count: number, fn: () => Promise<T>, met
   return result;
 }
 
-async function createPurchaseCode(options: { customerType: "user", customerId: string, productId: string, userAuth?: RequestUserAuth }) {
+async function createPurchaseCode(options: { customerType: "user", customerId: string, productId: string }) {
   const res = await niceBackendFetch("/api/latest/payments/purchases/create-purchase-url", {
     method: "POST",
     accessType: "server",
@@ -122,7 +103,6 @@ async function createPurchaseCode(options: { customerType: "user", customerId: s
       customer_id: options.customerId,
       product_id: options.productId,
     },
-    userAuth: options.userAuth,
   });
   expect(res.status).toBe(200);
   const codeMatch = (res.body.url as string).match(/\/purchase\/([a-z0-9-_]+)/);
@@ -180,69 +160,80 @@ function appendPrefillLog(index: number, stage: number, elapsedMs: number): void
 }
 
 async function prefillOne(index: number, stage: number): Promise<void> {
-  const startedAt = performance.now();
-  const { userId } = await Auth.fastSignUp();
+  // Prefill customers are created concurrently, and `Auth.fastSignUp()` writes the tokens of the
+  // user it just created into the process-wide backend context. Pinning `userAuth` for this
+  // customer's async subtree (a `with` value wins over any `set` value) means a worker can never
+  // pick up another worker's ambient token, instead of every request in here having to remember to
+  // override it. Prefill only needs server/admin access with explicit customer IDs anyway.
+  await backendContext.with({ userAuth: null }, async () => {
+    const startedAt = performance.now();
+    const { userId } = await Auth.fastSignUp();
 
-  const subscriptionCode = await createPurchaseCode({
-    customerType: "user",
-    customerId: userId,
-    productId: "perf-sub",
-    userAuth: PREFILL_NO_USER_AUTH,
-  });
-  const subscriptionResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
-    accessType: "admin",
-    method: "POST",
-    body: { full_code: subscriptionCode, price_id: "monthly", quantity: 1 },
-    userAuth: PREFILL_NO_USER_AUTH,
-  });
-  expect(subscriptionResponse.status).toBe(200);
-
-  const oneTimeCode = await createPurchaseCode({
-    customerType: "user",
-    customerId: userId,
-    productId: "perf-otp",
-    userAuth: PREFILL_NO_USER_AUTH,
-  });
-  const oneTimeResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
-    accessType: "admin",
-    method: "POST",
-    body: { full_code: oneTimeCode, price_id: "single", quantity: 2 },
-    userAuth: PREFILL_NO_USER_AUTH,
-  });
-  expect(oneTimeResponse.status).toBe(200);
-
-  for (let grant = 0; grant < 2; grant++) {
-    const grantResponse = await niceBackendFetch(urlString`/api/v1/payments/products/user/${userId}`, {
-      method: "POST",
-      accessType: "server",
-      body: { product_id: "perf-api-grant", quantity: 1 },
-      userAuth: PREFILL_NO_USER_AUTH,
+    const subscriptionCode = await createPurchaseCode({
+      customerType: "user",
+      customerId: userId,
+      productId: "perf-sub",
     });
-    expect(grantResponse.status).toBe(200);
-  }
-
-  for (let update = 0; update < ITEM_UPDATES_PER_USER; update++) {
-    const itemId = update % 2 === 0 ? "credits" : "boosts";
-    const updateResponse = await niceBackendFetch(urlString`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
+    const subscriptionResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
+      accessType: "admin",
       method: "POST",
-      accessType: "server",
-      query: { allow_negative: "false" },
-      body: { delta: update + 1, description: `prefill-${index}-${update}` },
-      userAuth: PREFILL_NO_USER_AUTH,
+      body: { full_code: subscriptionCode, price_id: "monthly", quantity: 1 },
     });
-    expect(updateResponse.status).toBe(200);
-  }
+    expect(subscriptionResponse.status).toBe(200);
 
-  appendPrefillLog(index, stage, performance.now() - startedAt);
+    const oneTimeCode = await createPurchaseCode({
+      customerType: "user",
+      customerId: userId,
+      productId: "perf-otp",
+    });
+    const oneTimeResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
+      accessType: "admin",
+      method: "POST",
+      body: { full_code: oneTimeCode, price_id: "single", quantity: 2 },
+    });
+    expect(oneTimeResponse.status).toBe(200);
+
+    for (let grant = 0; grant < 2; grant++) {
+      const grantResponse = await niceBackendFetch(urlString`/api/v1/payments/products/user/${userId}`, {
+        method: "POST",
+        accessType: "server",
+        body: { product_id: "perf-api-grant", quantity: 1 },
+      });
+      expect(grantResponse.status).toBe(200);
+    }
+
+    for (let update = 0; update < ITEM_UPDATES_PER_USER; update++) {
+      const itemId = update % 2 === 0 ? "credits" : "boosts";
+      const updateResponse = await niceBackendFetch(urlString`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
+        method: "POST",
+        accessType: "server",
+        query: { allow_negative: "false" },
+        body: { delta: update + 1, description: `prefill-${index}-${update}` },
+      });
+      expect(updateResponse.status).toBe(200);
+    }
+
+    appendPrefillLog(index, stage, performance.now() - startedAt);
+  });
 }
 
 async function prefillCustomersInRange(startIndex: number, count: number, stage: number): Promise<void> {
   let nextIndex = 0;
+  // Without this, the other workers would keep hammering the backend for another customer each after
+  // one of them has already failed the whole prefill, which makes the failure output much noisier
+  // (and, for a benchmark, wastes minutes of a run that is going to be discarded anyway).
+  let failed = false;
   const worker = async (): Promise<void> => {
     while (true) {
+      if (failed) return;
       const offset = nextIndex++;
       if (offset >= count) return;
-      await prefillOne(startIndex + offset, stage);
+      try {
+        await prefillOne(startIndex + offset, stage);
+      } catch (error) {
+        failed = true;
+        throw error;
+      }
     }
   };
   await Promise.all(Array.from({ length: Math.min(PREFILL_CONCURRENCY, count) }, worker));

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
@@ -228,15 +228,21 @@ async function prefillCustomersInRange(startIndex: number, count: number, stage:
       if (failed) return;
       const offset = nextIndex++;
       if (offset >= count) return;
+      let completed = false;
       try {
         await prefillOne(startIndex + offset, stage);
-      } catch (error) {
-        failed = true;
-        throw error;
+        completed = true;
+      } finally {
+        if (!completed) failed = true;
       }
     }
   };
-  await Promise.all(Array.from({ length: Math.min(PREFILL_CONCURRENCY, count) }, worker));
+  // Every worker has to settle before the failure propagates: `Promise.all` would reject while the
+  // other workers still had a customer in flight, so their mutating requests would land in the middle
+  // of the caller's teardown.
+  const results = await Promise.allSettled(Array.from({ length: Math.min(PREFILL_CONCURRENCY, count) }, worker));
+  const failure = results.find((result): result is PromiseRejectedResult => result.status === "rejected");
+  if (failure !== undefined) throw failure.reason;
 }
 
 async function setupPayments(): Promise<void> {

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
@@ -1,9 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
 import { expect } from "vitest";
 import { it } from "../../../../../helpers";
 import { Auth, Payments, Project, niceBackendFetch } from "../../../../backend-helpers";
 
 const USER_COUNT = 6;
 const ITEM_UPDATES_PER_USER = 10;
+
+// The benchmark can be run against a tenancy that already holds payments data, to see how the
+// measured flows scale with the amount of data Bulldozer keeps in its trees. One prefill unit is one
+// fully-populated customer (a subscription purchase, a one-time purchase, two granted stackable
+// products and ITEM_UPDATES_PER_USER item-quantity changes) written into the same tenancy before any
+// measurement happens. The measured workload stays identical at every level, so the only thing that
+// varies between runs is the volume of pre-existing data.
+const PREFILL_CUSTOMERS = Number(process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL ?? "0");
+if (!Number.isInteger(PREFILL_CUSTOMERS) || PREFILL_CUSTOMERS < 0) {
+  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL must be a non-negative integer, got ${process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL}`);
+}
+// When set, the summary is also written to this path as JSON, so that a sweep over several prefill
+// levels can be aggregated and plotted afterwards.
+const OUTPUT_PATH = process.env.HEXCLAVE_PAYMENTS_PERF_OUTPUT;
 
 type PerfMetric = {
   name: string,
@@ -16,7 +32,8 @@ async function measure<T>(name: string, count: number, fn: () => Promise<T>, met
   const result = await fn();
   const elapsedMs = performance.now() - startedAt;
   metrics.push({ name, count, elapsedMs });
-  console.log(`[bulldozer-payments-e2e-perf] ${name}: ${elapsedMs.toFixed(1)} ms (${count} ops, ${(count / elapsedMs * 1000).toFixed(2)} ops/s)`);
+  const throughput = count === 0 ? "n/a" : `${(count / elapsedMs * 1000).toFixed(2)} ops/s`;
+  console.log(`[bulldozer-payments-e2e-perf] ${name}: ${elapsedMs.toFixed(1)} ms (${count} ops, ${throughput})`);
   return result;
 }
 
@@ -56,7 +73,11 @@ async function listAllTransactions() {
   return transactions;
 }
 
-it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary", { timeout: 240_000 }, async () => {
+// The measured workload alone fits comfortably into the base timeout; prefilling is what can take
+// arbitrarily long, so the budget grows with the requested prefill size.
+const TEST_TIMEOUT_MS = 240_000 + PREFILL_CUSTOMERS * 30_000;
+
+it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary", { timeout: TEST_TIMEOUT_MS }, async () => {
   const metrics: PerfMetric[] = [];
 
   await measure("setup project + payments config", 1, async () => {
@@ -111,6 +132,48 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
         },
       },
     });
+  }, metrics);
+
+  await measure("prefill existing payments data", PREFILL_CUSTOMERS, async () => {
+    for (let i = 0; i < PREFILL_CUSTOMERS; i++) {
+      const { userId } = await Auth.fastSignUp();
+
+      const subscriptionCode = await createPurchaseCode({ customerType: "user", customerId: userId, productId: "perf-sub" });
+      const subscriptionResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
+        accessType: "admin",
+        method: "POST",
+        body: { full_code: subscriptionCode, price_id: "monthly", quantity: 1 },
+      });
+      expect(subscriptionResponse.status).toBe(200);
+
+      const oneTimeCode = await createPurchaseCode({ customerType: "user", customerId: userId, productId: "perf-otp" });
+      const oneTimeResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
+        accessType: "admin",
+        method: "POST",
+        body: { full_code: oneTimeCode, price_id: "single", quantity: 2 },
+      });
+      expect(oneTimeResponse.status).toBe(200);
+
+      for (let grant = 0; grant < 2; grant++) {
+        const grantResponse = await niceBackendFetch(`/api/v1/payments/products/user/${userId}`, {
+          method: "POST",
+          accessType: "server",
+          body: { product_id: "perf-api-grant", quantity: 1 },
+        });
+        expect(grantResponse.status).toBe(200);
+      }
+
+      for (let update = 0; update < ITEM_UPDATES_PER_USER; update++) {
+        const itemId = update % 2 === 0 ? "credits" : "boosts";
+        const updateResponse = await niceBackendFetch(`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
+          method: "POST",
+          accessType: "server",
+          query: { allow_negative: "false" },
+          body: { delta: update + 1, description: `prefill-${i}-${update}` },
+        });
+        expect(updateResponse.status).toBe(200);
+      }
+    }
   }, metrics);
 
   const users = await measure("create users", USER_COUNT, async () => {
@@ -205,14 +268,21 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
   const transactions = await measure("list all transactions with pagination", 1, listAllTransactions, metrics);
   expect(transactions.length).toBeGreaterThanOrEqual(users.length * 4);
 
-  console.log("[bulldozer-payments-e2e-perf] summary", JSON.stringify({
+  const summary = {
+    prefillCustomers: PREFILL_CUSTOMERS,
     users: users.length,
     transactions: transactions.length,
     metrics: metrics.map((metric) => ({
       name: metric.name,
       count: metric.count,
       elapsedMs: Number(metric.elapsedMs.toFixed(1)),
-      opsPerSecond: Number((metric.count / metric.elapsedMs * 1000).toFixed(2)),
+      opsPerSecond: metric.count === 0 ? null : Number((metric.count / metric.elapsedMs * 1000).toFixed(2)),
     })),
-  }));
+  };
+  console.log("[bulldozer-payments-e2e-perf] summary", JSON.stringify(summary));
+
+  if (OUTPUT_PATH != null) {
+    fs.mkdirSync(path.dirname(path.resolve(OUTPUT_PATH)), { recursive: true });
+    fs.writeFileSync(OUTPUT_PATH, JSON.stringify(summary, null, 2));
+  }
 });

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
@@ -11,28 +11,84 @@ const ITEM_UPDATES_PER_USER = 10;
 // The benchmark can be run against a tenancy that already holds payments data, to see how the
 // measured flows scale with the amount of data Bulldozer keeps in its trees. One prefill unit is one
 // fully-populated customer (a subscription purchase, a one-time purchase, two granted stackable
-// products and ITEM_UPDATES_PER_USER item-quantity changes) written into the same tenancy before any
-// measurement happens. The measured workload stays identical at every level, so the only thing that
-// varies between runs is the volume of pre-existing data.
+// products and ITEM_UPDATES_PER_USER item-quantity changes) written into the same tenancy before
+// each measured workload.
 const PREFILL_VALUE = process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL;
-if (PREFILL_VALUE != null && !/^\d+$/.test(PREFILL_VALUE)) {
-  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL must be a non-negative integer, got ${PREFILL_VALUE}`);
+const PREFILL_STAGES_VALUE = process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES;
+if (PREFILL_VALUE != null && PREFILL_STAGES_VALUE != null) {
+  throw new Error("HEXCLAVE_PAYMENTS_PERF_PREFILL and HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES cannot both be set");
 }
-const PREFILL_CUSTOMERS = PREFILL_VALUE == null ? 0 : Number(PREFILL_VALUE);
-if (PREFILL_VALUE != null && !Number.isSafeInteger(PREFILL_CUSTOMERS)) {
-  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL must be a non-negative integer, got ${PREFILL_VALUE}`);
+
+function parseNonNegativeInteger(envName: string, value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${envName} must be a non-negative integer, got ${value}`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed)) {
+    throw new Error(`${envName} must be a non-negative integer, got ${value}`);
+  }
+  return parsed;
 }
-// When set, the summary is also written to this path as JSON, so that a sweep over several prefill
-// levels can be aggregated and plotted afterwards.
+
+function parsePositiveInteger(envName: string, value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new Error(`${envName} must be a positive integer, got ${value}`);
+  }
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${envName} must be a positive integer, got ${value}`);
+  }
+  return parsed;
+}
+
+function parsePrefillStages(value: string): number[] {
+  const stages: number[] = [];
+  for (const rawStage of value.split(",")) {
+    const stageValue = rawStage.trim();
+    if (!/^\d+$/.test(stageValue)) {
+      throw new Error(
+        `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES must be a comma-separated list of strictly increasing non-negative integers, offending value ${rawStage}`,
+      );
+    }
+    const stage = Number(stageValue);
+    if (!Number.isSafeInteger(stage)) {
+      throw new Error(
+        `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES must be a comma-separated list of strictly increasing non-negative integers, offending value ${rawStage}`,
+      );
+    }
+    if (stages.length > 0 && stage <= stages[stages.length - 1]) {
+      throw new Error(
+        `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES must be strictly increasing, offending value ${rawStage}`,
+      );
+    }
+    stages.push(stage);
+  }
+  return stages;
+}
+
+const PREFILL_CUSTOMERS = PREFILL_VALUE == null ? 0 : parseNonNegativeInteger("HEXCLAVE_PAYMENTS_PERF_PREFILL", PREFILL_VALUE);
+const PREFILL_STAGES = PREFILL_STAGES_VALUE == null ? [PREFILL_CUSTOMERS] : parsePrefillStages(PREFILL_STAGES_VALUE);
+const PREFILL_CONCURRENCY_VALUE = process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL_CONCURRENCY;
+const PREFILL_CONCURRENCY = PREFILL_CONCURRENCY_VALUE == null
+  ? 8
+  : parsePositiveInteger("HEXCLAVE_PAYMENTS_PERF_PREFILL_CONCURRENCY", PREFILL_CONCURRENCY_VALUE);
 const OUTPUT_PATH = process.env.HEXCLAVE_PAYMENTS_PERF_OUTPUT;
 if (OUTPUT_PATH != null && OUTPUT_PATH.trim() === "") {
   throw new Error(`HEXCLAVE_PAYMENTS_PERF_OUTPUT must be a non-empty path, got ${OUTPUT_PATH}`);
+}
+if (PREFILL_STAGES.length > 1 && OUTPUT_PATH != null && !OUTPUT_PATH.includes("{prefill}")) {
+  throw new Error("HEXCLAVE_PAYMENTS_PERF_OUTPUT must contain the {prefill} placeholder when multiple prefill stages are configured");
 }
 
 type PerfMetric = {
   name: string,
   count: number,
   elapsedMs: number,
+};
+
+type RequestUserAuth = {
+  accessToken: string,
+  refreshToken: string,
 };
 
 async function measure<T>(name: string, count: number, fn: () => Promise<T>, metrics: PerfMetric[]): Promise<T> {
@@ -45,7 +101,7 @@ async function measure<T>(name: string, count: number, fn: () => Promise<T>, met
   return result;
 }
 
-async function createPurchaseCode(options: { customerType: "user", customerId: string, productId: string }) {
+async function createPurchaseCode(options: { customerType: "user", customerId: string, productId: string, userAuth?: RequestUserAuth }) {
   const res = await niceBackendFetch("/api/latest/payments/purchases/create-purchase-url", {
     method: "POST",
     accessType: "server",
@@ -54,6 +110,7 @@ async function createPurchaseCode(options: { customerType: "user", customerId: s
       customer_id: options.customerId,
       product_id: options.productId,
     },
+    userAuth: options.userAuth,
   });
   expect(res.status).toBe(200);
   const codeMatch = (res.body.url as string).match(/\/purchase\/([a-z0-9-_]+)/);
@@ -81,118 +138,166 @@ async function listAllTransactions() {
   return transactions;
 }
 
-// The measured workload alone fits comfortably into the base timeout; prefilling is what can take
-// arbitrarily long, so the budget grows with the requested prefill size.
 const BASE_TEST_TIMEOUT_MS = 240_000;
 const PREFILL_TIMEOUT_MS = 30_000;
 const MAX_NODE_TIMER_MS = 2 ** 31 - 1;
-const MAX_PREFILL_CUSTOMERS = Math.floor((MAX_NODE_TIMER_MS - BASE_TEST_TIMEOUT_MS) / PREFILL_TIMEOUT_MS);
-if (PREFILL_CUSTOMERS > MAX_PREFILL_CUSTOMERS) {
+const MAX_PREFILL_CUSTOMERS = PREFILL_STAGES.reduce((maximum, stage) => Math.max(maximum, stage), 0);
+const MAX_ALLOWED_PREFILL_CUSTOMERS = Math.floor(
+  (MAX_NODE_TIMER_MS - BASE_TEST_TIMEOUT_MS * PREFILL_STAGES.length) / PREFILL_TIMEOUT_MS,
+);
+if (MAX_ALLOWED_PREFILL_CUSTOMERS < 0 || MAX_PREFILL_CUSTOMERS > MAX_ALLOWED_PREFILL_CUSTOMERS) {
+  const prefillVariable = PREFILL_STAGES_VALUE == null
+    ? "HEXCLAVE_PAYMENTS_PERF_PREFILL"
+    : "HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES";
   throw new Error(
-    `HEXCLAVE_PAYMENTS_PERF_PREFILL assumes the derived test timeout stays within Node's maximum timer delay of ${MAX_NODE_TIMER_MS} ms; effective maximum prefill count is ${MAX_PREFILL_CUSTOMERS}, got ${PREFILL_CUSTOMERS}`,
+    `${prefillVariable} assumes the derived test timeout stays within Node's maximum timer delay of ${MAX_NODE_TIMER_MS} ms; effective maximum cumulative prefill count is ${Math.max(0, MAX_ALLOWED_PREFILL_CUSTOMERS)} for ${PREFILL_STAGES.length} stage(s), got ${MAX_PREFILL_CUSTOMERS}`,
   );
 }
-const TEST_TIMEOUT_MS = BASE_TEST_TIMEOUT_MS + PREFILL_CUSTOMERS * PREFILL_TIMEOUT_MS;
+const TEST_TIMEOUT_MS = BASE_TEST_TIMEOUT_MS * PREFILL_STAGES.length
+  + MAX_PREFILL_CUSTOMERS * PREFILL_TIMEOUT_MS;
 
-it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary", { timeout: TEST_TIMEOUT_MS }, async () => {
-  const metrics: PerfMetric[] = [];
+async function prefillOne(index: number): Promise<void> {
+  const { userId, accessToken, refreshToken } = await Auth.fastSignUp();
+  const userAuth = { accessToken, refreshToken };
 
-  await measure("setup project + payments config", 1, async () => {
-    await Project.createAndSwitch();
-    await Payments.setup();
-    await Project.updateConfig({
-      payments: {
-        testMode: true,
-        products: {
-          "perf-sub": {
-            displayName: "Perf Subscription",
-            customerType: "user",
-            serverOnly: false,
-            stackable: true,
-            prices: {
-              monthly: { USD: "10.00", interval: [1, "month"] },
-            },
-            includedItems: {
-              credits: { quantity: 10, repeat: [1, "month"], expires: "when-repeated" },
-              seats: { quantity: 1, expires: "when-purchase-expires" },
-            },
+  const subscriptionCode = await createPurchaseCode({
+    customerType: "user",
+    customerId: userId,
+    productId: "perf-sub",
+    userAuth,
+  });
+  const subscriptionResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
+    accessType: "admin",
+    method: "POST",
+    body: { full_code: subscriptionCode, price_id: "monthly", quantity: 1 },
+    userAuth,
+  });
+  expect(subscriptionResponse.status).toBe(200);
+
+  const oneTimeCode = await createPurchaseCode({
+    customerType: "user",
+    customerId: userId,
+    productId: "perf-otp",
+    userAuth,
+  });
+  const oneTimeResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
+    accessType: "admin",
+    method: "POST",
+    body: { full_code: oneTimeCode, price_id: "single", quantity: 2 },
+    userAuth,
+  });
+  expect(oneTimeResponse.status).toBe(200);
+
+  for (let grant = 0; grant < 2; grant++) {
+    const grantResponse = await niceBackendFetch(urlString`/api/v1/payments/products/user/${userId}`, {
+      method: "POST",
+      accessType: "server",
+      body: { product_id: "perf-api-grant", quantity: 1 },
+      userAuth,
+    });
+    expect(grantResponse.status).toBe(200);
+  }
+
+  for (let update = 0; update < ITEM_UPDATES_PER_USER; update++) {
+    const itemId = update % 2 === 0 ? "credits" : "boosts";
+    const updateResponse = await niceBackendFetch(urlString`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
+      method: "POST",
+      accessType: "server",
+      query: { allow_negative: "false" },
+      body: { delta: update + 1, description: `prefill-${index}-${update}` },
+      userAuth,
+    });
+    expect(updateResponse.status).toBe(200);
+  }
+}
+
+async function prefillCustomersInRange(startIndex: number, count: number): Promise<void> {
+  let nextIndex = 0;
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const offset = nextIndex++;
+      if (offset >= count) return;
+      await prefillOne(startIndex + offset);
+    }
+  };
+  await Promise.all(Array.from({ length: Math.min(PREFILL_CONCURRENCY, count) }, worker));
+}
+
+async function setupPayments(): Promise<void> {
+  await Project.createAndSwitch();
+  await Payments.setup();
+  await Project.updateConfig({
+    payments: {
+      testMode: true,
+      products: {
+        "perf-sub": {
+          displayName: "Perf Subscription",
+          customerType: "user",
+          serverOnly: false,
+          stackable: true,
+          prices: {
+            monthly: { USD: "10.00", interval: [1, "month"] },
           },
-          "perf-otp": {
-            displayName: "Perf One-Time Purchase",
-            customerType: "user",
-            serverOnly: false,
-            stackable: true,
-            prices: {
-              single: { USD: "5.00" },
-            },
-            includedItems: {
-              credits: { quantity: 5, expires: "never" },
-            },
-          },
-          "perf-api-grant": {
-            displayName: "Perf API Grant",
-            customerType: "user",
-            serverOnly: false,
-            stackable: true,
-            prices: {
-              monthly: { USD: "0.00", interval: [1, "month"] },
-            },
-            includedItems: {
-              credits: { quantity: 3, expires: "when-purchase-expires" },
-            },
+          includedItems: {
+            credits: { quantity: 10, repeat: [1, "month"], expires: "when-repeated" },
+            seats: { quantity: 1, expires: "when-purchase-expires" },
           },
         },
-        items: {
-          credits: { displayName: "Credits", customerType: "user" },
-          seats: { displayName: "Seats", customerType: "user" },
-          boosts: { displayName: "Boosts", customerType: "user" },
+        "perf-otp": {
+          displayName: "Perf One-Time Purchase",
+          customerType: "user",
+          serverOnly: false,
+          stackable: true,
+          prices: {
+            single: { USD: "5.00" },
+          },
+          includedItems: {
+            credits: { quantity: 5, expires: "never" },
+          },
+        },
+        "perf-api-grant": {
+          displayName: "Perf API Grant",
+          customerType: "user",
+          serverOnly: false,
+          stackable: true,
+          prices: {
+            monthly: { USD: "0.00", interval: [1, "month"] },
+          },
+          includedItems: {
+            credits: { quantity: 3, expires: "when-purchase-expires" },
+          },
         },
       },
-    });
-  }, metrics);
+      items: {
+        credits: { displayName: "Credits", customerType: "user" },
+        seats: { displayName: "Seats", customerType: "user" },
+        boosts: { displayName: "Boosts", customerType: "user" },
+      },
+    },
+  });
+}
 
-  await measure("prefill existing payments data", PREFILL_CUSTOMERS, async () => {
-    for (let i = 0; i < PREFILL_CUSTOMERS; i++) {
-      const { userId } = await Auth.fastSignUp();
+type PerfSummary = {
+  prefillCustomers: number,
+  prefillCustomersAdded: number,
+  prefillConcurrency: number,
+  users: number,
+  transactions: number,
+  metrics: Array<{
+    name: string,
+    count: number,
+    elapsedMs: number,
+    opsPerSecond: number | null,
+  }>,
+};
 
-      const subscriptionCode = await createPurchaseCode({ customerType: "user", customerId: userId, productId: "perf-sub" });
-      const subscriptionResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
-        accessType: "admin",
-        method: "POST",
-        body: { full_code: subscriptionCode, price_id: "monthly", quantity: 1 },
-      });
-      expect(subscriptionResponse.status).toBe(200);
-
-      const oneTimeCode = await createPurchaseCode({ customerType: "user", customerId: userId, productId: "perf-otp" });
-      const oneTimeResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
-        accessType: "admin",
-        method: "POST",
-        body: { full_code: oneTimeCode, price_id: "single", quantity: 2 },
-      });
-      expect(oneTimeResponse.status).toBe(200);
-
-      for (let grant = 0; grant < 2; grant++) {
-        const grantResponse = await niceBackendFetch(urlString`/api/v1/payments/products/user/${userId}`, {
-          method: "POST",
-          accessType: "server",
-          body: { product_id: "perf-api-grant", quantity: 1 },
-        });
-        expect(grantResponse.status).toBe(200);
-      }
-
-      for (let update = 0; update < ITEM_UPDATES_PER_USER; update++) {
-        const itemId = update % 2 === 0 ? "credits" : "boosts";
-        const updateResponse = await niceBackendFetch(urlString`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
-          method: "POST",
-          accessType: "server",
-          query: { allow_negative: "false" },
-          body: { delta: update + 1, description: `prefill-${i}-${update}` },
-        });
-        expect(updateResponse.status).toBe(200);
-      }
-    }
-  }, metrics);
-
+async function runMeasuredWorkload(
+  prefillCustomers: number,
+  prefillCustomersAdded: number,
+  prefillConcurrency: number,
+  metricsBeforeWorkload: PerfMetric[],
+): Promise<PerfSummary> {
+  const metrics = metricsBeforeWorkload.map((metric) => ({ ...metric }));
   const users = await measure("create users", USER_COUNT, async () => {
     const createdUsers: string[] = [];
     for (let i = 0; i < USER_COUNT; i++) {
@@ -229,7 +334,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
   await measure("grant stackable subscription products via server API", users.length * 2, async () => {
     for (const userId of users) {
       for (let i = 0; i < 2; i++) {
-        const response = await niceBackendFetch(`/api/v1/payments/products/user/${userId}`, {
+        const response = await niceBackendFetch(urlString`/api/v1/payments/products/user/${userId}`, {
           method: "POST",
           accessType: "server",
           body: {
@@ -246,7 +351,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
     for (const userId of users) {
       for (let i = 0; i < ITEM_UPDATES_PER_USER; i++) {
         const itemId = i % 2 === 0 ? "credits" : "boosts";
-        const response = await niceBackendFetch(`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
+        const response = await niceBackendFetch(urlString`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
           method: "POST",
           accessType: "server",
           query: { allow_negative: "false" },
@@ -262,7 +367,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
 
   await measure("read owned products for all users", users.length, async () => {
     for (const userId of users) {
-      const response = await niceBackendFetch(`/api/v1/payments/products/user/${userId}`, {
+      const response = await niceBackendFetch(urlString`/api/v1/payments/products/user/${userId}`, {
         accessType: "server",
       });
       expect(response.status).toBe(200);
@@ -273,7 +378,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
   await measure("read item quantities for all users", users.length * 3, async () => {
     for (const userId of users) {
       for (const itemId of ["credits", "seats", "boosts"]) {
-        const response = await niceBackendFetch(`/api/latest/payments/items/user/${userId}/${itemId}`, {
+        const response = await niceBackendFetch(urlString`/api/latest/payments/items/user/${userId}/${itemId}`, {
           accessType: "server",
         });
         expect(response.status).toBe(200);
@@ -285,8 +390,10 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
   const transactions = await measure("list all transactions with pagination", 1, listAllTransactions, metrics);
   expect(transactions.length).toBeGreaterThanOrEqual(users.length * 4);
 
-  const summary = {
-    prefillCustomers: PREFILL_CUSTOMERS,
+  const summary: PerfSummary = {
+    prefillCustomers,
+    prefillCustomersAdded,
+    prefillConcurrency,
     users: users.length,
     transactions: transactions.length,
     metrics: metrics.map((metric) => ({
@@ -297,9 +404,38 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
     })),
   };
   console.log("[bulldozer-payments-e2e-perf] summary", JSON.stringify(summary));
+  return summary;
+}
 
-  if (OUTPUT_PATH != null) {
-    fs.mkdirSync(path.dirname(path.resolve(OUTPUT_PATH)), { recursive: true });
-    fs.writeFileSync(OUTPUT_PATH, JSON.stringify(summary, null, 2));
+function writeSummary(summary: PerfSummary, outputPath: string): void {
+  fs.mkdirSync(path.dirname(path.resolve(outputPath)), { recursive: true });
+  fs.writeFileSync(outputPath, JSON.stringify(summary, null, 2));
+}
+
+it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary", { timeout: TEST_TIMEOUT_MS }, async () => {
+  const setupMetrics: PerfMetric[] = [];
+  await measure("setup project + payments config", 1, setupPayments, setupMetrics);
+
+  let previousPrefillCustomers = 0;
+  for (const prefillCustomers of PREFILL_STAGES) {
+    const delta = prefillCustomers - previousPrefillCustomers;
+    console.log(`[bulldozer-payments-e2e-perf] prefill stage ${prefillCustomers}: adding ${delta} customers`);
+    const metricsBeforeWorkload = setupMetrics.map((metric) => ({ ...metric }));
+    // Prefill runs before measurements, so bounded concurrency cannot taint the measured workload.
+    await measure(
+      "prefill existing payments data",
+      delta,
+      () => prefillCustomersInRange(previousPrefillCustomers, delta),
+      metricsBeforeWorkload,
+    );
+
+    const summary = await runMeasuredWorkload(prefillCustomers, delta, PREFILL_CONCURRENCY, metricsBeforeWorkload);
+    if (OUTPUT_PATH != null) {
+      const outputPath = PREFILL_STAGES.length > 1
+        ? OUTPUT_PATH.replace(/\{prefill\}/g, String(prefillCustomers))
+        : OUTPUT_PATH;
+      writeSummary(summary, outputPath);
+    }
+    previousPrefillCustomers = prefillCustomers;
   }
 });

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { urlString } from "@hexclave/shared/dist/utils/urls";
 import { expect } from "vitest";
 import { it } from "../../../../../helpers";
 import { Auth, Payments, Project, niceBackendFetch } from "../../../../backend-helpers";
@@ -13,13 +14,20 @@ const ITEM_UPDATES_PER_USER = 10;
 // products and ITEM_UPDATES_PER_USER item-quantity changes) written into the same tenancy before any
 // measurement happens. The measured workload stays identical at every level, so the only thing that
 // varies between runs is the volume of pre-existing data.
-const PREFILL_CUSTOMERS = Number(process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL ?? "0");
-if (!Number.isInteger(PREFILL_CUSTOMERS) || PREFILL_CUSTOMERS < 0) {
-  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL must be a non-negative integer, got ${process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL}`);
+const PREFILL_VALUE = process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL;
+if (PREFILL_VALUE != null && !/^\d+$/.test(PREFILL_VALUE)) {
+  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL must be a non-negative integer, got ${PREFILL_VALUE}`);
+}
+const PREFILL_CUSTOMERS = PREFILL_VALUE == null ? 0 : Number(PREFILL_VALUE);
+if (PREFILL_VALUE != null && !Number.isSafeInteger(PREFILL_CUSTOMERS)) {
+  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL must be a non-negative integer, got ${PREFILL_VALUE}`);
 }
 // When set, the summary is also written to this path as JSON, so that a sweep over several prefill
 // levels can be aggregated and plotted afterwards.
 const OUTPUT_PATH = process.env.HEXCLAVE_PAYMENTS_PERF_OUTPUT;
+if (OUTPUT_PATH != null && OUTPUT_PATH.trim() === "") {
+  throw new Error(`HEXCLAVE_PAYMENTS_PERF_OUTPUT must be a non-empty path, got ${OUTPUT_PATH}`);
+}
 
 type PerfMetric = {
   name: string,
@@ -75,7 +83,16 @@ async function listAllTransactions() {
 
 // The measured workload alone fits comfortably into the base timeout; prefilling is what can take
 // arbitrarily long, so the budget grows with the requested prefill size.
-const TEST_TIMEOUT_MS = 240_000 + PREFILL_CUSTOMERS * 30_000;
+const BASE_TEST_TIMEOUT_MS = 240_000;
+const PREFILL_TIMEOUT_MS = 30_000;
+const MAX_NODE_TIMER_MS = 2 ** 31 - 1;
+const MAX_PREFILL_CUSTOMERS = Math.floor((MAX_NODE_TIMER_MS - BASE_TEST_TIMEOUT_MS) / PREFILL_TIMEOUT_MS);
+if (PREFILL_CUSTOMERS > MAX_PREFILL_CUSTOMERS) {
+  throw new Error(
+    `HEXCLAVE_PAYMENTS_PERF_PREFILL assumes the derived test timeout stays within Node's maximum timer delay of ${MAX_NODE_TIMER_MS} ms; effective maximum prefill count is ${MAX_PREFILL_CUSTOMERS}, got ${PREFILL_CUSTOMERS}`,
+  );
+}
+const TEST_TIMEOUT_MS = BASE_TEST_TIMEOUT_MS + PREFILL_CUSTOMERS * PREFILL_TIMEOUT_MS;
 
 it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary", { timeout: TEST_TIMEOUT_MS }, async () => {
   const metrics: PerfMetric[] = [];
@@ -155,7 +172,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
       expect(oneTimeResponse.status).toBe(200);
 
       for (let grant = 0; grant < 2; grant++) {
-        const grantResponse = await niceBackendFetch(`/api/v1/payments/products/user/${userId}`, {
+        const grantResponse = await niceBackendFetch(urlString`/api/v1/payments/products/user/${userId}`, {
           method: "POST",
           accessType: "server",
           body: { product_id: "perf-api-grant", quantity: 1 },
@@ -165,7 +182,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
 
       for (let update = 0; update < ITEM_UPDATES_PER_USER; update++) {
         const itemId = update % 2 === 0 ? "credits" : "boosts";
-        const updateResponse = await niceBackendFetch(`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
+        const updateResponse = await niceBackendFetch(urlString`/api/latest/payments/items/user/${userId}/${itemId}/update-quantity`, {
           method: "POST",
           accessType: "server",
           query: { allow_negative: "false" },

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
@@ -80,6 +80,14 @@ if (PREFILL_STAGES.length > 1 && OUTPUT_PATH != null && !OUTPUT_PATH.includes("{
   throw new Error("HEXCLAVE_PAYMENTS_PERF_OUTPUT must contain the {prefill} placeholder when multiple prefill stages are configured");
 }
 
+// The per-stage summaries only land once a stage completes, which for the larger stages is tens of
+// minutes of blindness. This log instead appends one line per prefilled customer as it finishes, so
+// the shape of the curve (and any regression in it) is visible while the sweep is still running.
+const PREFILL_LOG_PATH = process.env.HEXCLAVE_PAYMENTS_PERF_PREFILL_LOG;
+if (PREFILL_LOG_PATH != null && PREFILL_LOG_PATH.trim() === "") {
+  throw new Error(`HEXCLAVE_PAYMENTS_PERF_PREFILL_LOG must be a non-empty path, got ${PREFILL_LOG_PATH}`);
+}
+
 type PerfMetric = {
   name: string,
   count: number,
@@ -160,7 +168,19 @@ if (MAX_ALLOWED_PREFILL_CUSTOMERS < 0 || MAX_PREFILL_CUSTOMERS > MAX_ALLOWED_PRE
 const TEST_TIMEOUT_MS = BASE_TEST_TIMEOUT_MS * PREFILL_STAGES.length
   + MAX_PREFILL_CUSTOMERS * PREFILL_TIMEOUT_MS;
 
-async function prefillOne(index: number): Promise<void> {
+let prefillLogInitialized = false;
+function appendPrefillLog(index: number, stage: number, elapsedMs: number): void {
+  if (PREFILL_LOG_PATH == null) return;
+  if (!prefillLogInitialized) {
+    fs.mkdirSync(path.dirname(path.resolve(PREFILL_LOG_PATH)), { recursive: true });
+    fs.writeFileSync(PREFILL_LOG_PATH, "index,stage,finished_at_iso,elapsed_ms\n");
+    prefillLogInitialized = true;
+  }
+  fs.appendFileSync(PREFILL_LOG_PATH, `${index},${stage},${new Date().toISOString()},${elapsedMs.toFixed(3)}\n`);
+}
+
+async function prefillOne(index: number, stage: number): Promise<void> {
+  const startedAt = performance.now();
   const { userId } = await Auth.fastSignUp();
 
   const subscriptionCode = await createPurchaseCode({
@@ -212,15 +232,17 @@ async function prefillOne(index: number): Promise<void> {
     });
     expect(updateResponse.status).toBe(200);
   }
+
+  appendPrefillLog(index, stage, performance.now() - startedAt);
 }
 
-async function prefillCustomersInRange(startIndex: number, count: number): Promise<void> {
+async function prefillCustomersInRange(startIndex: number, count: number, stage: number): Promise<void> {
   let nextIndex = 0;
   const worker = async (): Promise<void> => {
     while (true) {
       const offset = nextIndex++;
       if (offset >= count) return;
-      await prefillOne(startIndex + offset);
+      await prefillOne(startIndex + offset, stage);
     }
   };
   await Promise.all(Array.from({ length: Math.min(PREFILL_CONCURRENCY, count) }, worker));
@@ -428,7 +450,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
     await measure(
       "prefill existing payments data",
       delta,
-      () => prefillCustomersInRange(previousPrefillCustomers, delta),
+      () => prefillCustomersInRange(previousPrefillCustomers, delta, prefillCustomers),
       metricsBeforeWorkload,
     );
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/payments.perf.test.ts
@@ -87,9 +87,13 @@ type PerfMetric = {
 };
 
 type RequestUserAuth = {
-  accessToken: string,
-  refreshToken: string,
+  accessToken?: string,
+  refreshToken?: string,
 };
+
+// Prefill requests use server/admin access and explicit customer IDs, so an empty override avoids
+// pinning a 60-second user token while also suppressing the shared ambient auth state.
+const PREFILL_NO_USER_AUTH: RequestUserAuth = {};
 
 async function measure<T>(name: string, count: number, fn: () => Promise<T>, metrics: PerfMetric[]): Promise<T> {
   const startedAt = performance.now();
@@ -157,20 +161,19 @@ const TEST_TIMEOUT_MS = BASE_TEST_TIMEOUT_MS * PREFILL_STAGES.length
   + MAX_PREFILL_CUSTOMERS * PREFILL_TIMEOUT_MS;
 
 async function prefillOne(index: number): Promise<void> {
-  const { userId, accessToken, refreshToken } = await Auth.fastSignUp();
-  const userAuth = { accessToken, refreshToken };
+  const { userId } = await Auth.fastSignUp();
 
   const subscriptionCode = await createPurchaseCode({
     customerType: "user",
     customerId: userId,
     productId: "perf-sub",
-    userAuth,
+    userAuth: PREFILL_NO_USER_AUTH,
   });
   const subscriptionResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
     accessType: "admin",
     method: "POST",
     body: { full_code: subscriptionCode, price_id: "monthly", quantity: 1 },
-    userAuth,
+    userAuth: PREFILL_NO_USER_AUTH,
   });
   expect(subscriptionResponse.status).toBe(200);
 
@@ -178,13 +181,13 @@ async function prefillOne(index: number): Promise<void> {
     customerType: "user",
     customerId: userId,
     productId: "perf-otp",
-    userAuth,
+    userAuth: PREFILL_NO_USER_AUTH,
   });
   const oneTimeResponse = await niceBackendFetch("/api/latest/internal/payments/test-mode-purchase-session", {
     accessType: "admin",
     method: "POST",
     body: { full_code: oneTimeCode, price_id: "single", quantity: 2 },
-    userAuth,
+    userAuth: PREFILL_NO_USER_AUTH,
   });
   expect(oneTimeResponse.status).toBe(200);
 
@@ -193,7 +196,7 @@ async function prefillOne(index: number): Promise<void> {
       method: "POST",
       accessType: "server",
       body: { product_id: "perf-api-grant", quantity: 1 },
-      userAuth,
+      userAuth: PREFILL_NO_USER_AUTH,
     });
     expect(grantResponse.status).toBe(200);
   }
@@ -205,7 +208,7 @@ async function prefillOne(index: number): Promise<void> {
       accessType: "server",
       query: { allow_negative: "false" },
       body: { delta: update + 1, description: `prefill-${index}-${update}` },
-      userAuth,
+      userAuth: PREFILL_NO_USER_AUTH,
     });
     expect(updateResponse.status).toBe(200);
   }
@@ -431,9 +434,7 @@ it("benchmarks backend-level payments flows through the Bulldozer HTTP boundary"
 
     const summary = await runMeasuredWorkload(prefillCustomers, delta, PREFILL_CONCURRENCY, metricsBeforeWorkload);
     if (OUTPUT_PATH != null) {
-      const outputPath = PREFILL_STAGES.length > 1
-        ? OUTPUT_PATH.replace(/\{prefill\}/g, String(prefillCustomers))
-        : OUTPUT_PATH;
+      const outputPath = OUTPUT_PATH.replace(/\{prefill\}/g, String(prefillCustomers));
       writeSummary(summary, outputPath);
     }
     previousPrefillCustomers = prefillCustomers;


### PR DESCRIPTION
Lets the in-memory low-level backend emulate the IO cost of a real storage engine, so a benchmark can separate "how much IO Piledriver issues" from "how fast that IO is". The in-memory backend alone can't answer that, because it makes IO free.

New `declareDelayedLowLevelDatabase(wrapped, { readDelayMs, writeDelayMs })` wraps any `LowLevelDatabase` and models the two shapes LMDB's IO has:

- reads (`get`, `listEntries`) are memory-mapped and independent → plain per-operation latency, concurrent reads pay it in parallel;
- writes (`setAll`, `deleteAll`, `insertAll`) go through a single writer → `writeDelayMs` is the service time of one emulated device that serializes, so N concurrent writes take `N * writeDelayMs`;
- `compareAndSetAll` pays a read delay always and a write delay when it actually wrote.

Wired in `apps/bulldozer-js/src/index.ts` behind the existing `HEXCLAVE_BULLDOZER_JS_LOW_LEVEL_BACKEND=in-memory` path, opt-in via `HEXCLAVE_BULLDOZER_JS_IN_MEMORY_READ_DELAY_MS` / `..._WRITE_DELAY_MS`. With both unset, behaviour is byte-for-byte the previous in-memory backend.

Also adds `HEXCLAVE_PAYMENTS_PERF_PREFILL_LOG` to the payments perf benchmark: appends one CSV line per prefilled customer as it finishes, so the shape of the curve is visible while a multi-hour sweep is still running instead of only at stage boundaries.

Tests: `delayed.test.ts` covers pass-through correctness, per-read latency + read parallelism, write serialization, and the debug counters.


Link to Devin session: https://app.devin.ai/sessions/7e5adddd6b5b48d7a4e1e70fd42e800c
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Benchmark and test-harness changes only; production LMDB path is untouched and in-memory delays are opt-in via env vars.
> 
> **Overview**
> Adds **`declareDelayedLowLevelDatabase`**, a wrapper that layers LMDB-shaped IO cost on any low-level backend (reads: parallel per-op latency; writes: serialized single-writer queue; `compareAndSetAll` pays read plus conditional write). On the **in-memory** path, it activates only when `HEXCLAVE_BULLDOZER_JS_IN_MEMORY_READ_DELAY_MS` and/or `HEXCLAVE_BULLDOZER_JS_IN_MEMORY_WRITE_DELAY_MS` are set; otherwise behavior is unchanged. Startup logs include the delay settings; **`delayed.test.ts`** covers correctness, timing, and debug counters.
> 
> The **payments e2e perf** test gains **staged tenancy prefill** (`HEXCLAVE_PAYMENTS_PERF_PREFILL` or `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES`), bounded prefill concurrency, optional JSON output per stage (`{prefill}` placeholder), and **per-customer CSV progress** via `HEXCLAVE_PAYMENTS_PERF_PREFILL_LOG`, with env validation and a derived timeout capped for Node’s max timer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3983141b62bb169bd7c35f6f6c8ae6ca7cdb357a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in LMDB-shaped IO delay wrapper to the in-memory low-level backend and extends the payments perf benchmark with staged prefill and progress/output. Previously, in-memory IO was free; with env flags, reads now pay per-op latency and writes serialize through a single-writer queue. Default behavior and the LMDB path remain unchanged.

- Delayed in-memory backend
  - New `declareDelayedLowLevelDatabase(wrapped, { readDelayMs, writeDelayMs })`: reads pay latency in parallel; writes run in a single-writer slot; `compareAndSetAll` pays read always and write only on mutation.
  - Writer failures do not poison the queue; writes execute inside their slot. `close()` becomes an admission barrier (rejects new ops) and drains queued writes and all in-flight work, including compare-and-sets still paying read delay and pending sequence waiters.
  - Debug info reports op counts and accumulated delay; traces carry backend attributes.
  - Activated only when `HEXCLAVE_BULLDOZER_JS_LOW_LEVEL_BACKEND=in-memory` and at least one of `HEXCLAVE_BULLDOZER_JS_IN_MEMORY_READ_DELAY_MS`/`..._WRITE_DELAY_MS` is set; only these envs are validated. Startup logs include backend and delay settings. Tests cover write serialization, queue survival after failure, admission barrier, and close-order draining (including sequence waiters).

- Payments perf benchmark
  - Staged prefill via `HEXCLAVE_PAYMENTS_PERF_PREFILL` or `HEXCLAVE_PAYMENTS_PERF_PREFILL_STAGES` (mutually exclusive) with bounded concurrency (`HEXCLAVE_PAYMENTS_PERF_PREFILL_CONCURRENCY`, default 8), per-customer CSV progress (`HEXCLAVE_PAYMENTS_PERF_PREFILL_LOG`), and per-stage JSON summaries (`HEXCLAVE_PAYMENTS_PERF_OUTPUT`; must include `{prefill}` for multiple stages). Throughput prints “n/a” for zero-op sections.
  - Validates inputs and derives a test timeout that stays within Node’s max timer. Prefill uses server/admin access, isolates auth context to avoid leaking tokens, and ensures all workers settle on failure to prevent stray writes during teardown.

<sup>Written for commit ef76d2c4655e08ba1f74fbeda2e8f4af73614d8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable read and write delays for the in-memory database, with startup diagnostics showing active settings.
  - Added database diagnostics for operation counts and accumulated delay.

- **Performance Testing**
  - Enhanced payment performance testing with staged prefill, bounded concurrency, progress reporting, throughput metrics, and summary files.
  - Added configuration validation and improved handling of empty workloads.

- **Tests**
  - Added comprehensive coverage for delayed database behavior, including latency, concurrent reads, serialized writes, recovery, and diagnostic counters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->