### PR TITLE
fix marshal file naming to fix vercel issue

### DIFF
--- a/apps/marshal/src/builds.test.ts
+++ b/apps/marshal/src/builds.test.ts
@@ -276,7 +276,7 @@ describe("buildTimeEnv", () => {
 });
 
 describe("the build completion webhook", () => {
-  // The gate in app.ts authenticates /internal/* BEFORE any handler runs and 404s a path it
+  // The gate in marshal-app.ts authenticates /internal/* BEFORE any handler runs and 404s a path it
   // does not recognize, so a webhook URL the gate cannot match means no real Fly build can
   // ever complete — and nothing in e2e notices, because the mock builder completes in
   // process without crossing HTTP. Both sides derive from buildCompletionPath; this pins

--- a/apps/marshal/src/marshal-app.ts
+++ b/apps/marshal/src/marshal-app.ts
@@ -1,3 +1,9 @@
+// NOT named app.ts, and must not be renamed back: Vercel's Elysia preset detects the
+// function entrypoint by scanning known paths — src/index.ts and src/app.ts among them —
+// for a file that imports `elysia`. This file does, so as src/app.ts it tied with the real
+// entrypoint and won ("Multiple entrypoints found: src/app.ts, src/index.ts. Using
+// src/app.ts."), which builds a function out of a module that default-exports nothing and
+// drops the maxDuration declared in src/index.ts.
 import { node } from "@elysiajs/node";
 import { Elysia } from "elysia";
 import { randomUUID, timingSafeEqual } from "node:crypto";

--- a/apps/marshal/src/server.ts
+++ b/apps/marshal/src/server.ts
@@ -2,7 +2,7 @@
 // src/vercel.ts instead, which exports the same app without binding a port. This file is
 // what `pnpm start` / `pnpm dev` / the e2e workflows run.
 import "./load-env.js";
-import { createMarshalApp } from "./app.js";
+import { createMarshalApp } from "./marshal-app.js";
 import { getConfig } from "./config.js";
 
 const config = getConfig();

--- a/apps/marshal/src/vercel.ts
+++ b/apps/marshal/src/vercel.ts
@@ -7,7 +7,7 @@
 // dev/mock defaults that must never be a fallback for a production process. Configuration is
 // read at import time (createMarshalApp calls getConfig), so a missing or unsafe variable
 // fails the function's cold start with marshal's own message instead of failing per request.
-import { createMarshalApp } from "./app.js";
+import { createMarshalApp } from "./marshal-app.js";
 
 const { app } = createMarshalApp();
 


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Vercel’s entrypoint detection by renaming `apps/marshal/src/app.ts` to `apps/marshal/src/marshal-app.ts`. Previously, Vercel’s Elysia preset chose `src/app.ts` over `src/index.ts`, producing a function with no default export and dropping `maxDuration`; now `src/index.ts` is used and `maxDuration` is preserved.

- Updated imports from "./app.js" to "./marshal-app.js" in `server.ts` and `vercel.ts`.
- Adjusted the test comment in `builds.test.ts` to reference `marshal-app.ts`.
- No runtime behavior changes; only Vercel bundling and entrypoint selection are affected.
- Do not add a `src/app.ts` that imports `elysia`, or Vercel may select it as the entrypoint.

<sup>Written for commit 92df8e7024336f68b6b3a34449accda409f98d69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to prevent incorrect application entrypoint selection in hosted deployments.

* **Chores**
  * Updated server startup configuration for consistent application loading across deployment environments.
  * Clarified internal authentication and routing references in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->