### PR TITLE
feat(observability): consolidate observability UI updates

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "node": "22.x"
+    "node": ">=22.13.0"
   },
   "scripts": {
     "clean": "rimraf src/generated && rimraf dist && rimraf node_modules",

--- a/apps/backend/prisma/migrations/20260701000000_add_session_replay_segment/migration.sql
+++ b/apps/backend/prisma/migrations/20260701000000_add_session_replay_segment/migration.sql
@@ -8,24 +8,24 @@
 -- no row. That keeps this migration O(1) on a table with millions of chunks, and
 -- the aggregate is bounded by one replay's chunk count.
 --
--- The table and each foreign key are separate outside-transaction statements.
--- PostgreSQL holds the referenced-table lock until the statement transaction
--- commits, so keeping both FKs inside the migration transaction would extend
--- the first lock through every later statement and the bookkeeping insert.
+-- The table and each foreign key are separate statements in the migration
+-- transaction. Keeping them atomic is important: the migration runner holds
+-- its advisory-lock transaction while applying the file, and an outside-
+-- transaction statement would need a second pool connection that can deadlock
+-- behind concurrent migration waiters.
 --
 -- No secondary indexes: both cascade paths ((tenancyId, sessionReplayId) from
 -- SessionReplay and (tenancyId) from Tenancy) are prefixes of the primary key,
 -- as is the upsert's conflict target.
 
 -- The FK adds below take a brief SHARE ROW EXCLUSIVE lock on the hot referenced
--- tables (SessionReplay, Tenancy). Each DO block sets a local timeout and runs
--- outside the bookkeeping transaction, so the lock is released immediately
--- after that one constraint is installed.
+-- tables (SessionReplay, Tenancy). Each DO block sets a local timeout; if a
+-- lock cannot be acquired, the whole migration rolls back instead of leaving
+-- a table committed without its constraints.
 
 -- CreateTable
 -- SPLIT_STATEMENT_SENTINEL
 -- SINGLE_STATEMENT_SENTINEL
--- RUN_OUTSIDE_TRANSACTION_SENTINEL
 CREATE TABLE IF NOT EXISTS /* SCHEMA_NAME_SENTINEL */."SessionReplaySegment" (
     "id" TEXT NOT NULL,
     "tenancyId" UUID NOT NULL,
@@ -41,7 +41,6 @@ CREATE TABLE IF NOT EXISTS /* SCHEMA_NAME_SENTINEL */."SessionReplaySegment" (
 -- AddForeignKey
 -- SPLIT_STATEMENT_SENTINEL
 -- SINGLE_STATEMENT_SENTINEL
--- RUN_OUTSIDE_TRANSACTION_SENTINEL
 DO $$
 BEGIN
   PERFORM set_config('lock_timeout', '2s', true);
@@ -59,7 +58,6 @@ $$;
 -- AddForeignKey
 -- SPLIT_STATEMENT_SENTINEL
 -- SINGLE_STATEMENT_SENTINEL
--- RUN_OUTSIDE_TRANSACTION_SENTINEL
 DO $$
 BEGIN
   PERFORM set_config('lock_timeout', '2s', true);

--- a/apps/backend/prisma/migrations/20260701000000_add_session_replay_segment/migration.sql
+++ b/apps/backend/prisma/migrations/20260701000000_add_session_replay_segment/migration.sql
@@ -8,25 +8,25 @@
 -- no row. That keeps this migration O(1) on a table with millions of chunks, and
 -- the aggregate is bounded by one replay's chunk count.
 --
--- The two foreign keys are added as validating constraints rather than
--- NOT VALID + VALIDATE: the child table is empty, so there is nothing to
--- validate, and NOT VALID would still take the same lock on the referenced
--- tables to install the trigger. Splitting it would add a migration without
--- shortening the lock.
+-- The table and each foreign key are separate outside-transaction statements.
+-- PostgreSQL holds the referenced-table lock until the statement transaction
+-- commits, so keeping both FKs inside the migration transaction would extend
+-- the first lock through every later statement and the bookkeeping insert.
 --
 -- No secondary indexes: both cascade paths ((tenancyId, sessionReplayId) from
 -- SessionReplay and (tenancyId) from Tenancy) are prefixes of the primary key,
 -- as is the upsert's conflict target.
 
 -- The FK adds below take a brief SHARE ROW EXCLUSIVE lock on the hot referenced
--- tables (SessionReplay, Tenancy). Fail fast instead of queueing an exclusive
--- lock request behind long-running production queries for the lifetime of the
--- deploy transaction.
-SET LOCAL lock_timeout = '2s';
-SET LOCAL statement_timeout = '5min';
+-- tables (SessionReplay, Tenancy). Each DO block sets a local timeout and runs
+-- outside the bookkeeping transaction, so the lock is released immediately
+-- after that one constraint is installed.
 
 -- CreateTable
-CREATE TABLE "SessionReplaySegment" (
+-- SPLIT_STATEMENT_SENTINEL
+-- SINGLE_STATEMENT_SENTINEL
+-- RUN_OUTSIDE_TRANSACTION_SENTINEL
+CREATE TABLE IF NOT EXISTS /* SCHEMA_NAME_SENTINEL */."SessionReplaySegment" (
     "id" TEXT NOT NULL,
     "tenancyId" UUID NOT NULL,
     "sessionReplayId" UUID NOT NULL,
@@ -39,7 +39,37 @@ CREATE TABLE "SessionReplaySegment" (
 );
 
 -- AddForeignKey
-ALTER TABLE "SessionReplaySegment" ADD CONSTRAINT "SessionReplaySegment_tenancyId_sessionReplayId_fkey" FOREIGN KEY ("tenancyId", "sessionReplayId") REFERENCES "SessionReplay"("tenancyId", "id") ON DELETE CASCADE ON UPDATE CASCADE;
+-- SPLIT_STATEMENT_SENTINEL
+-- SINGLE_STATEMENT_SENTINEL
+-- RUN_OUTSIDE_TRANSACTION_SENTINEL
+DO $$
+BEGIN
+  PERFORM set_config('lock_timeout', '2s', true);
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'SessionReplaySegment_tenancyId_sessionReplayId_fkey'
+      AND conrelid = '/* SCHEMA_NAME_SENTINEL */."SessionReplaySegment"'::regclass
+  ) THEN
+    EXECUTE 'ALTER TABLE /* SCHEMA_NAME_SENTINEL */."SessionReplaySegment" ADD CONSTRAINT "SessionReplaySegment_tenancyId_sessionReplayId_fkey" FOREIGN KEY ("tenancyId", "sessionReplayId") REFERENCES /* SCHEMA_NAME_SENTINEL */."SessionReplay"("tenancyId", "id") ON DELETE CASCADE ON UPDATE CASCADE';
+  END IF;
+END
+$$;
 
 -- AddForeignKey
-ALTER TABLE "SessionReplaySegment" ADD CONSTRAINT "SessionReplaySegment_tenancyId_fkey" FOREIGN KEY ("tenancyId") REFERENCES "Tenancy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+-- SPLIT_STATEMENT_SENTINEL
+-- SINGLE_STATEMENT_SENTINEL
+-- RUN_OUTSIDE_TRANSACTION_SENTINEL
+DO $$
+BEGIN
+  PERFORM set_config('lock_timeout', '2s', true);
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'SessionReplaySegment_tenancyId_fkey'
+      AND conrelid = '/* SCHEMA_NAME_SENTINEL */."SessionReplaySegment"'::regclass
+  ) THEN
+    EXECUTE 'ALTER TABLE /* SCHEMA_NAME_SENTINEL */."SessionReplaySegment" ADD CONSTRAINT "SessionReplaySegment_tenancyId_fkey" FOREIGN KEY ("tenancyId") REFERENCES /* SCHEMA_NAME_SENTINEL */."Tenancy"("id") ON DELETE CASCADE ON UPDATE CASCADE';
+  END IF;
+END
+$$;

--- a/apps/backend/prisma/migrations/20260726000000_add_releases/migration.sql
+++ b/apps/backend/prisma/migrations/20260726000000_add_releases/migration.sql
@@ -30,6 +30,7 @@ SET LOCAL statement_timeout = '5min';
 -- crashed-previous-attempt case; the happy path takes no lock at all.
 -- SPLIT_STATEMENT_SENTINEL
 -- SINGLE_STATEMENT_SENTINEL
+-- RUN_OUTSIDE_TRANSACTION_SENTINEL
 DO $$
 DECLARE
   invalid_index_oid oid;

--- a/apps/backend/prisma/migrations/20260726000000_add_releases/migration.sql
+++ b/apps/backend/prisma/migrations/20260726000000_add_releases/migration.sql
@@ -35,6 +35,11 @@ DO $$
 DECLARE
   invalid_index_oid oid;
 BEGIN
+  -- This block runs outside the migration transaction so the invalid-index
+  -- cleanup can commit independently. Reapply the transaction-local timeout
+  -- here; otherwise a crashed-attempt retry can wait indefinitely for the
+  -- ACCESS EXCLUSIVE lock this DROP INDEX requires.
+  PERFORM set_config('lock_timeout', '2s', true);
   SELECT i.indexrelid INTO invalid_index_oid
   FROM pg_index i
   JOIN pg_class c ON c.oid = i.indexrelid

--- a/apps/backend/prisma/migrations/20260814000000_enforce_issue_subject_natural_keys/migration.sql
+++ b/apps/backend/prisma/migrations/20260814000000_enforce_issue_subject_natural_keys/migration.sql
@@ -14,7 +14,7 @@
 -- in-transaction index rebuild is O(small). Fail quickly instead of waiting
 -- behind live traffic if one of those environments has a busy table.
 SET LOCAL lock_timeout = '2s';
-SET LOCAL statement_timeout = '5min';
+SET LOCAL statement_timeout = '60s';
 
 -- The DO block below must be its own single statement: the migration runner
 -- wraps non-single-statement chunks in its own dollar-quoted DO envelope, and

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -1276,6 +1276,9 @@ model Event {
   eventStartedAt DateTime
   eventEndedAt   DateTime
 
+  // Prisma does not support nullable scalar lists. This ignored model is
+  // retained only so migration diff does not propose dropping the nullable
+  // legacy TEXT[] column; it has no Prisma Client API or write path.
   systemEventTypeIds String[]
   data               Json
 

--- a/apps/backend/scripts/clickhouse-migrations.ts
+++ b/apps/backend/scripts/clickhouse-migrations.ts
@@ -305,6 +305,7 @@ const LEGACY_TELEMETRY_MIGRATION_STATE_TABLE = "telemetry_legacy_migration_state
 const LEGACY_TELEMETRY_EVENTS_STAGE_TABLE = "telemetry_legacy_events_stage";
 const LEGACY_TELEMETRY_LOGS_STAGE_TABLE = "telemetry_legacy_logs_stage";
 const LEGACY_TELEMETRY_TARGET_STAGE_TABLE = "telemetry_legacy_target_stage";
+const LEGACY_TELEMETRY_RETIRING_SUFFIX = "_legacy_cutover_retiring";
 
 const LEGACY_EVENTS_MIGRATION_COLUMNS = [
   { name: "body", type: "String", default: "''" },
@@ -511,7 +512,7 @@ function assertLegacyTelemetryFingerprintsEqual(
 }
 
 type LegacyTelemetryMigrationState = {
-  phase: "prepared" | "completed",
+  phase: "prepared" | "fenced" | "completed",
   fingerprint: LegacyTelemetryFingerprint,
 };
 
@@ -574,7 +575,7 @@ async function getLegacyTelemetryMigrationState(
   }>();
   const row = rows.at(0);
   if (row === undefined) return null;
-  if (row.phase !== "prepared" && row.phase !== "completed") {
+  if (row.phase !== "prepared" && row.phase !== "fenced" && row.phase !== "completed") {
     throwErr(`Legacy telemetry migration has an invalid phase: ${JSON.stringify(row.phase)}`);
   }
   return {
@@ -614,6 +615,28 @@ async function writeLegacyTelemetryMigrationState(
 
 async function dropLegacyTelemetryTable(client: ClickHouseClient, table: string): Promise<void> {
   await client.command({ query: `DROP TABLE IF EXISTS ${table}` });
+}
+
+function legacyTelemetryRetiringTableName(tableName: string): string {
+  if (!/^[A-Za-z0-9_]+$/.test(tableName)) {
+    throwErr(`Invalid legacy telemetry table name: ${JSON.stringify(tableName)}`);
+  }
+  return `${tableName}${LEGACY_TELEMETRY_RETIRING_SUFFIX}`;
+}
+
+async function fenceLegacyTelemetrySources(
+  client: ClickHouseClient,
+  sources: readonly { table: string, retiringTable: string }[],
+): Promise<void> {
+  if (sources.length === 0) return;
+  // RENAME is the write fence: an old writer that already acquired the old
+  // name finishes into the retiring table and is copied below; a writer that
+  // starts after this metadata operation can only fail against the freed name.
+  // Dropping after a plain drain check has a gap where the latter write can be
+  // accepted and then destroyed before the source is copied.
+  await client.command({
+    query: `RENAME TABLE ${sources.map(({ table, retiringTable }) => `${table} TO ${retiringTable}`).join(", ")}`,
+  });
 }
 
 /**
@@ -682,6 +705,9 @@ export async function migrateLegacyTelemetryTables(
         throwErr("Legacy telemetry migration is marked complete but analytics_internal.telemetry is missing");
       }
       return;
+    }
+    if (migrationState?.phase === "fenced") {
+      throwErr("Legacy telemetry cutover is fenced; finish the cutover before recreating compatibility views");
     }
     if (migrationState?.phase === "prepared") {
       throwErr("Legacy telemetry migration is prepared but its source tables are missing before completion");
@@ -776,21 +802,25 @@ export async function migrateLegacyTelemetryTables(
  *
  * 1. Drain check: rows without the `dual_written` marker can only come from
  *    pre-expand instances, so requiring the newest such row to be at least
- *    `minDrainSeconds` old proves every writer is on the expand release. From
- *    that point the `dual_written = 0` set is frozen.
- * 2. Checkpointed partition backfill: each source partition's frozen
+ *    `minDrainSeconds` old proves every writer is on the expand release.
+ * 2. Rename fence: the legacy names are atomically moved to retiring names.
+ *    An old writer that already acquired the name finishes in the retiring
+ *    table; a writer that starts afterwards fails instead of producing a row
+ *    that a later DROP could destroy.
+ * 3. Checkpointed partition backfill: each fenced source partition's
  *    `dual_written = 0` rows are copied straight into telemetry, stamped with
  *    a reserved `batch_id` marker so the copy stays identifiable among live
  *    rows. Each partition INSERT carries a deterministic
  *    `insert_deduplication_token`, so a crash between the INSERT and its
  *    checkpoint row retries as a no-op instead of duplicating.
- * 3. Per-partition verification: the frozen source slice and the marker slice
+ * 4. Per-partition verification: the frozen source slice and the marker slice
  *    in telemetry must fingerprint identically before the checkpoint is
  *    written. A mismatch (e.g. a dedup token evicted between crash and retry)
  *    aborts with the exact recovery statement instead of guessing.
- * 4. Only after every partition is verified are the sources dropped and the
- *    completed marker stamped. Callers should rerun the normal migration phase
- *    afterwards so the freed names are recreated as compatibility views.
+ * 5. Only after every partition is verified are the retiring sources dropped
+ *    and the completed marker stamped. Callers should rerun the normal
+ *    migration phase afterwards so the freed names are recreated as
+ *    compatibility views.
  *
  * Dual-written rows (`dual_written = 1`) are intentionally NOT copied — their
  * canonical copy already reached telemetry through the primary write path.
@@ -800,8 +830,31 @@ export async function cutoverLegacyTelemetryTables(
   options: LegacyTelemetryMigrationOptions & { minDrainSeconds?: number } = {},
 ): Promise<void> {
   const database = options.database ?? "analytics_internal";
-  const eventsTable = qualifiedClickhouseTable(database, options.eventsTable ?? "events");
-  const logsTable = qualifiedClickhouseTable(database, options.logsTable ?? "logs");
+  const eventsTableName = options.eventsTable ?? "events";
+  const logsTableName = options.logsTable ?? "logs";
+  if (eventsTableName === logsTableName) throwErr("Legacy telemetry events and logs tables must have different names");
+  const sourceDefinitions: Array<{
+    source: LegacyTelemetrySource,
+    tableName: string,
+    table: string,
+    retiringTableName: string,
+    retiringTable: string,
+  }> = [
+    {
+      source: "events",
+      tableName: eventsTableName,
+      table: qualifiedClickhouseTable(database, eventsTableName),
+      retiringTableName: legacyTelemetryRetiringTableName(eventsTableName),
+      retiringTable: qualifiedClickhouseTable(database, legacyTelemetryRetiringTableName(eventsTableName)),
+    },
+    {
+      source: "logs",
+      tableName: logsTableName,
+      table: qualifiedClickhouseTable(database, logsTableName),
+      retiringTableName: legacyTelemetryRetiringTableName(logsTableName),
+      retiringTable: qualifiedClickhouseTable(database, legacyTelemetryRetiringTableName(logsTableName)),
+    },
+  ];
   const telemetryTable = qualifiedClickhouseTable(database, "telemetry");
   const stateTable = qualifiedClickhouseTable(database, LEGACY_TELEMETRY_MIGRATION_STATE_TABLE);
   const minDrainSeconds = options.minDrainSeconds ?? 15 * 60;
@@ -809,17 +862,23 @@ export async function cutoverLegacyTelemetryTables(
     throwErr(`Invalid minDrainSeconds value: ${String(minDrainSeconds)}`);
   }
 
-  const [eventsExists, logsExists, telemetryExists] = await Promise.all([
-    clickhousePhysicalTableExists(client, { database, table: options.eventsTable ?? "events" }),
-    clickhousePhysicalTableExists(client, { database, table: options.logsTable ?? "logs" }),
-    clickhousePhysicalTableExists(client, { database, table: "telemetry" }),
-  ]);
+  const sourcePresence = await Promise.all(sourceDefinitions.map(async definition => ({
+    definition,
+    sourceExists: await clickhousePhysicalTableExists(client, { database, table: definition.tableName }),
+    retiringExists: await clickhousePhysicalTableExists(client, { database, table: definition.retiringTableName }),
+  })));
+  const telemetryExists = await clickhousePhysicalTableExists(client, { database, table: "telemetry" });
   const migrationState = await getLegacyTelemetryMigrationState(client, stateTable);
+  const originalSources = sourcePresence.filter(({ sourceExists }) => sourceExists).map(({ definition }) => definition);
+  const retiredSources = sourcePresence.filter(({ retiringExists }) => retiringExists).map(({ definition }) => definition);
 
-  if (!eventsExists && !logsExists) {
+  if (originalSources.length === 0 && retiredSources.length === 0) {
     if (migrationState?.phase === "completed") {
       console.log("[Clickhouse] Legacy telemetry cutover already completed; nothing to do.");
       return;
+    }
+    if (migrationState?.phase === "fenced") {
+      throwErr("Legacy telemetry cutover is fenced but its retiring source tables are missing; inspect telemetry before retrying");
     }
     if (migrationState?.phase === "prepared") {
       throwErr("Legacy telemetry migration is prepared but its source tables are missing; run the normal migration phase first");
@@ -834,20 +893,37 @@ export async function cutoverLegacyTelemetryTables(
     throwErr("A retired copy/EXCHANGE attempt left a prepared marker; run the normal migration phase to finish it before the cutover");
   }
 
-  await ensureLegacyTelemetryMigrationStateTable(client, stateTable);
-  const sources = [
-    ...eventsExists ? [{ source: "events" as const, table: eventsTable, tableName: options.eventsTable ?? "events" }] : [],
-    ...logsExists ? [{ source: "logs" as const, table: logsTable, tableName: options.logsTable ?? "logs" }] : [],
-  ];
-
-  // Idempotent: the expand phase normally already ran this, but the cutover
-  // must not depend on it (pre-release environments may skip straight here).
-  for (const { source, table } of sources) {
-    await client.command({ query: buildLegacyTelemetrySourceUpgradeSql(source, table) });
+  if (originalSources.length > 0 && retiredSources.length > 0) {
+    throwErr("Legacy telemetry cutover found both active and retiring source tables; refuse to guess which set is authoritative");
+  }
+  if (migrationState?.phase === "completed" && originalSources.length > 0) {
+    throwErr("Legacy telemetry cutover is marked complete, but a physical legacy source exists again");
   }
 
-  for (const { table } of sources) {
-    await assertLegacyTelemetrySourceDrained(client, table, minDrainSeconds);
+  await ensureLegacyTelemetryMigrationStateTable(client, stateTable);
+  let sources: Array<{ source: LegacyTelemetrySource, table: string, tableName: string }>;
+  if (retiredSources.length > 0) {
+    if (migrationState?.phase !== "fenced") {
+      // A process can die between the atomic rename and the fenced marker. The
+      // reserved retiring suffix makes that state recoverable without copying
+      // from a table that an old writer can still mutate.
+      await writeLegacyTelemetryMigrationState(client, stateTable, "fenced", { count: 0n, sum: 0n, xor: 0n });
+    }
+    sources = retiredSources.map(({ source, retiringTable, retiringTableName }) => ({ source, table: retiringTable, tableName: retiringTableName }));
+  } else {
+    // Idempotent: the expand phase normally already ran this, but the cutover
+    // must not depend on it (pre-release environments may skip straight here).
+    for (const { source, table } of originalSources) {
+      await client.command({ query: buildLegacyTelemetrySourceUpgradeSql(source, table) });
+    }
+
+    for (const { table } of originalSources) {
+      await assertLegacyTelemetrySourceDrained(client, table, minDrainSeconds);
+    }
+
+    await fenceLegacyTelemetrySources(client, originalSources.map(({ table, retiringTable }) => ({ table, retiringTable })));
+    await writeLegacyTelemetryMigrationState(client, stateTable, "fenced", { count: 0n, sum: 0n, xor: 0n });
+    sources = originalSources.map(({ source, retiringTable, retiringTableName }) => ({ source, table: retiringTable, tableName: retiringTableName }));
   }
 
   let combinedFingerprint: LegacyTelemetryFingerprint | undefined = undefined;
@@ -856,18 +932,9 @@ export async function cutoverLegacyTelemetryTables(
     combinedFingerprint = combineLegacyTelemetryFingerprints(combinedFingerprint, copied);
   }
 
-  // A pre-expand writer can wake up after the initial drain while the
-  // partition backfill is running. Re-check immediately before retirement so
-  // a fresh row cannot be mistaken for the frozen set and then destroyed with
-  // its source table. A non-zero drain window makes this a loud retry rather
-  // than silently dropping the late write.
-  for (const { table } of sources) {
-    await assertLegacyTelemetrySourceDrained(client, table, minDrainSeconds);
-  }
-
-  // The commit point: sources are dropped only after every partition above has
-  // been verified, and the marker is stamped only after the drops so a crash
-  // in between leaves a state the startup integrity check can explain.
+  // The commit point: fenced sources are dropped only after every partition
+  // above has been verified, and the marker is stamped only after the drops so
+  // a crash in between leaves a state the startup integrity check can explain.
   await Promise.all(sources.map(({ table }) => dropLegacyTelemetryTable(client, table)));
   await writeLegacyTelemetryMigrationState(
     client,

--- a/apps/backend/scripts/clickhouse-migrations.ts
+++ b/apps/backend/scripts/clickhouse-migrations.ts
@@ -805,6 +805,9 @@ export async function cutoverLegacyTelemetryTables(
   const telemetryTable = qualifiedClickhouseTable(database, "telemetry");
   const stateTable = qualifiedClickhouseTable(database, LEGACY_TELEMETRY_MIGRATION_STATE_TABLE);
   const minDrainSeconds = options.minDrainSeconds ?? 15 * 60;
+  if (!Number.isFinite(minDrainSeconds) || minDrainSeconds < 0) {
+    throwErr(`Invalid minDrainSeconds value: ${String(minDrainSeconds)}`);
+  }
 
   const [eventsExists, logsExists, telemetryExists] = await Promise.all([
     clickhousePhysicalTableExists(client, { database, table: options.eventsTable ?? "events" }),
@@ -851,6 +854,15 @@ export async function cutoverLegacyTelemetryTables(
   for (const { source, table, tableName } of sources) {
     const copied = await backfillLegacyTelemetrySource(client, { source, table, tableName, database, telemetryTable, stateTable });
     combinedFingerprint = combineLegacyTelemetryFingerprints(combinedFingerprint, copied);
+  }
+
+  // A pre-expand writer can wake up after the initial drain while the
+  // partition backfill is running. Re-check immediately before retirement so
+  // a fresh row cannot be mistaken for the frozen set and then destroyed with
+  // its source table. A non-zero drain window makes this a loud retry rather
+  // than silently dropping the late write.
+  for (const { table } of sources) {
+    await assertLegacyTelemetrySourceDrained(client, table, minDrainSeconds);
   }
 
   // The commit point: sources are dropped only after every partition above has
@@ -2938,6 +2950,63 @@ FINAL
 WHERE sync_is_deleted = 0;
 `;
 
+const OTEL_VIEW_COLUMN_DESCRIPTIONS = new Map<string, string>([
+  ["event_type", "Event or log classification emitted by the OpenTelemetry producer"],
+  ["event_at", "Time at which the OpenTelemetry record occurred (UTC)"],
+  ["message", "Human-readable message associated with the record, when present"],
+  ["level", "Normalized severity level reported by the producer"],
+  ["data", "Structured application payload as JSON"],
+  ["body", "OpenTelemetry log body serialized as JSON"],
+  ["attributes", "OpenTelemetry record attributes as JSON"],
+  ["resource_attributes", "OpenTelemetry resource attributes as JSON"],
+  ["scope_attributes", "OpenTelemetry instrumentation-scope attributes as JSON"],
+  ["trace_id", "Trace identity shared by all spans and records in the trace"],
+  ["span_id", "Span identity associated with this record, when present"],
+  ["parent_span_id", "Immediate parent span identity, when present"],
+  ["span_type", "OpenTelemetry span name"],
+  ["started_at", "Time at which the span started (UTC)"],
+  ["ended_at", "Time at which the span ended (UTC)"],
+  ["kind", "OpenTelemetry span kind"],
+  ["status_code", "OpenTelemetry operation status"],
+  ["status_message", "Optional OpenTelemetry operation status message"],
+  ["service_namespace", "Logical namespace of the producing service, when reported"],
+  ["service_name", "Name of the producing service"],
+  ["service_version", "Version of the producing service, when reported"],
+  ["deployment_environment_name", "Deployment environment reported by the producer"],
+  ["project_id", "Project identifier, automatically constrained by row-level security"],
+  ["branch_id", "Branch identifier, automatically constrained by row-level security"],
+  ["user_id", "User associated with the record, when known"],
+  ["refresh_token_id", "Session refresh-token identifier, when known"],
+  ["session_replay_id", "Session replay identifier, when known"],
+  ["session_replay_segment_id", "Session replay segment identifier, when known"],
+  ["page_view_span_id", "Page-view span associated with the record, when known"],
+  ["created_at", "Time at which the record was inserted (UTC)"],
+]);
+
+function buildOtelViewColumnCommentStatements(
+  table: string,
+  columns: readonly ClickhouseColumn[],
+  omittedColumns: readonly string[] = [],
+): string[] {
+  const omitted = new Set(omittedColumns);
+  return columns
+    .filter((column) => !omitted.has(column.name))
+    .map((column) => {
+      const description = OTEL_VIEW_COLUMN_DESCRIPTIONS.get(column.name)
+        ?? `OpenTelemetry ${column.name.replace(/_/g, " ")} value exposed by the ${table} view`;
+      return `ALTER TABLE default.${table} COMMENT COLUMN ${column.name} '${description}'`;
+    });
+}
+
+const OTEL_VIEW_COLUMN_COMMENT_STATEMENTS = [
+  ...buildOtelViewColumnCommentStatements("logs", LOGS_COLUMNS, [...ERROR_GROUPING_COLUMN_NAMES, ...ERROR_ENVELOPE_COLUMN_NAMES]),
+  ...buildOtelViewColumnCommentStatements("errors", LOGS_COLUMNS),
+  ...buildOtelViewColumnCommentStatements("span_events", SPAN_EVENTS_COLUMNS),
+  ...buildOtelViewColumnCommentStatements("span_links", SPAN_LINKS_COLUMNS),
+  ...buildOtelViewColumnCommentStatements("trace_roots", TRACE_ROOTS_COLUMNS, ["version"]),
+  ...buildOtelViewColumnCommentStatements("trace_services", TRACE_SERVICES_COLUMNS, ["created_at", "version"]),
+];
+
 // ─── Column comments ────────────────────────────────────────────────
 // Applied to the default.* views after creation so that DESCRIBE TABLE
 // returns useful descriptions for each column. The AI assistant uses
@@ -3134,6 +3203,8 @@ const COLUMN_COMMENT_STATEMENTS: string[] = [
   `ALTER TABLE default.connected_accounts COMMENT COLUMN provider 'OAuth/SSO provider name, e.g. google, github'`,
   `ALTER TABLE default.connected_accounts COMMENT COLUMN provider_account_id 'User account ID at the external provider'`,
   `ALTER TABLE default.connected_accounts COMMENT COLUMN created_at 'When this account was linked (UTC)'`,
+
+  ...OTEL_VIEW_COLUMN_COMMENT_STATEMENTS,
 ];
 
 const COLUMN_COMMENT_TABLES = [
@@ -3150,6 +3221,12 @@ const COLUMN_COMMENT_TABLES = [
   "notification_preferences",
   "refresh_tokens",
   "connected_accounts",
+  "logs",
+  "errors",
+  "span_events",
+  "span_links",
+  "trace_roots",
+  "trace_services",
 ];
 
 function buildColumnCommentSql(): string[] {

--- a/apps/backend/scripts/db-migrations.ts
+++ b/apps/backend/scripts/db-migrations.ts
@@ -272,10 +272,15 @@ const main = async () => {
       // (0 skips the check; only for fresh/pre-release environments).
       const drainArg = args.find((arg) => arg.startsWith('--min-drain-seconds='))?.split('=')[1];
       const minDrainSeconds = drainArg === undefined ? undefined : Number(drainArg);
-      if (minDrainSeconds !== undefined && !Number.isFinite(minDrainSeconds)) {
+      if (minDrainSeconds !== undefined && (!Number.isFinite(minDrainSeconds) || minDrainSeconds < 0)) {
         throw new Error(`Invalid --min-drain-seconds value: ${JSON.stringify(drainArg)}`);
       }
-      await cutoverLegacyTelemetryTables(getClickhouseAdminClient(), { minDrainSeconds });
+      const clickhouseClient = getClickhouseAdminClient();
+      try {
+        await cutoverLegacyTelemetryTables(clickhouseClient, { minDrainSeconds });
+      } finally {
+        await clickhouseClient.close();
+      }
       // Rerun the migration phase so the freed legacy names are immediately
       // recreated as compatibility views — without this, default.events would
       // point at a dropped table until the next deploy's db:migrate.

--- a/apps/backend/src/app/api/latest/analytics/events/batch/route.test.tsx
+++ b/apps/backend/src/app/api/latest/analytics/events/batch/route.test.tsx
@@ -69,8 +69,8 @@ describe("analytics batch wire-version data contract", () => {
   });
 
   it("applies the serialized-size cap to versioned batches only", async () => {
-    // One byte over the cap once serialized (the JSON envelope around the
-    // object adds its own bytes on top of the repeated payload).
+    // The serialized object is 11 bytes over the cap because the JSON
+    // envelope adds `{"blob":"` and the closing `"}` around the payload.
     const oversized = { blob: "x".repeat(CUSTOM_TELEMETRY_MAX_ITEM_DATA_BYTES) };
     const withOversizedData = (base: typeof LEGACY_BODY) => ({
       ...base,

--- a/apps/backend/src/app/api/latest/analytics/events/batch/route.tsx
+++ b/apps/backend/src/app/api/latest/analytics/events/batch/route.tsx
@@ -508,7 +508,9 @@ export const POST = createSmartRouteHandler({
     const isErrorIngestPolicyEvent = (event: { event_type: string }) =>
       event.event_type === ERROR_EVENT_TYPE || event.event_type === LOG_EVENT_TYPE;
     const policyItems = events.flatMap((event, index) =>
-      isErrorIngestPolicyEvent(event) ? [{ itemId: `event:${index}`, itemType: "event" as const, data: event.data }] : []);
+      isErrorIngestPolicyEvent(event)
+        ? [{ itemId: `event:${index}`, itemType: event.event_type === LOG_EVENT_TYPE ? "log" as const : "event" as const, data: event.data }]
+        : []);
     const policyDecision = evaluateErrorIngestPolicy({
       config: auth.tenancy.config,
       scope: { tenancyId, projectId, branchId },
@@ -756,7 +758,7 @@ export const POST = createSmartRouteHandler({
     // ledger and sprout a bogus `ingest` block in the response.
     const protocolProjection = createLegacyBatchProtocolProjection(
       body.batch_id,
-      events.length,
+      body.events?.length ?? 0,
       spans.length,
       policyItems.length > 0 ? policyDecision.outcomes : undefined,
     );
@@ -773,12 +775,11 @@ export const POST = createSmartRouteHandler({
       statusCode: 200,
       bodyType: "json",
       body: {
-        // `inserted` keeps its released semantics: the number of events the
-        // request carried. Old SDKs may compare it against what they sent, and
-        // for legacy batches (only $page-view/$click, which the error-ingest
-        // policy never drops) it always equals the stored count anyway.
+        // Report the number of event rows that survived policy filtering. The
+        // previous request-count value over-reported storage when a versioned
+        // batch dropped or rate-limited an error/log item.
         // Item-level outcomes for versioned callers live in `ingest` below.
-        inserted: body.events?.length ?? 0,
+        inserted: events.length,
         accepted_spans: spans.length,
         ...(protocolProjection.status === "accepted" ? {} : {
           ingest: {

--- a/apps/backend/src/app/api/latest/internal/issues/[issue_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/issues/[issue_id]/route.tsx
@@ -2,8 +2,8 @@ import { createProductionErrorAttachmentService } from "@/lib/attachments";
 import { getErrorAttachmentEventId } from "@/lib/attachments/attachment-event-id";
 import { validateErrorAttachmentScope } from "@/lib/attachments/attachment-contract";
 import { loadIssueDetailContext, projectIssueListItem } from "@/lib/issues/issue-detail";
-import { resolveIssueIdentity } from "@/lib/issues/issue-identity";
-import { IssueNotFoundError, transitionIssueStatus } from "@/lib/issues/issue-lifecycle";
+import { transitionIssueStatus } from "@/lib/issues/issue-lifecycle";
+import { withIssueActionTarget } from "@/app/api/latest/issues/[issue_id]/actions/_shared";
 import { decodeOccurrenceCursor, issueRangeStart, loadIssueWindowStats, loadOccurrence } from "@/lib/issues/issue-queries";
 import { loadIssueProductSnapshot } from "@/lib/issues/issue-product";
 import { serializeIssueProductSnapshot } from "@/lib/issues/issue-product-projection";
@@ -185,11 +185,6 @@ export const PATCH = createSmartRouteHandler({
     const tenancy = auth.tenancy;
     assertObservabilityEnabled(tenancy);
 
-    // Only the canonical id is needed for the mutation; the full aggregate row
-    // would be a wasted read here.
-    const identity = await resolveIssueIdentity(tenancy, params.issue_id);
-    if (identity === null) throw new StatusError(StatusError.NotFound, "Issue not found");
-
     const now = new Date();
 
     // Delegates to the ONE lifecycle implementation (the same one behind the
@@ -202,22 +197,19 @@ export const PATCH = createSmartRouteHandler({
     // later occurrence against it to decide whether a recurrence counts as a
     // regression — and `regressedAt` is cleared on resolve because the badge
     // describes the CURRENT unresolved state.
-    try {
-      await transitionIssueStatus({
+    const { target } = await withIssueActionTarget({
+      tenancy,
+      rawIssueId: params.issue_id,
+      action: (resolved) => transitionIssueStatus({
         tenancy,
-        issueId: identity.issueId,
+        issueId: resolved.issueId,
         mutation: {
           status: body.status,
           ignoredUntil: body.status === "ignored" && body.ignored_until_millis != null ? new Date(body.ignored_until_millis) : null,
         },
         changedAt: now,
-      });
-    } catch (error) {
-      // The row can vanish between identity resolution and the locked read if
-      // a concurrent merge deletes it — a not-found, not a server error.
-      if (error instanceof IssueNotFoundError) throw new StatusError(StatusError.NotFound, "Issue not found");
-      throw error;
-    }
+      }),
+    });
 
     // The `issue.resolved` / `issue.ignored` webhook is emitted by
     // `transitionIssueStatus` itself (fire-and-forget, only on a genuine
@@ -227,7 +219,7 @@ export const PATCH = createSmartRouteHandler({
     return {
       statusCode: 200,
       bodyType: "json",
-      body: { id: identity.issueId, status: body.status },
+      body: { id: target.issueId, status: body.status },
     } as const;
   },
 });

--- a/apps/backend/src/app/api/latest/internal/issues/merge/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/issues/merge/route.tsx
@@ -5,6 +5,8 @@ import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { KnownErrors } from "@hexclave/shared";
 import { IssueMergeRequestSchema, IssueMergeResponseSchema } from "@hexclave/shared/dist/interface/admin-issues";
 import { adaptSchema, adminAuthTypeSchema, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
+import { resolveIssueIdentity } from "@/lib/issues/issue-identity";
+import { createHash } from "node:crypto";
 
 /**
  * Merge two or more issues into one.
@@ -45,18 +47,31 @@ export const POST = createSmartRouteHandler({
       tenancy: auth.tenancy,
       issueIds: body.issue_ids,
     });
+    const mergeEventId = createHash("sha256")
+      .update(JSON.stringify([primaryIssueId, [...new Set(body.issue_ids)].sort()]))
+      .digest("hex");
+    // A merge retry resolves to one target and therefore returns no newly
+    // merged ids. If the requested set contains a redirect, that no-op is the
+    // durable proof that a previous request completed the merge. Re-enqueue
+    // the same lifecycle event with the same id so a send that failed after
+    // the provider accepted it is retried without creating a duplicate.
+    const retryingCompletedMerge = mergedIssueIds.length === 0 && (await Promise.all(
+      body.issue_ids.map(async (issueId) => {
+        const identity = await resolveIssueIdentity(auth.tenancy, issueId);
+        return identity !== null && identity.redirectedFromIssueId !== null;
+      }),
+    )).some(Boolean);
     // Announced against the SURVIVING issue: the merged-away ids no longer
     // resolve to a row, so a consumer receiving one of those could not look it
-    // up. A no-op merge (a retried request, or a concurrent merge that already
-    // completed) returns an empty `mergedIssueIds` and changed nothing, so it
-    // must not announce anything — `issue.merged` is unthrottled and keyed on
-    // the request instant, so re-emitting here would NOT dedup at Svix.
-    if (mergedIssueIds.length > 0) {
+    // up. A true no-op has no redirect and stays silent; a retry of a completed
+    // merge is the one no-op that re-enqueues the deterministic event above.
+    if (mergedIssueIds.length > 0 || retryingCompletedMerge) {
       runAsynchronouslyAndWaitUntil(emitIssueLifecycleWebhook({
         tenancy: auth.tenancy,
         issueId: primaryIssueId,
         event: "merged",
         now: new Date(),
+        eventId: mergeEventId,
       }));
     }
 

--- a/apps/backend/src/app/api/latest/internal/issues/merge/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/issues/merge/route.tsx
@@ -5,6 +5,7 @@ import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { KnownErrors } from "@hexclave/shared";
 import { IssueMergeRequestSchema, IssueMergeResponseSchema } from "@hexclave/shared/dist/interface/admin-issues";
 import { adaptSchema, adminAuthTypeSchema, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
+import { mapWithConcurrency } from "@hexclave/shared/dist/utils/promises";
 import { resolveIssueIdentity } from "@/lib/issues/issue-identity";
 import { createHash } from "node:crypto";
 
@@ -47,20 +48,29 @@ export const POST = createSmartRouteHandler({
       tenancy: auth.tenancy,
       issueIds: body.issue_ids,
     });
-    const mergeEventId = createHash("sha256")
-      .update(JSON.stringify([primaryIssueId, [...new Set(body.issue_ids)].sort()]))
-      .digest("hex");
     // A merge retry resolves to one target and therefore returns no newly
     // merged ids. If the requested set contains a redirect, that no-op is the
     // durable proof that a previous request completed the merge. Re-enqueue
     // the same lifecycle event with the same id so a send that failed after
     // the provider accepted it is retried without creating a duplicate.
-    const retryingCompletedMerge = mergedIssueIds.length === 0 && (await Promise.all(
-      body.issue_ids.map(async (issueId) => {
-        const identity = await resolveIssueIdentity(auth.tenancy, issueId);
-        return identity !== null && identity.redirectedFromIssueId !== null;
-      }),
-    )).some(Boolean);
+    const retryIdentities = mergedIssueIds.length === 0
+      ? await mapWithConcurrency(body.issue_ids, 8, (issueId) => resolveIssueIdentity(auth.tenancy, issueId, { consistency: "primary" }))
+      : [];
+    const retryingCompletedMerge = retryIdentities.length > 0
+      && retryIdentities.every((identity) => identity !== null && identity.issueId === primaryIssueId)
+      && retryIdentities.some((identity) => identity !== null && identity.redirectedFromIssueId !== null);
+    // Canonicalize a completed retry to the surviving issue plus the original
+    // merged-away ids. This makes a retry containing only a subset of the
+    // redirects reuse the same event id as the original merge.
+    const mergeEventIssueIds = retryingCompletedMerge
+      ? [primaryIssueId, ...retryIdentities.map((identity) => {
+        if (identity === null) throw new Error("Completed merge retry proof contained a missing issue identity");
+        return identity.redirectedFromIssueId ?? identity.issueId;
+      })]
+      : [primaryIssueId, ...body.issue_ids];
+    const mergeEventId = createHash("sha256")
+      .update(JSON.stringify([...new Set(mergeEventIssueIds)].sort()))
+      .digest("hex");
     // Announced against the SURVIVING issue: the merged-away ids no longer
     // resolve to a row, so a consumer receiving one of those could not look it
     // up. A true no-op has no redirect and stays silent; a retry of a completed

--- a/apps/backend/src/app/api/latest/issues/[issue_id]/actions/_shared.ts
+++ b/apps/backend/src/app/api/latest/issues/[issue_id]/actions/_shared.ts
@@ -11,12 +11,9 @@ import { IssueProductInputError } from "@/lib/issues/issue-product";
 import type { SmartRequest } from "@/route-handlers/smart-request";
 import { adaptSchema, serverOrHigherAuthTypeSchema, yupBoolean, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
 import { StatusError } from "@hexclave/shared/dist/utils/errors";
+import { MAX_ISSUE_TIMESTAMP_MILLIS } from "@hexclave/shared/dist/interface/admin-issues";
 
-// 2100-01-01T00:00:00Z. Must stay equal to `MAX_ISSUE_TIMESTAMP_MILLIS` in
-// `@hexclave/shared`'s `interface/admin-issues` — the internal PATCH schema
-// bounds `ignored_until_millis` with that constant, and the public action
-// routes here must accept exactly the same timestamp range.
-export const MAX_ACTION_TIMESTAMP_MILLIS = 4_102_444_800_000;
+export const MAX_ACTION_TIMESTAMP_MILLIS = MAX_ISSUE_TIMESTAMP_MILLIS;
 const MAX_ACTION_ISSUE_ID_LENGTH = 64;
 
 export const IssueActionAuthSchema = yupObject({

--- a/apps/backend/src/lib/artifacts/artifact-archive-safety.test.ts
+++ b/apps/backend/src/lib/artifacts/artifact-archive-safety.test.ts
@@ -78,5 +78,10 @@ describe("artifact archive safety", () => {
     recomputeTarHeaderChecksum(tar);
     expectInvalidArchive(() => validateGzipTarArtifactArchive(gzipSync(tar)));
     expect(() => validateGzipTarArtifactArchive(gzipSync(tar))).toThrowError(/only regular files and directories/u);
+
+    const malformedOctal = createTar([{ path: "static/chunk.js", data: new TextEncoder().encode("bundle") }]);
+    malformedOctal[124] = "x".charCodeAt(0);
+    recomputeTarHeaderChecksum(malformedOctal);
+    expect(() => validateGzipTarArtifactArchive(gzipSync(malformedOctal))).toThrowError(/malformed octal header field/u);
   });
 });

--- a/apps/backend/src/lib/artifacts/artifact-archive-safety.ts
+++ b/apps/backend/src/lib/artifacts/artifact-archive-safety.ts
@@ -91,6 +91,7 @@ export function validateGzipTarArtifactArchive(
       const safeMessages = new Set([
         "Invalid tarball: not a ustar archive",
         "Invalid tarball: header checksum mismatch",
+        "Invalid tarball: malformed octal header field",
         "Invalid tarball: missing end-of-archive marker",
         "Invalid tarball: only regular files and directories are supported",
         "Invalid tarball: directory entry with non-zero size",

--- a/apps/backend/src/lib/artifacts/artifact-archive-safety.ts
+++ b/apps/backend/src/lib/artifacts/artifact-archive-safety.ts
@@ -84,12 +84,21 @@ export function validateGzipTarArtifactArchive(
       maxTotalBytes: maxBytes,
     });
   } catch (error) {
-    // parseTar throws StatusError(400, ...) with messages documented as safe
-    // to show the uploader (limit exceeded, unsafe path, checksum mismatch,
-    // truncation, ...). Forward them so a legitimate uploader can actually fix
-    // the archive; anything else stays behind the generic classification.
+    // Only forward static parseTar diagnostics. Its unsafe-path diagnostic
+    // includes the archive's raw entry name, which is attacker-controlled and
+    // must not be reflected through the API error response.
     if (error instanceof StatusError && error.statusCode === 400) {
-      throw invalidArchive(`Artifact archive is not a safe ustar archive: ${error.message}`);
+      const safeMessages = new Set([
+        "Invalid tarball: not a ustar archive",
+        "Invalid tarball: header checksum mismatch",
+        "Invalid tarball: missing end-of-archive marker",
+        "Invalid tarball: only regular files and directories are supported",
+        "Invalid tarball: directory entry with non-zero size",
+      ]);
+      if (safeMessages.has(error.message)) throw invalidArchive(`Artifact archive is not a safe ustar archive: ${error.message}`);
+      if (/^(?:Tarball contains too many files|Tarball contents too large|Invalid tarball: truncated)/u.test(error.message)) {
+        throw invalidArchive(`Artifact archive is not a safe ustar archive: ${error.message}`);
+      }
     }
     throw invalidArchive("Artifact archive is not a safe ustar archive.");
   }

--- a/apps/backend/src/lib/artifacts/artifact-storage.ts
+++ b/apps/backend/src/lib/artifacts/artifact-storage.ts
@@ -14,6 +14,8 @@ export type ArtifactStorageObject = {
 
 export type ArtifactStorageObjectInfo = {
   byteLength: number,
+  /** The object version observed by the size check, when the provider exposes one. */
+  eTag?: string,
 };
 
 export type ArtifactObjectStorage = {
@@ -24,7 +26,7 @@ export type ArtifactObjectStorage = {
     contentEncoding?: "gzip",
   }): Promise<string>;
   headObject(key: string): Promise<ArtifactStorageObjectInfo | null>;
-  readObject(key: string): Promise<Uint8Array | null>;
+  readObject(key: string, expectedETag?: string): Promise<Uint8Array | null>;
 };
 
 /** The production adapter: private S3/R2 is the durable artifact registry. */
@@ -59,30 +61,30 @@ export function createS3ArtifactObjectStorage(): ArtifactObjectStorage {
     async headObject(key) {
       try {
         const result = await headBytes({ key, private: true });
-        return result === null ? null : { byteLength: result.byteLength };
+        return result === null ? null : { byteLength: result.byteLength, eTag: result.eTag };
       } catch (error) {
         throw translateStorageConfigurationError(error);
       }
     },
-    async readObject(key) {
+    async readObject(key, expectedETag) {
       try {
-        // The HEAD here is not redundant with the callers' own headObject size
-        // checks: it captures the ETag of the exact version those checks (and
-        // this read) must observe. Presigned upload URLs stay valid for a while
-        // after registration, so without If-Match a concurrent overwrite could
-        // hand the GET a different (possibly far larger) body than the size
-        // check approved.
-        const info = await headBytes({ key, private: true });
-        if (info === null) return null;
+        // If the caller already performed a size check, carry its ETag through
+        // to the conditional GET. Re-HEADing here would leave a TOCTOU window:
+        // a replacement could be observed by this second HEAD and then be
+        // downloaded before the caller's original byte limit is applied.
+        const eTag = expectedETag ?? (await headBytes({ key, private: true }))?.eTag;
+        if (eTag === undefined) return null;
         try {
-          return await downloadBytes({ key, private: true, ifMatch: info.eTag });
+          return await downloadBytes({ key, private: true, ifMatch: eTag });
         } catch (error) {
-          // 412 = the object was replaced between the HEAD and the GET; 404 =
-          // it was deleted in that window. Both mean "the version we vetted is
-          // gone" — return null so callers fail their read loudly instead of
-          // consuming bytes that bypassed the pre-read checks.
-          if (error instanceof S3ServiceException && [404, 412].includes(error.$metadata.httpStatusCode ?? 0)) {
+          // A deleted object is a not-found result. A failed If-Match means the
+          // object still exists but changed after validation, so preserve that
+          // distinction for callers that report integrity/concurrency errors.
+          if (error instanceof S3ServiceException && error.$metadata.httpStatusCode === 404) {
             return null;
+          }
+          if (error instanceof S3ServiceException && error.$metadata.httpStatusCode === 412) {
+            throw new ArtifactServiceError("integrity_mismatch", "The artifact object changed while it was being read.");
           }
           throw error;
         }

--- a/apps/backend/src/lib/artifacts/artifact-upload-service.ts
+++ b/apps/backend/src/lib/artifacts/artifact-upload-service.ts
@@ -318,9 +318,12 @@ export class ArtifactUploadService {
     if (info.byteLength !== expectedBytes) {
       throw new ArtifactServiceError("integrity_mismatch", `Uploaded ${kind} byte length does not match its manifest.`);
     }
-    const bytes = await this.storage.readObject(key);
-    if (bytes === null || bytes.byteLength !== expectedBytes) {
+    const bytes = await this.storage.readObject(key, info.eTag);
+    if (bytes === null) {
       throw new ArtifactServiceError("artifact_not_found", `Uploaded ${kind} is missing.`);
+    }
+    if (bytes.byteLength !== expectedBytes) {
+      throw new ArtifactServiceError("integrity_mismatch", `Uploaded ${kind} byte length changed while it was being read.`);
     }
     return bytes;
   }
@@ -556,7 +559,10 @@ function verifySourceMap(sourceMapText: string, artifact: ArtifactManifestArtifa
  * finalization what the symbolicator would later reject.
  */
 function readInlineSourceMap(bundleBytes: Uint8Array): Uint8Array | null {
-  const source = new TextDecoder().decode(bundleBytes);
+  const source = decodeStrictUtf8(bundleBytes);
+  if (source === null) {
+    throw new ArtifactServiceError("integrity_mismatch", "The uploaded bundle is not valid UTF-8.");
+  }
   const matcher = /^[ \t]*\/\/[#@][ \t]*sourceMappingURL=([^\s]*)[ \t]*$/gmu;
   let lastUrl: string | null = null;
   let match = matcher.exec(source);

--- a/apps/backend/src/lib/customer-request-observability.test.ts
+++ b/apps/backend/src/lib/customer-request-observability.test.ts
@@ -148,6 +148,34 @@ describe("customer request observability", () => {
     expect(rows[0]).toMatchObject({ user_id: "user-a", refresh_token_id: null });
   });
 
+  it("does not fill a missing pair member from an enrichment without its counterpart", async () => {
+    const rows: SpanInsertRow[] = [];
+
+    await runWithCustomerRequestObservability(
+      request(),
+      async () => {
+        resolveCustomerRequestObservability({
+          projectId: "project",
+          branchId: "main",
+          userId: "user-a",
+          refreshTokenId: null,
+        });
+        resolveCustomerRequestObservability({
+          projectId: "project",
+          branchId: "main",
+          userId: null,
+          refreshTokenId: "refresh-b",
+        });
+        return new Response(null, { status: 200 });
+      },
+      async (row) => {
+        rows.push(row);
+      },
+    );
+
+    expect(rows[0]).toMatchObject({ user_id: "user-a", refresh_token_id: null });
+  });
+
   it("starts a fresh rooted trace for an unsampled caller", async () => {
     const traceId = "55555555555555555555555555555555";
     const rows: SpanInsertRow[] = [];

--- a/apps/backend/src/lib/customer-request-observability.test.ts
+++ b/apps/backend/src/lib/customer-request-observability.test.ts
@@ -117,6 +117,37 @@ describe("customer request observability", () => {
     expect(rows[0]?.trace_id).toBe(traceId);
   });
 
+  it("does not combine a first user's identity with a conflicting refresh token", async () => {
+    const rows: SpanInsertRow[] = [];
+
+    await runWithCustomerRequestObservability(
+      request(),
+      async () => {
+        resolveCustomerRequestObservability({
+          projectId: "project",
+          branchId: "main",
+          userId: "user-a",
+          refreshTokenId: null,
+        });
+        // A later auth enrichment can describe a different principal. The
+        // request span must keep the first verified pair, not cross-wire user A
+        // with user B's refresh token.
+        resolveCustomerRequestObservability({
+          projectId: "project",
+          branchId: "main",
+          userId: "user-b",
+          refreshTokenId: "refresh-b",
+        });
+        return new Response(null, { status: 200 });
+      },
+      async (row) => {
+        rows.push(row);
+      },
+    );
+
+    expect(rows[0]).toMatchObject({ user_id: "user-a", refresh_token_id: null });
+  });
+
   it("starts a fresh rooted trace for an unsampled caller", async () => {
     const traceId = "55555555555555555555555555555555";
     const rows: SpanInsertRow[] = [];

--- a/apps/backend/src/lib/customer-request-observability.ts
+++ b/apps/backend/src/lib/customer-request-observability.ts
@@ -47,21 +47,31 @@ type CustomerRequestSpanWriter = (row: SpanInsertRow) => Promise<void>;
 const customerRequestStorage = new AsyncLocalStorage<CustomerRequestObservabilityHolder>();
 
 function mergeTrustedIdentity(
-  current: string | null,
-  incoming: string | null,
-): string | null {
-  if (current !== null && incoming !== null && current !== incoming) {
+  current: CustomerRequestTenancy | null,
+  incoming: Pick<CustomerRequestTenancy, "userId" | "refreshTokenId">,
+): Pick<CustomerRequestTenancy, "userId" | "refreshTokenId"> {
+  if (current === null) return incoming;
+
+  const userConflict = current.userId !== null
+    && incoming.userId !== null
+    && current.userId !== incoming.userId;
+  const refreshTokenConflict = current.refreshTokenId !== null
+    && incoming.refreshTokenId !== null
+    && current.refreshTokenId !== incoming.refreshTokenId;
+  if (userConflict || refreshTokenConflict) {
     // NOT an invariant violation: auth endpoints can mint tokens for a
     // DIFFERENT principal than the (incidental) session that authenticated
-    // the request — e.g. signing in user B while user A's access token is
-    // still attached, which is exactly what SDK sign-in flows do. The request
-    // span belongs to the authenticated caller, so the identity resolved
-    // first wins and the conflicting enrichment is dropped. This used to
-    // throw, which killed the whole logEvent pipeline mid-loop and silently
-    // lost the second principal's $token-refresh telemetry row.
-    return current;
+    // the request. Keep the first verified pair together; merging fields
+    // independently could combine user A with user B's refresh token.
+    return {
+      userId: current.userId,
+      refreshTokenId: current.refreshTokenId,
+    };
   }
-  return incoming ?? current;
+  return {
+    userId: current.userId ?? incoming.userId,
+    refreshTokenId: current.refreshTokenId ?? incoming.refreshTokenId,
+  };
 }
 
 /**
@@ -91,12 +101,16 @@ export function resolveCustomerRequestObservability(options: {
   const labels = options.headers === undefined
     ? null
     : decodeCorrelationBaggage(readBaggageHeader(options.headers));
+  const identity = mergeTrustedIdentity(current, {
+    userId: options.userId,
+    refreshTokenId: options.refreshTokenId,
+  });
 
   holder.tenancy = {
     projectId: options.projectId,
     branchId: options.branchId,
-    userId: mergeTrustedIdentity(current?.userId ?? null, options.userId),
-    refreshTokenId: mergeTrustedIdentity(current?.refreshTokenId ?? null, options.refreshTokenId),
+    userId: identity.userId,
+    refreshTokenId: identity.refreshTokenId,
     sessionReplayId: current?.sessionReplayId ?? labels?.sessionReplayId ?? null,
     sessionReplaySegmentId: current?.sessionReplaySegmentId ?? labels?.sessionReplaySegmentId ?? null,
     pageViewSpanId: current?.pageViewSpanId ?? labels?.pageViewSpanId ?? null,

--- a/apps/backend/src/lib/customer-request-observability.ts
+++ b/apps/backend/src/lib/customer-request-observability.ts
@@ -69,8 +69,16 @@ function mergeTrustedIdentity(
     };
   }
   return {
-    userId: current.userId ?? incoming.userId,
-    refreshTokenId: current.refreshTokenId ?? incoming.refreshTokenId,
+    userId: current.userId ?? (
+      current.refreshTokenId === null || incoming.refreshTokenId === current.refreshTokenId
+        ? incoming.userId
+        : null
+    ),
+    refreshTokenId: current.refreshTokenId ?? (
+      current.userId === null || incoming.userId === current.userId
+        ? incoming.refreshTokenId
+        : null
+    ),
   };
 }
 

--- a/apps/backend/src/lib/error-ingest/error-ingest-client-reports.test.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-client-reports.test.ts
@@ -150,6 +150,10 @@ describe("error ingest client report persistence contract", () => {
     }
     expect(thrown).toBeInstanceOf(ErrorIngestClientReportParseError);
     expect(String(thrown)).toContain("secret-bearing");
+    expect(() => parseErrorIngestClientReportRequest({
+      idempotency_key: "Bearer secret-token",
+      discarded_events: [],
+    })).toThrow(/secret-bearing/iu);
     expect(() => parseErrorIngestClientReportRequest("not-an-object")).toThrow(ErrorIngestClientReportParseError);
   });
 

--- a/apps/backend/src/lib/error-ingest/error-ingest-client-reports.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-client-reports.ts
@@ -215,6 +215,7 @@ function parseReportEntries(value: unknown, field: string): ErrorIngestClientRep
 export function parseErrorIngestClientReportRequest(value: unknown): ErrorIngestClientReportRequest {
   if (!isRecord(value)) throw new ErrorIngestClientReportParseError("Error ingest client report must be an object");
   if (!isBoundedText(value.idempotency_key, ERROR_INGEST_CLIENT_REPORT_IDEMPOTENCY_KEY_MAX_BYTES)) throw new ErrorIngestClientReportParseError("Error ingest client report idempotency_key is required and must be bounded");
+  if (SECRET_TEXT_RE.test(value.idempotency_key)) throw new ErrorIngestClientReportParseError("Error ingest client report idempotency_key must not contain secret-bearing text");
   const timestampMs = parseReportTimestamp(value.timestamp);
   const clientReport = {
     discarded_events: parseReportEntries(value.discarded_events, "discarded_events"),

--- a/apps/backend/src/lib/error-ingest/error-ingest-envelope.test.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-envelope.test.ts
@@ -290,6 +290,32 @@ describe("Sentry-style error ingest envelope contract", () => {
     expect(parsed.items[0]?.transaction).toBeUndefined();
   });
 
+  it("rejects all-zero W3C transaction and child identities", () => {
+    const eventId = "99999999999999999999999999999999";
+    const parse = (traceId: string, spanId: string, spans: unknown[] = []) => parseErrorIngestEnvelope(envelope(
+      { event_id: eventId },
+      [{
+        header: { type: "transaction" },
+        payload: json({
+          event_id: eventId,
+          transaction: "/checkout",
+          start_timestamp: 1_754_444_800,
+          timestamp: 1_754_444_801,
+          contexts: { trace: { trace_id: traceId, span_id: spanId } },
+          spans,
+        }),
+      }],
+    ));
+
+    expect(parse("0".repeat(32), "7777777777777777").items[0]?.outcome).toEqual(expect.objectContaining({ status: "rejected", reason: "invalid" }));
+    expect(parse("66666666666666666666666666666666", "7777777777777777", [{
+      trace_id: "66666666666666666666666666666666",
+      span_id: "0".repeat(16),
+      start_timestamp: 1_754_444_800,
+      timestamp: 1_754_444_801,
+    }]).items[0]?.outcome).toEqual(expect.objectContaining({ status: "rejected", reason: "invalid" }));
+  });
+
   it("scrubs JSON and source-map-like attachments before the private callback", () => {
     const eventId = "11111111111111111111111111111111";
     const sourceMap = json({

--- a/apps/backend/src/lib/error-ingest/error-ingest-envelope.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-envelope.ts
@@ -9,6 +9,7 @@ import {
   scrubErrorIngestPayload,
   type ErrorIngestScrubbedValue,
 } from "./error-ingest-scrubber";
+import { isW3cSpanId, isW3cTraceId } from "@hexclave/shared/dist/utils/analytics-wire";
 
 const TEXT_ENCODER = new TextEncoder();
 const EVENT_ID_RE = /^[0-9a-f]{32}$/u;
@@ -411,18 +412,18 @@ function parseTransactionSpan(
   if (!isRecord(value) || !isScrubbedRecord(scrubbedValue)) {
     throw new ErrorIngestEnvelopeError("malformed", `Transaction span ${index} must be an object`);
   }
-  const traceId = transactionId(value.trace_id, `Transaction span ${index} trace_id`, /^[0-9a-f]{32}$/u);
+  const traceId = transactionId(value.trace_id, `Transaction span ${index} trace_id`, /^[0-9a-f]{32}$/u, isW3cTraceId);
   if (traceId !== transaction.traceId) {
     throw new ErrorIngestEnvelopeError("malformed", `Transaction span ${index} trace_id does not match the transaction`);
   }
-  const spanId = transactionId(value.span_id, `Transaction span ${index} span_id`, /^[0-9a-f]{16}$/u);
+  const spanId = transactionId(value.span_id, `Transaction span ${index} span_id`, /^[0-9a-f]{16}$/u, isW3cSpanId);
   if (spanId === transaction.spanId) {
     throw new ErrorIngestEnvelopeError("malformed", `Transaction span ${index} reuses the transaction span_id`);
   }
 
   let parentSpanId: string | null = null;
   if (value.parent_span_id !== undefined && value.parent_span_id !== null) {
-    parentSpanId = transactionId(value.parent_span_id, `Transaction span ${index} parent_span_id`, /^[0-9a-f]{16}$/u);
+    parentSpanId = transactionId(value.parent_span_id, `Transaction span ${index} parent_span_id`, /^[0-9a-f]{16}$/u, isW3cSpanId);
     if (parentSpanId === spanId) {
       throw new ErrorIngestEnvelopeError("malformed", `Transaction span ${index} is self-parented`);
     }
@@ -470,8 +471,8 @@ function parseTransactionSpan(
   };
 }
 
-function transactionId(value: unknown, name: string, pattern: RegExp): string {
-  if (typeof value !== "string" || !pattern.test(value)) {
+function transactionId(value: unknown, name: string, pattern: RegExp, validator: (value: unknown) => boolean = () => true): string {
+  if (typeof value !== "string" || !pattern.test(value) || !validator(value)) {
     throw new ErrorIngestEnvelopeError("malformed", `${name} is not a valid Sentry trace identifier`);
   }
   return value;
@@ -514,11 +515,11 @@ function parseTransactionMetadata(
   if (!isRecord(rawContexts)) throw new ErrorIngestEnvelopeError("malformed", "Transaction contexts are required");
   const rawTrace = rawContexts.trace;
   if (!isRecord(rawTrace)) throw new ErrorIngestEnvelopeError("malformed", "Transaction trace context is required");
-  const traceId = transactionId(rawTrace.trace_id, "Transaction trace_id", /^[0-9a-f]{32}$/u);
-  const spanId = transactionId(rawTrace.span_id, "Transaction span_id", /^[0-9a-f]{16}$/u);
+  const traceId = transactionId(rawTrace.trace_id, "Transaction trace_id", /^[0-9a-f]{32}$/u, isW3cTraceId);
+  const spanId = transactionId(rawTrace.span_id, "Transaction span_id", /^[0-9a-f]{16}$/u, isW3cSpanId);
   let parentSpanId: string | null = null;
   if (rawTrace.parent_span_id !== undefined && rawTrace.parent_span_id !== null) {
-    parentSpanId = transactionId(rawTrace.parent_span_id, "Transaction parent_span_id", /^[0-9a-f]{16}$/u);
+    parentSpanId = transactionId(rawTrace.parent_span_id, "Transaction parent_span_id", /^[0-9a-f]{16}$/u, isW3cSpanId);
     if (parentSpanId === spanId) {
       throw new ErrorIngestEnvelopeError("malformed", "Transaction is self-parented");
     }

--- a/apps/backend/src/lib/error-ingest/error-ingest-outcomes.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-outcomes.ts
@@ -78,6 +78,14 @@ function emptyCounts(): Record<ErrorIngestOutcomeStatus, number> {
   };
 }
 
+export function countErrorIngestOutcomes(
+  outcomes: readonly { status: ErrorIngestOutcomeStatus }[],
+): ErrorIngestBatchCounts {
+  const counts = emptyCounts();
+  for (const outcome of outcomes) counts[outcome.status] += 1;
+  return counts;
+}
+
 /**
  * The one canonical aggregation from item outcomes to a batch-level summary,
  * shared by every projection so status/count semantics cannot drift between
@@ -88,8 +96,7 @@ function emptyCounts(): Record<ErrorIngestOutcomeStatus, number> {
 export function summarizeErrorIngestOutcomes(
   outcomes: readonly { status: ErrorIngestOutcomeStatus }[],
 ): ErrorIngestOutcomeSummary {
-  const counts = emptyCounts();
-  for (const outcome of outcomes) counts[outcome.status] += 1;
+  const counts = countErrorIngestOutcomes(outcomes);
 
   if (outcomes.length === 0) return { status: "rejected", counts, reason: "empty_batch" };
   const firstStatus = outcomes[0].status;

--- a/apps/backend/src/lib/error-ingest/error-ingest-protocol-adapter.test.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-protocol-adapter.test.ts
@@ -54,7 +54,7 @@ describe("error-ingest protocol adapter", () => {
       ],
     });
     // Each OTLP signal counts only its own item types: the filtered log for
-    // `logs`, the sampled-out span for `traces`. The other five rejections are
+    // `logs`, the sampled-out span for `traces`. The other three rejections are
     // events/unknown items that no OTLP signal may claim.
     expect(projection.otlpPartialSuccess.logs).toEqual({
       rejectedItems: 1,

--- a/apps/backend/src/lib/error-ingest/error-ingest-protocol-adapter.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-protocol-adapter.ts
@@ -2,6 +2,7 @@ import { Buffer } from "node:buffer";
 import { createHash } from "node:crypto";
 import {
   ERROR_INGEST_OUTCOME_STATUSES,
+  countErrorIngestOutcomes,
   summarizeErrorIngestOutcomes,
   type ErrorIngestBatchCounts,
   type ErrorIngestBatchStatus,
@@ -530,7 +531,7 @@ function otlpPartialSuccess(
   // Each OTLP signal reports only its own item types. Counting the whole batch
   // would let a rejected transaction surface as `rejectedLogRecords` (and vice
   // versa) in mixed batches, telling the client the wrong signal failed.
-  const counts = summarizeErrorIngestOutcomes(items.filter((item) => isSignalItemType(item.itemType, signal))).counts;
+  const counts = countErrorIngestOutcomes(items.filter((item) => isSignalItemType(item.itemType, signal)));
   const rejectedItems = rejectedItemCount(counts);
   const errorMessage = boundedErrorMessage(counts, maxErrorMessageBytes);
   if (rejectedItems === 0 || errorMessage === undefined) {

--- a/apps/backend/src/lib/error-ingest/error-ingest-protocol-projections.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-protocol-projections.ts
@@ -38,9 +38,22 @@ export function createLegacyBatchProtocolProjection(
   policyOutcomes?: readonly ErrorIngestPolicyItemOutcome[],
 ): ErrorIngestProtocolProjection {
   if (policyOutcomes !== undefined) {
+    const outcomes: ErrorIngestItemOutcome[] = policyOutcomes.map(({ scrubbed: _scrubbed, scrubbedBytes: _scrubbedBytes, ...outcome }) => outcome);
+    const policyItemIds = new Set(outcomes.map((outcome) => outcome.itemId));
+    // Policy evaluation only sees `$error`/`$log` records. Add the product
+    // events and spans that bypass that policy so the legacy projection and
+    // durable client-report ledger describe the complete batch.
+    for (let itemIndex = 0; itemIndex < eventCount; itemIndex++) {
+      if (!policyItemIds.has(`event:${itemIndex}`)) {
+        outcomes.push(createErrorIngestItemOutcome({ itemId: `event:${itemIndex}`, itemType: "event" }, { status: "accepted" }));
+      }
+    }
+    for (let itemIndex = 0; itemIndex < spanCount; itemIndex++) {
+      outcomes.push(createErrorIngestItemOutcome({ itemId: `span:${itemIndex}`, itemType: "span" }, { status: "accepted" }));
+    }
     return createErrorIngestProtocolProjection(
       batchId,
-      policyOutcomes.map(({ scrubbed: _scrubbed, scrubbedBytes: _scrubbedBytes, ...outcome }) => outcome),
+      outcomes,
     );
   }
   const outcomes: ErrorIngestItemOutcome[] = [];

--- a/apps/backend/src/lib/error-ingest/error-ingest-scrubber.test.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-scrubber.test.ts
@@ -52,6 +52,16 @@ describe("scrubErrorIngestPayload", () => {
     expect(serialized).not.toContain("abc123");
   });
 
+  it("does not consume query or fragment at-signs as URL password text", () => {
+    const result = scrubErrorIngestPayload({
+      message: "redirect https://user:pass@example.test/callback?next=a@b#owner=c@d",
+    });
+
+    expect(result.value).toEqual({
+      message: "redirect https://[Filtered]@example.test/callback?next=a@b#owner=c@d",
+    });
+  });
+
   it("keeps the built-in drop policy authoritative over urlKeys overrides", () => {
     // A urlKeys override may only relax a plain field to a path-only URL
     // projection. Pointing it at a built-in sensitive key must not resurrect

--- a/apps/backend/src/lib/error-ingest/error-ingest-scrubber.test.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-scrubber.test.ts
@@ -38,7 +38,7 @@ describe("scrubErrorIngestPayload", () => {
 
   it("filters secrets in serialized JSON messages and protocol-relative URL credentials", () => {
     const result = scrubErrorIngestPayload({
-      message: 'sign-in failed: {"password":"hunter2","user":"bob"} via //login:hunter3@auth.example.test/callback',
+      message: 'sign-in failed: {"password":"hunter2","user":"bob"} via //login:hunter3@secret-suffix@auth.example.test/callback',
       detail: "config {'api_key':'abc123'}",
     });
 

--- a/apps/backend/src/lib/error-ingest/error-ingest-scrubber.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-scrubber.ts
@@ -66,7 +66,7 @@ const PRIVATE_KEY_PATTERN = /-----BEGIN [^-]*PRIVATE KEY-----[\s\S]*?-----END [^
 const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g;
 // The scheme is optional so protocol-relative references (`//user:pass@host`)
 // lose their userinfo credentials just like absolute URLs.
-const URL_AUTH_PATTERN = /((?:[a-z][a-z\d+.-]*:)?\/\/)(?:[^/@\s:]+):(?:[^/\s]+)@/gi;
+const URL_AUTH_PATTERN = /((?:[a-z][a-z\d+.-]*:)?\/\/)(?:[^/@\s:]+):(?:[^/\s?#]+)@/gi;
 // The optional quote around the key (backreference \2) covers serialized JSON
 // embedded in message strings (`{"password":"..."}`), which the bare-key form
 // cannot reach because the closing key quote sits between the key and the colon.

--- a/apps/backend/src/lib/error-ingest/error-ingest-scrubber.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-scrubber.ts
@@ -66,7 +66,7 @@ const PRIVATE_KEY_PATTERN = /-----BEGIN [^-]*PRIVATE KEY-----[\s\S]*?-----END [^
 const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g;
 // The scheme is optional so protocol-relative references (`//user:pass@host`)
 // lose their userinfo credentials just like absolute URLs.
-const URL_AUTH_PATTERN = /((?:[a-z][a-z\d+.-]*:)?\/\/)(?:[^/@\s]+):(?:[^/@\s]+)@/gi;
+const URL_AUTH_PATTERN = /((?:[a-z][a-z\d+.-]*:)?\/\/)(?:[^/@\s:]+):(?:[^/\s]+)@/gi;
 // The optional quote around the key (backreference \2) covers serialized JSON
 // embedded in message strings (`{"password":"..."}`), which the bare-key form
 // cannot reach because the closing key quote sits between the key and the colon.

--- a/apps/backend/src/lib/error-ingest/error-ingest-transaction-adapter.test.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-transaction-adapter.test.ts
@@ -173,5 +173,18 @@ describe("Sentry transaction to canonical OTLP adapter", () => {
       timestamp: 20_000_000_001,
     });
     expect(() => sentryTransactionToCanonicalOtlpSpans(outsideOtlpRange, context)).toThrow(/OTLP timestamp range/iu);
+
+    const zeroParent = parseTransaction({
+      contexts: {
+        trace: {
+          trace_id: TRACE_ID,
+          span_id: ROOT_SPAN_ID,
+          parent_span_id: "0000000000000000",
+          op: "http.server",
+          status: "ok",
+        },
+      },
+    });
+    expect(() => sentryTransactionToCanonicalOtlpSpans(zeroParent, context)).toThrow(/valid W3C span id/iu);
   });
 });

--- a/apps/backend/src/lib/error-ingest/error-ingest-transaction-adapter.ts
+++ b/apps/backend/src/lib/error-ingest/error-ingest-transaction-adapter.ts
@@ -3,6 +3,7 @@ import { scrubErrorIngestPayload } from "./error-ingest-scrubber";
 import type { ErrorIngestEnvelopeTransactionMetadata } from "./error-ingest-envelope";
 import type { CanonicalOtlpSpan, CanonicalOtlpSpanEvent, CanonicalOtlpSpanLink } from "@/lib/otlp/traces";
 import type { OtlpAttributeValue, OtlpAttributes } from "@/lib/otlp/json";
+import { isW3cSpanId } from "@hexclave/shared/dist/utils/analytics-wire";
 
 const MAX_OTLP_TIMESTAMP_NANO = 18_446_744_073_709_551_615n;
 const MAX_ATTRIBUTE_DEPTH = 8;
@@ -165,6 +166,9 @@ export function sentryTransactionToCanonicalOtlpSpans(
 ): CanonicalOtlpSpan[] {
   if (transaction.name === null) {
     throw new ErrorIngestTransactionAdapterError("invalid", "Transaction name is required");
+  }
+  if (transaction.parentSpanId !== null && !isW3cSpanId(transaction.parentSpanId)) {
+    throw new ErrorIngestTransactionAdapterError("invalid", "Transaction parent_span_id must be a valid W3C span id");
   }
 
   const seenSpanIds = new Set<string>([transaction.spanId]);

--- a/apps/backend/src/lib/events.tsx
+++ b/apps/backend/src/lib/events.tsx
@@ -324,7 +324,19 @@ export async function logEvent<T extends EventType[]>(
   // function's doc comment forbids wrapping it in waitUntil). Event types
   // whose data schema carries `ipInfo` already embed the same signal in their
   // validated data; the capture below covers every other event type.
-  const requestIpInfo = await getEndUserIpInfoForEvent();
+  let requestIpInfo: EndUserIpInfo | null = null;
+  try {
+    requestIpInfo = await getEndUserIpInfoForEvent();
+  } catch (error) {
+    // Some internal event producers run outside the request ALS scope. The
+    // request-local headers helper deliberately throws there; preserve that
+    // signal for observability while allowing the event itself to be written
+    // without request IP enrichment. Other failures must still fail loudly.
+    if (!(error instanceof Error) || error.message !== "Backend request context is only available while handling a backend request") {
+      throw error;
+    }
+    captureError("events:request-ip-info-outside-request", error);
+  }
 
   // rest is no more dynamic APIs so we can run it asynchronously
   runAsynchronouslyAndWaitUntil((async () => {
@@ -414,6 +426,7 @@ export async function logEvent<T extends EventType[]>(
           email,
           auth_method: authMethod,
           oauth_provider: oauthProvider,
+          ip_info: toClickhouseEndUserIpInfo(requestIpInfo),
         };
       } else if (matchingEventType.id === "$sign-in-attempt") {
         const outcome =

--- a/apps/backend/src/lib/events.tsx
+++ b/apps/backend/src/lib/events.tsx
@@ -17,6 +17,8 @@ import { dualWriteLegacyEvents } from "./legacy-telemetry-dual-write";
 import { DEFAULT_BRANCH_ID } from "./tenancies";
 import { resolveCustomerRequestObservability } from "./customer-request-observability";
 
+let hasReportedMissingRequestIpContext = false;
+
 export const endUserIpInfoSchema = yupObject({
   ip: yupString().defined(),
   isTrusted: yupBoolean().defined(),
@@ -335,7 +337,14 @@ export async function logEvent<T extends EventType[]>(
     if (!(error instanceof Error) || error.message !== "Backend request context is only available while handling a backend request") {
       throw error;
     }
-    captureError("events:request-ip-info-outside-request", error);
+    // This is an expected path for detached internal event producers. The
+    // normal error sink flushes through Vercel's waitUntil, which is itself
+    // unavailable here; report it once per process without re-entering that
+    // sink and turning a harmless enrichment miss into a recursive error.
+    if (!hasReportedMissingRequestIpContext) {
+      hasReportedMissingRequestIpContext = true;
+      console.warn("Event logging skipped request IP enrichment outside a backend request context", error);
+    }
   }
 
   // rest is no more dynamic APIs so we can run it asynchronously

--- a/apps/backend/src/lib/issues/grouping-fingerprint.test.ts
+++ b/apps/backend/src/lib/issues/grouping-fingerprint.test.ts
@@ -4,6 +4,7 @@ import {
   GROUPING_FINGERPRINT_TOKENS,
   classifyGroupingFingerprint,
   readGroupingFingerprint,
+  resolveGroupingFingerprint,
 } from "./grouping-fingerprint";
 import { computeGrouping } from "./grouping";
 import type { GroupingInput } from "./types";
@@ -147,6 +148,22 @@ describe("readGroupingFingerprint", () => {
     expect(readGroupingFingerprint({ fingerprint: Array.from({ length: 33 }, (_, index) => `token-${index}`) })).toBeUndefined();
     expect(readGroupingFingerprint({ fingerprint: ["x".repeat(513)] })).toBeUndefined();
     expect(readGroupingFingerprint({ fingerprint: Array.from({ length: 32 }, (_, index) => `token-${index}`) })).toHaveLength(32);
+  });
+
+  it("marks an oversized durable fingerprint as degraded provenance", () => {
+    const resolved = resolveGroupingFingerprint(["{{ stack }}"], input(), [{
+      function: "renderRow",
+      filename: "x".repeat(70_000),
+      absPath: null,
+      module: null,
+      lineno: null,
+      colno: null,
+      inApp: true,
+    }]);
+
+    expect(resolved.provenance.source).toBe("degraded");
+    expect(resolved.provenance.tokens).toEqual([]);
+    expect(resolved.resolvedValues).toEqual([]);
   });
 });
 

--- a/apps/backend/src/lib/issues/grouping-fingerprint.ts
+++ b/apps/backend/src/lib/issues/grouping-fingerprint.ts
@@ -63,6 +63,7 @@ function readField(data: unknown, key: string): unknown {
  */
 export const MAX_GROUPING_FINGERPRINT_TOKENS = 32;
 export const MAX_GROUPING_FINGERPRINT_TOKEN_BYTES = 512;
+export const MAX_GROUPING_FINGERPRINT_PROVENANCE_BYTES = 64 * 1024;
 const FINGERPRINT_TEXT_ENCODER = new TextEncoder();
 
 function readStringArray(value: unknown): string[] | undefined {
@@ -85,8 +86,16 @@ function readStringArray(value: unknown): string[] | undefined {
  * canonical exception to that rule.
  */
 export function readGroupingFingerprint(data: unknown): readonly string[] | undefined {
-  const override = readStringArray(readField(data, "fingerprint_override"));
-  if (override !== undefined) return override;
+  const rawOverride = readField(data, "fingerprint_override");
+  if (rawOverride !== undefined) {
+    // An explicit but malformed override must not silently fall back to the
+    // rich envelope's `fingerprint`: the caller asked for one grouping rule,
+    // and accepting a different field would make invalid input regroup under
+    // an undisclosed contract. A valid empty array still means default
+    // grouping; malformed input remains undefined so the caller can fail
+    // closed without treating an invalid value as a usable fingerprint.
+    return readStringArray(rawOverride);
+  }
   return readStringArray(readField(data, "fingerprint"));
 }
 
@@ -131,6 +140,22 @@ export function resolveGroupingFingerprint(
     }
     if (name === "default") continue;
     resolvedValues.push(resolveToken(name, token, input, frames));
+  }
+
+  if (FINGERPRINT_TEXT_ENCODER.encode(JSON.stringify(resolvedValues)).byteLength > MAX_GROUPING_FINGERPRINT_PROVENANCE_BYTES) {
+    // The occurrence projection has the same 64 KiB durable read cap. Hashing
+    // a value that cannot be returned as provenance creates an issue whose
+    // grouping decision cannot be explained, so degrade to the default owner
+    // before the oversized value reaches either the hash or storage layer.
+    return {
+      resolvedValues: [],
+      provenance: {
+        type: "default",
+        source: "default",
+        tokens: [],
+        resolvedTokens: [],
+      },
+    };
   }
 
   return {

--- a/apps/backend/src/lib/issues/grouping-fingerprint.ts
+++ b/apps/backend/src/lib/issues/grouping-fingerprint.ts
@@ -142,7 +142,13 @@ export function resolveGroupingFingerprint(
     resolvedValues.push(resolveToken(name, token, input, frames));
   }
 
-  if (FINGERPRINT_TEXT_ENCODER.encode(JSON.stringify(resolvedValues)).byteLength > MAX_GROUPING_FINGERPRINT_PROVENANCE_BYTES) {
+  const durableFingerprint = {
+    type,
+    source: type === "default" ? "default" : "event",
+    tokens,
+    resolved_tokens: resolvedValues,
+  };
+  if (FINGERPRINT_TEXT_ENCODER.encode(JSON.stringify(durableFingerprint)).byteLength > MAX_GROUPING_FINGERPRINT_PROVENANCE_BYTES) {
     // The occurrence projection has the same 64 KiB durable read cap. Hashing
     // a value that cannot be returned as provenance creates an issue whose
     // grouping decision cannot be explained, so degrade to the default owner
@@ -151,7 +157,7 @@ export function resolveGroupingFingerprint(
       resolvedValues: [],
       provenance: {
         type: "default",
-        source: "default",
+        source: "degraded",
         tokens: [],
         resolvedTokens: [],
       },

--- a/apps/backend/src/lib/issues/in-app.test.ts
+++ b/apps/backend/src/lib/issues/in-app.test.ts
@@ -10,6 +10,7 @@ describe("isInAppPath — javascript", () => {
     ["a nested dependency", "/srv/app/node_modules/react-dom/index.js", false],
     ["a webpack-internal module", "webpack-internal:///./src/app/page.tsx", false],
     ["a legacy webpack dependency marker", "webpack:///./~/react-proxy/modules/createPrototypeProxy.js", false],
+    ["a namespaced legacy webpack dependency marker", "webpack://app/./~/react-proxy/modules/createPrototypeProxy.js", false],
     ["a node builtin leaking into a browser stack", "node:internal/process/task_queues", false],
     ["the Next framework chunk", "https://app.example.com/_next/static/chunks/framework-2c79e2a64abdb08b.js", false],
     ["the Next framework chunk without an origin", "/_next/static/chunks/framework-2c79e2a64abdb08b.js", false],

--- a/apps/backend/src/lib/issues/in-app.ts
+++ b/apps/backend/src/lib/issues/in-app.ts
@@ -26,7 +26,8 @@ import type { StackPlatform } from "./types";
  * meant `node_modules/pkg`), still seen from older toolchains; treating it as
  * app code would pull third-party frames into the `app` grouping hash.
  */
-const JAVASCRIPT_NOT_IN_APP_SUBSTRINGS = ["/node_modules/", "/~/"];
+const JAVASCRIPT_NOT_IN_APP_SUBSTRINGS = ["/node_modules/"];
+const LEGACY_WEBPACK_MODULE_PATH = "webpack:///./~/";
 const JAVASCRIPT_NOT_IN_APP_PREFIXES = ["webpack-internal:", "node:"];
 /**
  * Next.js emits its own runtime into `framework-<hash>.js` under this directory.
@@ -62,6 +63,7 @@ export function isInAppPath(path: string, platform: StackPlatform): boolean {
     case "javascript": {
       if (JAVASCRIPT_NOT_IN_APP_PREFIXES.some((prefix) => path.startsWith(prefix))) return false;
       if (JAVASCRIPT_NOT_IN_APP_SUBSTRINGS.some((needle) => path.includes(needle))) return false;
+      if (path.includes(LEGACY_WEBPACK_MODULE_PATH)) return false;
       // Matched on the pathname so it holds for both `https://host/_next/...` and a bare `/_next/...`.
       if (path.includes(NEXT_FRAMEWORK_CHUNK_PREFIX)) return false;
       return true;

--- a/apps/backend/src/lib/issues/in-app.ts
+++ b/apps/backend/src/lib/issues/in-app.ts
@@ -27,7 +27,7 @@ import type { StackPlatform } from "./types";
  * app code would pull third-party frames into the `app` grouping hash.
  */
 const JAVASCRIPT_NOT_IN_APP_SUBSTRINGS = ["/node_modules/"];
-const LEGACY_WEBPACK_MODULE_PATH = "webpack:///./~/";
+const LEGACY_WEBPACK_MODULE_PATH_RE = /^webpack:\/\/(?:[^/]+)?\/\.\/~\//;
 const JAVASCRIPT_NOT_IN_APP_PREFIXES = ["webpack-internal:", "node:"];
 /**
  * Next.js emits its own runtime into `framework-<hash>.js` under this directory.
@@ -63,7 +63,7 @@ export function isInAppPath(path: string, platform: StackPlatform): boolean {
     case "javascript": {
       if (JAVASCRIPT_NOT_IN_APP_PREFIXES.some((prefix) => path.startsWith(prefix))) return false;
       if (JAVASCRIPT_NOT_IN_APP_SUBSTRINGS.some((needle) => path.includes(needle))) return false;
-      if (path.includes(LEGACY_WEBPACK_MODULE_PATH)) return false;
+      if (LEGACY_WEBPACK_MODULE_PATH_RE.test(path)) return false;
       // Matched on the pathname so it holds for both `https://host/_next/...` and a bare `/_next/...`.
       if (path.includes(NEXT_FRAMEWORK_CHUNK_PREFIX)) return false;
       return true;

--- a/apps/backend/src/lib/issues/issue-alerts/api.ts
+++ b/apps/backend/src/lib/issues/issue-alerts/api.ts
@@ -205,10 +205,10 @@ export async function assertIssueAlertRecipients(tenancy: Tenancy, rule: IssueAl
       select: { projectUserId: true },
     });
     if (users.length !== userIds.length) {
-      if (ownerTeamMatch?.status === "missing_email") {
-        throw new StatusError(StatusError.BadRequest, "Issue alert recipients must have a primary email on this project's team");
-      }
       throw new StatusError(StatusError.BadRequest, "Issue alert recipients must be members of this project's team");
+    }
+    if (ownerTeamMatch?.status === "missing_email") {
+      throw new StatusError(StatusError.BadRequest, "Issue alert recipients must have a primary email on this project's team");
     }
     return;
   }

--- a/apps/backend/src/lib/issues/issue-alerts/api.ts
+++ b/apps/backend/src/lib/issues/issue-alerts/api.ts
@@ -205,10 +205,10 @@ export async function assertIssueAlertRecipients(tenancy: Tenancy, rule: IssueAl
       select: { projectUserId: true },
     });
     if (users.length !== userIds.length) {
+      if (ownerTeamMatch?.status === "missing_email") {
+        throw new StatusError(StatusError.BadRequest, "Issue alert recipients must have a primary email on this project's team");
+      }
       throw new StatusError(StatusError.BadRequest, "Issue alert recipients must be members of this project's team");
-    }
-    if (ownerTeamMatch?.status === "missing_email") {
-      throw new StatusError(StatusError.BadRequest, "Issue alert recipients must have a primary email on this project's team");
     }
     return;
   }

--- a/apps/backend/src/lib/issues/issue-alerts/ingestion.ts
+++ b/apps/backend/src/lib/issues/issue-alerts/ingestion.ts
@@ -195,6 +195,27 @@ function ownershipRoutingKey(issueId: string, routing: NonNullable<Extract<Issue
   return JSON.stringify([issueId, routing]);
 }
 
+async function issueStillOwnsHashInTransaction(
+  tx: PrismaClientTransaction,
+  tenancy: Tenancy,
+  issueId: string,
+  hash: string,
+): Promise<boolean> {
+  // The ownership check is part of the same serializable transaction as the
+  // delivery claim. FOR UPDATE makes a concurrent unmerge linearize before or
+  // after this decision instead of moving the hash between the check and the
+  // durable enqueue.
+  const rows = await tx.$queryRaw<Array<{ hash: string }>>`
+    SELECT "hash"
+    FROM "IssueHash"
+    WHERE "tenancyId" = ${tenancy.id}::uuid
+      AND "issueId" = ${issueId}::uuid
+      AND "hash" = ${hash}
+    FOR UPDATE
+  `;
+  return rows.length > 0;
+}
+
 export async function dispatchIssueAlertsForMaterialization(options: {
   tenancy: Tenancy,
   outcomes: readonly IssueBatchApplyOutcome[],
@@ -229,6 +250,16 @@ export async function dispatchIssueAlertsForMaterialization(options: {
     select: { id: true, shortId: true, type: true, value: true, culprit: true, status: true },
   });
   const issues = new Map(issueRows.map((issue) => [issue.id, issue]));
+  const issueHashRows = await prisma.issueHash.findMany({
+    where: { tenancyId: options.tenancy.id, issueId: { in: outcomeIds } },
+    select: { issueId: true, hash: true },
+  });
+  const ownedHashesByIssueId = new Map<string, string[]>();
+  for (const row of issueHashRows) {
+    const hashes = ownedHashesByIssueId.get(row.issueId);
+    if (hashes === undefined) ownedHashesByIssueId.set(row.issueId, [row.hash]);
+    else hashes.push(row.hash);
+  }
   const rules = records.map((record) => record.rule);
   const frequencyWindows = collectIssueAlertFrequencyWindows(rules);
   const needsEnvelope = rules.some(ruleNeedsOccurrenceEnvelope);
@@ -243,17 +274,10 @@ export async function dispatchIssueAlertsForMaterialization(options: {
     const envelope = needsEnvelope
       ? await loadOccurrenceEnvelope(options.tenancy, input.occurrenceId ?? null)
       : undefined;
-    // Re-read the owning hashes immediately before building the signal. An
-    // unmerge can commit after the initial materialization read and move this
-    // outcome's owner hash to a new issue; dispatching it against the old issue
-    // would send an alert for the wrong tenant-visible identity. Do not fall
-    // back to the wire hash when the ownership row is gone: the committed
-    // Postgres mapping is authoritative at dispatch time.
-    const currentHashRows = await prisma.issueHash.findMany({
-      where: { tenancyId: options.tenancy.id, issueId: outcome.issueId },
-      select: { hash: true },
-    });
-    const ownedHashes = currentHashRows.map((row) => row.hash);
+    // This batch snapshot supplies the signal and frequency cache without an
+    // N+1 lookup. The matched-delivery path below rechecks the exact hash under
+    // the claim transaction, because an unmerge can repoint it after this read.
+    const ownedHashes = ownedHashesByIssueId.get(outcome.issueId) ?? [];
     if (!ownedHashes.includes(outcome.ownerHash)) continue;
     const frequencyCacheKey = JSON.stringify([...ownedHashes].sort());
     const cachedFrequencyCounts = frequencyCountsCache.get(frequencyCacheKey);
@@ -287,15 +311,19 @@ export async function dispatchIssueAlertsForMaterialization(options: {
         routingResolution = await pending;
       }
 
-      const delivery = await retryTransaction(prisma, async (tx) => await enqueueMatchInTransaction(
-        tx,
-        options.tenancy,
-        scope,
-        record.databaseId,
-        evaluation,
-        options.receivedAt,
-        routingResolution,
-      ), { level: "serializable" });
+      const delivery = await retryTransaction(prisma, async (tx) => {
+        if (!await issueStillOwnsHashInTransaction(tx, options.tenancy, outcome.issueId, outcome.ownerHash)) return null;
+        return await enqueueMatchInTransaction(
+          tx,
+          options.tenancy,
+          scope,
+          record.databaseId,
+          evaluation,
+          options.receivedAt,
+          routingResolution,
+        );
+      }, { level: "serializable" });
+      if (delivery === null) continue;
       if (delivery.claim.status === "claimed") {
         result.claimed += 1;
         if (delivery.enqueued) result.enqueued += 1;

--- a/apps/backend/src/lib/issues/issue-alerts/ingestion.ts
+++ b/apps/backend/src/lib/issues/issue-alerts/ingestion.ts
@@ -229,26 +229,11 @@ export async function dispatchIssueAlertsForMaterialization(options: {
     select: { id: true, shortId: true, type: true, value: true, culprit: true, status: true },
   });
   const issues = new Map(issueRows.map((issue) => [issue.id, issue]));
-  // Frequency counts must be scoped to the hashes CURRENTLY owned by the
-  // materialized issue — never the occurrence's `[ownerHash, ...aliasHashes]`
-  // wire set. After an unmerge, an alias hash in that set can be owned by the
-  // split-off issue, and counting its occurrences here would let the other
-  // issue's traffic satisfy THIS issue's frequency threshold. Owned hashes are
-  // the same single-owner invariant every issue read path resolves by.
-  const issueHashRows = await prisma.issueHash.findMany({
-    where: { tenancyId: options.tenancy.id, issueId: { in: outcomeIds } },
-    select: { issueId: true, hash: true },
-  });
-  const ownedHashesByIssueId = new Map<string, string[]>();
-  for (const row of issueHashRows) {
-    const list = ownedHashesByIssueId.get(row.issueId) ?? [];
-    list.push(row.hash);
-    ownedHashesByIssueId.set(row.issueId, list);
-  }
   const rules = records.map((record) => record.rule);
   const frequencyWindows = collectIssueAlertFrequencyWindows(rules);
   const needsEnvelope = rules.some(ruleNeedsOccurrenceEnvelope);
   const ownershipResolutionCache = new Map<string, Promise<OwnershipRoutingResolution>>();
+  const frequencyCountsCache = new Map<string, Promise<ReadonlyMap<number, number>>>();
 
   for (const outcome of options.outcomes) {
     const input = inputsByHash.get(outcome.ownerHash);
@@ -258,11 +243,24 @@ export async function dispatchIssueAlertsForMaterialization(options: {
     const envelope = needsEnvelope
       ? await loadOccurrenceEnvelope(options.tenancy, input.occurrenceId ?? null)
       : undefined;
-    // Falls back to the delta's owner hash only if the owned set vanished
-    // mid-dispatch (a concurrent merge deleted the issue's rows) — that hash
-    // provably resolved to this issue when the batch materialized.
-    const ownedHashes = ownedHashesByIssueId.get(outcome.issueId) ?? [outcome.ownerHash];
-    const frequencyCounts = await loadFrequencyCounts(options.tenancy, ownedHashes, frequencyWindows, options.receivedAt);
+    // Re-read the owning hashes immediately before building the signal. An
+    // unmerge can commit after the initial materialization read and move this
+    // outcome's owner hash to a new issue; dispatching it against the old issue
+    // would send an alert for the wrong tenant-visible identity. Do not fall
+    // back to the wire hash when the ownership row is gone: the committed
+    // Postgres mapping is authoritative at dispatch time.
+    const currentHashRows = await prisma.issueHash.findMany({
+      where: { tenancyId: options.tenancy.id, issueId: outcome.issueId },
+      select: { hash: true },
+    });
+    const ownedHashes = currentHashRows.map((row) => row.hash);
+    if (!ownedHashes.includes(outcome.ownerHash)) continue;
+    const frequencyCacheKey = JSON.stringify([...ownedHashes].sort());
+    const cachedFrequencyCounts = frequencyCountsCache.get(frequencyCacheKey);
+    const pendingFrequencyCounts = cachedFrequencyCounts
+      ?? loadFrequencyCounts(options.tenancy, ownedHashes, frequencyWindows, options.receivedAt);
+    if (cachedFrequencyCounts === undefined) frequencyCountsCache.set(frequencyCacheKey, pendingFrequencyCounts);
+    const frequencyCounts = await pendingFrequencyCounts;
     const signal = buildIssueAlertSignal({
       scope,
       outcome,

--- a/apps/backend/src/lib/issues/issue-alerts/persistence.ts
+++ b/apps/backend/src/lib/issues/issue-alerts/persistence.ts
@@ -125,6 +125,12 @@ export type IssueAlertWorkflowUpdate =
   | { kind: "failed", error: string, nextRetryAt: Date | null, at?: Date }
   | { kind: "dropped", error?: string, at?: Date };
 
+export type IssueAlertWorkflowDeliveryExpectation = {
+  state: IssueAlertDeliveryStateValue,
+  nextRetryAt: Date | null,
+  lastAttemptAt: Date | null,
+};
+
 type StoredRuleRow = {
   id: string,
   tenancyId: string,
@@ -729,25 +735,36 @@ async function recordWorkflowUpdateInTransaction(
   deliveryId: string,
   update: IssueAlertWorkflowUpdate,
   expectedWorkflowEventId?: string,
+  expectedDelivery?: IssueAlertWorkflowDeliveryExpectation,
 ): Promise<IssueAlertDeliverySnapshot | null> {
   validateScope(scope);
   if (!UUID_PATTERN.test(deliveryId)) throw new IssueAlertPersistenceInputError("deliveryId must be a UUID");
   if (expectedWorkflowEventId !== undefined) validateWorkflowEventId(expectedWorkflowEventId);
+  if (expectedWorkflowEventId === undefined && expectedDelivery !== undefined) {
+    throw new IssueAlertPersistenceInputError("expected workflow delivery state requires an expected workflow event id");
+  }
   const at = validateTimestamp(update.at, "workflow update time");
   const workflowEventGuard = expectedWorkflowEventId === undefined ? {} : { workflowEventId: expectedWorkflowEventId };
+  const expectedDeliveryGuard = expectedDelivery === undefined ? {} : {
+    state: expectedDelivery.state,
+    nextRetryAt: expectedDelivery.nextRetryAt,
+    lastAttemptAt: expectedDelivery.lastAttemptAt,
+  };
   const lifecycleStateGuard = expectedWorkflowEventId === undefined ? {} : {
     state: { notIn: [IssueAlertDeliveryState.DELIVERED, IssueAlertDeliveryState.DROPPED] },
   };
   if (update.kind === "enqueued") {
     validateWorkflowEventId(update.workflowEventId);
+    if (expectedDelivery !== undefined && expectedDelivery.state !== IssueAlertDeliveryState.CLAIMED) return null;
     const updated = await client.issueAlertDelivery.updateMany({
       where: {
         tenancyId: scope.tenancyId,
         projectId: scope.projectId,
         branchId: scope.branchId,
         id: deliveryId,
-        ...workflowEventGuard,
-        state: IssueAlertDeliveryState.CLAIMED,
+        ...(expectedDelivery === undefined
+          ? { ...workflowEventGuard, state: IssueAlertDeliveryState.CLAIMED }
+          : { ...workflowEventGuard, ...expectedDeliveryGuard }),
       },
       data: {
         state: IssueAlertDeliveryState.ENQUEUED,
@@ -760,7 +777,15 @@ async function recordWorkflowUpdateInTransaction(
     if (expectedWorkflowEventId !== undefined && updated.count === 0) return null;
   } else if (update.kind === "delivered") {
     const updated = await client.issueAlertDelivery.updateMany({
-      where: { tenancyId: scope.tenancyId, projectId: scope.projectId, branchId: scope.branchId, id: deliveryId, ...workflowEventGuard, ...lifecycleStateGuard },
+      where: {
+        tenancyId: scope.tenancyId,
+        projectId: scope.projectId,
+        branchId: scope.branchId,
+        id: deliveryId,
+        ...workflowEventGuard,
+        ...lifecycleStateGuard,
+        ...expectedDeliveryGuard,
+      },
       data: {
         state: IssueAlertDeliveryState.DELIVERED,
         outcome: IssueAlertDeliveryOutcome.WORKFLOW_DELIVERED,
@@ -777,7 +802,15 @@ async function recordWorkflowUpdateInTransaction(
       throw new IssueAlertPersistenceInputError("workflow failure error must be a non-empty bounded string");
     }
     const updated = await client.issueAlertDelivery.updateMany({
-      where: { tenancyId: scope.tenancyId, projectId: scope.projectId, branchId: scope.branchId, id: deliveryId, ...workflowEventGuard, ...lifecycleStateGuard },
+      where: {
+        tenancyId: scope.tenancyId,
+        projectId: scope.projectId,
+        branchId: scope.branchId,
+        id: deliveryId,
+        ...workflowEventGuard,
+        ...lifecycleStateGuard,
+        ...expectedDeliveryGuard,
+      },
       data: {
         state: IssueAlertDeliveryState.FAILED,
         outcome: IssueAlertDeliveryOutcome.WORKFLOW_FAILED,
@@ -794,7 +827,15 @@ async function recordWorkflowUpdateInTransaction(
       throw new IssueAlertPersistenceInputError("workflow drop error must be a bounded string");
     }
     const updated = await client.issueAlertDelivery.updateMany({
-      where: { tenancyId: scope.tenancyId, projectId: scope.projectId, branchId: scope.branchId, id: deliveryId, ...workflowEventGuard, ...lifecycleStateGuard },
+      where: {
+        tenancyId: scope.tenancyId,
+        projectId: scope.projectId,
+        branchId: scope.branchId,
+        id: deliveryId,
+        ...workflowEventGuard,
+        ...lifecycleStateGuard,
+        ...expectedDeliveryGuard,
+      },
       data: {
         state: IssueAlertDeliveryState.DROPPED,
         outcome: IssueAlertDeliveryOutcome.WORKFLOW_DROPPED,
@@ -859,10 +900,7 @@ export class IssueAlertPersistenceService implements IssueAlertRuleRepository {
     `);
 
     const records: IssueAlertRuleRecord[] = [];
-    const seenRuleKeys = new Set<string>();
     for (const row of rows) {
-      if (seenRuleKeys.has(row.ruleKey)) continue;
-      seenRuleKeys.add(row.ruleKey);
       const rule = parseStoredIssueAlertRule(row);
       if (rule === null) continue;
       if (records.length >= ISSUE_ALERT_MAX_ACTIVE_RULES) break;
@@ -933,9 +971,17 @@ export class IssueAlertPersistenceService implements IssueAlertRuleRepository {
     scope: IssueAlertRuleScope,
     deliveryId: string,
     expectedWorkflowEventId: string,
+    expectedDelivery: IssueAlertWorkflowDeliveryExpectation,
     update: IssueAlertWorkflowUpdate,
   ): Promise<IssueAlertDeliverySnapshot | null> {
-    return await retryTransaction(this.client, async (tx) => await recordWorkflowUpdateInTransaction(tx, scope, deliveryId, update, expectedWorkflowEventId));
+    return await retryTransaction(this.client, async (tx) => await recordWorkflowUpdateInTransaction(
+      tx,
+      scope,
+      deliveryId,
+      update,
+      expectedWorkflowEventId,
+      expectedDelivery,
+    ));
   }
 
   async inspectDelivery(scope: IssueAlertRuleScope, deliveryId: string): Promise<IssueAlertDeliverySnapshot | null> {

--- a/apps/backend/src/lib/issues/issue-alerts/workflow-status.test.ts
+++ b/apps/backend/src/lib/issues/issue-alerts/workflow-status.test.ts
@@ -80,10 +80,15 @@ function makeStore(
       if (foundTenancyId !== tenancyId || foundWorkflowEventId !== delivery.workflowEventId) return null;
       return delivery;
     },
-    async applyWorkflowUpdate(updateScope, foundDeliveryId, expectedWorkflowEventId, update) {
+    async applyWorkflowUpdate(updateScope, foundDeliveryId, expectedWorkflowEventId, expectedDelivery, update) {
       expect(updateScope).toEqual(scope);
       expect(foundDeliveryId).toBe(deliveryId);
       expect(expectedWorkflowEventId).toBe(delivery.workflowEventId);
+      expect(expectedDelivery).toEqual({
+        state: delivery.state,
+        nextRetryAt: delivery.nextRetryAt,
+        lastAttemptAt: delivery.lastAttemptAt,
+      });
       if (!shouldApply) return false;
       updates.push(update);
       if (update.kind === "delivered") {

--- a/apps/backend/src/lib/issues/issue-alerts/workflow-status.ts
+++ b/apps/backend/src/lib/issues/issue-alerts/workflow-status.ts
@@ -20,6 +20,7 @@ import { parseOwnershipRoutingMetadata } from "@/lib/issues/ownership/routing-me
 import {
   IssueAlertPersistenceInputError,
   issueAlertPersistenceService,
+  type IssueAlertWorkflowDeliveryExpectation,
   type IssueAlertWorkflowUpdate,
 } from "./persistence";
 import type { IssueAlertRuleScope } from "./types";
@@ -48,7 +49,13 @@ export type IssueAlertWorkflowDeliveryRef = {
 
 export type IssueAlertWorkflowStatusStore = {
   findDeliveryByWorkflowEventId(tenancyId: string, workflowEventId: string): Promise<IssueAlertWorkflowDeliveryRef | null>,
-  applyWorkflowUpdate(scope: IssueAlertRuleScope, deliveryId: string, expectedWorkflowEventId: string, update: IssueAlertWorkflowUpdate): Promise<boolean>,
+  applyWorkflowUpdate(
+    scope: IssueAlertRuleScope,
+    deliveryId: string,
+    expectedWorkflowEventId: string,
+    expectedDelivery: IssueAlertWorkflowDeliveryExpectation,
+    update: IssueAlertWorkflowUpdate,
+  ): Promise<boolean>,
 };
 
 export type IssueAlertWorkflowLifecycle = {
@@ -242,8 +249,14 @@ const defaultStatusStore: IssueAlertWorkflowStatusStore = {
       lastAttemptAt: row.lastAttemptAt,
     };
   },
-  async applyWorkflowUpdate(scope, deliveryId, expectedWorkflowEventId, update) {
-    const result = await issueAlertPersistenceService.recordWorkflowUpdateIfCurrent(scope, deliveryId, expectedWorkflowEventId, update);
+  async applyWorkflowUpdate(scope, deliveryId, expectedWorkflowEventId, expectedDelivery, update) {
+    const result = await issueAlertPersistenceService.recordWorkflowUpdateIfCurrent(
+      scope,
+      deliveryId,
+      expectedWorkflowEventId,
+      expectedDelivery,
+      update,
+    );
     return result !== null;
   },
 };
@@ -272,7 +285,17 @@ export async function reconcileIssueAlertWorkflowLifecycle(options: {
   if (isStaleLifecycle(delivery, lifecycle.payload.lifecycle, retryAt, lifecycleOccurredAt)) {
     return { status: "ignored", reason: "stale_lifecycle" };
   }
-  const applied = await store.applyWorkflowUpdate(delivery.scope, delivery.id, triggerEventId, update);
+  const applied = await store.applyWorkflowUpdate(
+    delivery.scope,
+    delivery.id,
+    triggerEventId,
+    {
+      state: delivery.state,
+      nextRetryAt: delivery.nextRetryAt,
+      lastAttemptAt: delivery.lastAttemptAt,
+    },
+    update,
+  );
   if (!applied) return { status: "ignored", reason: "stale_lifecycle" };
   return {
     status: "reconciled",

--- a/apps/backend/src/lib/issues/issue-identity.ts
+++ b/apps/backend/src/lib/issues/issue-identity.ts
@@ -2,7 +2,12 @@ import { Prisma } from "@/generated/prisma/client";
 import type { Tenancy } from "@/lib/tenancies";
 import { getPrismaClientForTenancy } from "@/prisma-client";
 import { StatusError } from "@hexclave/shared/dist/utils/errors";
-import { isUuid } from "@hexclave/shared/dist/utils/uuids";
+
+const ISSUE_UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+
+function isIssueUuid(value: string): boolean {
+  return ISSUE_UUID_PATTERN.test(value);
+}
 
 /**
  * The ONE canonical resolver for a user-supplied issue identifier (the
@@ -44,7 +49,7 @@ export function isValidShortId(raw: string): boolean {
 // have to cast one of them per row and lose its index.
 function issueIdentityPredicate(rawId: string): Prisma.Sql {
   if (isValidShortId(rawId)) return Prisma.sql`i."shortId" = ${rawId}::bigint`;
-  if (isUuid(rawId)) return Prisma.sql`i."id" = ${rawId}::uuid`;
+  if (isIssueUuid(rawId)) return Prisma.sql`i."id" = ${rawId}::uuid`;
   throw new StatusError(StatusError.BadRequest, "issue_id must be a UUID or a numeric short id");
 }
 
@@ -54,7 +59,7 @@ function issueIdentityPredicate(rawId: string): Prisma.Sql {
 // `fromShortId` with its own unique constraint.
 function issueRedirectPredicate(rawId: string): Prisma.Sql {
   if (isValidShortId(rawId)) return Prisma.sql`"fromShortId" = ${rawId}::bigint`;
-  if (isUuid(rawId)) return Prisma.sql`"fromIssueId" = ${rawId}::uuid`;
+  if (isIssueUuid(rawId)) return Prisma.sql`"fromIssueId" = ${rawId}::uuid`;
   throw new StatusError(StatusError.BadRequest, "issue_id must be a UUID or a numeric short id");
 }
 
@@ -89,7 +94,7 @@ export type ResolvedIssueIdentity = {
  * duplication, not a consistency requirement.)
  */
 export async function resolveIssueIdentity(tenancy: Tenancy, rawId: string): Promise<ResolvedIssueIdentity | null> {
-  if (!isValidShortId(rawId) && !isUuid(rawId)) {
+  if (!isValidShortId(rawId) && !isIssueUuid(rawId)) {
     throw new StatusError(StatusError.BadRequest, "issue_id must be a UUID or a numeric short id");
   }
 

--- a/apps/backend/src/lib/issues/issue-identity.ts
+++ b/apps/backend/src/lib/issues/issue-identity.ts
@@ -3,7 +3,7 @@ import type { Tenancy } from "@/lib/tenancies";
 import { getPrismaClientForTenancy } from "@/prisma-client";
 import { StatusError } from "@hexclave/shared/dist/utils/errors";
 
-const ISSUE_UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
+const ISSUE_UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/iu;
 
 function isIssueUuid(value: string): boolean {
   return ISSUE_UUID_PATTERN.test(value);
@@ -86,20 +86,27 @@ export type ResolvedIssueIdentity = {
  * rather than a state to traverse, and walking it would hide that (or, for an
  * accidental cycle, hang the request).
  *
- * All three lookups go through `$replica()`: identity resolution is read-only,
+ * Ordinary lookups go through `$replica()`: identity resolution is read-only,
  * and every mutation that follows re-checks the canonical id against the
- * primary in its own `WHERE tenancyId/id` clause, so a stale replica can at
- * worst produce a not-found or a no-op, never a cross-issue write. (The
- * internal detail route used to read the primary here; that was an accident of
- * duplication, not a consistency requirement.)
+ * primary in its own `WHERE tenancyId/id` clause. Callers that use the result as
+ * read-after-write proof can request a primary read explicitly.
  */
-export async function resolveIssueIdentity(tenancy: Tenancy, rawId: string): Promise<ResolvedIssueIdentity | null> {
+export async function resolveIssueIdentity(
+  tenancy: Tenancy,
+  rawId: string,
+  options: { consistency?: "replica" | "primary" } = {},
+): Promise<ResolvedIssueIdentity | null> {
   if (!isValidShortId(rawId) && !isIssueUuid(rawId)) {
     throw new StatusError(StatusError.BadRequest, "issue_id must be a UUID or a numeric short id");
   }
 
   const prisma = await getPrismaClientForTenancy(tenancy);
-  const directRows = await prisma.$replica().$queryRaw<{ id: string }[]>(Prisma.sql`
+  // Merge retries run immediately after a write and use the result as proof
+  // that a specific lifecycle event already committed. A replica can lag and
+  // report the old live issue instead, so that proof must opt into the primary.
+  // All ordinary identity lookups remain replica-routed by default.
+  const readClient = options.consistency === "primary" ? prisma : prisma.$replica();
+  const directRows = await readClient.$queryRaw<{ id: string }[]>(Prisma.sql`
     SELECT i."id"
     FROM "Issue" i
     WHERE i."tenancyId" = ${tenancy.id}::uuid
@@ -109,7 +116,7 @@ export async function resolveIssueIdentity(tenancy: Tenancy, rawId: string): Pro
   const direct = directRows.at(0);
   if (direct !== undefined) return { issueId: direct.id, redirectedFromIssueId: null };
 
-  const redirectRows = await prisma.$replica().$queryRaw<{ fromIssueId: string, toIssueId: string }[]>(Prisma.sql`
+  const redirectRows = await readClient.$queryRaw<{ fromIssueId: string, toIssueId: string }[]>(Prisma.sql`
     SELECT "fromIssueId", "toIssueId"
     FROM "IssueRedirect"
     WHERE "tenancyId" = ${tenancy.id}::uuid
@@ -121,7 +128,7 @@ export async function resolveIssueIdentity(tenancy: Tenancy, rawId: string): Pro
 
   // The one explicit hop: verify the redirect target actually exists rather
   // than trusting the redirect row (the survivor may itself have been deleted).
-  const targetRows = await prisma.$replica().$queryRaw<{ id: string }[]>(Prisma.sql`
+  const targetRows = await readClient.$queryRaw<{ id: string }[]>(Prisma.sql`
     SELECT i."id"
     FROM "Issue" i
     WHERE i."tenancyId" = ${tenancy.id}::uuid

--- a/apps/backend/src/lib/issues/issue-lifecycle.ts
+++ b/apps/backend/src/lib/issues/issue-lifecycle.ts
@@ -346,7 +346,7 @@ export async function assignIssue(options: IssueScope & {
     // mutations) so a user deleted concurrently cannot slip through; throws
     // `IssueProductInputError`, which the action routes map to 400.
     if (options.assigneeUserId !== null) {
-      await assertIssueProjectUserInTransaction(tx, scope.tenancy, options.assigneeUserId, "assigneeUserId");
+      await assertIssueProjectUserInTransaction(tx, scope.tenancy, options.assigneeUserId, "assigneeUserId", { allowInternalMirror: false });
     }
     if (actorUserId !== null) {
       await assertIssueProjectUserInTransaction(tx, scope.tenancy, actorUserId, "actorUserId");
@@ -479,7 +479,7 @@ export async function transitionIssueStatus(options: IssueScope & {
       issueId: options.issueId,
       event: transition.current.status,
       now: changedAt,
-      eventId: `${options.issueId}:${transition.current.status}:${actionId}`,
+      eventId: `${options.issueId}.${transition.current.status}.${changedAt.getTime()}`,
     }));
   }
   return transition;

--- a/apps/backend/src/lib/issues/issue-lifecycle.ts
+++ b/apps/backend/src/lib/issues/issue-lifecycle.ts
@@ -2,6 +2,7 @@ import { IssueStatus as PrismaIssueStatus } from "@/generated/prisma/enums";
 import type { Tenancy } from "@/lib/tenancies";
 import { getPrismaClientForTenancy, retryTransaction, type PrismaClientTransaction } from "@/prisma-client";
 import { runAsynchronouslyAndWaitUntil } from "@/utils/background-tasks";
+import { randomUUID } from "node:crypto";
 import { appendIssueActivityInTransaction, assertIssueProjectUserInTransaction, assignIssueToTeam as persistIssueTeamAssignment, setIssuePriority as persistIssuePriority } from "./issue-product";
 import { emitIssueLifecycleWebhook } from "./issue-webhooks";
 
@@ -335,6 +336,7 @@ export async function assignIssue(options: IssueScope & {
   const actorUserId = validateActorUserId(options.actorUserId);
   if (options.assigneeUserId !== null) assertUuid(options.assigneeUserId, "assigneeUserId");
   const changedAt = resolveAt(options.changedAt, "changedAt");
+  const actionId = randomUUID();
   const scope: IssueScope = { tenancy: options.tenancy, issueId: options.issueId };
 
   return await withLockedIssue(scope, async (tx, current) => {
@@ -361,7 +363,7 @@ export async function assignIssue(options: IssueScope & {
         issueId: scope.issueId,
         actorUserId,
         type: "assignment_changed",
-        idempotencyKey: `assignment:${current.assigneeUserId ?? "none"}:${options.assigneeUserId ?? "none"}:${changedAt.toISOString()}`,
+        idempotencyKey: `assignment:${current.assigneeUserId ?? "none"}:${options.assigneeUserId ?? "none"}:${changedAt.toISOString()}:${actionId}`,
         data: { previous_assignee_user_id: current.assigneeUserId, assignee_user_id: options.assigneeUserId },
         occurredAt: changedAt,
       });
@@ -408,6 +410,7 @@ export async function transitionIssueStatus(options: IssueScope & {
   onlyIfCurrentStatus?: readonly IssueLifecycleStatus[],
 }): Promise<IssueLifecycleTransition> {
   const changedAt = resolveAt(options.changedAt, "changedAt");
+  const actionId = randomUUID();
   if (options.mutation.status === "ignored" && options.mutation.ignoredUntil !== undefined && options.mutation.ignoredUntil !== null) {
     assertDate(options.mutation.ignoredUntil, "ignoredUntil");
   }
@@ -452,7 +455,7 @@ export async function transitionIssueStatus(options: IssueScope & {
       issueId: scope.issueId,
       actorUserId: null,
       type: "status_changed",
-      idempotencyKey: `status:${transition.previous.status}:${transition.current.status}:${changedAt.toISOString()}`,
+      idempotencyKey: `status:${transition.previous.status}:${transition.current.status}:${changedAt.toISOString()}:${actionId}`,
       data: {
         from: transition.previous.status,
         to: transition.current.status,
@@ -476,6 +479,7 @@ export async function transitionIssueStatus(options: IssueScope & {
       issueId: options.issueId,
       event: transition.current.status,
       now: changedAt,
+      eventId: `${options.issueId}:${transition.current.status}:${actionId}`,
     }));
   }
   return transition;
@@ -485,6 +489,7 @@ export async function applyIssueOccurrenceLifecycle(options: IssueScope & {
   receivedAt: Date,
 }): Promise<IssueLifecycleTransition> {
   const receivedAt = resolveAt(options.receivedAt, "receivedAt");
+  const actionId = randomUUID();
   const scope: IssueScope = { tenancy: options.tenancy, issueId: options.issueId };
 
   return await withLockedIssue(scope, async (tx, current) => {
@@ -515,7 +520,7 @@ export async function applyIssueOccurrenceLifecycle(options: IssueScope & {
       issueId: scope.issueId,
       actorUserId: null,
       type: "regressed",
-      idempotencyKey: `regressed:${transition.kind}:${receivedAt.toISOString()}`,
+      idempotencyKey: `regressed:${transition.kind}:${receivedAt.toISOString()}:${actionId}`,
       data: { kind: transition.kind, received_at: receivedAt.toISOString() },
       occurredAt: receivedAt,
     });

--- a/apps/backend/src/lib/issues/issue-merge.ts
+++ b/apps/backend/src/lib/issues/issue-merge.ts
@@ -519,15 +519,12 @@ async function applyMerge(
           "lastSeenAt"       = GREATEST(i."lastSeenAt", COALESCE(f."lastSeenAt", i."lastSeenAt")),
           -- An issue produced by unmergeIssue carries a windowed counter seed,
           -- marked by countersTruncatedAt. Folding such a loser in makes the
-          -- primary's counter approximate too, so the marker must survive the
-          -- merge (GREATEST skips NULLs; NULL only when no participant had
-          -- one) — otherwise the merged number would silently claim all-time
-          -- precision it does not have. The window-overlap double count when a
-          -- split issue is merged back into its original source is accepted,
-          -- as the corollary of unmerge deliberately leaving the source's
-          -- lifetime counter alone; the marker is what keeps the UI honest
-          -- ("N events since <date>") about that approximation.
-          "countersTruncatedAt" = GREATEST(i."countersTruncatedAt", f."countersTruncatedAt"),
+          -- primary's counter approximate too, so the EARLIEST marker must
+          -- survive the merge: the summed counter includes every event from
+          -- each participant's retained window, and the oldest boundary is the
+          -- only honest lower bound for that union. (LEAST skips NULLs; NULL
+          -- only when no participant had one.)
+          "countersTruncatedAt" = LEAST(i."countersTruncatedAt", f."countersTruncatedAt"),
           "assigneeUserId"   = ${metadata.assigneeUserId}::uuid,
           "firstSeenRelease" = ${metadata.firstSeenRelease},
           "lastSeenRelease"  = ${metadata.lastSeenRelease},
@@ -814,7 +811,9 @@ async function applyUnmerge(
     ),
     counter AS (
       INSERT INTO "IssueCounter" ("tenancyId", "nextShortId")
-      VALUES (${tenancyId}::uuid, 2::bigint)
+      SELECT ${tenancyId}::uuid, 2::bigint
+      FROM lease
+      WHERE "held"
       ON CONFLICT ("tenancyId") DO UPDATE
         SET "nextShortId" = "IssueCounter"."nextShortId" + 1
       RETURNING "nextShortId" - 1 AS "shortId"
@@ -859,6 +858,7 @@ async function applyUnmerge(
         AND h."hash" = ANY(${[...lockedHashes]}::text[])
         AND h."state" = 'LOCKED'::"IssueHashState"
         AND h."lockedAt" = ${now}::timestamptz
+        AND EXISTS (SELECT 1 FROM created)
       RETURNING h."hash"
     )
     SELECT c."id", c."shortId", (SELECT COUNT(*)::int FROM rebound) AS "reboundHashes"

--- a/apps/backend/src/lib/issues/issue-merge.ts
+++ b/apps/backend/src/lib/issues/issue-merge.ts
@@ -509,7 +509,7 @@ async function applyMerge(
         COALESCE(SUM("timesSeen"), 0)::bigint AS "timesSeen",
         MIN("firstSeenAt") AS "firstSeenAt",
         MAX("lastSeenAt") AS "lastSeenAt",
-        MAX("countersTruncatedAt") AS "countersTruncatedAt"
+        MIN("countersTruncatedAt") AS "countersTruncatedAt"
       FROM losers
     ),
     primary_updated AS (

--- a/apps/backend/src/lib/issues/issue-occurrences.ts
+++ b/apps/backend/src/lib/issues/issue-occurrences.ts
@@ -5,6 +5,7 @@ import {
 import { getErrorAttachmentEventId } from "@/lib/attachments/attachment-event-id";
 import { getSharedClickhouseAdminClient } from "@/lib/clickhouse";
 import type { Tenancy } from "@/lib/tenancies";
+import { mapWithConcurrency } from "@hexclave/shared/dist/utils/promises";
 import { StatusError } from "@hexclave/shared/dist/utils/errors";
 import { loadIssueDetailContext } from "./issue-detail";
 import { encodeOccurrenceCursor, type OccurrenceCursor } from "./issue-queries";
@@ -77,29 +78,39 @@ export async function loadPublicIssueOccurrences(options: {
 
   const rows = await resultSet.json<PublicOccurrenceRow>();
   const page = await resolveOccurrenceReplayIds(options.tenancy, rows.slice(0, options.limit));
-  const attachmentEventIds = page.map((row) => getErrorAttachmentEventId({
-    occurrenceId: row.occurrence_id,
-    data: row.data,
-    errorEnvelope: parsePublicErrorEnvelope(row.error_envelope),
-  })).filter((eventId): eventId is string => eventId !== null);
+  const prepared = page.map((row) => {
+    const errorEnvelope = parsePublicErrorEnvelope(row.error_envelope);
+    return {
+      row,
+      errorEnvelope,
+      attachmentEventId: getErrorAttachmentEventId({
+        occurrenceId: row.occurrence_id,
+        data: row.data,
+        errorEnvelope,
+      }),
+    };
+  });
+  const attachmentEventIds = prepared
+    .map((entry) => entry.attachmentEventId)
+    .filter((eventId): eventId is string => eventId !== null);
   const attachmentsByEvent = await loadPublicIssueAttachments(options.tenancy, attachmentEventIds);
   const last = page.at(-1);
-  const items: PublicIssueOccurrence[] = [];
-  for (const row of page) {
-    const attachmentEventId = getErrorAttachmentEventId({
-      occurrenceId: row.occurrence_id,
-      data: row.data,
-      errorEnvelope: parsePublicErrorEnvelope(row.error_envelope),
-    });
-    items.push(await projectPublicIssueOccurrence(row, {
+  // Symbolication may perform an artifact lookup per frame. Keep the page
+  // responsive when one artifact store call is slow without opening an
+  // unbounded burst against the storage backend.
+  const items = await mapWithConcurrency(
+    prepared,
+    8,
+    async (entry) => await projectPublicIssueOccurrence(entry.row, {
       scope: {
         tenantId: options.tenancy.id,
         projectId: options.tenancy.project.id,
         branchId: options.tenancy.branchId,
       },
-      attachments: attachmentEventId === null ? [] : attachmentsByEvent.get(attachmentEventId) ?? [],
-    }));
-  }
+      errorEnvelope: entry.errorEnvelope,
+      attachments: entry.attachmentEventId === null ? [] : attachmentsByEvent.get(entry.attachmentEventId) ?? [],
+    }),
+  );
   return {
     items,
     next_cursor: rows.length > options.limit && last !== undefined

--- a/apps/backend/src/lib/issues/issue-product.ts
+++ b/apps/backend/src/lib/issues/issue-product.ts
@@ -234,15 +234,22 @@ async function assertIssueExists(tx: PrismaClientTransaction, scope: IssueProduc
   if (issue === null) throw new IssueProductInputError("Issue was not found in the authenticated branch");
 }
 
-async function assertProjectUser(tx: PrismaClientTransaction, tenancy: Tenancy, userId: string, fieldName: string): Promise<void> {
+async function assertProjectUser(
+  tx: PrismaClientTransaction,
+  tenancy: Tenancy,
+  userId: string,
+  fieldName: string,
+  options: { allowInternalMirror?: boolean } = {},
+): Promise<void> {
   assertUuid(userId, fieldName);
+  const allowInternalMirror = options.allowInternalMirror ?? true;
   const rows = await tx.$queryRaw<{ projectUserId: string }[]>`
     SELECT "projectUserId"
     FROM "ProjectUser"
     WHERE "projectUserId" = ${userId}::uuid
       AND (
         "tenancyId" = ${tenancy.id}::uuid
-        OR ("mirroredProjectId" = 'internal' AND "mirroredBranchId" = ${DEFAULT_BRANCH_ID})
+        ${allowInternalMirror ? Prisma.sql`OR ("mirroredProjectId" = 'internal' AND "mirroredBranchId" = ${DEFAULT_BRANCH_ID})` : Prisma.empty}
       )
     ORDER BY CASE WHEN "tenancyId" = ${tenancy.id}::uuid THEN 0 ELSE 1 END
     LIMIT 1
@@ -258,8 +265,14 @@ async function assertProjectUser(tx: PrismaClientTransaction, tenancy: Tenancy, 
  * purpose. Kept here rather than duplicated so "is this a project user?" is
  * answered by exactly one query shape.
  */
-export async function assertIssueProjectUserInTransaction(tx: PrismaClientTransaction, tenancy: Tenancy, userId: string, fieldName: string): Promise<void> {
-  await assertProjectUser(tx, tenancy, userId, fieldName);
+export async function assertIssueProjectUserInTransaction(
+  tx: PrismaClientTransaction,
+  tenancy: Tenancy,
+  userId: string,
+  fieldName: string,
+  options: { allowInternalMirror?: boolean } = {},
+): Promise<void> {
+  await assertProjectUser(tx, tenancy, userId, fieldName, options);
 }
 
 /**
@@ -469,7 +482,7 @@ export async function setIssueOwner(options: IssueProductScope & {
   return await retryOnceOnUniqueConstraintRace(() => retryTransaction(prisma, async (tx) => {
     await assertIssueExists(tx, options);
     if (actorUserId !== null) await assertProjectUser(tx, options.tenancy, actorUserId, "actorUserId");
-    if (ownerUserId !== null) await assertProjectUser(tx, options.tenancy, ownerUserId, "owner.userId");
+    if (ownerUserId !== null) await assertProjectUser(tx, options.tenancy, ownerUserId, "owner.userId", { allowInternalMirror: false });
     if (ownerTeamId !== null) assertProjectOwnerTeam(options.tenancy, ownerTeamId, "owner.teamId");
     const ownerWhere = {
       tenancyId: options.tenancy.id,
@@ -512,7 +525,7 @@ export async function addIssueComment(options: IssueProductScope & {
   const prisma = await getPrismaClientForTenancy(options.tenancy);
   return await retryTransaction(prisma, async (tx) => {
     await assertIssueExists(tx, options);
-    await assertProjectUser(tx, options.tenancy, options.actorUserId, "actorUserId");
+    await assertProjectUser(tx, options.tenancy, options.actorUserId, "actorUserId", { allowInternalMirror: false });
     const comment = await tx.issueComment.upsert({
       where: {
         tenancyId_projectId_branchId_issueId_idempotencyKey: {
@@ -563,7 +576,7 @@ export async function setIssueSubscription(options: IssueProductScope & {
   return await retryOnceOnUniqueConstraintRace(() => retryTransaction(prisma, async (tx) => {
     await assertIssueExists(tx, options);
     if (actorUserId !== null) await assertProjectUser(tx, options.tenancy, actorUserId, "actorUserId");
-    if (subjectUserId !== null) await assertProjectUser(tx, options.tenancy, subjectUserId, "subject.id");
+    if (subjectUserId !== null) await assertProjectUser(tx, options.tenancy, subjectUserId, "subject.id", { allowInternalMirror: false });
     if (subjectTeamId !== null) assertProjectOwnerTeam(options.tenancy, subjectTeamId, "subject.id");
     const subscriptionWhere = {
       tenancyId: options.tenancy.id, projectId: options.tenancy.project.id, branchId: options.tenancy.branchId,
@@ -602,7 +615,7 @@ export async function setIssueBookmark(options: IssueProductScope & {
   const prisma = await getPrismaClientForTenancy(options.tenancy);
   return await retryTransaction(prisma, async (tx) => {
     await assertIssueExists(tx, options);
-    await assertProjectUser(tx, options.tenancy, options.userId, "userId");
+    await assertProjectUser(tx, options.tenancy, options.userId, "userId", { allowInternalMirror: false });
     if (actorUserId !== null) await assertProjectUser(tx, options.tenancy, actorUserId, "actorUserId");
     // Atomic create-if-absent / delete-if-present, with `changed` derived from
     // the affected-row count. A read-then-decide-then-write here would let two

--- a/apps/backend/src/lib/issues/issue-product.ts
+++ b/apps/backend/src/lib/issues/issue-product.ts
@@ -11,6 +11,7 @@ import { getBillingTeamId } from "@/lib/plan-entitlements";
 import { getPrismaClientForTenancy, isPrismaError, retryTransaction, type PrismaClientTransaction } from "@/prisma-client";
 import { deepPlainEquals } from "@hexclave/shared/dist/utils/objects";
 import { createHash, randomUUID } from "node:crypto";
+import { DEFAULT_BRANCH_ID } from "@/lib/branch-constants";
 import type { IssuePriority } from "./issue-lifecycle";
 import type { IssueActivitySubject } from "./issue-activity";
 
@@ -235,11 +236,19 @@ async function assertIssueExists(tx: PrismaClientTransaction, scope: IssueProduc
 
 async function assertProjectUser(tx: PrismaClientTransaction, tenancy: Tenancy, userId: string, fieldName: string): Promise<void> {
   assertUuid(userId, fieldName);
-  const user = await tx.projectUser.findUnique({
-    where: { tenancyId_projectUserId: { tenancyId: tenancy.id, projectUserId: userId } },
-    select: { projectUserId: true },
-  });
-  if (user === null) throw new IssueProductInputError(`${fieldName} is not a member of the authenticated branch`);
+  const rows = await tx.$queryRaw<{ projectUserId: string }[]>`
+    SELECT "projectUserId"
+    FROM "ProjectUser"
+    WHERE "projectUserId" = ${userId}::uuid
+      AND (
+        "tenancyId" = ${tenancy.id}::uuid
+        OR ("mirroredProjectId" = 'internal' AND "mirroredBranchId" = ${DEFAULT_BRANCH_ID})
+      )
+    ORDER BY CASE WHEN "tenancyId" = ${tenancy.id}::uuid THEN 0 ELSE 1 END
+    LIMIT 1
+    FOR KEY SHARE
+  `;
+  if (rows.length === 0) throw new IssueProductInputError(`${fieldName} is not a member of the authenticated branch`);
 }
 
 /**
@@ -351,6 +360,7 @@ export async function setIssuePriority(options: IssueProductScope & {
   assertScope(options);
   const actorUserId = actorId(options.actorUserId);
   const occurredAt = assertValidDate(options.occurredAt ?? new Date(), "occurredAt");
+  const actionId = randomUUID();
   const prisma = await getPrismaClientForTenancy(options.tenancy);
   return await retryTransaction(prisma, async (tx) => {
     await assertIssueExists(tx, options);
@@ -371,7 +381,7 @@ export async function setIssuePriority(options: IssueProductScope & {
     });
     await appendActivityInTransaction({
       tx, tenancy: options.tenancy, issueId: options.issueId, actorUserId,
-      type: "priority_changed", idempotencyKey: activityKey("priority", `${previousPriority ?? "none"}:${options.priority ?? "none"}:${occurredAt.toISOString()}`),
+      type: "priority_changed", idempotencyKey: activityKey("priority", `${previousPriority ?? "none"}:${options.priority ?? "none"}:${occurredAt.toISOString()}:${actionId}`),
       data: { from: previousPriority, to: options.priority }, occurredAt,
     });
     return {
@@ -397,6 +407,7 @@ export async function assignIssueToTeam(options: IssueProductScope & {
   const teamId = options.teamId ?? ownerTeamId;
   assertProjectOwnerTeam(options.tenancy, teamId, "teamId");
   const changedAt = assertValidDate(options.changedAt ?? new Date(), "changedAt");
+  const actionId = randomUUID();
   const prisma = await getPrismaClientForTenancy(options.tenancy);
   return await retryTransaction(prisma, async (tx) => {
     await assertIssueExists(tx, options);
@@ -416,7 +427,7 @@ export async function assignIssueToTeam(options: IssueProductScope & {
     });
     await appendActivityInTransaction({
       tx, tenancy: options.tenancy, issueId: options.issueId, actorUserId,
-      type: "team_changed", idempotencyKey: activityKey("team", `${current.assignedTeamId ?? "none"}:${teamId}:${changedAt.toISOString()}`),
+      type: "team_changed", idempotencyKey: activityKey("team", `${current.assignedTeamId ?? "none"}:${teamId}:${changedAt.toISOString()}:${actionId}`),
       data: { from: current.assignedTeamId, to: teamId }, occurredAt: changedAt,
     });
     return {
@@ -453,6 +464,7 @@ export async function setIssueOwner(options: IssueProductScope & {
       throw new IssueProductInputError("owner.type must be user or team");
     }
   }
+  const actionId = randomUUID();
   const prisma = await getPrismaClientForTenancy(options.tenancy);
   return await retryOnceOnUniqueConstraintRace(() => retryTransaction(prisma, async (tx) => {
     await assertIssueExists(tx, options);
@@ -475,7 +487,7 @@ export async function setIssueOwner(options: IssueProductScope & {
       : await tx.issueOwner.update({ where: { tenancyId_id: { tenancyId: options.tenancy.id, id: existingOwner.id } }, data: { context: options.owner.context ?? Prisma.JsonNull, updatedAt: occurredAt } });
     await appendActivityInTransaction({
       tx, tenancy: options.tenancy, issueId: options.issueId, actorUserId,
-      type: "owner_changed", idempotencyKey: activityKey("owner", `${owner.id}:${occurredAt.toISOString()}`),
+      type: "owner_changed", idempotencyKey: activityKey("owner", `${owner.id}:${occurredAt.toISOString()}:${actionId}`),
       data: { owner_type: ownerType, owner_id: ownerUserId ?? ownerTeamId, source: options.owner.source }, occurredAt,
     });
     return {
@@ -696,6 +708,7 @@ export async function removeIssueOwner(options: IssueProductScope & { ownerId: s
   assertUuid(options.ownerId, "ownerId");
   const actorUserId = actorId(options.actorUserId);
   const occurredAt = assertValidDate(options.occurredAt ?? new Date(), "occurredAt");
+  const actionId = randomUUID();
   const prisma = await getPrismaClientForTenancy(options.tenancy);
   await retryTransaction(prisma, async (tx) => {
     await assertIssueExists(tx, options);
@@ -705,7 +718,7 @@ export async function removeIssueOwner(options: IssueProductScope & { ownerId: s
     await tx.issueOwner.delete({ where: { tenancyId_id: { tenancyId: options.tenancy.id, id: options.ownerId } } });
     await appendActivityInTransaction({
       tx, tenancy: options.tenancy, issueId: options.issueId, actorUserId,
-      type: "owner_changed", idempotencyKey: activityKey("owner-remove", `${owner.id}:${occurredAt.toISOString()}`),
+      type: "owner_changed", idempotencyKey: activityKey("owner-remove", `${owner.id}:${occurredAt.toISOString()}:${actionId}`),
       data: { owner_id: owner.id, removed: true }, occurredAt,
     });
   });

--- a/apps/backend/src/lib/issues/issue-webhooks.ts
+++ b/apps/backend/src/lib/issues/issue-webhooks.ts
@@ -205,6 +205,7 @@ export async function emitIssueLifecycleWebhook(options: {
   issueId: string,
   event: "resolved" | "ignored" | "merged",
   now: Date,
+  eventId?: string,
 }): Promise<void> {
   const { tenancy, issueId, event, now } = options;
   if (!isWebhooksAppEnabled(tenancy)) return;
@@ -239,7 +240,7 @@ export async function emitIssueLifecycleWebhook(options: {
     ...buildIssueWebhookData(tenancy, row, "ongoing"),
     ...event === "merged" ? {} : { status: event },
   };
-  const eventId = `${row.id}:${event}:${now.getTime()}`;
+  const eventId = options.eventId ?? `${row.id}:${event}:${now.getTime()}`;
 
   switch (event) {
     case "resolved": {

--- a/apps/backend/src/lib/issues/occurrence-projection.ts
+++ b/apps/backend/src/lib/issues/occurrence-projection.ts
@@ -181,10 +181,10 @@ function toPublicFrame(frame: StoredIssueFrame, symbolication: PublicIssueFrameS
 
 /** The release recorded ON this occurrence row, from its data column or envelope. */
 function occurrenceRelease(row: PublicOccurrenceRow, envelope: PublicIssueErrorEnvelope | null): string | null {
-  const dataRelease = row.data.release;
-  if (typeof dataRelease === "string" && dataRelease !== "") return dataRelease;
   const envelopeRelease = envelope?.release;
   if (typeof envelopeRelease === "string" && envelopeRelease !== "") return envelopeRelease;
+  const dataRelease = row.data.release;
+  if (typeof dataRelease === "string" && dataRelease !== "") return dataRelease;
   return null;
 }
 
@@ -194,10 +194,13 @@ export async function projectPublicIssueOccurrence(
     scope: { tenantId: string, projectId: string, branchId: string },
     symbolicator?: PublicIssueSymbolicator,
     attachments?: readonly IssueAttachment[],
+    errorEnvelope?: PublicIssueErrorEnvelope | null,
   },
 ): Promise<PublicIssueOccurrence> {
   const storedFrames = parseStoredFrames(row.error_frames);
-  const errorEnvelope = parsePublicErrorEnvelope(row.error_envelope);
+  const errorEnvelope = options.errorEnvelope === undefined
+    ? parsePublicErrorEnvelope(row.error_envelope)
+    : options.errorEnvelope;
   const release = occurrenceRelease(row, errorEnvelope);
   const groupingProvenance = parsePublicGroupingProvenance(row.issue_grouping_provenance);
   const symbolication = await symbolicatePublicFrames({

--- a/apps/backend/src/lib/issues/public-scrub.ts
+++ b/apps/backend/src/lib/issues/public-scrub.ts
@@ -20,6 +20,12 @@ export function scrubPublicText(value: string): string {
   return typeof scrubbed === "string" ? scrubbed : "";
 }
 
+export function scrubPublicOptionalText(value: unknown): string | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  const scrubbed = scrubPublicValue(value);
+  return typeof scrubbed === "string" && scrubbed.length > 0 ? scrubbed : null;
+}
+
 export function scrubPublicRecord(value: unknown): Record<string, unknown> {
   const scrubbed = scrubPublicValue(value);
   return isRecord(scrubbed) ? scrubbed : {};

--- a/apps/backend/src/lib/issues/public-search/contract.test.ts
+++ b/apps/backend/src/lib/issues/public-search/contract.test.ts
@@ -137,6 +137,7 @@ describe("public observability search contract", () => {
     // record key, which the response schema caps at 128 characters — a
     // 124-char key fits alone but not behind `property:`.
     expect(() => parsePublicSearchQuery({ record: "event", facets: `property:${"k".repeat(124)}` })).toThrow("including their prefix");
+    expect(() => parsePublicSearchQuery({ record: "event", facets: "tag:" })).toThrow("tag: facets require a non-empty key");
     expect(parsePublicSearchQuery({ record: "event", facets: `property:${"k".repeat(119)}` })).toMatchObject({
       facets: [`property:${"k".repeat(119)}`],
     });

--- a/apps/backend/src/lib/issues/public-search/contract.ts
+++ b/apps/backend/src/lib/issues/public-search/contract.ts
@@ -326,9 +326,8 @@ function parseFacets(raw: string | undefined, record: PublicSearchRecordType): s
       // schema caps at 128 characters — a key that fits on its own but not
       // with its prefix would pass request validation and then fail response
       // validation, turning a valid-looking search into a server error.
-      if (key === "" || facet.length > 128) {
-        return badRequest("dynamic facets must be between 1 and 128 characters including their prefix");
-      }
+      if (key === "") return badRequest(`${dynamicPrefix} facets require a non-empty key`);
+      if (facet.length > 128) return badRequest("dynamic facet identifiers must be at most 128 characters including their prefix");
       if (record === "issue") return badRequest(`${facet.split(":", 1)[0]} facets are only supported for event and occurrence records`);
       continue;
     }

--- a/apps/backend/src/lib/issues/public-search/projection.ts
+++ b/apps/backend/src/lib/issues/public-search/projection.ts
@@ -1,5 +1,10 @@
-import { scrubErrorIngestPayload } from "@/lib/error-ingest";
 import { getErrorAttachmentEventId } from "@/lib/attachments/attachment-event-id";
+import {
+  isRecord,
+  scrubPublicOptionalText,
+  scrubPublicRecord,
+  scrubPublicText,
+} from "@/lib/issues/public-scrub";
 import type {
   PublicSearchAttachment,
   PublicSearchFilters,
@@ -54,26 +59,6 @@ export type PublicSearchIssueRow = {
   updatedAt: Date,
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function scrubText(value: string): string {
-  const scrubbed = scrubErrorIngestPayload(value).value;
-  return typeof scrubbed === "string" ? scrubbed : "";
-}
-
-function scrubOptionalText(value: unknown): string | null {
-  if (typeof value !== "string" || value.length === 0) return null;
-  const scrubbed = scrubErrorIngestPayload(value).value;
-  return typeof scrubbed === "string" && scrubbed.length > 0 ? scrubbed : null;
-}
-
-function scrubRecord(value: unknown): Record<string, unknown> {
-  const scrubbed = scrubErrorIngestPayload(value).value;
-  return isRecord(scrubbed) ? scrubbed : {};
-}
-
 function readString(record: Record<string, unknown>, key: string): string | null {
   const value = record[key];
   return typeof value === "string" && value.length > 0 ? value : null;
@@ -112,7 +97,7 @@ const PUBLIC_SEARCH_ERROR_ENVELOPE_MAX_BYTES = 256 * 1024;
 function storedErrorEnvelope(raw: string | null): Record<string, unknown> {
   if (raw === null || raw === "" || new TextEncoder().encode(raw).byteLength > PUBLIC_SEARCH_ERROR_ENVELOPE_MAX_BYTES) return {};
   const parsed = parseJson(raw);
-  return scrubRecord(parsed);
+  return scrubPublicRecord(parsed);
 }
 
 export function publicSearchTimestamp(raw: string): number {
@@ -137,7 +122,7 @@ function publicEventId(value: unknown): string | null {
 }
 
 function sourcePath(value: unknown): string | null {
-  const text = scrubOptionalText(value);
+  const text = scrubPublicOptionalText(value);
   if (text === null) return null;
 
   let path = text;
@@ -157,12 +142,12 @@ function sourcePath(value: unknown): string | null {
 export function toPublicSearchAttachmentMetadata(value: unknown): PublicSearchAttachment | null {
   if (!isRecord(value)) return null;
   return {
-    id: scrubOptionalText(value.id),
+    id: scrubPublicOptionalText(value.id),
     filename: sourcePath(value.filename),
-    content_type: scrubOptionalText(value.content_type ?? value.contentType),
+    content_type: scrubPublicOptionalText(value.content_type ?? value.contentType),
     size: readFiniteNonNegativeInteger(value.size ?? value.byte_length ?? value.byteLength),
-    checksum: scrubOptionalText(value.checksum ?? value.sha256),
-    attachment_type: scrubOptionalText(value.attachment_type ?? value.attachmentType),
+    checksum: scrubPublicOptionalText(value.checksum ?? value.sha256),
+    attachment_type: scrubPublicOptionalText(value.attachment_type ?? value.attachmentType),
   };
 }
 
@@ -179,7 +164,7 @@ function attachmentMetadata(value: unknown): PublicSearchAttachment[] {
 export function publicSearchAttachmentEventId(row: PublicSearchOccurrenceRow): string | null {
   return getErrorAttachmentEventId({
     occurrenceId: row.occurrence_id,
-    data: scrubRecord(row.data),
+    data: scrubPublicRecord(row.data),
     errorEnvelope: storedErrorEnvelope(row.error_envelope),
   });
 }
@@ -189,11 +174,11 @@ function sourceLink(value: unknown): PublicSearchSourceLink | null {
   const path = sourcePath(value.absPath ?? value.abs_path ?? value.filename ?? value.code_file);
   const link: PublicSearchSourceLink = {
     path,
-    function: scrubOptionalText(value.function),
-    module: scrubOptionalText(value.module),
+    function: scrubPublicOptionalText(value.function),
+    module: scrubPublicOptionalText(value.module),
     line: readFiniteNonNegativeInteger(value.lineno),
     column: readFiniteNonNegativeInteger(value.colno),
-    debug_id: scrubOptionalText(value.debugId ?? value.debug_id),
+    debug_id: scrubPublicOptionalText(value.debugId ?? value.debug_id),
   };
   return link.path === null
     && link.function === null
@@ -243,8 +228,8 @@ function matchedTag(filters: PublicSearchFilters, ...metadataRecords: readonly R
     }
   }
   if (typeof rawValue !== "string" || rawValue !== filters.tagValue) return null;
-  const key = scrubOptionalText(filters.tagKey);
-  const value = scrubOptionalText(rawValue);
+  const key = scrubPublicOptionalText(filters.tagKey);
+  const value = scrubPublicOptionalText(rawValue);
   return key === null || value === null ? null : { key, value };
 }
 
@@ -259,7 +244,7 @@ export function toPublicSearchFacets(rows: readonly PublicSearchFacetRow[]): Pub
   for (const row of rows) {
     if (row.facet_key.length === 0 || row.facet_key.length > 128) throw new Error("ClickHouse returned an invalid public search facet key");
     if (!Object.prototype.hasOwnProperty.call(facets, row.facet_key) && Object.keys(facets).length >= PUBLIC_SEARCH_FACET_REQUEST_CAP) continue;
-    const value = scrubText(row.facet_value).slice(0, 512);
+    const value = scrubPublicText(row.facet_value).slice(0, 512);
     if (value === "") continue;
     const values = facets[row.facet_key] ?? [];
     if (values.length >= PUBLIC_SEARCH_FACET_COUNT_CAP) continue;
@@ -286,7 +271,7 @@ export function toPublicSearchOccurrence(
   additionalAttachments: readonly PublicSearchAttachment[] = [],
 ): PublicSearchRecord {
   if (row.occurrence_id.length === 0) throw new Error("ClickHouse returned an empty public search occurrence id");
-  const data = scrubRecord(row.data);
+  const data = scrubPublicRecord(row.data);
   const envelope = storedErrorEnvelope(row.error_envelope);
   const dataMessage = readString(data, "message");
   const envelopeMessage = readString(envelope, "message");
@@ -318,12 +303,12 @@ export function toPublicSearchOccurrence(
     event_id: publicEventId(eventId),
     occurrence_id: row.occurrence_id,
     event_at_millis: publicSearchTimestamp(row.event_at),
-    message: message === null ? "" : scrubText(message),
-    level: envelopeLevel === null && dataLevel === null ? scrubText(row.level) : scrubText(envelopeLevel ?? dataLevel ?? row.level),
+    message: message === null ? "" : scrubPublicText(message),
+    level: envelopeLevel === null && dataLevel === null ? scrubPublicText(row.level) : scrubPublicText(envelopeLevel ?? dataLevel ?? row.level),
     handled: envelopeHandled ?? dataHandled,
-    service: scrubOptionalText(service),
-    environment: scrubOptionalText(rawEnvironment),
-    release: scrubOptionalText(release),
+    service: scrubPublicOptionalText(service),
+    environment: scrubPublicOptionalText(rawEnvironment),
+    release: scrubPublicOptionalText(release),
     matched_tag: matchedTag(filters, envelope, data),
     attachments: additionalAttachments.length > 0
       ? [...additionalAttachments]
@@ -354,9 +339,9 @@ export function toPublicSearchIssue(
   const fields: Pick<PublicSearchRecord, "issue_id" | "issue_short_id" | "issue_type" | "issue_value" | "issue_culprit" | "issue_status"> = {
     issue_id: row.id,
     issue_short_id: row.shortId.toString(),
-    issue_type: scrubText(row.type),
-    issue_value: scrubText(row.value),
-    issue_culprit: scrubText(row.culprit),
+    issue_type: scrubPublicText(row.type),
+    issue_value: scrubPublicText(row.value),
+    issue_culprit: scrubPublicText(row.culprit),
     issue_status: status,
   };
   return {
@@ -366,15 +351,15 @@ export function toPublicSearchIssue(
     event_id: null,
     occurrence_id: null,
     event_at_millis: publicDate(row.lastSeenAt, "lastSeenAt"),
-    message: scrubText(row.value),
+    message: scrubPublicText(row.value),
     level: "error",
     handled: row.handled,
-    service: scrubOptionalText(row.serviceName),
-    environment: scrubOptionalText(row.deploymentEnvironmentName),
-    release: scrubOptionalText(row.lastSeenRelease),
+    service: scrubPublicOptionalText(row.serviceName),
+    environment: scrubPublicOptionalText(row.deploymentEnvironmentName),
+    release: scrubPublicOptionalText(row.lastSeenRelease),
     matched_tag: filters.tagKey === null || filters.tagValue === null
       ? null
-      : { key: scrubText(filters.tagKey), value: scrubText(filters.tagValue) },
+      : { key: scrubPublicText(filters.tagKey), value: scrubPublicText(filters.tagValue) },
     attachments: [],
     source_links: [],
   };

--- a/apps/backend/src/lib/legacy-telemetry-dual-write.test.ts
+++ b/apps/backend/src/lib/legacy-telemetry-dual-write.test.ts
@@ -44,6 +44,10 @@ describe("dualWriteLegacyEvents", () => {
     expect(insert).toHaveBeenCalledWith(expect.objectContaining({
       table: "analytics_internal.events",
       values: [{ ...ROW, dual_written: 1 }],
+      clickhouse_settings: expect.objectContaining({
+        async_insert: 1,
+        wait_for_async_insert: 1,
+      }),
     }));
 
     // The probe is cached: a second batch must not re-query system.tables.
@@ -97,12 +101,21 @@ describe("dualWriteLegacyEvents", () => {
   it("treats the recreated read-only view rejecting the write (code 48) the same way", async () => {
     const { client, insert } = createFakeClickhouseClient({
       engineRows: [{ engine: "MergeTree" }],
-      insertError: { code: 48 },
+      insertError: { code: 48, message: "Method write is not supported by storage View" },
     });
 
     await expect(dualWriteLegacyEvents(client, [ROW])).resolves.toBeUndefined();
     await dualWriteLegacyEvents(client, [ROW]);
     expect(insert).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not hide an unrelated NOT_IMPLEMENTED error", async () => {
+    const { client } = createFakeClickhouseClient({
+      engineRows: [{ engine: "MergeTree" }],
+      insertError: { code: 48, message: "This feature is not implemented" },
+    });
+
+    await expect(dualWriteLegacyEvents(client, [ROW])).rejects.toMatchObject({ code: 48 });
   });
 
   it("propagates every other insert failure — the legacy table is the customer-visible read surface", async () => {

--- a/apps/backend/src/lib/legacy-telemetry-dual-write.ts
+++ b/apps/backend/src/lib/legacy-telemetry-dual-write.ts
@@ -1,4 +1,4 @@
-import { captureError } from "@hexclave/shared/dist/utils/errors";
+import { captureWarning } from "@hexclave/shared/dist/utils/errors";
 import { type ClickHouseClient } from "./clickhouse";
 
 /**
@@ -64,7 +64,10 @@ async function isLegacyEventsDualWriteEnabled(client: ClickHouseClient): Promise
 function isRetiredLegacyTableError(error: unknown): boolean {
   if (typeof error !== "object" || error === null || !("code" in error)) return false;
   const code: unknown = error.code;
-  return code === "60" || code === "48" || code === 60 || code === 48;
+  if (code === "60" || code === 60) return true;
+  if (code !== "48" && code !== 48) return false;
+  const message = "message" in error && typeof error.message === "string" ? error.message : "";
+  return /write is not supported.*view|storage view/i.test(message);
 }
 
 /**
@@ -94,6 +97,11 @@ export async function dualWriteLegacyEvents(
       clickhouse_settings: {
         date_time_input_format: "best_effort",
         async_insert: 1,
+        // The legacy table is the read surface until cutover. Do not let the
+        // ClickHouse client resolve before an async insert has been accepted;
+        // otherwise the request can report success while the mirror row is
+        // still only queued in the server-side async buffer.
+        wait_for_async_insert: 1,
       },
     });
   } catch (error) {
@@ -101,7 +109,7 @@ export async function dualWriteLegacyEvents(
       dualWriteEnabledCache = false;
       // Informational, not an incident: this is the expected way a process
       // that outlived the cutover learns dual-writing is over.
-      captureError("legacy-telemetry-dual-write-retired", error);
+      captureWarning("legacy-telemetry-dual-write-retired", error);
       return;
     }
     throw error;

--- a/apps/backend/src/lib/otlp/json.ts
+++ b/apps/backend/src/lib/otlp/json.ts
@@ -16,6 +16,14 @@ export type OtlpAttributeValue =
   | { type: "null", value: null };
 export type OtlpAttributes = Map<string, OtlpAttributeValue>;
 
+// Shared with metrics normalization so logs and metrics enforce the same
+// recursive AnyValue collection bounds.
+export const DEFAULT_OTLP_ATTRIBUTE_LIMITS = {
+  maxDepth: 16,
+  maxAttributesPerList: 256,
+  maxAttributeArrayValues: 256,
+} as const;
+
 function isOtlpRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -88,9 +96,9 @@ export function otlpCanonicalUint64String(value: unknown, path: string): string 
 // the call stack, and the resulting RangeError is not an OtlpJsonRequestError —
 // so it would bypass the routes' 400 handling and surface as a 500. The
 // collection caps bound CPU/allocation before any per-record limit can run.
-const MAX_OTLP_ANY_VALUE_DEPTH = 16;
-const MAX_OTLP_ATTRIBUTES_PER_LIST = 256;
-const MAX_OTLP_ATTRIBUTE_ARRAY_VALUES = 256;
+const MAX_OTLP_ANY_VALUE_DEPTH = DEFAULT_OTLP_ATTRIBUTE_LIMITS.maxDepth;
+const MAX_OTLP_ATTRIBUTES_PER_LIST = DEFAULT_OTLP_ATTRIBUTE_LIMITS.maxAttributesPerList;
+const MAX_OTLP_ATTRIBUTE_ARRAY_VALUES = DEFAULT_OTLP_ATTRIBUTE_LIMITS.maxAttributeArrayValues;
 
 export function otlpAnyValue(value: unknown, path: string, depth = 0): OtlpAttributeValue {
   if (depth > MAX_OTLP_ANY_VALUE_DEPTH) throw new OtlpJsonRequestError(`${path} exceeds the maximum attribute depth of ${MAX_OTLP_ANY_VALUE_DEPTH}`);
@@ -127,6 +135,7 @@ export function otlpAnyValue(value: unknown, path: string, depth = 0): OtlpAttri
 }
 
 export function otlpAttributes(value: unknown, path: string, depth = 0): OtlpAttributes {
+  if (depth > MAX_OTLP_ANY_VALUE_DEPTH) throw new OtlpJsonRequestError(`${path} exceeds the maximum attribute depth of ${MAX_OTLP_ANY_VALUE_DEPTH}`);
   const result = new Map<string, OtlpAttributeValue>();
   const entries = otlpArray(value, path);
   if (entries.length > MAX_OTLP_ATTRIBUTES_PER_LIST) throw new OtlpJsonRequestError(`${path} must contain at most ${MAX_OTLP_ATTRIBUTES_PER_LIST} entries`);

--- a/apps/backend/src/lib/otlp/log-writer.ts
+++ b/apps/backend/src/lib/otlp/log-writer.ts
@@ -1,4 +1,4 @@
-import { classifyTelemetrySignal, CUSTOM_TELEMETRY_NAME_RE, isAnalyticsSystemEvent, isW3cSpanId, TELEMETRY_UUID_RE } from "@hexclave/shared/dist/utils/analytics-wire";
+import { CUSTOM_TELEMETRY_NAME_RE, isAnalyticsSystemEvent, isW3cSpanId, TELEMETRY_UUID_RE } from "@hexclave/shared/dist/utils/analytics-wire";
 import { createHash } from "crypto";
 import { stripLoneSurrogates, type ClickHouseClient } from "@/lib/clickhouse";
 import { computeOccurrenceId, normalizeErrorOccurrence } from "@/lib/analytics-telemetry-writers";
@@ -230,25 +230,19 @@ export type OtlpLogBillingDebit = {
 };
 
 /**
- * Metering inputs for one accepted OTLP logs request, using the same taxonomy
- * rule as the legacy events/batch route: a record is billed when its projected
- * event type carries the `analytics_events` billing item (which covers product
- * events, `$log`, and `$error` alike — OTLP must not be a quota bypass for any
- * of them). Keyed by occurrence id so an OTLP exporter retry (same content →
+ * Metering inputs for one accepted OTLP logs request. Every accepted projected
+ * record is an analytics event (`$log`, `$error`, or a product event), so OTLP
+ * must not become a quota bypass for any of them. Keyed by occurrence id so an
+ * OTLP exporter retry (same content →
  * same batch id → same occurrence ids) collapses onto the same metering rows
  * instead of double-debiting.
  */
 export function getOtlpLogBillingDebits(logs: CanonicalOtlpLogRecord[], tenant: OtlpLogTenantContext): OtlpLogBillingDebit[] {
   const batchId = getOtlpLogsBatchId(logs, tenant);
   return logs.flatMap((log, ordinal) => {
-    const signalType = stringAttribute(log.attributes, "hexclave.signal.type");
     // Billing-wise only the projected event TYPE matters, so the (expensive)
     // error grouping projection is not computed here: a `$error`-classified
     // record and the `$log` fallback carry the same billing item.
-    const eventType = signalType === "event" && isProductEventName(log.eventName)
-      ? log.eventName
-      : signalType === "error" && log.eventName === "$error" ? "$error" : "$log";
-    if (classifyTelemetrySignal(eventType, "event").billingItem !== "analytics_events") return [];
     const eventNano = log.timeUnixNano === "0" ? log.observedTimeUnixNano : log.timeUnixNano;
     return [{
       occurrenceId: getOtlpLogOccurrenceId(log, batchId, ordinal),

--- a/apps/backend/src/lib/otlp/metric-query.test.ts
+++ b/apps/backend/src/lib/otlp/metric-query.test.ts
@@ -84,12 +84,13 @@ describe("OTLP metric query contract", () => {
   });
 
   it("requires a metric name when selecting by metric type", async () => {
-    const { client } = fakeCatalogClient([{ rows: [] }]);
+    const { client, executed } = fakeCatalogClient([]);
     await expect(queryOtlpMetrics({
       tenancy: { project: { id: "p" }, branchId: "b" },
       request: { metricType: "histogram" },
       client,
     })).rejects.toThrow("metric_type requires metric_name");
+    expect(executed).toHaveLength(0);
   });
 
   it("scopes the targeted catalog-entry lookup by name and optionally type", () => {

--- a/apps/backend/src/lib/otlp/metric-query.test.ts
+++ b/apps/backend/src/lib/otlp/metric-query.test.ts
@@ -83,6 +83,15 @@ describe("OTLP metric query contract", () => {
     expect(() => parseOtlpMetricQueryType("timer")).toThrow("metric_type must be one of");
   });
 
+  it("requires a metric name when selecting by metric type", async () => {
+    const { client } = fakeCatalogClient([{ rows: [] }]);
+    await expect(queryOtlpMetrics({
+      tenancy: { project: { id: "p" }, branchId: "b" },
+      request: { metricType: "histogram" },
+      client,
+    })).rejects.toThrow("metric_type requires metric_name");
+  });
+
   it("scopes the targeted catalog-entry lookup by name and optionally type", () => {
     expect(buildOtlpMetricCatalogEntryQuery(false)).toContain("metric_name = {metricName:String}");
     expect(buildOtlpMetricCatalogEntryQuery(false)).not.toContain("{metricType:String}");

--- a/apps/backend/src/lib/otlp/metric-query.ts
+++ b/apps/backend/src/lib/otlp/metric-query.ts
@@ -155,7 +155,7 @@ export function getOtlpMetricBucketNanoseconds(hours: OtlpMetricQueryHours): big
   return 86_400n * 1_000_000_000n;
 }
 
-export function buildOtlpMetricCatalogQuery(hours: OtlpMetricQueryHours): string {
+function buildOtlpMetricCatalogQuerySql(options: { where: string, limit: number }): string {
   return `
 SELECT
   metric_name,
@@ -167,13 +167,20 @@ SELECT
   count() AS point_count,
   toString(max(time_unix_nano)) AS latest_time_unix_nano
 FROM analytics_internal.metrics FINAL
-PREWHERE project_id = {projectId:String}
-  AND branch_id = {branchId:String}
-  AND time_unix_nano >= toUnixTimestamp64Nano(now64(9) - INTERVAL {hours:UInt32} HOUR)
+PREWHERE ${options.where}
 GROUP BY metric_name, metric_type
 ORDER BY point_count DESC, metric_name ASC, metric_type ASC
-LIMIT ${MAX_CATALOG_ROWS}
+LIMIT ${options.limit}
 `;
+}
+
+export function buildOtlpMetricCatalogQuery(hours: OtlpMetricQueryHours): string {
+  return buildOtlpMetricCatalogQuerySql({
+    where: `project_id = {projectId:String}
+  AND branch_id = {branchId:String}
+  AND time_unix_nano >= toUnixTimestamp64Nano(now64(9) - INTERVAL {hours:UInt32} HOUR)`,
+    limit: MAX_CATALOG_ROWS,
+  });
 }
 
 /**
@@ -186,26 +193,14 @@ LIMIT ${MAX_CATALOG_ROWS}
  * types one name can carry.
  */
 export function buildOtlpMetricCatalogEntryQuery(withMetricType: boolean): string {
-  return `
-SELECT
-  metric_name,
-  argMax(metric_description, (time_unix_nano, created_at, point_id)) AS metric_description,
-  argMax(metric_unit, (time_unix_nano, created_at, point_id)) AS metric_unit,
-  metric_type,
-  argMax(aggregation_temporality, (time_unix_nano, created_at, point_id)) AS aggregation_temporality,
-  argMax(is_monotonic, (time_unix_nano, created_at, point_id)) AS is_monotonic,
-  count() AS point_count,
-  toString(max(time_unix_nano)) AS latest_time_unix_nano
-FROM analytics_internal.metrics FINAL
-PREWHERE project_id = {projectId:String}
+  return buildOtlpMetricCatalogQuerySql({
+    where: `project_id = {projectId:String}
   AND branch_id = {branchId:String}
   AND metric_name = {metricName:String}
   ${withMetricType ? "AND metric_type = {metricType:String}" : ""}
-  AND time_unix_nano >= toUnixTimestamp64Nano(now64(9) - INTERVAL {hours:UInt32} HOUR)
-GROUP BY metric_name, metric_type
-ORDER BY point_count DESC, metric_name ASC, metric_type ASC
-LIMIT ${OTLP_METRIC_TYPES.length}
-`;
+  AND time_unix_nano >= toUnixTimestamp64Nano(now64(9) - INTERVAL {hours:UInt32} HOUR)`,
+    limit: OTLP_METRIC_TYPES.length,
+  });
 }
 
 export function buildOtlpMetricSeriesQuery(hours: OtlpMetricQueryHours): string {
@@ -318,6 +313,9 @@ export async function queryOtlpMetrics(options: {
   });
   const catalog = parseOtlpMetricCatalogRows(await catalogResult.json<RawCatalogRow>());
   const requestedType = parseOtlpMetricQueryType(options.request.metricType);
+  if (requestedType !== null && options.request.metricName == null) {
+    throw new StatusError(StatusError.BadRequest, "metric_type requires metric_name");
+  }
   let selected = options.request.metricName == null
     ? catalog[0]
     : catalog.find((entry) => entry.metric_name === options.request.metricName

--- a/apps/backend/src/lib/otlp/metric-query.ts
+++ b/apps/backend/src/lib/otlp/metric-query.ts
@@ -300,6 +300,10 @@ export async function queryOtlpMetrics(options: {
   client?: ClickHouseClient,
 }): Promise<OtlpMetricQueryResponse> {
   const hours = parseOtlpMetricQueryHours(options.request.hours);
+  const requestedType = parseOtlpMetricQueryType(options.request.metricType);
+  if (requestedType !== null && options.request.metricName == null) {
+    throw new StatusError(StatusError.BadRequest, "metric_type requires metric_name");
+  }
   const client = options.client ?? getClickhouseAdminClientForMetrics();
   const query_params = {
     projectId: options.tenancy.project.id,
@@ -312,10 +316,6 @@ export async function queryOtlpMetrics(options: {
     format: "JSONEachRow",
   });
   const catalog = parseOtlpMetricCatalogRows(await catalogResult.json<RawCatalogRow>());
-  const requestedType = parseOtlpMetricQueryType(options.request.metricType);
-  if (requestedType !== null && options.request.metricName == null) {
-    throw new StatusError(StatusError.BadRequest, "metric_type requires metric_name");
-  }
   let selected = options.request.metricName == null
     ? catalog[0]
     : catalog.find((entry) => entry.metric_name === options.request.metricName

--- a/apps/backend/src/lib/otlp/metrics.ts
+++ b/apps/backend/src/lib/otlp/metrics.ts
@@ -1,5 +1,6 @@
 import { isW3cSpanId, isW3cTraceId } from "@hexclave/shared/dist/utils/analytics-wire";
 import {
+  DEFAULT_OTLP_ATTRIBUTE_LIMITS,
   OtlpJsonRequestError,
   otlpArray,
   otlpRecord,
@@ -41,9 +42,9 @@ export const DEFAULT_OTLP_METRICS_NORMALIZATION_LIMITS: OtlpMetricsNormalization
   maxScopeMetricsPerResource: 128,
   maxMetricsPerScope: 1_024,
   maxDataPointsPerMetric: 10_000,
-  maxAttributesPerList: 256,
-  maxAttributeArrayValues: 256,
-  maxAttributeDepth: 16,
+  maxAttributesPerList: DEFAULT_OTLP_ATTRIBUTE_LIMITS.maxAttributesPerList,
+  maxAttributeArrayValues: DEFAULT_OTLP_ATTRIBUTE_LIMITS.maxAttributeArrayValues,
+  maxAttributeDepth: DEFAULT_OTLP_ATTRIBUTE_LIMITS.maxDepth,
   maxExemplarsPerDataPoint: 256,
   maxHistogramBuckets: 10_000,
   maxQuantileValues: 256,

--- a/apps/backend/src/lib/qstash-outbox.ts
+++ b/apps/backend/src/lib/qstash-outbox.ts
@@ -136,13 +136,15 @@ export function decodeQstashMessage(value: unknown): QstashMessage<Record<string
     delay = value.delay;
   }
 
-  return {
+  const message: QstashMessage<Record<string, unknown>> = {
     url,
     body,
     ...(flowControl === undefined ? {} : { flowControl }),
     ...(delay === undefined ? {} : { delay }),
     ...(job === undefined ? {} : { job }),
   };
+  assertMessage(message);
+  return message;
 }
 
 /**

--- a/apps/backend/src/lib/releases/release-route-handlers.test.ts
+++ b/apps/backend/src/lib/releases/release-route-handlers.test.ts
@@ -180,6 +180,7 @@ function database(options: {
       findMany: async () => [deployment],
       findUnique: async () => null,
       upsert: async () => deployment,
+      update: async () => deployment,
     },
     releaseCommit: {
       findMany: async () => [commit],

--- a/apps/backend/src/lib/releases/release-service.test.ts
+++ b/apps/backend/src/lib/releases/release-service.test.ts
@@ -142,6 +142,7 @@ function fakeDatabase(overrides: ReleaseDatabaseOverrides = {}): ReleaseDatabase
       findMany: async () => [],
       findUnique: async () => null,
       upsert: async () => deployment,
+      update: async () => deployment,
       ...overrides.releaseDeployment,
     },
     releaseCommit: {

--- a/apps/backend/src/lib/releases/release-service.ts
+++ b/apps/backend/src/lib/releases/release-service.ts
@@ -77,6 +77,7 @@ export type ReleaseDatabase = {
     findMany(args: Prisma.ReleaseDeploymentFindManyArgs): Promise<ReleaseDeployment[]>,
     findUnique(args: Prisma.ReleaseDeploymentFindUniqueArgs): Promise<ReleaseDeployment | null>,
     upsert(args: Prisma.ReleaseDeploymentUpsertArgs): Promise<ReleaseDeployment>,
+    update(args: Prisma.ReleaseDeploymentUpdateArgs): Promise<ReleaseDeployment>,
   },
   releaseCommit: {
     findMany(args: Prisma.ReleaseCommitFindManyArgs): Promise<ReleaseCommit[]>,
@@ -92,7 +93,7 @@ export type ReleaseDatabase = {
       // promises the ReleaseArtifactLookupRow relation shape, so the adapter
       // is the single owner of the matching `include` — callers cannot pass a
       // competing one that the adapter would silently overwrite.
-      findMany(args: Omit<Prisma.ReleaseArtifactDebugIdFindManyArgs, "include">): Promise<ReleaseArtifactLookupRow[]>,
+      findMany(args: Omit<Prisma.ReleaseArtifactDebugIdFindManyArgs, "select" | "include">): Promise<ReleaseArtifactLookupRow[]>,
   },
 };
 
@@ -393,6 +394,14 @@ export class ReleaseService {
     const metadata = input.metadata === undefined
       ? undefined
       : validateReleaseJson(input.metadata, "deployment metadata");
+    const mutableFields: Prisma.ReleaseDeploymentUpdateInput = {
+      environment,
+      ...(input.name === undefined ? {} : { name: input.name }),
+      ...(input.url === undefined ? {} : { url: input.url }),
+      ...(input.startedAt === undefined ? {} : { startedAt: input.startedAt }),
+      ...(input.finishedAt === undefined ? {} : { finishedAt: input.finishedAt }),
+      ...(metadata === undefined ? {} : { metadata }),
+    };
 
     const db = await this.resolveDatabase(scope);
     const existing = await db.releaseDeployment.findUnique({
@@ -415,32 +424,26 @@ export class ReleaseService {
         ...(input.finishedAt === undefined ? {} : { finishedAt: input.finishedAt }),
         ...(metadata === undefined ? {} : { metadata }),
       },
-      update: {
-        environment,
-        ...(input.name === undefined ? {} : { name: input.name }),
-        ...(input.url === undefined ? {} : { url: input.url }),
-        ...(input.startedAt === undefined ? {} : { startedAt: input.startedAt }),
-        ...(input.finishedAt === undefined ? {} : { finishedAt: input.finishedAt }),
-        ...(metadata === undefined ? {} : { metadata }),
-      },
+      // Do not mutate the conflict winner here. A concurrent request for a
+      // different release can win the unique-key race after the friendly
+      // pre-read; Prisma's upsert update branch would otherwise overwrite the
+      // winner's environment/name before the ownership check can reject us.
+      update: {},
     });
     // The pre-upsert ownership check above is a friendly early exit only: two
     // concurrent registrations that reuse one deploymentKey for different
-    // releases can both pass it (TOCTOU). The upsert's update clause never
-    // moves a row between releases, so re-checking the row we actually got
-    // back detects the loser of that race — it must fail loudly instead of
-    // reporting success against a deployment that is attached to another
-    // release. (The loser's mutable-field update may have landed on the
-    // winner's row inside the race window; both requests come from the same
-    // tenant reusing one idempotency key, so surfacing the conflict is the
-    // correct resolution and no cross-tenant data can be touched.)
-    if (deployment.tenancyId !== fields.tenancyId
-      || deployment.projectId !== fields.projectId
+    // releases can both pass it (TOCTOU). The conflict winner is immutable
+    // until this ownership check succeeds, so the loser cannot mutate the
+    // winner's fields before failing.
+    if (deployment.projectId !== fields.projectId
       || deployment.branchId !== fields.branchId
       || deployment.releaseId !== releaseId) {
       throw new ReleaseScopeInvariantError(`deploymentKey ${deploymentKey} is already attached to a different release scope`);
     }
-    return deployment;
+    return await db.releaseDeployment.update({
+      where: { tenancyId_id: { tenancyId: fields.tenancyId, id: deployment.id } },
+      data: mutableFields,
+    });
   }
 
   public async upsertCommit(scope: ReleaseScope, input: UpsertReleaseCommitInput): Promise<ReleaseCommit> {
@@ -703,6 +706,7 @@ function adaptPrismaClient(client: PrismaClientTransaction): ReleaseDatabase {
       findMany: async (args) => await client.releaseDeployment.findMany(args),
       findUnique: async (args) => await client.releaseDeployment.findUnique(args),
       upsert: async (args) => await client.releaseDeployment.upsert(args),
+      update: async (args) => await client.releaseDeployment.update(args),
     },
     releaseCommit: {
       findMany: async (args) => await client.releaseCommit.findMany(args),

--- a/apps/backend/src/lib/safe-request-context.test.ts
+++ b/apps/backend/src/lib/safe-request-context.test.ts
@@ -64,6 +64,15 @@ describe("safe request context", () => {
       headers: new Headers(),
     });
     expect(bounded.url.length).toBeLessThanOrEqual(512);
+
+    const encoded = createSafeRequestContext({
+      requestId: "request-encoded-path",
+      method: "GET",
+      url: "https://api.example.test/api/alice%40example.test/eyJhbGciOiJIUzI1NiJ9%2EeyJzdWIiOiIxIn0%2Esignature-material",
+      headers: new Headers(),
+    });
+    expect(encoded.url).not.toContain("alice@example.test");
+    expect(encoded.url).not.toContain("signature-material");
   });
 
   it("bounds and scrubs cookie names", () => {
@@ -81,6 +90,15 @@ describe("safe request context", () => {
     // …and the collection is bounded with an explicit truncation marker.
     expect(context.cookies.names.length).toBeLessThanOrEqual(51);
     expect(context.cookies.names).toContain("[Names limited]");
+
+    const encoded = createSafeRequestContext({
+      requestId: "request-encoded-cookie",
+      method: "GET",
+      url: "https://api.example.test/api/users",
+      headers: new Headers({ cookie: "alice%40example.test=1; eyJhbGciOiJIUzI1NiJ9%2EeyJzdWIiOiIxIn0%2Esignature-material=1" }),
+    });
+    expect(JSON.stringify(encoded.cookies)).not.toContain("alice@example.test");
+    expect(JSON.stringify(encoded.cookies)).not.toContain("signature-material");
   });
 
   it("recursively bounds and scrubs approved structured diagnostics", () => {

--- a/apps/backend/src/lib/safe-request-context.ts
+++ b/apps/backend/src/lib/safe-request-context.ts
@@ -155,6 +155,14 @@ function scrubHeaderValue(name: string, value: string): string {
 // without hiding which legitimate cookies were present.
 const MAX_COOKIE_NAMES = 50;
 
+function decodeUriComponentSafely(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 function safeHeadersFromEntries(entries: Iterable<readonly [string, string]>): { headers: Record<string, string>, cookieNames: string[] } {
   const headers: Record<string, string> = {};
   const cookieNames = new Set<string>();
@@ -165,7 +173,7 @@ function safeHeadersFromEntries(entries: Iterable<readonly [string, string]>): {
       for (const cookie of rawValue.split(";")) {
         const cookieName = cookie.split("=", 1)[0]?.trim();
         if (cookieName !== "") {
-          cookieNames.add(scrubString(cookieName, { remainingCharacters: MAX_CONTEXT_STRING_LENGTH }));
+          cookieNames.add(scrubString(decodeUriComponentSafely(cookieName), { remainingCharacters: MAX_CONTEXT_STRING_LENGTH }));
         }
       }
       continue;
@@ -192,7 +200,7 @@ function safeUrlPath(url: string): { path: string, queryParameterCount: number }
     // value-shaped secrets (emails, JWTs, tokens) — so it goes through the
     // same string scrubber and size bound as every other retained string.
     return {
-      path: scrubString(parsed.pathname, { remainingCharacters: MAX_CONTEXT_STRING_LENGTH }),
+      path: scrubString(decodeUriComponentSafely(parsed.pathname), { remainingCharacters: MAX_CONTEXT_STRING_LENGTH }),
       queryParameterCount: [...parsed.searchParams.keys()].length,
     };
   } catch {

--- a/apps/backend/src/lib/symbolication/javascript-symbolication.test.ts
+++ b/apps/backend/src/lib/symbolication/javascript-symbolication.test.ts
@@ -38,6 +38,7 @@ const SOURCE_MAP = new TextEncoder().encode(JSON.stringify({
 
 class MemoryArtifactStorage implements ArtifactObjectStorage {
   private readonly objects = new Map<string, Uint8Array>();
+  public readonly readExpectedETags: string[] = [];
 
   public async putImmutableObject(object: ArtifactStorageObject): Promise<boolean> {
     if (this.objects.has(object.key)) return false;
@@ -51,10 +52,11 @@ class MemoryArtifactStorage implements ArtifactObjectStorage {
 
   public async headObject(key: string): Promise<ArtifactStorageObjectInfo | null> {
     const body = this.objects.get(key);
-    return body === undefined ? null : { byteLength: body.byteLength };
+    return body === undefined ? null : { byteLength: body.byteLength, eTag: `etag:${key}` };
   }
 
-  public async readObject(key: string): Promise<Uint8Array | null> {
+  public async readObject(key: string, expectedETag?: string): Promise<Uint8Array | null> {
+    if (expectedETag !== undefined) this.readExpectedETags.push(expectedETag);
     const body = this.objects.get(key);
     return body === undefined ? null : new Uint8Array(body);
   }
@@ -168,6 +170,8 @@ describe("JavaScriptSymbolicationService", () => {
       },
       diagnostics: [],
     });
+    expect(fixture.storage.readExpectedETags.length).toBeGreaterThan(0);
+    expect(fixture.storage.readExpectedETags.every((etag) => etag.startsWith("etag:"))).toBe(true);
   });
 
   it("preserves raw frames and diagnoses missing, mismatched, and invalid artifacts", async () => {

--- a/apps/backend/src/lib/symbolication/javascript-symbolication.ts
+++ b/apps/backend/src/lib/symbolication/javascript-symbolication.ts
@@ -524,7 +524,10 @@ export class JavaScriptSymbolicationService {
     }
     let bytes: Uint8Array | null;
     try {
-      bytes = await this.storage.readObject(key);
+      // Preserve the version observed by the size check. Without the ETag,
+      // storage re-HEADs the key and a replacement can pass the new size
+      // check before the old artifact's read limit is applied.
+      bytes = await this.storage.readObject(key, info.eTag);
     } catch (error) {
       if (!(error instanceof ArtifactServiceError) || error.code !== "storage_unavailable") throw error;
       return { ok: false, diagnostic: artifactDiagnostic("artifact_storage_unavailable", "Artifact storage is unavailable.", lookup.artifact.debugId, lookup.artifact.codeFile) };

--- a/apps/backend/src/lib/symbolication/javascript-symbolication.ts
+++ b/apps/backend/src/lib/symbolication/javascript-symbolication.ts
@@ -750,8 +750,8 @@ function parseMappings(
     let line: MappingSegment[] | null = null;
     let segmentStart = position;
     while (segmentStart < lineEnd) {
-      const segmentSeparator = mappings.indexOf(",", segmentStart);
-      const segmentEnd = segmentSeparator === -1 || segmentSeparator > lineEnd ? lineEnd : segmentSeparator;
+      let segmentEnd = segmentStart;
+      while (segmentEnd < lineEnd && mappings.charCodeAt(segmentEnd) !== 0x2c /* "," */) segmentEnd += 1;
       const segmentText = mappings.slice(segmentStart, segmentEnd);
       segmentStart = segmentEnd + 1;
       if (segmentText === "") continue;
@@ -1046,12 +1046,12 @@ function resolveLimits(input: Partial<JavaScriptSymbolicationLimits>): JavaScrip
 }
 
 /**
- * trimContextLine's worst-case output is `{snip} <one code point> {snip}`, so
- * a limit below that width could not be honored (the markers alone would
- * exceed it). Rejecting such configs up front keeps the "output is at most
- * maxContextLineBytes" invariant true instead of silently violating it.
+ * trimContextLine can honor a 14-byte line by retaining the two six-byte
+ * markers and their separating spaces while shrinking the excerpt to the
+ * smallest representable boundary. Rejecting smaller configs up front keeps
+ * the "output is at most maxContextLineBytes" invariant explicit.
  */
-const MIN_CONTEXT_LINE_BYTES = 2 * utf8ByteLength(SOURCE_MAP_SNIP_MARKER) + 3;
+const MIN_CONTEXT_LINE_BYTES = 2 * utf8ByteLength(SOURCE_MAP_SNIP_MARKER) + 2;
 
 function contextLineBytesLimit(value: number | undefined): number {
   const limit = positiveLimit(value, DEFAULT_JAVASCRIPT_SYMBOLICATION_LIMITS.maxContextLineBytes, "maxContextLineBytes");

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/playground/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/playground/page-client.tsx
@@ -13,6 +13,7 @@ import {
 import { DesignAnalyticsCard, DesignAnalyticsCardHeader, DesignChartLegend } from "@/components/design-components/analytics-card";
 import { Typography } from "@/components/ui";
 import { cn } from "@/lib/utils";
+import { typedEntries } from "@hexclave/shared/dist/utils/objects";
 import {
   CheckCircle,
   Cube,
@@ -206,10 +207,26 @@ const DEMO_PRODUCTS: DemoProduct[] = [
   { id: "4", name: "Sensor Hub", category: "Hardware", price: 79.99, status: "active" },
 ];
 
-/** Every DesignBadgeColor, in the order the component declares them. */
-const BADGE_PALETTE: readonly DesignBadgeColor[] = [
-  "zinc", "blue", "cyan", "purple", "green", "orange", "red",
-];
+/**
+ * Single compile-checked source for the badge palette: the `satisfies
+ * Record<DesignBadgeColor, string>` makes adding a color to DesignBadge
+ * without listing it here a type error, and the swatch row, dropdown options,
+ * and change guard below all derive from it (previously three hand-kept
+ * copies that could silently drift). A record rather than a Map because only
+ * Record keys get that exhaustiveness check. Zinc leads on purpose: the only
+ * way to judge the neutral is beside the colored badges it must recede behind.
+ */
+const BADGE_PALETTE_LABELS = {
+  zinc: "Zinc (neutral)",
+  blue: "Blue",
+  cyan: "Cyan",
+  purple: "Purple",
+  green: "Green",
+  orange: "Orange",
+  red: "Red",
+} as const satisfies Record<DesignBadgeColor, string>;
+
+const BADGE_PALETTE: readonly DesignBadgeColor[] = typedEntries(BADGE_PALETTE_LABELS).map(([color]) => color);
 
 const STATUS_BADGE: Record<DemoProduct["status"], { label: string, color: DesignBadgeColor }> = {
   active: { label: "Active", color: "green" },
@@ -1478,21 +1495,14 @@ export default function PageClient() {
             <DesignSelectorDropdown
               value={badgeColor}
               onValueChange={(v) => {
-                if (v === "blue" || v === "cyan" || v === "purple" || v === "green" || v === "orange" || v === "red" || v === "zinc") {
-                  setBadgeColor(v);
-                  return;
-                }
-                throw new Error(`Unknown badge color "${v}"`);
+                // find() narrows the raw dropdown string back to the palette
+                // union without a cast, and keeps the guard derived from the
+                // same source as the options.
+                const color = BADGE_PALETTE.find((candidate) => candidate === v);
+                if (color == null) throw new Error(`Unknown badge color "${v}"`);
+                setBadgeColor(color);
               }}
-              options={[
-                { value: "blue", label: "Blue" },
-                { value: "cyan", label: "Cyan" },
-                { value: "purple", label: "Purple" },
-                { value: "green", label: "Green" },
-                { value: "orange", label: "Orange" },
-                { value: "red", label: "Red" },
-                { value: "zinc", label: "Zinc (neutral)" },
-              ]}
+              options={BADGE_PALETTE.map((color) => ({ value: color, label: BADGE_PALETTE_LABELS[color] }))}
               size="sm"
             />
           </PropField>

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/force-layout.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/force-layout.ts
@@ -1,9 +1,6 @@
 /**
- * Path graph layout using ForceAtlas2-style simulation with:
- * 1. Landing page detection → average distance for soft x-position
- * 2. ForceAtlas2 forces with collision avoidance
- * 3. Spring strength proportional to log(clicks)
- * 4. Edge bundling for parallel edges
+ * Path graph layout: landing-page distance for a soft x-position, ForceAtlas2
+ * forces with collision avoidance, and spring strength proportional to traffic.
  */
 
 export type GraphNode = {
@@ -20,11 +17,9 @@ export type GraphEdge = {
   from: string,
   to: string,
   count: number,
-  /** Weight (linear): raw transition count */
   weight: number,
 };
 
-// Layout constants
 const CARD_HEIGHT = 60;
 const ITERATIONS = 500;
 const GRAVITY = 0.005;
@@ -42,10 +37,6 @@ function stableUnitValue(value: string, salt: number): number {
   return (hash >>> 0) / 4294967295;
 }
 
-/**
- * Detect landing pages: pages with high outbound relative to inbound,
- * or common root paths like "/", "/home", etc.
- */
 function findLandingPages(nodes: GraphNode[], edges: GraphEdge[]): Set<string> {
   const inbound = new Map<string, number>();
   const outbound = new Map<string, number>();
@@ -76,16 +67,15 @@ function findLandingPages(nodes: GraphNode[], edges: GraphEdge[]): Set<string> {
   if (landings.size === 0) {
     const sorted = [...nodes].sort((a, b) => (outbound.get(b.id) ?? 0) - (outbound.get(a.id) ?? 0));
     for (let i = 0; i < Math.min(3, sorted.length); i++) {
-      landings.add(sorted[i]!.id);
+      const node = sorted[i];
+      if (node === undefined) break;
+      landings.add(node.id);
     }
   }
 
   return landings;
 }
 
-/**
- * Compute average shortest-path distance from landing pages using BFS.
- */
 function computeDistanceFromLandings(
   nodes: GraphNode[],
   edges: GraphEdge[],
@@ -110,8 +100,10 @@ function computeDistanceFromLandings(
     dist.set(landing, 0);
 
     while (queue.length > 0) {
-      const current = queue.shift()!;
-      const currentDist = dist.get(current)!;
+      const current = queue.shift();
+      if (current === undefined) break;
+      const currentDist = dist.get(current);
+      if (currentDist === undefined) continue;
       const neighbors = adj.get(current) ?? [];
       for (const { to } of neighbors) {
         if (!dist.has(to)) {
@@ -129,20 +121,13 @@ function computeDistanceFromLandings(
   const avgDist = new Map<string, number>();
   let maxDist = 0;
   for (const [nodeId, dists] of distances) {
-    if (dists.length > 0) {
-      const avg = dists.reduce((a, b) => a + b, 0) / dists.length;
-      avgDist.set(nodeId, avg);
-      maxDist = Math.max(maxDist, avg);
-    } else {
-      avgDist.set(nodeId, maxDist + 1);
-    }
+    if (dists.length === 0) continue;
+    const avg = dists.reduce((a, b) => a + b, 0) / dists.length;
+    avgDist.set(nodeId, avg);
+    maxDist = Math.max(maxDist, avg);
   }
-
-  // Normalize unreachable nodes
-  for (const [nodeId, d] of avgDist) {
-    if (d > maxDist) {
-      avgDist.set(nodeId, maxDist + 1);
-    }
+  for (const n of nodes) {
+    if (!avgDist.has(n.id)) avgDist.set(n.id, maxDist + 1);
   }
 
   return avgDist;
@@ -159,28 +144,18 @@ type SimNode = {
   targetX: number,
 };
 
-/**
- * ForceAtlas2-style layout with:
- * - Soft x-constraint from landing page distance
- * - Repulsion inversely proportional to distance
- * - Spring attraction proportional to log(clicks)
- * - Collision avoidance based on card dimensions
- */
 export function computeLayout(nodes: GraphNode[], edges: GraphEdge[]): GraphNode[] {
   if (nodes.length === 0) return [];
 
-  // Find landing pages and compute distances
   const landings = findLandingPages(nodes, edges);
   const distFromLanding = computeDistanceFromLandings(nodes, edges, landings);
 
-  // Normalize distances to x-range
   const maxDist = Math.max(...distFromLanding.values(), 1);
   // The old node-count-based spread made a 150-page graph roughly 7,500px
   // wide before fitting. Stage count describes navigation depth; node count
   // does not, so cap the overview around a readable desktop canvas.
   const xSpread = Math.max(720, Math.min(2200, (maxDist + 1) * 320));
 
-  // Initialize simulation nodes
   const simNodes: SimNode[] = nodes.map((n, i) => {
     const dist = distFromLanding.get(n.id) ?? 0;
     const targetX = (dist / maxDist) * xSpread;
@@ -200,13 +175,12 @@ export function computeLayout(nodes: GraphNode[], edges: GraphEdge[]): GraphNode
   });
 
   const nodeIndex = new Map<string, number>();
-  for (let i = 0; i < simNodes.length; i++) {
-    nodeIndex.set(simNodes[i]!.id, i);
+  for (const [i, node] of simNodes.entries()) {
+    nodeIndex.set(node.id, i);
   }
 
   const maxWeight = edges.reduce((m, e) => Math.max(m, e.weight), 1);
 
-  // Collision padding
   const collisionPadX = 30;
   const collisionPadY = 25;
   const collisionH = CARD_HEIGHT / 2 + collisionPadY;
@@ -215,17 +189,16 @@ export function computeLayout(nodes: GraphNode[], edges: GraphEdge[]): GraphNode
     const alpha = 1 - iter / ITERATIONS;
     const cool = 0.1 + 0.9 * alpha;
 
-    // Repulsion between all pairs + collision avoidance
     for (let i = 0; i < simNodes.length; i++) {
       for (let j = i + 1; j < simNodes.length; j++) {
-        const a = simNodes[i]!;
-        const b = simNodes[j]!;
+        const a = simNodes[i];
+        const b = simNodes[j];
+        if (a === undefined || b === undefined) break;
         const dx = b.x - a.x;
         const dy = b.y - a.y;
         let dist = Math.sqrt(dx * dx + dy * dy);
         if (dist < MIN_DIST) dist = MIN_DIST;
 
-        // Repulsion
         const repForce = REPULSION_SCALE * cool / (dist * dist);
         const fx = (dx / dist) * repForce;
         const fy = (dy / dist) * repForce;
@@ -235,8 +208,6 @@ export function computeLayout(nodes: GraphNode[], edges: GraphEdge[]): GraphNode
         b.vx += fx;
         b.vy += fy;
 
-        // Collision avoidance: push apart if rectangular bounds overlap
-        // Use per-node width for accurate collision detection
         const collisionW = (a.width + b.width) / 2 + collisionPadX;
         const overlapX = collisionW - Math.abs(dx);
         const overlapY = collisionH * 2 - Math.abs(dy);
@@ -251,15 +222,15 @@ export function computeLayout(nodes: GraphNode[], edges: GraphEdge[]): GraphNode
       }
     }
 
-    // Spring attraction along edges, strength ∝ log(clicks)
-    // Reverse x-force when arrow points left to bias left-to-right flow
+    // Reverse x-force when the arrow points left so the layout stays left-to-right.
     for (const edge of edges) {
       const ai = nodeIndex.get(edge.from);
       const bi = nodeIndex.get(edge.to);
       if (ai == null || bi == null) continue;
 
-      const a = simNodes[ai]!;
-      const b = simNodes[bi]!;
+      const a = simNodes[ai];
+      const b = simNodes[bi];
+      if (a === undefined || b === undefined) continue;
       const dx = b.x - a.x;
       const dy = b.y - a.y;
       const dist = Math.sqrt(dx * dx + dy * dy);
@@ -267,8 +238,7 @@ export function computeLayout(nodes: GraphNode[], edges: GraphEdge[]): GraphNode
 
       const strength = 0.008 * (edge.weight / maxWeight) * cool;
       const fy = dy * strength;
-      // Reverse x-component when edge points left (to.x < from.x)
-      // This makes backward edges repulsive on x, reinforcing left-to-right flow
+      // Backward edges repel on x so they cannot fold the graph right-to-left.
       const fx = dx < 0 ? -(dx * strength) : dx * strength;
 
       a.vx += fx;
@@ -277,39 +247,33 @@ export function computeLayout(nodes: GraphNode[], edges: GraphEdge[]): GraphNode
       b.vy -= fy;
     }
 
-    // Horizontal alignment bias: strong edges pull nodes toward same y-level
-    // Weak edges don't care about vertical alignment
     for (const edge of edges) {
       const ai = nodeIndex.get(edge.from);
       const bi = nodeIndex.get(edge.to);
       if (ai == null || bi == null) continue;
 
-      const a = simNodes[ai]!;
-      const b = simNodes[bi]!;
+      const a = simNodes[ai];
+      const b = simNodes[bi];
+      if (a === undefined || b === undefined) continue;
       const dy = b.y - a.y;
 
-      // Strength proportional to normalized edge weight (squared for emphasis)
       const relWeight = edge.weight / maxWeight;
       const alignStrength = 0.012 * relWeight * relWeight * cool;
       const fy = dy * alignStrength;
 
-      // Pull both nodes toward their shared y-midpoint
       a.vy += fy;
       b.vy -= fy;
     }
 
-    // Soft x-constraint: pull toward target x based on distance from landings
     for (const node of simNodes) {
       const xDiff = node.targetX - node.x;
       node.vx += xDiff * X_CONSTRAINT_STRENGTH * cool;
     }
 
-    // Gravity toward center (y-axis only)
     for (const node of simNodes) {
       node.vy -= node.y * GRAVITY * cool;
     }
 
-    // Apply velocity with damping
     for (const node of simNodes) {
       node.vx *= DAMPING;
       node.vy *= DAMPING;
@@ -318,11 +282,10 @@ export function computeLayout(nodes: GraphNode[], edges: GraphEdge[]): GraphNode
     }
   }
 
-  // Restore full node data with updated positions
   const nodeById = new Map(nodes.map((n) => [n.id, n]));
-  return simNodes.map((n) => ({
-    ...nodeById.get(n.id)!,
-    x: n.x,
-    y: n.y,
-  }));
+  return simNodes.flatMap((n) => {
+    const original = nodeById.get(n.id);
+    if (original === undefined) return [];
+    return [{ ...original, x: n.x, y: n.y }];
+  });
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/normalize-url.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/normalize-url.test.ts
@@ -13,7 +13,11 @@ describe("normalizeUrlPath", () => {
   });
 
   it("normalizes the shortest URL-safe base64 token accepted by the contract", () => {
-    expect(normalizeUrlPath("/api/Abcdefghijklmnop/details")).toBe("/api/:id/details");
+    expect(normalizeUrlPath("/api/Abcdefghijklmnop1/details")).toBe("/api/:id/details");
     expect(normalizeUrlPath("/api/auth/details")).toBe("/api/auth/details");
+  });
+
+  it("keeps a static 16-character word literal when it has no digits", () => {
+    expect(normalizeUrlPath("/docs/abcdefghijklmnop/details")).toBe("/docs/abcdefghijklmnop/details");
   });
 });

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/normalize-url.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/normalize-url.test.ts
@@ -11,4 +11,9 @@ describe("normalizeUrlPath", () => {
   it("does not group ordinary static route segments", () => {
     expect(normalizeUrlPath("/projects/internal/analytics/paths")).toBe("/projects/internal/analytics/paths");
   });
+
+  it("normalizes the shortest URL-safe base64 token accepted by the contract", () => {
+    expect(normalizeUrlPath("/api/Abcdefghijklmnop/details")).toBe("/api/:id/details");
+    expect(normalizeUrlPath("/api/auth/details")).toBe("/api/auth/details");
+  });
 });

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/normalize-url.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/normalize-url.ts
@@ -21,7 +21,7 @@ function isLikelyDynamicSegment(segment: string): boolean {
 
   // The regex's minimum is long enough to avoid ordinary words such as `api`
   // and `auth`, while keeping the runtime check aligned with the contract.
-  if (BASE64_TOKEN_REGEX.test(segment)) return true;
+  if (/\d/u.test(segment) && BASE64_TOKEN_REGEX.test(segment)) return true;
 
   return false;
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/normalize-url.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/normalize-url.ts
@@ -19,9 +19,9 @@ function isLikelyDynamicSegment(segment: string): boolean {
   if (HEX_ID_REGEX.test(segment)) return true;
   if (PREFIXED_ID_REGEX.test(segment)) return true;
 
-  // Length 20, not the regex's 16: shorter base64-shaped words (`api`, `auth`)
-  // would otherwise collapse into `:id`.
-  if (segment.length >= 20 && BASE64_TOKEN_REGEX.test(segment)) return true;
+  // The regex's minimum is long enough to avoid ordinary words such as `api`
+  // and `auth`, while keeping the runtime check aligned with the contract.
+  if (BASE64_TOKEN_REGEX.test(segment)) return true;
 
   return false;
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/normalize-url.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/normalize-url.ts
@@ -4,45 +4,36 @@
  * similar pages (e.g. /users/abc123 and /users/def456 → /users/:id).
  */
 
-// UUID pattern: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-// Purely numeric segments (e.g. /posts/12345)
 const NUMERIC_REGEX = /^\d+$/;
-
-// Long hex strings (8+ chars) — likely IDs or hashes
 const HEX_ID_REGEX = /^[0-9a-f]{8,}$/i;
-
-// Base64-like tokens (16+ chars of alphanumeric + padding chars)
 const BASE64_TOKEN_REGEX = /^[A-Za-z0-9_-]{16,}[=]{0,2}$/;
-
-// MongoDB ObjectIDs (24 hex chars)
-const OBJECTID_REGEX = /^[0-9a-f]{24}$/i;
-
-// Short numeric-heavy mixed IDs (e.g. "a1b2c3d4", "usr_abc123")
-// Require at least one digit in the suffix to avoid matching static words like "sign_in"
+// Require a digit in the suffix so static segments like `sign_in` stay literal.
 const PREFIXED_ID_REGEX = /^[a-z]{1,10}_[a-z0-9]*\d[a-z0-9]*$/i;
 
 function isLikelyDynamicSegment(segment: string): boolean {
   if (segment.length === 0) return false;
 
-  // Check each pattern from most specific to least
   if (UUID_REGEX.test(segment)) return true;
-  if (OBJECTID_REGEX.test(segment)) return true;
   if (NUMERIC_REGEX.test(segment)) return true;
   if (HEX_ID_REGEX.test(segment)) return true;
   if (PREFIXED_ID_REGEX.test(segment)) return true;
 
-  // Base64 tokens (only for longer segments to avoid false positives on
-  // short path segments like "api" or "auth")
+  // Length 20, not the regex's 16: shorter base64-shaped words (`api`, `auth`)
+  // would otherwise collapse into `:id`.
   if (segment.length >= 20 && BASE64_TOKEN_REGEX.test(segment)) return true;
 
   return false;
 }
 
 export function normalizeUrlPath(path: string): string {
-  // Strip query string and hash
-  const cleanPath = path.split("?")[0]!.split("#")[0]!;
+  const queryStart = path.indexOf("?");
+  const hashStart = path.indexOf("#");
+  const end = Math.min(
+    queryStart < 0 ? path.length : queryStart,
+    hashStart < 0 ? path.length : hashStart,
+  );
+  const cleanPath = path.slice(0, end);
 
   const segments = cleanPath.split("/");
   const normalized = segments.map((seg) =>

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/page-client.tsx
@@ -106,7 +106,6 @@ export default function PageClient() {
         return { from_path, to_path, cnt: String(cnt) } satisfies TransitionRow;
       });
 
-      // Normalize paths and aggregate
       const edgeMap = new Map<string, Map<string, number>>();
       const nodeSet = new Set<string>();
 
@@ -163,7 +162,6 @@ export default function PageClient() {
         }
       }
 
-      // Build nodes
       const nodeArray: GraphNode[] = Array.from(nodeSet).map((path) => {
         const pvInfo = pageViewsMap.get(path);
         return {
@@ -177,7 +175,6 @@ export default function PageClient() {
         };
       });
 
-      // Build edges
       const allEdges: { from: string, to: string, count: number, weight: number }[] = [];
       for (const [from, outgoingEdges] of edgeMap) {
         for (const [to, count] of outgoingEdges) {

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/paths-graph-canvas.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/paths/paths-graph-canvas.tsx
@@ -154,7 +154,6 @@ export function PathsGraphCanvas({
       .slice(0, 8);
   }, [edges, focusedNode, weakEdges]);
 
-  // Compute bundle offsets for parallel edges
   const edgeBundleOffsets = useMemo(() => {
     const pairCounts = new Map<string, number>();
     const offsets = new Map<string, number>();

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/event-sparkline.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/event-sparkline.tsx
@@ -87,7 +87,10 @@ export function EventSparkline({
   const toneClasses = getToneClasses(tone);
 
   if (pending) return <SparklineHairline className={className} label="Loading activity" />;
-  if (buckets.length === 0) return <SparklineHairline className={className} label={null} />;
+  // A loaded-but-empty series keeps the caller's summary label: hiding the
+  // hairline from assistive tech would make "no activity" indistinguishable
+  // from "no chart here at all" for screen-reader users.
+  if (buckets.length === 0) return <SparklineHairline className={className} label={ariaLabel} />;
 
   return (
     <div className={cn("flex h-6 items-end gap-px", className)} role="img" aria-label={ariaLabel}>

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/format.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatAbsoluteTimeFromMillis,
+  formatCount,
   formatDateFromMillis,
   formatDuration,
   formatRelativeTimeFromMillis,
@@ -51,6 +52,31 @@ describe("formatDuration", () => {
     expect(formatDuration(null)).toBe("—");
     expect(formatDuration(0.4)).toBe("400µs");
     expect(formatDuration(90_000)).toBe("1m 30s");
+  });
+});
+
+describe("formatCount", () => {
+  it("keeps small counts exact and compacts large ones", () => {
+    expect(formatCount(0)).toBe("0");
+    expect(formatCount(1_203)).toBe("1,203");
+    expect(formatCount(9_999)).toBe("9,999");
+    expect(formatCount(10_000)).toBe("10.0k");
+    expect(formatCount(125_000)).toBe("125k");
+    expect(formatCount(1_500_000)).toBe("1.5M");
+    expect(formatCount(15_000_000)).toBe("15M");
+  });
+
+  it("drops the decimal exactly at the 100k / 10M readability boundaries", () => {
+    expect(formatCount(99_999)).toBe("100.0k");
+    expect(formatCount(100_000)).toBe("100k");
+    expect(formatCount(9_999_999)).toBe("10.0M");
+    expect(formatCount(10_000_000)).toBe("10M");
+  });
+
+  it("throws on non-finite and negative input rather than rendering nonsense", () => {
+    expect(() => formatCount(Number.NaN)).toThrow();
+    expect(() => formatCount(Number.POSITIVE_INFINITY)).toThrow();
+    expect(() => formatCount(-4)).toThrow();
   });
 });
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/format.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/format.ts
@@ -69,7 +69,10 @@ export function formatCount(value: number): string {
   if (!Number.isFinite(value)) throw new Error(`Cannot format a non-finite count: ${value}`);
   if (value < 0) throw new Error(`Cannot format a negative count: ${value}`);
   if (value < 10_000) return value.toLocaleString();
-  if (value < 1_000_000) return `${(value / 1_000).toFixed(value < 100_000 ? 1 : 0)}k`;
+  if (value < 1_000_000) {
+    const thousands = (value / 1_000).toFixed(value < 100_000 ? 1 : 0);
+    return thousands === "1000" ? "1.0M" : `${thousands}k`;
+  }
   return `${(value / 1_000_000).toFixed(value < 10_000_000 ? 1 : 0)}M`;
 }
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/format.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/format.ts
@@ -7,8 +7,12 @@
  * "400µs" in the other — the same span could show two different durations
  * depending on which page you were looking at.
  *
- * Only genuinely cross-page helpers belong here. Count/percent formatting is
- * still services-local because nothing else renders those yet.
+ * Only genuinely cross-page helpers belong here. Count formatting lives here
+ * too, because Services, Performance, and Issues all render compact counts and
+ * had each grown an identical copy. Percent formatting stays page-local: the
+ * pages render percents at deliberately different precision (Services shows one
+ * decimal in dense cells, Performance rounds to whole percents in summaries),
+ * so there is no single shared rule to lift.
  *
  * The time formatters take epoch milliseconds rather than a ClickHouse
  * timestamp string: Issues gets its timestamps from a REST payload (`*_millis`
@@ -49,6 +53,24 @@ export function formatDuration(ms: number | null): string {
   const days = Math.floor(totalHours / 24);
   const hours = totalHours % 24;
   return hours === 0 ? `${days}d` : `${days}d ${hours}h`;
+}
+
+/**
+ * Compact count formatting for dense table cells. Values below 10k stay exact
+ * because at that size the digits are still readable and the precision matters
+ * when comparing two similar rows; above that only the magnitude counts, so
+ * 10k–100k keeps one decimal ("12.5k"), then "125k", "1.5M", "15M".
+ *
+ * Counts are non-negative by definition, so a negative value means an upstream
+ * aggregation bug — fail loudly rather than rendering "-50,000" (the thresholds
+ * only make sense for positive magnitudes anyway).
+ */
+export function formatCount(value: number): string {
+  if (!Number.isFinite(value)) throw new Error(`Cannot format a non-finite count: ${value}`);
+  if (value < 0) throw new Error(`Cannot format a negative count: ${value}`);
+  if (value < 10_000) return value.toLocaleString();
+  if (value < 1_000_000) return `${(value / 1_000).toFixed(value < 100_000 ? 1 : 0)}k`;
+  return `${(value / 1_000_000).toFixed(value < 10_000_000 ? 1 : 0)}M`;
 }
 
 const RELATIVE_TIME_UNITS: readonly { limitMs: number, divisorMs: number, unit: Intl.RelativeTimeFormatUnit }[] = [

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/[issueId]/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/[issueId]/page-client.tsx
@@ -22,7 +22,7 @@ import {
   SpinnerGapIcon,
 } from "@phosphor-icons/react";
 import { useRouter } from "@/components/router";
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { AppEnabledGuard } from "../../../app-enabled-guard";
 import { PageLayout } from "../../../page-layout";
@@ -44,9 +44,10 @@ import {
   type LeadingUpToLogLine,
 } from "../correlation";
 import { formatIssueCount, issueCulprit, issueShortIdLabel, issueSubtitle, issueTitle, parseIssueRouteId } from "../issue-format";
+import { parseIssueRangeHours } from "../issue-filters";
 import { issueDetailHref, issuesListHref, traceDetailHref } from "../issue-links";
 import { sessionReplayHref } from "../../observability-links";
-import { issueStatusBadge, primaryIssueStatusAction } from "../issue-status";
+import { issueStatusBadge, nextStatusForAction, primaryIssueStatusAction } from "../issue-status";
 import {
   fetchIssueDetail,
   addIssueComment,
@@ -174,15 +175,43 @@ export default function PageClient() {
   const projectId = adminApp.projectId;
   const rawIssueId = params.issueId;
   const routeId = useMemo(() => parseIssueRouteId(rawIssueId), [rawIssueId]);
+  // The list forwards its selected time window via `?range=` (see
+  // `issueDetailHref`) so the Impact card's window-scoped counts match the
+  // numbers the reader just clicked. `useSearchParams` (not a one-shot
+  // location read) so a client-side navigation between issues re-reads it.
+  // Unlike the list page there is no `history.replaceState` writer here, so
+  // Next's cached search params cannot go stale.
+  const searchParams = useSearchParams();
+  const rangeHours = parseIssueRangeHours(searchParams);
 
   const [detail, setDetail] = useState<IssueDetailResponse | null>(null);
   // The cursor alone is ambiguous — the same `(event_at, occurrence_id)` pair
   // means "the one before" or "the one after" depending on the direction, so
-  // both travel together.
-  const [occurrenceStep, setOccurrenceStep] = useState<{ cursor: string, direction: IssueOccurrenceDirection } | null>(null);
+  // both travel together. The step is additionally stamped with the route
+  // segment it belongs to and IGNORED for any other segment: a client-side
+  // navigation to another issue keeps this component mounted, and without the
+  // stamp the previous issue's cursor would be forwarded with the new issue's
+  // id, opening it at an unrelated occurrence (or failing to find one at all).
+  const [occurrenceStepState, setOccurrenceStepState] = useState<{
+    routeKey: string,
+    cursor: string,
+    direction: IssueOccurrenceDirection,
+  } | null>(null);
+  const occurrenceStep = occurrenceStepState != null && occurrenceStepState.routeKey === rawIssueId
+    ? occurrenceStepState
+    : null;
+  const setOccurrenceStep = useCallback((step: { cursor: string, direction: IssueOccurrenceDirection } | null) => {
+    setOccurrenceStepState(step == null ? null : { routeKey: rawIssueId, ...step });
+  }, [rawIssueId]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusError, setStatusError] = useState<string | null>(null);
+  // Serializes the four status mutations (resolve/ignore/snooze/regress): each
+  // one snapshots `detail` for its rollback, so two racing mutations could
+  // resolve/revert independently and leave the page showing a state the server
+  // never settled on. While one is in flight the other controls no-op, same
+  // pattern as `productSaving` below.
+  const [statusSaving, setStatusSaving] = useState(false);
   const [productError, setProductError] = useState<string | null>(null);
   const [productSaving, setProductSaving] = useState(false);
   const [frameOrder, setFrameOrder] = useState<StackFrameOrder>(DEFAULT_STACK_FRAME_ORDER);
@@ -203,12 +232,24 @@ export default function PageClient() {
         const next = await fetchIssueDetail(
           adminApp,
           routeId.value,
-          occurrenceStep == null ? {} : { occurrence: occurrenceStep.cursor, direction: occurrenceStep.direction },
+          {
+            hours: rangeHours,
+            ...occurrenceStep == null ? {} : { occurrence: occurrenceStep.cursor, direction: occurrenceStep.direction },
+          },
         );
         if (cancelled) return;
         setDetail(next);
         setError(null);
         setNowMs(Date.now());
+        // A merged-away link resolves to the surviving issue but keeps the
+        // obsolete URL, so sharing/bookmarking it would rely on the server
+        // redirect forever. Swap the URL to the survivor's canonical id; the
+        // resulting params change re-runs this load once with the new id,
+        // after which `redirected_from_issue_id` is null and the URL is stable.
+        if (next.redirected_from_issue_id != null) {
+          // Keep the selected range across the canonical-id rewrite.
+          router.replace(issueDetailHref(projectId, next.issue.id, { rangeHours }));
+        }
       } catch (caught) {
         if (cancelled) return;
         setError(caught instanceof Error ? caught.message : String(caught));
@@ -219,7 +260,7 @@ export default function PageClient() {
     return () => {
       cancelled = true;
     };
-  }, [adminApp, routeId, occurrenceStep]);
+  }, [adminApp, routeId, occurrenceStep, rangeHours, router, projectId]);
 
   useEffect(() => load(), [load]);
 
@@ -260,8 +301,9 @@ export default function PageClient() {
   }, [adminApp, anchor, occurrence]);
 
   const changeStatus = useCallback(async (status: IssueStatus) => {
-    if (detail == null) return;
+    if (detail == null || statusSaving) return;
     setStatusError(null);
+    setStatusSaving(true);
     const previous = detail;
     setDetail({ ...detail, issue: { ...detail.issue, status } });
     try {
@@ -272,12 +314,15 @@ export default function PageClient() {
     } catch (caught) {
       setDetail(previous);
       setStatusError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setStatusSaving(false);
     }
-  }, [adminApp, detail]);
+  }, [adminApp, detail, statusSaving]);
 
   const changeSnooze = useCallback(async (durationMs: number) => {
-    if (detail == null) return;
+    if (detail == null || statusSaving) return;
     setStatusError(null);
+    setStatusSaving(true);
     const previous = detail;
     setDetail({ ...detail, issue: { ...detail.issue, status: "ignored" } });
     try {
@@ -289,12 +334,15 @@ export default function PageClient() {
     } catch (caught) {
       setDetail(previous);
       setStatusError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setStatusSaving(false);
     }
-  }, [adminApp, detail]);
+  }, [adminApp, detail, statusSaving]);
 
   const changeUnsnooze = useCallback(async () => {
-    if (detail == null) return;
+    if (detail == null || statusSaving) return;
     setStatusError(null);
+    setStatusSaving(true);
     const previous = detail;
     setDetail({ ...detail, issue: { ...detail.issue, status: "unresolved" } });
     try {
@@ -306,12 +354,15 @@ export default function PageClient() {
     } catch (caught) {
       setDetail(previous);
       setStatusError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setStatusSaving(false);
     }
-  }, [adminApp, detail]);
+  }, [adminApp, detail, statusSaving]);
 
   const changeRegress = useCallback(async () => {
-    if (detail == null) return;
+    if (detail == null || statusSaving) return;
     setStatusError(null);
+    setStatusSaving(true);
     const previous = detail;
     setDetail({ ...detail, issue: { ...detail.issue, status: "unresolved", substatus: "regressed" } });
     try {
@@ -330,8 +381,10 @@ export default function PageClient() {
     } catch (caught) {
       setDetail(previous);
       setStatusError(caught instanceof Error ? caught.message : String(caught));
+    } finally {
+      setStatusSaving(false);
     }
-  }, [adminApp, detail]);
+  }, [adminApp, detail, statusSaving]);
 
   const changePriority = useCallback(async (priority: IssuePriority | null) => {
     if (detail == null) return;
@@ -510,13 +563,16 @@ export default function PageClient() {
     setProductSaving(true);
     try {
       const result = await unmergeIssue(adminApp, detail.issue.id, hashes);
-      router.push(issueDetailHref(projectId, result.new_issue_id));
-    } catch (caught) {
-      setProductError(caught instanceof Error ? caught.message : String(caught));
+      router.push(issueDetailHref(projectId, result.new_issue_id, { rangeHours }));
     } finally {
+      // Deliberately no catch: the unmerge dialog (GroupingSection) awaits this
+      // callback and shows the failure inside the still-open dialog, preserving
+      // the user's hash selection for a retry. Swallowing the rejection here
+      // would read as success to the dialog, closing it and clearing the
+      // selection while the error appeared elsewhere on the page.
       setProductSaving(false);
     }
-  }, [adminApp, detail, productSaving, projectId, router]);
+  }, [adminApp, detail, productSaving, projectId, rangeHours, router]);
 
   if (routeId == null) {
     return (
@@ -548,7 +604,7 @@ export default function PageClient() {
           <DesignButton
             variant="secondary"
             size="sm"
-            onClick={() => changeStatus(primaryAction === "resolve" ? "resolved" : "unresolved")}
+            onClick={() => changeStatus(nextStatusForAction(primaryAction))}
           >
             {primaryAction === "resolve" ? "Resolve" : "Unresolve"}
           </DesignButton>

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/[issueId]/page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/[issueId]/page.tsx
@@ -1,9 +1,14 @@
 import PageClient from "./page-client";
+import { Suspense } from "react";
 
 export const metadata = { title: "Issue" };
 
 // Stays a static server component: the route segment is read client-side with
 // `useParams`, per the repo's preference for keeping pages statically rendered.
 export default function Page() {
-  return <PageClient />;
+  return (
+    <Suspense fallback={null}>
+      <PageClient />
+    </Suspense>
+  );
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/alerts/issue-alert-email-template.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/alerts/issue-alert-email-template.test.ts
@@ -1,3 +1,6 @@
+// Interpolation semantics themselves are covered by the shared contract's
+// tests in `packages/shared/src/utils/issue-alert-email-template.test.ts`;
+// this file only covers the dashboard-local defaults and preview values.
 import { describe, expect, it } from "vitest";
 import {
   createIssueAlertEmailPreviewValues,
@@ -5,38 +8,13 @@ import {
   DEFAULT_ISSUE_ALERT_EMAIL_SUBJECT,
   interpolateIssueAlertEmailTemplate,
   ISSUE_ALERT_EMAIL_PLACEHOLDERS,
-  type IssueAlertEmailPlaceholderToken,
+  ISSUE_ALERT_EMAIL_PLACEHOLDER_TOKENS,
 } from "./issue-alert-email-template";
 
-function sampleValues(): Map<IssueAlertEmailPlaceholderToken, string> {
-  return new Map<IssueAlertEmailPlaceholderToken, string>([
-    ["short_id", "12"],
-    ["type", "TypeError"],
-    ["summary", "<script>alert(1)</script>"],
-    ["culprit", "app.ts"],
-    ["environment", "production"],
-    ["release", "1.0.0"],
-    ["status", "unresolved"],
-    ["kind", "New issue"],
-    ["occurred_at", "2026-08-12 19:04 UTC"],
-    ["issue_url", "https://app.example.test/issues/12"],
-  ]);
-}
-
 describe("issue-alert email templates", () => {
-  it("substitutes known placeholders and HTML-escapes values in the body", () => {
-    const values = sampleValues();
-
-    expect(interpolateIssueAlertEmailTemplate(
-      "Issue {{short_id}}: {{summary}} {{unknown}}",
-      values,
-      { escapeHtml: false },
-    )).toBe("Issue 12: <script>alert(1)</script> {{unknown}}");
-    expect(interpolateIssueAlertEmailTemplate(
-      "<p>{{summary}}</p><a href=\"{{issue_url}}\">open</a>",
-      values,
-      { escapeHtml: true },
-    )).toBe("<p>&lt;script&gt;alert(1)&lt;/script&gt;</p><a href=\"https://app.example.test/issues/12\">open</a>");
+  it("documents a hint for every placeholder token in the shared contract", () => {
+    expect(ISSUE_ALERT_EMAIL_PLACEHOLDERS.map((placeholder) => placeholder.token))
+      .toEqual([...ISSUE_ALERT_EMAIL_PLACEHOLDER_TOKENS]);
   });
 
   it("covers every advertised placeholder in the default subject and HTML", () => {

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/alerts/issue-alert-email-template.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/alerts/issue-alert-email-template.ts
@@ -1,29 +1,16 @@
-import { escapeHtml } from "@hexclave/shared/dist/utils/html";
+import { type IssueAlertEmailPlaceholderToken } from "@hexclave/shared/dist/utils/issue-alert-email-template";
 import { deindent } from "@hexclave/shared/dist/utils/strings";
 
-/**
- * Tokens authors can put in an issue-alert subject or HTML body. The backend
- * substitutes the same names from the triggering issue when the email is
- * enqueued. Keep this list aligned with
- * `apps/backend/src/lib/issues/issue-alerts/email-template.ts`.
- *
- * Unknown `{{tokens}}` are left untouched so a typo is visible in the sent
- * mail instead of silently disappearing.
- */
-export const ISSUE_ALERT_EMAIL_PLACEHOLDER_TOKENS = [
-  "short_id",
-  "type",
-  "summary",
-  "culprit",
-  "environment",
-  "release",
-  "status",
-  "kind",
-  "occurred_at",
-  "issue_url",
-] as const;
-
-export type IssueAlertEmailPlaceholderToken = typeof ISSUE_ALERT_EMAIL_PLACEHOLDER_TOKENS[number];
+// The token vocabulary and interpolation semantics are a cross-app contract
+// with the backend's alert-email renderer, so they live in `@hexclave/shared`
+// (utils/issue-alert-email-template). This module re-exports them for the
+// alert editor and adds the dashboard-only pieces: per-token hints, the
+// default subject/body, and sample values for the live preview.
+export {
+  ISSUE_ALERT_EMAIL_PLACEHOLDER_TOKENS,
+  interpolateIssueAlertEmailTemplate,
+  type IssueAlertEmailPlaceholderToken,
+} from "@hexclave/shared/dist/utils/issue-alert-email-template";
 
 export const ISSUE_ALERT_EMAIL_PLACEHOLDERS: readonly {
   token: IssueAlertEmailPlaceholderToken,
@@ -40,13 +27,6 @@ export const ISSUE_ALERT_EMAIL_PLACEHOLDERS: readonly {
   { token: "occurred_at", hint: "When this occurrence was seen" },
   { token: "issue_url", hint: "Dashboard link to the issue" },
 ];
-
-const PLACEHOLDER_PATTERN = /\{\{([a-z_]+)\}\}/g;
-const KNOWN_PLACEHOLDER_TOKENS: ReadonlySet<string> = new Set(ISSUE_ALERT_EMAIL_PLACEHOLDER_TOKENS);
-
-function isPlaceholderToken(name: string): name is IssueAlertEmailPlaceholderToken {
-  return KNOWN_PLACEHOLDER_TOKENS.has(name);
-}
 
 export const DEFAULT_ISSUE_ALERT_EMAIL_SUBJECT = "[{{kind}}] {{short_id}}: {{summary}}";
 
@@ -79,19 +59,6 @@ export const DEFAULT_ISSUE_ALERT_EMAIL_HTML = deindent`
     </p>
   </div>
 `;
-
-export function interpolateIssueAlertEmailTemplate(
-  template: string,
-  values: ReadonlyMap<IssueAlertEmailPlaceholderToken, string>,
-  options: { escapeHtml: boolean },
-): string {
-  return template.replace(PLACEHOLDER_PATTERN, (match, name: string) => {
-    if (!isPlaceholderToken(name)) return match;
-    const value = values.get(name);
-    if (value == null) return match;
-    return options.escapeHtml ? escapeHtml(value) : value;
-  });
-}
 
 export function createIssueAlertEmailPreviewValues(options: {
   projectId: string,

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/alerts/issue-alert-email-template.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/alerts/issue-alert-email-template.ts
@@ -1,4 +1,7 @@
-import { type IssueAlertEmailPlaceholderToken } from "@hexclave/shared/dist/utils/issue-alert-email-template";
+import {
+  ISSUE_ALERT_EMAIL_PLACEHOLDER_TOKENS,
+  type IssueAlertEmailPlaceholderToken,
+} from "@hexclave/shared/dist/utils/issue-alert-email-template";
 import { deindent } from "@hexclave/shared/dist/utils/strings";
 
 // The token vocabulary and interpolation semantics are a cross-app contract
@@ -12,21 +15,27 @@ export {
   type IssueAlertEmailPlaceholderToken,
 } from "@hexclave/shared/dist/utils/issue-alert-email-template";
 
+const ISSUE_ALERT_EMAIL_PLACEHOLDER_HINTS = new Map<IssueAlertEmailPlaceholderToken, string>([
+  ["short_id", "Per-project issue number"],
+  ["type", "Error type, for example TypeError"],
+  ["summary", "Error message"],
+  ["culprit", "Code location"],
+  ["environment", "production, staging, …"],
+  ["release", "Release that reported it"],
+  ["status", "unresolved, resolved, or ignored"],
+  ["kind", "New issue, regression, or frequency"],
+  ["occurred_at", "When this occurrence was seen"],
+  ["issue_url", "Dashboard link to the issue"],
+]);
+
 export const ISSUE_ALERT_EMAIL_PLACEHOLDERS: readonly {
   token: IssueAlertEmailPlaceholderToken,
   hint: string,
-}[] = [
-  { token: "short_id", hint: "Per-project issue number" },
-  { token: "type", hint: "Error type, for example TypeError" },
-  { token: "summary", hint: "Error message" },
-  { token: "culprit", hint: "Code location" },
-  { token: "environment", hint: "production, staging, …" },
-  { token: "release", hint: "Release that reported it" },
-  { token: "status", hint: "unresolved, resolved, or ignored" },
-  { token: "kind", hint: "New issue, regression, or frequency" },
-  { token: "occurred_at", hint: "When this occurrence was seen" },
-  { token: "issue_url", hint: "Dashboard link to the issue" },
-];
+}[] = ISSUE_ALERT_EMAIL_PLACEHOLDER_TOKENS.map((token) => {
+  const hint = ISSUE_ALERT_EMAIL_PLACEHOLDER_HINTS.get(token);
+  if (hint == null) throw new Error(`No hint is defined for issue-alert email placeholder ${token}`);
+  return { token, hint };
+});
 
 export const DEFAULT_ISSUE_ALERT_EMAIL_SUBJECT = "[{{kind}}] {{short_id}}: {{summary}}";
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/correlation.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/correlation.ts
@@ -1,5 +1,5 @@
 import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
-import type { IssueOccurrence } from "./issues-data";
+import { parseClickHouseUtc, type IssueOccurrence } from "./issues-data";
 
 /**
  * "Leading up to this" — the log lines immediately before an error occurrence.
@@ -111,18 +111,8 @@ export function parseLeadingUpToLogRows(
   rows: readonly Record<string, unknown>[],
 ): LeadingUpToLogLine[] {
   return rows.map((row) => {
-    const rawEventAt = row.event_at;
-    if (typeof rawEventAt !== "string") {
-      throw new HexclaveAssertionError("Expected log row event_at to be a ClickHouse timestamp string");
-    }
-    const trimmed = rawEventAt.trim();
-    const normalized = trimmed.replace(" ", "T") + (trimmed.includes("Z") || trimmed.includes("+") ? "" : "Z");
-    const eventAtMillis = new Date(normalized).getTime();
-    if (Number.isNaN(eventAtMillis)) {
-      throw new HexclaveAssertionError(`Invalid log row event_at: ${rawEventAt}`);
-    }
     return {
-      eventAtMillis,
+      eventAtMillis: parseClickHouseUtc(row.event_at, "log row event_at"),
       level: typeof row.level === "string" ? row.level : "",
       message: typeof row.message === "string" ? row.message : "",
       serviceName: typeof row.service_name === "string" && row.service_name !== "" ? row.service_name : null,

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-columns.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-columns.tsx
@@ -11,10 +11,12 @@ import { formatIssueCount, issueCulprit, issueShortIdLabel, issueSubtitle, issue
 import { issueDetailHref } from "./issue-links";
 import {
   issueStatusBadge,
+  nextStatusForAction,
   primaryIssueStatusAction,
   resolveIssueRowStatus,
   type IssueStatusOverrides,
 } from "./issue-status";
+import type { ObservabilityTimeRangeHours } from "../filters";
 import type { IssueListItem, IssueStatus } from "./issues-data";
 
 /**
@@ -31,6 +33,12 @@ import type { IssueListItem, IssueStatus } from "./issues-data";
 
 export type IssueCellContext = {
   projectId: string,
+  /**
+   * The list's selected time window, carried into each row's detail link so
+   * the detail page's window-scoped counts match the column the reader
+   * clicked.
+   */
+  rangeHours: ObservabilityTimeRangeHours,
   /** Fixed at load so a table of relative times shares one "now". */
   nowMs: number,
   overrides: IssueStatusOverrides,
@@ -69,7 +77,7 @@ function IssueCell({ issue, context }: { issue: IssueListItem, context: IssueCel
     >
       <div className="flex min-w-0 items-baseline gap-1.5">
         <Link
-          href={issueDetailHref(context.projectId, issue.id)}
+          href={issueDetailHref(context.projectId, issue.id, { rangeHours: context.rangeHours })}
           className="truncate text-[13px] font-semibold text-foreground hover:underline"
           title={title}
         >
@@ -96,9 +104,13 @@ function IssueCell({ issue, context }: { issue: IssueListItem, context: IssueCel
 function GraphCell({ issue, context }: { issue: IssueListItem, context: IssueCellContext }) {
   // An issue can own several hashes after a merge, so its series is the sum of
   // its hashes' series. Missing hashes mean "not loaded yet" — the whole cell
-  // stays pending rather than drawing half a chart.
+  // stays pending rather than drawing half a chart. An issue with NO hashes
+  // (a server anomaly — every issue owns at least one) must NOT be pending:
+  // the loader only ever resolves requested hashes, so nothing could ever
+  // complete that cell and it would read "Loading activity" forever instead of
+  // the honest empty hairline.
   const series = issue.issue_hashes.map((hash) => context.sparklinesByHash.get(hash));
-  const pending = issue.issue_hashes.length === 0 || series.some((entry) => entry == null);
+  const pending = series.some((entry) => entry == null);
   const merged = new Map<string | number, number>();
   if (!pending) {
     for (const buckets of series) {
@@ -141,7 +153,7 @@ function ActionsCell({ issue, context }: { issue: IssueListItem, context: IssueC
         variant="ghost"
         size="sm"
         className="h-7 px-2 text-[11px]"
-        onClick={() => context.onChangeStatus(issue, primary === "resolve" ? "resolved" : "unresolved")}
+        onClick={() => context.onChangeStatus(issue, nextStatusForAction(primary))}
       >
         {primary === "resolve" ? "Resolve" : "Undo"}
       </DesignButton>

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-event-search.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-event-search.tsx
@@ -5,8 +5,10 @@ import { Link } from "@/components/link";
 import { MagnifyingGlassIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 import { issueDetailHref } from "./issue-links";
-import { searchPublicIssues, type IssuePublicSearchRecord } from "./issues-data";
+import { searchPublicIssues, type IssuePublicSearchRecord, type IssuePublicSearchRequest } from "./issues-data";
 import type { IssueFilters } from "./issue-filters";
+
+type IssueEventSearchFilters = Omit<IssuePublicSearchRequest, "cursor">;
 
 export function IssueEventSearch({
   adminApp,
@@ -24,6 +26,7 @@ export function IssueEventSearch({
   const [tagValue, setTagValue] = useState("");
   const [items, setItems] = useState<IssuePublicSearchRecord[] | null>(null);
   const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [cursorFilters, setCursorFilters] = useState<IssueEventSearchFilters | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -32,28 +35,36 @@ export function IssueEventSearch({
   const runSearch = async (cursor: string | null) => {
     setBusy(true);
     setError(null);
+    const currentFilters: IssueEventSearchFilters = {
+      hours: filters.hours,
+      status: filters.status,
+      service: filters.service,
+      environment: filters.environment,
+      handled: filters.handled,
+      search: filters.search,
+      level: level.trim() === "" ? null : level.trim(),
+      release: release.trim() === "" ? null : release.trim(),
+      userId: userId.trim() === "" ? null : userId.trim(),
+      tagKey: tagKey.trim() === "" ? null : tagKey.trim(),
+      tagValue: tagValue.trim() === "" ? null : tagValue.trim(),
+    };
+    const requestFilters = cursor == null || cursorFilters == null ? currentFilters : cursorFilters;
     try {
       const result = await searchPublicIssues(adminApp, {
-        hours: filters.hours,
-        status: filters.status,
-        service: filters.service,
-        environment: filters.environment,
-        handled: filters.handled,
-        search: filters.search,
-        level: level.trim() === "" ? null : level.trim(),
-        release: release.trim() === "" ? null : release.trim(),
-        userId: userId.trim() === "" ? null : userId.trim(),
-        tagKey: tagKey.trim() === "" ? null : tagKey.trim(),
-        tagValue: tagValue.trim() === "" ? null : tagValue.trim(),
+        ...requestFilters,
         cursor,
       });
       setItems((current) => cursor == null || current == null ? result.items : [...current, ...result.items]);
       setNextCursor(result.nextCursor);
+      setCursorFilters(result.nextCursor == null ? null : requestFilters);
     } catch (caught) {
-      // Clear stale results: leaving a previous search's rows under the error
-      // banner would read as results for the CURRENT inputs.
-      setItems(null);
-      setNextCursor(null);
+      if (cursor == null) {
+        // Clear stale results only for a fresh search. A failed page request
+        // must leave the successful pages and cursor available for retry.
+        setItems(null);
+        setNextCursor(null);
+        setCursorFilters(null);
+      }
       setError(caught instanceof Error ? caught.message : String(caught));
     } finally {
       setBusy(false);

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-event-search.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-event-search.tsx
@@ -23,10 +23,13 @@ export function IssueEventSearch({
   const [tagKey, setTagKey] = useState("");
   const [tagValue, setTagValue] = useState("");
   const [items, setItems] = useState<IssuePublicSearchRecord[] | null>(null);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
-  const runSearch = async () => {
+  // `cursor: null` starts a fresh search; a cursor appends the next page to
+  // the already-rendered results.
+  const runSearch = async (cursor: string | null) => {
     setBusy(true);
     setError(null);
     try {
@@ -42,10 +45,15 @@ export function IssueEventSearch({
         userId: userId.trim() === "" ? null : userId.trim(),
         tagKey: tagKey.trim() === "" ? null : tagKey.trim(),
         tagValue: tagValue.trim() === "" ? null : tagValue.trim(),
-        cursor: null,
+        cursor,
       });
-      setItems(result.items);
+      setItems((current) => cursor == null || current == null ? result.items : [...current, ...result.items]);
+      setNextCursor(result.nextCursor);
     } catch (caught) {
+      // Clear stale results: leaving a previous search's rows under the error
+      // banner would read as results for the CURRENT inputs.
+      setItems(null);
+      setNextCursor(null);
       setError(caught instanceof Error ? caught.message : String(caught));
     } finally {
       setBusy(false);
@@ -62,7 +70,7 @@ export function IssueEventSearch({
         <DesignInput size="sm" value={tagValue} onChange={(event) => setTagValue(event.target.value)} placeholder="Tag value" aria-label="Search tag value" />
       </div>
       <div className="mt-2">
-        <DesignButton size="sm" variant="secondary" loading={busy} onClick={runSearch} className="gap-1.5">
+        <DesignButton size="sm" variant="secondary" loading={busy} onClick={() => runSearch(null)} className="gap-1.5">
           <MagnifyingGlassIcon className="h-3.5 w-3.5" />
           Search events
         </DesignButton>
@@ -92,6 +100,13 @@ export function IssueEventSearch({
             );
           })}
         </ul>
+      )}
+      {items != null && items.length > 0 && nextCursor != null && (
+        <div className="mt-2">
+          <DesignButton size="sm" variant="ghost" loading={busy} onClick={() => runSearch(nextCursor)}>
+            Load more
+          </DesignButton>
+        </div>
       )}
     </DesignCard>
   );

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-event-sections.test.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-event-sections.test.tsx
@@ -183,9 +183,12 @@ describe("IssueExceptionCauses", () => {
         ...retainedOccurrence,
         data: {
           exception: {
+            // Sentry chain order: root cause first, the actually-thrown
+            // (primary) exception LAST — the primary belongs to the hero
+            // stack, everything before it is an additional cause.
             values: [
-              { type: "PrimaryError", value: "primary", stacktrace: { frames: [] } },
               { type: "CauseError", value: "cause", stacktrace: { frames: [] } },
+              { type: "PrimaryError", value: "primary", stacktrace: { frames: [] } },
             ],
           },
         },

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-event-sections.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-event-sections.tsx
@@ -113,7 +113,11 @@ export function IssueExceptionCauses({
   frameOrder: StackFrameOrder,
 }) {
   const payload = getIssueEventPayload(occurrence);
-  const causes = payload.exceptionChain.slice(1);
+  // The LAST chain entry is the primary exception (the hero stack leads with
+  // it — see `heroStack`); everything before it is its cause chain, stored
+  // root-cause-first. Reversed so the list reads outward-in: the direct cause
+  // first, the root cause last, matching how "caused by" chains are read.
+  const causes = payload.exceptionChain.slice(0, -1).reverse();
   if (causes.length === 0) return null;
 
   return (

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-event.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-event.test.ts
@@ -194,4 +194,32 @@ describe("issue event payload", () => {
       },
     });
   });
+
+  it("leads with the LAST chain entry — the canonical exception ingestion groups on", () => {
+    // Sentry orders `exception.values` root-cause-first; ingestion's
+    // `lastExceptionValue` takes the issue's type/message/stack from the last
+    // entry, so the hero stack must match it, not the root cause.
+    const stack = heroStack({
+      data: {
+        exception: {
+          values: [
+            {
+              type: "DatabaseError",
+              value: "connection reset",
+              stacktrace: { frames: [{ filename: "db.ts", function: "query", lineno: 7, in_app: true }] },
+            },
+            {
+              type: "CheckoutFailed",
+              value: "could not place order",
+              stacktrace: { frames: [{ filename: "checkout.ts", function: "submit", lineno: 42, in_app: true }] },
+            },
+          ],
+        },
+      },
+      frames: [],
+      raw_stack: null,
+    });
+
+    expect(stack.frames[0]).toMatchObject({ filename: "checkout.ts", function: "submit" });
+  });
 });

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-event.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-event.ts
@@ -136,8 +136,8 @@ const RESERVED_EVENT_KEYS = new Set([
 /**
  * Request data is allowlisted at the display boundary too. The current issue
  * response carries opaque occurrence data, so rendering `data.request` raw
- * would make a future or legacy payload capable of exposing headers, query
- * strings, cookies, or bodies in an authenticated dashboard.
+ * would let an opaque occurrence payload expose headers, query strings,
+ * cookies, or bodies in an authenticated dashboard.
  */
 function isSensitiveEventKey(key: string): boolean {
   return /(authorization|cookie|password|secret|token|header|query|body|credential|private[-_.]?key|form[-_.]?data)/i.test(key);
@@ -470,7 +470,12 @@ export function heroStack(occurrence: Pick<IssueOccurrence, "data" | "frames" | 
   rawStack: string | null,
 } {
   const payload = getIssueEventPayload(occurrence);
-  const primary = payload.exceptionChain.at(0);
+  // Sentry orders `exception.values` root-cause-first, with the LAST value
+  // being the exception that was actually thrown — ingestion's
+  // `lastExceptionValue` derives the issue's type/message/grouping stack from
+  // it. Leading with anything else would put a cause's stack under the primary
+  // exception's title. The earlier values render in "Additional causes".
+  const primary = payload.exceptionChain.at(-1);
   if (primary !== undefined && (primary.frames.length > 0 || (primary.rawStack != null && primary.rawStack.trim() !== ""))) {
     return { frames: primary.frames, rawStack: primary.rawStack };
   }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-filters.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-filters.test.ts
@@ -7,10 +7,12 @@ import {
   isSortableIssueColumn,
   issueFiltersAreDefault,
   parseIssueFilters,
+  parseIssueRangeHours,
   resolveIssueSort,
   serializeIssueFilters,
   type IssueFilters,
 } from "./issue-filters";
+import { issueDetailHref } from "./issue-links";
 
 function roundTrip(filters: IssueFilters): IssueFilters {
   return parseIssueFilters(serializeIssueFilters(filters, new URLSearchParams()));
@@ -67,6 +69,19 @@ describe("parse / serialize round trip", () => {
     serializeIssueFilters(DEFAULT_ISSUE_FILTERS, params);
     expect(params.toString()).toBe("");
   });
+
+  it("treats whitespace-only search as the default", () => {
+    // The page trims before fetching, so "   " requests an unfiltered list —
+    // persisting it would mark the list as filtered and mislabel an empty
+    // project as "No matching issues".
+    const filters: IssueFilters = { ...DEFAULT_ISSUE_FILTERS, search: "   " };
+    expect(serializeIssueFilters(filters, new URLSearchParams()).toString()).toBe("");
+    expect(issueFiltersAreDefault(filters)).toBe(true);
+    // A non-blank search keeps its raw value (trailing spaces included) so the
+    // controlled input never fights the user mid-phrase.
+    expect(serializeIssueFilters({ ...DEFAULT_ISSUE_FILTERS, search: "boom " }, new URLSearchParams()).get("search"))
+      .toBe("boom ");
+  });
 });
 
 describe("parseIssueFilters treats the URL as untrusted", () => {
@@ -79,6 +94,35 @@ describe("parseIssueFilters treats the URL as untrusted", () => {
 
   it("survives a service value with broken percent-encoding", () => {
     expect(parseIssueFilters(new URLSearchParams("service=svc%3A%E0%A4%A")).service).toBeNull();
+  });
+});
+
+describe("parseIssueRangeHours (the one filter the detail page shares)", () => {
+  it("reads an allowlisted range", () => {
+    expect(parseIssueRangeHours(new URLSearchParams("range=168"))).toBe(168);
+  });
+
+  it("falls back to the default for missing or unknown values", () => {
+    expect(parseIssueRangeHours(new URLSearchParams())).toBe(DEFAULT_ISSUE_FILTERS.hours);
+    expect(parseIssueRangeHours(new URLSearchParams("range=999"))).toBe(DEFAULT_ISSUE_FILTERS.hours);
+    expect(parseIssueRangeHours(new URLSearchParams("range=banana"))).toBe(DEFAULT_ISSUE_FILTERS.hours);
+  });
+
+  it("agrees with parseIssueFilters on the same URL", () => {
+    const params = new URLSearchParams("range=720");
+    expect(parseIssueRangeHours(params)).toBe(parseIssueFilters(params).hours);
+  });
+
+  it("round-trips the range a detail link carries", () => {
+    // The list → detail handoff: `issueDetailHref` writes the param this
+    // parser reads, so the detail page's window matches the list's.
+    const href = issueDetailHref("p1", "42", { rangeHours: 720 });
+    expect(parseIssueRangeHours(new URL(href, "http://localhost").searchParams)).toBe(720);
+  });
+
+  it("omits the param entirely at the default range", () => {
+    expect(issueDetailHref("p1", "42", { rangeHours: DEFAULT_ISSUE_FILTERS.hours })).toBe("/projects/p1/observability/issues/42");
+    expect(issueDetailHref("p1", "42")).toBe("/projects/p1/observability/issues/42");
   });
 });
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-filters.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-filters.ts
@@ -9,6 +9,7 @@ import {
   serviceIdentityToSelectValue,
   type ServiceIdentity,
 } from "../service-identity";
+import { DEFAULT_ISSUE_RANGE_HOURS, ISSUE_RANGE_PARAM_KEY } from "./issue-links";
 import {
   ISSUE_STATUSES, type IssueHandledFilter, type IssueListSortField,
   type IssueStatus,
@@ -42,8 +43,9 @@ export type IssueFilters = {
 export const DEFAULT_ISSUE_FILTERS: IssueFilters = {
   // 24h, not Logs' 720h. Logs is an archive you go digging in; Issues is a
   // triage queue, and a month-wide default buries today's regression under
-  // everything that has ever gone wrong.
-  hours: 24,
+  // everything that has ever gone wrong. (The value lives in `issue-links.ts`
+  // because the href builders there omit the param at the default.)
+  hours: DEFAULT_ISSUE_RANGE_HOURS,
   status: "unresolved",
   service: null,
   environment: null,
@@ -54,7 +56,7 @@ export const DEFAULT_ISSUE_FILTERS: IssueFilters = {
 };
 
 const PARAM_KEYS = {
-  hours: "range",
+  hours: ISSUE_RANGE_PARAM_KEY,
   status: "status",
   service: "service",
   environment: "environment",
@@ -69,13 +71,12 @@ const PARAM_KEYS = {
  * (Values that come from our own UI are validated at the point they're set.)
  */
 export function parseIssueFilters(params: URLSearchParams): IssueFilters {
-  const rawHours = Number(params.get(PARAM_KEYS.hours));
   const rawHandled = params.get(PARAM_KEYS.handled);
   const rawService = params.get(PARAM_KEYS.service);
   const rawEnvironment = params.get(PARAM_KEYS.environment);
 
   return {
-    hours: isObservabilityTimeRangeHours(rawHours) ? rawHours : DEFAULT_ISSUE_FILTERS.hours,
+    hours: parseIssueRangeHours(params),
     status: parseIssueStatusFilter(params.get(PARAM_KEYS.status)),
     service: rawService == null || rawService === ALL_SERVICES_SELECT_VALUE
       ? null
@@ -85,6 +86,17 @@ export function parseIssueFilters(params: URLSearchParams): IssueFilters {
       ?? DEFAULT_ISSUE_FILTERS.handled,
     search: params.get(PARAM_KEYS.search) ?? DEFAULT_ISSUE_FILTERS.search,
   };
+}
+
+/**
+ * The one filter the DETAIL page shares with the list. Split out of
+ * `parseIssueFilters` because the detail page carries only the range (its
+ * window-scoped counts must match the list the reader came from), and typed
+ * against the `get` shape so Next's read-only `useSearchParams` works too.
+ */
+export function parseIssueRangeHours(params: Pick<URLSearchParams, "get">): ObservabilityTimeRangeHours {
+  const rawHours = Number(params.get(PARAM_KEYS.hours));
+  return isObservabilityTimeRangeHours(rawHours) ? rawHours : DEFAULT_ISSUE_FILTERS.hours;
 }
 
 export function parseIssueStatusFilter(raw: string | null): IssueStatusFilter {
@@ -119,7 +131,12 @@ export function serializeIssueFilters(filters: IssueFilters, params: URLSearchPa
   setOrDelete(PARAM_KEYS.service, filters.service == null ? null : serviceIdentityToSelectValue(filters.service));
   setOrDelete(PARAM_KEYS.environment, filters.environment);
   setOrDelete(PARAM_KEYS.handled, filters.handled === DEFAULT_ISSUE_FILTERS.handled ? null : filters.handled);
-  setOrDelete(PARAM_KEYS.search, filters.search === "" ? null : filters.search);
+  // Whitespace-only search is the default: the page trims before fetching, so
+  // "   " sends an unfiltered request — persisting it (and letting
+  // `issueFiltersAreDefault` call the list "filtered") would mislabel an empty
+  // project as "No matching issues". The raw value is kept when non-blank so
+  // typing a trailing space mid-phrase never fights the input.
+  setOrDelete(PARAM_KEYS.search, filters.search.trim() === "" ? null : filters.search);
   return params;
 }
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-format.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-format.test.ts
@@ -86,6 +86,14 @@ describe("issueCulprit", () => {
       .toBe("unhandledrejection");
   });
 
+  it("treats the backend's degraded-grouping sentinel as missing", () => {
+    // `degradedResult` in the backend's grouping stamps exactly "<unknown>";
+    // it must not shadow a real locator the occurrence still carries.
+    expect(issueCulprit({ culprit: "<unknown>", data: { url: "https://app.test/checkout" } }))
+      .toBe("https://app.test/checkout");
+    expect(issueCulprit({ culprit: "<unknown>" })).toBe("unknown");
+  });
+
   it("NEVER returns an empty string", () => {
     const degenerate = [
       { culprit: null },
@@ -126,10 +134,10 @@ describe("formatIssueCount", () => {
 });
 
 describe("parseIssueRouteId", () => {
-  it("accepts a uuid and an all-digits short id", () => {
-    expect(parseIssueRouteId("3F2504E0-4F89-11D3-9A0C-0305E82C3301")).toEqual({
+  it("accepts a v4 uuid and an all-digits short id", () => {
+    expect(parseIssueRouteId("3F2504E0-4F89-41D3-9A0C-0305E82C3301")).toEqual({
       kind: "uuid",
-      value: "3f2504e0-4f89-11d3-9a0c-0305e82c3301",
+      value: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
     });
     expect(parseIssueRouteId("42")).toEqual({ kind: "short-id", value: "42" });
   });
@@ -139,6 +147,14 @@ describe("parseIssueRouteId", () => {
     expect(parseIssueRouteId("")).toBeNull();
     expect(parseIssueRouteId("not-an-id")).toBeNull();
     expect(parseIssueRouteId("../secrets")).toBeNull();
+  });
+
+  it("rejects uuid-shaped-but-not-v4 ids, matching the backend's isUuid contract", () => {
+    // v1 version digit — the backend would 404 this anyway; catching it here
+    // gives the precise "not a valid issue reference" page instead.
+    expect(parseIssueRouteId("3f2504e0-4f89-11d3-9a0c-0305e82c3301")).toBeNull();
+    // wrong variant digit
+    expect(parseIssueRouteId("3f2504e0-4f89-41d3-7a0c-0305e82c3301")).toBeNull();
   });
 });
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-format.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-format.test.ts
@@ -119,6 +119,7 @@ describe("formatIssueCount", () => {
     expect(formatIssueCount("9999")).toBe("9,999");
     expect(formatIssueCount("10000")).toBe("10.0k");
     expect(formatIssueCount("125000")).toBe("125k");
+    expect(formatIssueCount("999500")).toBe("1.0M");
     expect(formatIssueCount("1500000")).toBe("1.5M");
   });
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-format.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-format.ts
@@ -1,11 +1,9 @@
+import { formatCount } from "../format";
 import type { IssueFrame } from "./issues-data";
 
 /**
- * How an Issue is named and described in the UI.
- *
- * All pure, all tested: these three functions decide what a triager reads
- * first, and every one of them has a degenerate input that the obvious
- * implementation gets subtly wrong.
+ * How an Issue is named and described in the UI. Each helper has a degenerate
+ * input that the obvious implementation gets subtly wrong.
  */
 
 const UNKNOWN_ISSUE_TITLE = "Unknown error";
@@ -84,9 +82,18 @@ function stringField(data: Record<string, unknown> | null | undefined, key: stri
  * culprit renders as a blank second line, which reads as a layout bug rather
  * than as missing data, so the terminal fallback is a visible word.
  */
+/**
+ * The backend's grouping fallback stamps this exact sentinel as the culprit
+ * when it could not derive one (see `degradedResult` in
+ * `apps/backend/src/lib/issues/grouping.ts`). It is non-empty, so without
+ * special-casing it here a degraded browser error would render "<unknown>"
+ * even when the occurrence still carries a usable `data.url`/`data.path`.
+ */
+const SERVER_UNKNOWN_CULPRIT_SENTINEL = "<unknown>";
+
 export function issueCulprit(input: IssueCulpritInput): string {
   const explicit = input.culprit?.trim();
-  if (explicit != null && explicit !== "") return explicit;
+  if (explicit != null && explicit !== "" && explicit !== SERVER_UNKNOWN_CULPRIT_SENTINEL) return explicit;
 
   const frames = input.frames ?? [];
   const topInApp = [...frames].reverse().find((frame) => frame.in_app);
@@ -112,18 +119,16 @@ export function issueShortIdLabel(shortId: string): string {
  * Counts that may exceed `Number.MAX_SAFE_INTEGER`.
  *
  * Lifetime counters arrive as decimal strings because they are Postgres
- * `BigInt`s. Below 10k the exact digits matter (you compare two similar issues
- * by eye); above it only the magnitude does, and the compaction step converts
- * to `Number`, which is lossy past 2^53 — irrelevant when the output is
- * "9007199254.7M" either way.
+ * `BigInt`s. This wrapper only normalizes that input; the compaction rules live
+ * in the shared `formatCount` so Issues and Services can never disagree about
+ * what "125k" means. Converting the BigInt to `Number` for the shared formatter
+ * is lossy past 2^53 — irrelevant because below 10k (where exact digits render)
+ * a BigInt fits a double exactly, and past 2^53 the output is "9007199254.7M"
+ * either way. Negative counts are rejected by the shared formatter.
  */
 export function formatIssueCount(value: number | string): string {
   const asBigInt = typeof value === "string" ? parseDecimalStringOrThrow(value) : BigInt(Math.round(value));
-  if (asBigInt < BigInt(0)) throw new Error(`Cannot format a negative issue count: ${value}`);
-  if (asBigInt < BigInt(10_000)) return asBigInt.toLocaleString();
-  const asNumber = Number(asBigInt);
-  if (asNumber < 1_000_000) return `${(asNumber / 1_000).toFixed(asNumber < 100_000 ? 1 : 0)}k`;
-  return `${(asNumber / 1_000_000).toFixed(asNumber < 10_000_000 ? 1 : 0)}M`;
+  return formatCount(Number(asBigInt));
 }
 
 function parseDecimalStringOrThrow(value: string): bigint {
@@ -140,7 +145,13 @@ function parseDecimalStringOrThrow(value: string): bigint {
  */
 export type IssueRouteId = { kind: "uuid", value: string } | { kind: "short-id", value: string };
 
-const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// Matches the backend's `isUuid` contract (v4 only, see
+// `@hexclave/shared/utils/uuids`): issue ids are backend-minted v4 uuids, and a
+// uuid-shaped-but-not-v4 segment would only be rejected server-side with a
+// generic load error — catching it here shows the precise "not a valid issue
+// reference" page instead. Case-insensitive because the value is lowercased
+// below before it is sent anywhere.
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function parseIssueRouteId(raw: string): IssueRouteId | null {
   const trimmed = raw.trim();

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-format.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-format.ts
@@ -73,6 +73,15 @@ function stringField(data: Record<string, unknown> | null | undefined, key: stri
 }
 
 /**
+ * The backend's grouping fallback stamps this exact sentinel as the culprit
+ * when it could not derive one (see `degradedResult` in
+ * `apps/backend/src/lib/issues/grouping.ts`). It is non-empty, so without
+ * special-casing it here a degraded browser error would render "<unknown>"
+ * even when the occurrence still carries a usable `data.url`/`data.path`.
+ */
+const SERVER_UNKNOWN_CULPRIT_SENTINEL = "<unknown>";
+
+/**
  * "Where did this happen" — the line under the title.
  *
  * Falls back through the whole chain rather than trusting any single source:
@@ -82,14 +91,6 @@ function stringField(data: Record<string, unknown> | null | undefined, key: stri
  * culprit renders as a blank second line, which reads as a layout bug rather
  * than as missing data, so the terminal fallback is a visible word.
  */
-/**
- * The backend's grouping fallback stamps this exact sentinel as the culprit
- * when it could not derive one (see `degradedResult` in
- * `apps/backend/src/lib/issues/grouping.ts`). It is non-empty, so without
- * special-casing it here a degraded browser error would render "<unknown>"
- * even when the occurrence still carries a usable `data.url`/`data.path`.
- */
-const SERVER_UNKNOWN_CULPRIT_SENTINEL = "<unknown>";
 
 export function issueCulprit(input: IssueCulpritInput): string {
   const explicit = input.culprit?.trim();

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-links.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-links.ts
@@ -1,12 +1,23 @@
 import { urlString } from "@hexclave/shared/dist/utils/urls";
+import type { ObservabilityTimeRangeHours } from "../filters";
 
 /**
  * Dashboard hrefs for the Issues surface.
  *
  * Kept apart from `issues-data.ts` so pages that only need to *link* at an
- * issue (Logs, the Traces rail, a future alert email preview) don't pull in the
+ * issue (Logs, the Traces rail, alert emails) don't pull in the
  * REST client and its response parsers.
  */
+
+/**
+ * The search param that carries the selected time window from the list to the
+ * detail page (and through the detail page's own URL rewrites). Declared here
+ * rather than in `issue-filters.ts` because the href builders below need it and
+ * this module must stay dependency-light; `issue-filters.ts` imports these back
+ * so the codec and the links can never disagree on the vocabulary.
+ */
+export const ISSUE_RANGE_PARAM_KEY = "range";
+export const DEFAULT_ISSUE_RANGE_HOURS: ObservabilityTimeRangeHours = 24;
 
 export function issuesListHref(projectId: string): string {
   return urlString`/projects/${projectId}/observability/issues`;
@@ -29,9 +40,23 @@ export function issueSearchHref(projectId: string, search: string): string {
   return `${issuesListHref(projectId)}?status=all&search=${encodeURIComponent(search)}`;
 }
 
-/** `idOrShortId` is either the issue uuid or its per-branch short id. */
-export function issueDetailHref(projectId: string, idOrShortId: string): string {
-  return urlString`/projects/${projectId}/observability/issues/${idOrShortId}`;
+/**
+ * `idOrShortId` is either the issue uuid or its per-branch short id.
+ *
+ * `rangeHours` carries the list's selected time window along so the detail
+ * page's window-scoped counts match the numbers the reader just clicked on.
+ * Omitted at the default so plain links (Logs, Traces, search) and
+ * freshly-opened pages keep a clean URL — "no param" and "the default" must
+ * never disagree, mirroring `serializeIssueFilters`.
+ */
+export function issueDetailHref(
+  projectId: string,
+  idOrShortId: string,
+  options: { rangeHours?: ObservabilityTimeRangeHours } = {},
+): string {
+  const base = urlString`/projects/${projectId}/observability/issues/${idOrShortId}`;
+  if (options.rangeHours == null || options.rangeHours === DEFAULT_ISSUE_RANGE_HOURS) return base;
+  return `${base}?${ISSUE_RANGE_PARAM_KEY}=${encodeURIComponent(String(options.rangeHours))}`;
 }
 
 export { traceDetailHref, type TraceHighlight } from "../observability-links";

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-status.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  adjustIssueStatusCounts,
   applyOptimisticStatus,
   clearOptimisticStatus,
   issueStatusBadge,
@@ -110,6 +111,58 @@ describe("optimistic overrides", () => {
     const row = issue({ status: "resolved" });
     const overrides = applyOptimisticStatus(NO_ISSUE_STATUS_OVERRIDES, row.id, "resolved", row.updated_at_millis);
     expect(resolveIssueRowStatus(row, overrides)).toEqual({ status: "resolved", isOptimistic: false });
+  });
+
+  it("reconciles only the stale override, leaving still-live siblings untouched", () => {
+    const a = applyOptimisticStatus(NO_ISSUE_STATUS_OVERRIDES, "a", "resolved", 2_000);
+    const both = applyOptimisticStatus(a, "b", "ignored", 2_000);
+
+    // Only "a" moved server-side; "b" is still at the version the user clicked.
+    const rowA = issue({ id: "a", updated_at_millis: 5_000 });
+    const rowB = issue({ id: "b", updated_at_millis: 2_000 });
+    const reconciled = reconcileIssueStatusOverrides(both, [rowA, rowB]);
+
+    expect(reconciled.has("a")).toBe(false);
+    expect(reconciled.get("b")?.status).toBe("ignored");
+    // Immutability: the input map is never mutated in place.
+    expect(both.has("a")).toBe(true);
+  });
+
+  it("keeps the same map reference when the overridden rows are not in the fetched page", () => {
+    const a = applyOptimisticStatus(NO_ISSUE_STATUS_OVERRIDES, "a", "resolved", 2_000);
+    const both = applyOptimisticStatus(a, "b", "ignored", 2_000);
+
+    // The fetched page contains neither overridden issue (e.g. it scrolled out
+    // of the window) — nothing to reconcile, identity must be preserved.
+    const reconciled = reconcileIssueStatusOverrides(both, [issue({ id: "c", updated_at_millis: 9_000 })]);
+
+    expect(reconciled).toBe(both);
+    expect(reconciled.size).toBe(2);
+  });
+});
+
+describe("adjustIssueStatusCounts", () => {
+  it("moves one issue between buckets", () => {
+    expect(adjustIssueStatusCounts({ unresolved: 5, resolved: 2, ignored: 1 }, "unresolved", "resolved"))
+      .toEqual({ unresolved: 4, resolved: 3, ignored: 1 });
+  });
+
+  it("is a no-op for same-status transitions and missing counts", () => {
+    const counts = { unresolved: 5, resolved: 2, ignored: 1 };
+    expect(adjustIssueStatusCounts(counts, "resolved", "resolved")).toBe(counts);
+    expect(adjustIssueStatusCounts(null, "unresolved", "resolved")).toBeNull();
+  });
+
+  it("never drives a count below zero, even if the server count was already stale", () => {
+    expect(adjustIssueStatusCounts({ unresolved: 0, resolved: 0, ignored: 0 }, "unresolved", "ignored"))
+      .toEqual({ unresolved: 0, resolved: 0, ignored: 1 });
+  });
+
+  it("telescopes across chained optimistic transitions", () => {
+    const start = { unresolved: 3, resolved: 0, ignored: 0 };
+    const afterResolve = adjustIssueStatusCounts(start, "unresolved", "resolved");
+    const afterUndo = adjustIssueStatusCounts(afterResolve, "resolved", "unresolved");
+    expect(afterUndo).toEqual(start);
   });
 });
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-status.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issue-status.ts
@@ -1,5 +1,5 @@
 import type { DesignBadgeColor } from "@/components/design-components";
-import type { IssueListItem, IssueStatus, IssueSubstatus } from "./issues-data";
+import type { IssueListItem, IssueStatus, IssueStatusCounts, IssueSubstatus } from "./issues-data";
 
 /**
  * The Issue lifecycle, as pure data.
@@ -28,18 +28,6 @@ export function nextStatusForAction(action: IssueStatusAction): IssueStatus {
       return "ignored";
     }
   }
-}
-
-export const ISSUE_STATUS_ACTION_LABELS = new Map<IssueStatusAction, string>([
-  ["resolve", "Resolve"],
-  ["unresolve", "Unresolve"],
-  ["ignore", "Ignore"],
-]);
-
-export function issueStatusActionLabel(action: IssueStatusAction): string {
-  const label = ISSUE_STATUS_ACTION_LABELS.get(action);
-  if (label == null) throw new Error(`Missing label for issue status action: ${action}`);
-  return label;
 }
 
 export type IssueStatusBadge = { label: string, color: DesignBadgeColor };
@@ -139,4 +127,26 @@ export function resolveIssueRowStatus(
  */
 export function primaryIssueStatusAction(status: IssueStatus): IssueStatusAction {
   return status === "unresolved" ? "resolve" : "unresolve";
+}
+
+/**
+ * Moves one issue between the status-tab counts, optimistically. The list page
+ * deliberately does not refetch after a single-row status change (a refetch
+ * would yank the row out from under the cursor mid-scan), so without this the
+ * tab counts would silently keep counting a resolved issue as Unresolved until
+ * the next natural refresh. `from === to` is a no-op so an idempotent click
+ * cannot drift the totals, and the caller reverts by calling this with the
+ * arguments swapped when the PATCH fails.
+ */
+export function adjustIssueStatusCounts(
+  counts: IssueStatusCounts | null,
+  from: IssueStatus,
+  to: IssueStatus,
+): IssueStatusCounts | null {
+  if (counts == null || from === to) return counts;
+  return {
+    ...counts,
+    [from]: Math.max(0, counts[from] - 1),
+    [to]: counts[to] + 1,
+  };
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issues-data.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issues-data.test.ts
@@ -111,27 +111,62 @@ describe("getIssueFacetsQuery", () => {
 });
 
 describe("parseIssueSparklineRows", () => {
-  it("returns an empty series for a requested hash with no occurrences", () => {
-    const parsed = parseIssueSparklineRows([], [SAMPLE_HASH_A, SAMPLE_HASH_B]);
-    expect(parsed.get(SAMPLE_HASH_A)).toEqual([]);
-    expect(parsed.get(SAMPLE_HASH_B)).toEqual([]);
+  // 12:30 UTC — deliberately mid-bucket so the tests exercise the flooring.
+  const NOW_MS = Date.parse("2026-07-31T12:30:00.000Z");
+  const LATEST_BUCKET_MS = Date.parse("2026-07-31T12:00:00.000Z");
+  const EARLIEST_BUCKET_MS = LATEST_BUCKET_MS - 23 * 3_600_000;
+
+  it("returns a dense zero-filled grid for a requested hash with no occurrences", () => {
+    const parsed = parseIssueSparklineRows([], [SAMPLE_HASH_A, SAMPLE_HASH_B], 24, NOW_MS);
+    const series = parsed.get(SAMPLE_HASH_A);
+    expect(series).toHaveLength(24);
+    expect(series?.[0]).toEqual({ bucketMs: EARLIEST_BUCKET_MS, occurrences: 0 });
+    expect(series?.[23]).toEqual({ bucketMs: LATEST_BUCKET_MS, occurrences: 0 });
+    expect(series?.every((bucket) => bucket.occurrences === 0)).toBe(true);
+    expect(parsed.get(SAMPLE_HASH_B)).toHaveLength(24);
   });
 
-  it("parses ClickHouse timestamps as UTC and string counts as numbers", () => {
+  it("places parsed rows onto the grid, leaving gaps at zero", () => {
     const parsed = parseIssueSparklineRows(
       [{ issue_hash: SAMPLE_HASH_A, bucket_start: "2026-07-31 12:00:00.000", occurrences: "17" }],
       [SAMPLE_HASH_A],
+      24,
+      NOW_MS,
     );
-    expect(parsed.get(SAMPLE_HASH_A)).toEqual([
-      { bucketMs: Date.parse("2026-07-31T12:00:00.000Z"), occurrences: 17 },
-    ]);
+    const series = parsed.get(SAMPLE_HASH_A);
+    expect(series?.[23]).toEqual({ bucketMs: LATEST_BUCKET_MS, occurrences: 17 });
+    // Every other bucket still exists and is zero — the sparkline renders
+    // buckets adjacently, so a missing bucket would misplace every later bar.
+    expect(series?.filter((bucket) => bucket.occurrences !== 0)).toHaveLength(1);
+  });
+
+  it("drops the clipped partial bucket outside the grid instead of misplacing it", () => {
+    const beforeEarliest = new Date(EARLIEST_BUCKET_MS - 3_600_000).toISOString().replace("T", " ").replace("Z", "");
+    const parsed = parseIssueSparklineRows(
+      [{ issue_hash: SAMPLE_HASH_A, bucket_start: beforeEarliest, occurrences: 5 }],
+      [SAMPLE_HASH_A],
+      24,
+      NOW_MS,
+    );
+    expect(parsed.get(SAMPLE_HASH_A)?.every((bucket) => bucket.occurrences === 0)).toBe(true);
   });
 
   it("throws when a row carries a hash nobody asked for", () => {
     expect(() => parseIssueSparklineRows(
       [{ issue_hash: SAMPLE_HASH_B, bucket_start: "2026-07-31 12:00:00.000", occurrences: 1 }],
       [SAMPLE_HASH_A],
+      24,
+      NOW_MS,
     )).toThrow(/unrequested issue hash/);
+  });
+
+  it("throws on a bucket that is not aligned to the grid", () => {
+    expect(() => parseIssueSparklineRows(
+      [{ issue_hash: SAMPLE_HASH_A, bucket_start: "2026-07-31 11:30:00.000", occurrences: 1 }],
+      [SAMPLE_HASH_A],
+      24,
+      NOW_MS,
+    )).toThrow(/not aligned/);
   });
 });
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issues-data.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issues-data.test.ts
@@ -140,6 +140,25 @@ describe("parseIssueSparklineRows", () => {
     expect(series?.filter((bucket) => bucket.occurrences !== 0)).toHaveLength(1);
   });
 
+  it("anchors the grid to ClickHouse time when the browser clock differs", () => {
+    const parsed = parseIssueSparklineRows(
+      [{
+        issue_hash: SAMPLE_HASH_A,
+        bucket_start: "2026-07-31 14:00:00.000",
+        occurrences: 3,
+        query_now: "2026-07-31 14:30:00.000",
+      }],
+      [SAMPLE_HASH_A],
+      24,
+      NOW_MS,
+    );
+    const series = parsed.get(SAMPLE_HASH_A);
+    expect(series?.[23]).toEqual({
+      bucketMs: Date.parse("2026-07-31T14:00:00.000Z"),
+      occurrences: 3,
+    });
+  });
+
   it("drops the clipped partial bucket outside the grid instead of misplacing it", () => {
     const beforeEarliest = new Date(EARLIEST_BUCKET_MS - 3_600_000).toISOString().replace("T", " ").replace("Z", "");
     const parsed = parseIssueSparklineRows(

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issues-data.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issues-data.ts
@@ -1,4 +1,4 @@
-import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+import { HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { stringCompare } from "@hexclave/shared/dist/utils/strings";
 import {
   IssueBulkStatusRequestSchema,
@@ -160,7 +160,15 @@ LIMIT 500
 export type IssueSparklineBucket = { bucketMs: number, occurrences: number };
 export type IssueFacets = { services: ServiceIdentity[], environments: string[] };
 
-function parseClickHouseUtc(value: unknown, key: string): number {
+/**
+ * ClickHouse `DateTime64` string → epoch millis, throwing on anything else.
+ * Shared by every issues-side ClickHouse parser (sparklines here, the
+ * "leading up to" excerpt in `correlation.ts`) so a date-format fix cannot land
+ * in one and not the other. The analytics grid has its own `parseClickHouseDate`
+ * with a different contract (returns a `Date`, no unknown-input handling), so
+ * this is deliberately not unified with it.
+ */
+export function parseClickHouseUtc(value: unknown, key: string): number {
   if (typeof value !== "string") {
     throw new HexclaveAssertionError(`Expected ${key} to be a ClickHouse timestamp string`);
   }
@@ -183,28 +191,54 @@ function toCount(value: unknown, key: string): number {
 export function parseIssueSparklineRows(
   rows: readonly Record<string, unknown>[],
   requestedHashes: readonly string[],
+  hours: ObservabilityTimeRangeHours,
+  nowMs: number,
 ): Map<string, IssueSparklineBucket[]> {
   // Every requested hash gets an entry, including hashes with no occurrences in
   // the window. Without that the row would stay in its "pending" state forever
   // and read as "still loading" rather than "nothing happened here".
+  //
+  // Each entry is a DENSE, zero-filled grid rather than the sparse GROUP BY
+  // rows: the shared sparkline renders buckets adjacently with no time axis, so
+  // a sparse series would silently compress quiet periods and misplace every
+  // bar after a gap (mirrors `buildServiceTimelines` in `services-data.ts`).
+  // The grid is recomputed from the granularity instead of inferred from the
+  // rows so an entirely silent tail can't shorten the series. Every step width
+  // divides evenly into the epoch, which is exactly how ClickHouse's
+  // `toStartOfInterval` aligns, so flooring against the epoch reproduces the
+  // server's bucket boundaries.
+  const granularity = getBucketGranularity(hours);
+  const latestBucketMs = Math.floor(nowMs / granularity.stepMs) * granularity.stepMs;
+  const earliestBucketMs = latestBucketMs - (granularity.bucketCount - 1) * granularity.stepMs;
   const byHash = new Map<string, IssueSparklineBucket[]>(
-    requestedHashes.map((hash) => [hash, []]),
+    requestedHashes.map((hash) => [hash, Array.from({ length: granularity.bucketCount }, (_unused, index) => ({
+      bucketMs: earliestBucketMs + index * granularity.stepMs,
+      occurrences: 0,
+    }))]),
   );
   for (const row of rows) {
     const hash = row.issue_hash;
     if (typeof hash !== "string") {
       throw new HexclaveAssertionError("Expected sparkline row issue_hash to be a string");
     }
-    const bucket = {
-      bucketMs: parseClickHouseUtc(row.bucket_start, "sparkline bucket_start"),
-      occurrences: toCount(row.occurrences, "sparkline occurrences"),
-    };
     const existing = byHash.get(hash);
     if (existing == null) {
       // A hash we didn't ask for means the query and the cache key disagree.
       throw new HexclaveAssertionError(`Sparkline row returned an unrequested issue hash: ${hash}`);
     }
-    existing.push(bucket);
+    const bucketMs = parseClickHouseUtc(row.bucket_start, "sparkline bucket_start");
+    // The query's rolling `now - INTERVAL hours` window can clip a partial
+    // bucket just before the grid (and clock skew could produce one just
+    // after); both would be misleading half-buckets, so they are dropped the
+    // same way the services timeline drops them.
+    if (bucketMs < earliestBucketMs || bucketMs > latestBucketMs) continue;
+    const index = (bucketMs - earliestBucketMs) / granularity.stepMs;
+    if (!Number.isInteger(index)) {
+      throw new HexclaveAssertionError(`Sparkline bucket ${bucketMs} is not aligned to the ${granularity.label} grid`);
+    }
+    const bucket = existing[index]
+      ?? throwErr(`Sparkline bucket index ${index} is out of range despite the bounds check above`);
+    bucket.occurrences += toCount(row.occurrences, "sparkline occurrences");
   }
   return byHash;
 }
@@ -268,10 +302,14 @@ export async function fetchIssueList(adminApp: object, request: IssueListRequest
 export async function fetchIssueDetail(
   adminApp: object,
   idOrShortId: string,
-  options: { occurrence?: string, direction?: IssueOccurrenceDirection } = {},
+  options: { occurrence?: string, direction?: IssueOccurrenceDirection, hours?: ObservabilityTimeRangeHours } = {},
 ): Promise<IssueDetailResponse> {
   const params = new URLSearchParams();
   if (options.occurrence != null) params.set("occurrence", options.occurrence);
+  // Scopes the response's window counts (`window_occurrences`/`window_users`)
+  // so the detail header shows the same numbers as the list the reader came
+  // from; the endpoint defaults to 24h when omitted.
+  if (options.hours != null) params.set("hours", String(options.hours));
   // The direction is what turns one cursor into two buttons: the same
   // `(event_at, occurrence_id)` cursor means "the one before" or "the one
   // after" depending on it, so sending only the cursor always steps older.

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issues-data.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/issues-data.ts
@@ -117,7 +117,8 @@ export function getIssueSparklineQuery(
 SELECT
   issue_hash,
   toStartOfInterval(event_at, ${granularity.stepSql}) AS bucket_start,
-  count() AS occurrences
+  count() AS occurrences,
+  max(now64(3)) AS query_now
 FROM default.errors
 WHERE event_at >= now64(3) - INTERVAL ${hours} HOUR
   AND issue_hash IN {issueHashes:Array(String)}
@@ -208,7 +209,12 @@ export function parseIssueSparklineRows(
   // `toStartOfInterval` aligns, so flooring against the epoch reproduces the
   // server's bucket boundaries.
   const granularity = getBucketGranularity(hours);
-  const latestBucketMs = Math.floor(nowMs / granularity.stepMs) * granularity.stepMs;
+  const queryNowValue = rows.find((row) => row.query_now != null)?.query_now;
+  // The query window and the bucket grid must share the same clock. Empty
+  // result sets have no row from which to read ClickHouse's clock, so retain
+  // the caller's timestamp only for the all-zero fallback series.
+  const gridNowMs = queryNowValue == null ? nowMs : parseClickHouseUtc(queryNowValue, "sparkline query_now");
+  const latestBucketMs = Math.floor(gridNowMs / granularity.stepMs) * granularity.stepMs;
   const earliestBucketMs = latestBucketMs - (granularity.bucketCount - 1) * granularity.stepMs;
   const byHash = new Map<string, IssueSparklineBucket[]>(
     requestedHashes.map((hash) => [hash, Array.from({ length: granularity.bucketCount }, (_unused, index) => ({

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/page-client.tsx
@@ -10,9 +10,10 @@ import {
   useDataGridUrlState,
   useDataSource,
   type DataGridDataSource,
+  type DataGridState,
   type DataGridToolbarContext,
 } from "@hexclave/dashboard-ui-components";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
 import { useDebounce } from "use-debounce";
 import { Link } from "@/components/link";
 import { AppEnabledGuard } from "../../app-enabled-guard";
@@ -24,6 +25,8 @@ import {
   ALL_SERVICES_SELECT_VALUE,
   OBSERVABILITY_TIME_RANGE_OPTIONS,
   parseObservabilityTimeRangeId,
+  readLocationSearch,
+  replaceLocationSearch,
 } from "../filters";
 import {
   serviceIdentityLabel,
@@ -50,10 +53,12 @@ import {
   type IssueFilters,
 } from "./issue-filters";
 import {
+  adjustIssueStatusCounts,
   applyOptimisticStatus,
   clearOptimisticStatus,
   NO_ISSUE_STATUS_OVERRIDES,
   reconcileIssueStatusOverrides,
+  resolveIssueRowStatus,
   type IssueStatusOverrides,
 } from "./issue-status";
 import {
@@ -71,7 +76,28 @@ import { useIssueFacets, useIssueSparklines } from "./use-issue-data";
 
 const SEARCH_DEBOUNCE_MS = 300;
 
+/**
+ * Environment dropdown values are namespaced so a real environment literally
+ * named "all" can never collide with the "All environments" sentinel (which
+ * would make it impossible to filter on). The prefix only lives inside the
+ * dropdown — the URL codec and the API both carry the raw environment name.
+ */
 const ALL_ENVIRONMENTS_SELECT_VALUE = "all";
+const ENVIRONMENT_SELECT_VALUE_PREFIX = "env:";
+
+function environmentToSelectValue(environment: string | null): string {
+  return environment == null ? ALL_ENVIRONMENTS_SELECT_VALUE : `${ENVIRONMENT_SELECT_VALUE_PREFIX}${environment}`;
+}
+
+function selectValueToEnvironment(value: string): string | null {
+  if (value === ALL_ENVIRONMENTS_SELECT_VALUE) return null;
+  if (!value.startsWith(ENVIRONMENT_SELECT_VALUE_PREFIX)) {
+    // The option list below is the only producer of these values, so anything
+    // else is a programming error rather than user input.
+    throw new Error(`Unknown environment select value: ${value}`);
+  }
+  return value.slice(ENVIRONMENT_SELECT_VALUE_PREFIX.length);
+}
 
 const HANDLED_FILTER_LABELS = new Map([
   ["all", "Handled & unhandled"],
@@ -86,8 +112,7 @@ function handledFilterLabel(value: string): string {
 }
 
 function readFiltersFromLocation(): IssueFilters {
-  if (typeof window === "undefined") return DEFAULT_ISSUE_FILTERS;
-  return parseIssueFilters(new URLSearchParams(window.location.search));
+  return parseIssueFilters(readLocationSearch());
 }
 
 /**
@@ -141,27 +166,28 @@ export default function PageClient() {
   const overridesRef = useRef(overrides);
   overridesRef.current = overrides;
 
-  // Filters are written back with `history.replaceState`, NOT `router.replace`:
-  // `useDataGridUrlState` writes the grid's own params the same way, and Next's
-  // router would rebuild the query string from its cached `useSearchParams`,
-  // which has never seen those params — silently dropping the user's column and
-  // sort choices on the next filter change.
+  // Filters are written back with `history.replaceState` (via the shared
+  // `replaceLocationSearch`), NOT `router.replace`: `useDataGridUrlState`
+  // writes the grid's own params the same way, and Next's router would rebuild
+  // the query string from its cached `useSearchParams`, which has never seen
+  // those params — silently dropping the user's column and sort choices on the
+  // next filter change.
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    const params = serializeIssueFilters(filters, new URLSearchParams(window.location.search));
-    const next = params.toString();
-    if (next === window.location.search.replace(/^\?/, "")) return;
-    window.history.replaceState(
-      window.history.state,
-      "",
-      `${window.location.pathname}${next === "" ? "" : `?${next}`}${window.location.hash}`,
-    );
+    replaceLocationSearch(serializeIssueFilters(filters, readLocationSearch()));
   }, [filters]);
 
   const facetsState = useIssueFacets(adminApp, filters.hours);
 
+  // Counts and the approximate-ranking banner are side effects applied BEFORE
+  // the generator yields, so `useDataSource`'s own abort guard never sees them.
+  // Without a guard of our own, a slow fetch for an old filter that resolves
+  // after a newer one would stamp its stale metadata over the visible list.
+  // Monotonic sequence: only the most recently started request may apply.
+  const listRequestSeqRef = useRef(0);
+
   const dataSource = useMemo<DataGridDataSource<IssueListItem>>(() => {
     return async function* (params) {
+      const requestId = ++listRequestSeqRef.current;
       const sort = resolveIssueSort(params.sorting);
       const response = await fetchIssueList(adminApp, {
         hours: filters.hours,
@@ -175,8 +201,10 @@ export default function PageClient() {
         cursor: typeof params.cursor === "string" ? params.cursor : null,
         limit: params.pagination.pageSize,
       });
-      setCounts(response.counts);
-      setApproximate(response.approximate);
+      if (listRequestSeqRef.current === requestId) {
+        setCounts(response.counts);
+        setApproximate(response.approximate);
+      }
       yield {
         rows: response.items,
         nextCursor: response.cursor,
@@ -193,19 +221,37 @@ export default function PageClient() {
     debouncedSearch,
   ]);
 
+  // Issue ids with a status PATCH in flight. A row exposes two independent
+  // status controls (the primary button and the actions menu); letting them
+  // race would allow the server's final status to differ from the user's last
+  // click while the optimistic row shows otherwise. One in-flight mutation per
+  // row keeps the outcome deterministic; extra clicks during it are no-ops (the
+  // primary button also shows its own loading state meanwhile).
+  const pendingStatusIssueIdsRef = useRef(new Set<string>());
+
   const changeStatus = useCallback(async (issue: IssueListItem, status: IssueStatus) => {
+    if (pendingStatusIssueIdsRef.current.has(issue.id)) return;
+    pendingStatusIssueIdsRef.current.add(issue.id);
     setStatusError(null);
+    // `from` is the status the user acted on (override included), so chained
+    // optimistic count adjustments telescope correctly.
+    const from = resolveIssueRowStatus(issue, overridesRef.current).status;
     setOverrides(applyOptimisticStatus(overridesRef.current, issue.id, status, issue.updated_at_millis));
+    setCounts((current) => adjustIssueStatusCounts(current, from, status));
     try {
       await updateIssueStatus(adminApp, issue.id, status);
       // Deliberately no refetch: under the default Unresolved filter a refetch
       // would yank the row out from under the cursor mid-scan. The override is
-      // versioned, so the next natural refresh reconciles it.
+      // versioned, so the next natural refresh reconciles it (and brings exact
+      // counts with it).
     } catch (error) {
       // Narrow catch around one call: revert and surface. Never swallowed, and
       // never a toast — a failed state change must stay on screen.
       setOverrides(clearOptimisticStatus(overridesRef.current, issue.id));
+      setCounts((current) => adjustIssueStatusCounts(current, status, from));
       setStatusError(error instanceof Error ? error.message : String(error));
+    } finally {
+      pendingStatusIssueIdsRef.current.delete(issue.id);
     }
   }, [adminApp]);
 
@@ -219,12 +265,13 @@ export default function PageClient() {
 
   const cellContext = useMemo<IssueCellContext>(() => ({
     projectId,
+    rangeHours: filters.hours,
     nowMs,
     overrides,
     sparklinesByHash: sparklines.byHash,
     bucketLabel,
     onChangeStatus: changeStatus,
-  }), [projectId, nowMs, overrides, sparklines.byHash, bucketLabel, changeStatus]);
+  }), [projectId, filters.hours, nowMs, overrides, sparklines.byHash, bucketLabel, changeStatus]);
 
   const columns = useMemo(() => buildIssueColumns(cellContext), [cellContext]);
 
@@ -235,6 +282,18 @@ export default function PageClient() {
       columnVisibility: INITIAL_ISSUE_COLUMN_VISIBILITY,
     },
   });
+
+  // The issues request carries exactly one (field, direction) and the backend
+  // orders by it alone, but DataGrid's shift-click multi-sort would happily
+  // DISPLAY a secondary sort column the server never applied. Clamping the
+  // model to the most recently toggled column keeps the indicators honest —
+  // shift-click simply behaves like a plain click on this grid.
+  const handleGridStateChange = useCallback<Dispatch<SetStateAction<DataGridState>>>((action) => {
+    setGridState((current) => {
+      const next = typeof action === "function" ? action(current) : action;
+      return next.sorting.length <= 1 ? next : { ...next, sorting: next.sorting.slice(-1) };
+    });
+  }, [setGridState]);
 
   const getRowId = useCallback((row: IssueListItem) => row.id, []);
 
@@ -360,15 +419,15 @@ export default function PageClient() {
             disabled={facetsState.loading}
           />
           <DesignSelectorDropdown
-            value={filters.environment ?? ALL_ENVIRONMENTS_SELECT_VALUE}
+            value={environmentToSelectValue(filters.environment)}
             onValueChange={(value) => setFilters((current) => ({
               ...current,
-              environment: value === ALL_ENVIRONMENTS_SELECT_VALUE ? null : value,
+              environment: selectValueToEnvironment(value),
             }))}
             options={[
               { value: ALL_ENVIRONMENTS_SELECT_VALUE, label: "All environments" },
               ...facetsState.facets.environments.map((environment) => ({
-                value: environment,
+                value: environmentToSelectValue(environment),
                 label: environment,
               })),
             ]}
@@ -588,7 +647,7 @@ export default function PageClient() {
                 hasMore={gridData.hasMore}
                 onLoadMore={gridData.loadMore}
                 state={gridState}
-                onChange={setGridState}
+                onChange={handleGridStateChange}
                 paginationMode="infinite"
                 selectionMode="multiple"
                 rowHeight={56}
@@ -598,7 +657,7 @@ export default function PageClient() {
                 toolbar={renderToolbar}
                 footer={false}
                 exportFilename="issues-export"
-                onRowClick={(row) => router.push(issueDetailHref(projectId, row.id))}
+                onRowClick={(row) => router.push(issueDetailHref(projectId, row.id, { rangeHours: filters.hours }))}
                 emptyState={<IssuesEmptyState filtered={filtersActive} />}
               />
             </div>

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/page-client.tsx
@@ -31,6 +31,8 @@ import {
 import {
   serviceIdentityLabel,
   serviceIdentityToSelectValue,
+  namespacedSelectValue,
+  selectValueToNamespacedValue,
   selectValueToServiceIdentity,
 } from "../service-identity";
 import {
@@ -82,22 +84,7 @@ const SEARCH_DEBOUNCE_MS = 300;
  * would make it impossible to filter on). The prefix only lives inside the
  * dropdown — the URL codec and the API both carry the raw environment name.
  */
-const ALL_ENVIRONMENTS_SELECT_VALUE = "all";
 const ENVIRONMENT_SELECT_VALUE_PREFIX = "env:";
-
-function environmentToSelectValue(environment: string | null): string {
-  return environment == null ? ALL_ENVIRONMENTS_SELECT_VALUE : `${ENVIRONMENT_SELECT_VALUE_PREFIX}${environment}`;
-}
-
-function selectValueToEnvironment(value: string): string | null {
-  if (value === ALL_ENVIRONMENTS_SELECT_VALUE) return null;
-  if (!value.startsWith(ENVIRONMENT_SELECT_VALUE_PREFIX)) {
-    // The option list below is the only producer of these values, so anything
-    // else is a programming error rather than user input.
-    throw new Error(`Unknown environment select value: ${value}`);
-  }
-  return value.slice(ENVIRONMENT_SELECT_VALUE_PREFIX.length);
-}
 
 const HANDLED_FILTER_LABELS = new Map([
   ["all", "Handled & unhandled"],
@@ -184,6 +171,7 @@ export default function PageClient() {
   // after a newer one would stamp its stale metadata over the visible list.
   // Monotonic sequence: only the most recently started request may apply.
   const listRequestSeqRef = useRef(0);
+  const countsRevisionRef = useRef(0);
 
   const dataSource = useMemo<DataGridDataSource<IssueListItem>>(() => {
     return async function* (params) {
@@ -202,6 +190,7 @@ export default function PageClient() {
         limit: params.pagination.pageSize,
       });
       if (listRequestSeqRef.current === requestId) {
+        countsRevisionRef.current += 1;
         setCounts(response.counts);
         setApproximate(response.approximate);
       }
@@ -228,10 +217,13 @@ export default function PageClient() {
   // row keeps the outcome deterministic; extra clicks during it are no-ops (the
   // primary button also shows its own loading state meanwhile).
   const pendingStatusIssueIdsRef = useRef(new Set<string>());
+  const pendingStatusCountRevisionsRef = useRef(new Map<string, number>());
 
   const changeStatus = useCallback(async (issue: IssueListItem, status: IssueStatus) => {
     if (pendingStatusIssueIdsRef.current.has(issue.id)) return;
     pendingStatusIssueIdsRef.current.add(issue.id);
+    const countRevisionAtStart = countsRevisionRef.current;
+    pendingStatusCountRevisionsRef.current.set(issue.id, countRevisionAtStart);
     setStatusError(null);
     // `from` is the status the user acted on (override included), so chained
     // optimistic count adjustments telescope correctly.
@@ -248,10 +240,16 @@ export default function PageClient() {
       // Narrow catch around one call: revert and surface. Never swallowed, and
       // never a toast — a failed state change must stay on screen.
       setOverrides(clearOptimisticStatus(overridesRef.current, issue.id));
-      setCounts((current) => adjustIssueStatusCounts(current, status, from));
+      // A list refresh may have replaced the optimistic counts while the PATCH
+      // was in flight. Reversing against that fresh server snapshot would
+      // subtract a real row, so only undo the delta on the revision it changed.
+      if (pendingStatusCountRevisionsRef.current.get(issue.id) === countsRevisionRef.current) {
+        setCounts((current) => adjustIssueStatusCounts(current, status, from));
+      }
       setStatusError(error instanceof Error ? error.message : String(error));
     } finally {
       pendingStatusIssueIdsRef.current.delete(issue.id);
+      pendingStatusCountRevisionsRef.current.delete(issue.id);
     }
   }, [adminApp]);
 
@@ -419,15 +417,15 @@ export default function PageClient() {
             disabled={facetsState.loading}
           />
           <DesignSelectorDropdown
-            value={environmentToSelectValue(filters.environment)}
+            value={namespacedSelectValue(filters.environment, ENVIRONMENT_SELECT_VALUE_PREFIX)}
             onValueChange={(value) => setFilters((current) => ({
               ...current,
-              environment: selectValueToEnvironment(value),
+              environment: selectValueToNamespacedValue(value, ENVIRONMENT_SELECT_VALUE_PREFIX),
             }))}
             options={[
-              { value: ALL_ENVIRONMENTS_SELECT_VALUE, label: "All environments" },
+              { value: "all", label: "All environments" },
               ...facetsState.facets.environments.map((environment) => ({
-                value: environmentToSelectValue(environment),
+                value: namespacedSelectValue(environment, ENVIRONMENT_SELECT_VALUE_PREFIX),
                 label: environment,
               })),
             ]}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/stack-frame-list.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/stack-frame-list.tsx
@@ -183,7 +183,7 @@ export function StackFrameList({
               // default) onto a DIFFERENT frame run after occurrence
               // navigation swaps the stack. First/last location plus length is
               // enough to distinguish runs without hashing every frame.
-              key={`collapsed-${group.startIndex}-${group.frames.length}-${frameLocationLabel(group.frames[0] ?? throwMissingCollapsedFrame())}-${frameLocationLabel(group.frames[group.frames.length - 1] ?? throwMissingCollapsedFrame())}`}
+              key={`collapsed-${group.startIndex}-${group.frames.length}-${group.defaultExpanded ? "expanded" : "collapsed"}-${frameLocationLabel(group.frames[0] ?? throwMissingCollapsedFrame())}-${frameLocationLabel(group.frames[group.frames.length - 1] ?? throwMissingCollapsedFrame())}`}
               frames={group.frames}
               defaultExpanded={group.defaultExpanded}
             />

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/stack-frame-list.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/stack-frame-list.tsx
@@ -55,9 +55,12 @@ function FrameSourceContext({
   ];
   return (
     <div className="mt-1.5 overflow-x-auto rounded-lg bg-foreground/[0.03] ring-1 ring-foreground/[0.06]">
+      {/* Each line is a `span` (styled `flex`), not a `div`: `pre` only allows
+          phrasing content, and flow children inside it are invalid HTML that
+          browsers/AT may re-nest unpredictably. Visually identical. */}
       <pre className="min-w-full py-1.5 font-mono text-[11px] leading-[1.6]">
         {rows.map((row) => (
-          <div
+          <span
             key={row.key}
             className={row.current ? "flex bg-red-500/10 px-3 text-foreground" : "flex px-3 text-muted-foreground/70"}
           >
@@ -67,7 +70,7 @@ function FrameSourceContext({
               </span>
             )}
             <span className="min-w-0 whitespace-pre">{row.text}</span>
-          </div>
+          </span>
         ))}
       </pre>
     </div>
@@ -83,7 +86,14 @@ function StackFrameRow({ frame }: { frame: StackFrameView }) {
           {frameLocationLabel(frame)}
         </span>
         {frame.in_app && <DesignBadge label="App" color="blue" size="sm" />}
-        {frame.context?.symbolicated === true && <DesignBadge label="Mapped" color="green" size="sm" />}
+        {/* Symbolication status, not context presence: a frame whose mapped
+            source content couldn't be fetched still displays the MAPPED
+            filename/function/line, so it must still carry the badge. The
+            `context.symbolicated` check remains as the fallback for wire
+            frames that carry no symbolication object. */}
+        {(frame.symbolication?.status === "symbolicated" || frame.context?.symbolicated === true) && (
+          <DesignBadge label="Mapped" color="green" size="sm" />
+        )}
       </div>
       {frame.context != null && <FrameSourceContext context={frame.context} lineno={frame.lineno} />}
     </li>
@@ -118,6 +128,10 @@ function CollapsedFrameGroup({
       )}
     </li>
   );
+}
+
+function throwMissingCollapsedFrame(): never {
+  throw new Error("A collapsed frame group can never be empty — groupStackFrames only emits runs of two or more frames");
 }
 
 export function StackFrameList({
@@ -163,7 +177,13 @@ export function StackFrameList({
           ? <StackFrameRow key={`frame-${group.index}`} frame={group.frame} />
           : (
             <CollapsedFrameGroup
-              key={`collapsed-${group.startIndex}`}
+              // Keyed by content, not just position: `expanded` is component
+              // state seeded from `defaultExpanded`, so a positional key would
+              // carry one occurrence's expand/collapse choice (and a stale
+              // default) onto a DIFFERENT frame run after occurrence
+              // navigation swaps the stack. First/last location plus length is
+              // enough to distinguish runs without hashing every frame.
+              key={`collapsed-${group.startIndex}-${group.frames.length}-${frameLocationLabel(group.frames[0] ?? throwMissingCollapsedFrame())}-${frameLocationLabel(group.frames[group.frames.length - 1] ?? throwMissingCollapsedFrame())}`}
               frames={group.frames}
               defaultExpanded={group.defaultExpanded}
             />

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/stack-frames.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/stack-frames.ts
@@ -5,7 +5,17 @@ import type { IssueFrame } from "./issues-data";
  * `heroStack` omit the API's nested symbolication object after flattening it
  * onto filename/lineno/context, so this pick is the shared contract.
  */
-export type StackFrameView = Pick<IssueFrame, "filename" | "function" | "module" | "abs_path" | "lineno" | "colno" | "in_app" | "debug_id" | "context">;
+export type StackFrameView = Pick<IssueFrame, "filename" | "function" | "module" | "abs_path" | "lineno" | "colno" | "in_app" | "debug_id" | "context"> & {
+  /**
+   * Only `status` is read by the renderer (for the "Mapped" badge). Declared
+   * structurally rather than via `Pick` because the wire `IssueFrame` and the
+   * flattened `IssueEventFrame` carry differently-shaped symbolication objects
+   * that agree on this field. The badge cannot key off `context.symbolicated`
+   * alone: a frame can be successfully mapped while its source context is
+   * unavailable, and its filename/line are still the mapped ones.
+   */
+  symbolication?: { status: "symbolicated" | "unsymbolicated" | "not_attempted" } | null,
+};
 
 /**
  * How a stack trace is laid out for reading.
@@ -112,7 +122,12 @@ function frameOrigin(frame: StackFrameView): string | null {
   return originMatch?.[1] ?? null;
 }
 
-/** The bold half of a frame row: the function, or the file when unnamed. */
+/**
+ * The bold half of a frame row: the function, or `<anonymous>` when unnamed.
+ * Deliberately NOT the file path as a fallback — `frameLocationLabel` already
+ * renders the location right next to this label, and repeating the path in
+ * bold would say one thing twice while hiding that the function is unnamed.
+ */
 export function frameFunctionLabel(frame: StackFrameView): string {
   const fn = frame.function?.trim();
   if (fn != null && fn !== "") return fn;

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/use-issue-data.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/use-issue-data.ts
@@ -106,7 +106,11 @@ export type IssueSparklines = {
   /** Keyed by issue hash. A missing key means "still loading". */
   byHash: ReadonlyMap<string, readonly EventSparklineBucket[]>,
   error: Error | null,
-  /** Re-requests everything currently on screen. */
+  /**
+   * Re-requests every on-screen hash that hasn't loaded yet (failed hashes are
+   * released back into that set). Already-loaded charts are kept — retry exists
+   * to recover from an error, not to refresh data.
+   */
   retry: () => void,
 };
 
@@ -166,7 +170,7 @@ export function useIssueSparklines(
       try {
         const { query, params } = getIssueSparklineQuery(hours, wanted);
         const response = await queryObservability(adminApp, { query, params });
-        const parsed = parseIssueSparklineRows(response.result, wanted);
+        const parsed = parseIssueSparklineRows(response.result, wanted, hours, Date.now());
         if (cancelled) return;
         setError(null);
         setCache((current) => {
@@ -189,6 +193,13 @@ export function useIssueSparklines(
 
     return () => {
       cancelled = true;
+      // Release this run's hashes: once `cancelled` is set the success path
+      // discards its result, so a hash that stays in `inFlight` here would
+      // never reach `byHash` and its row would show "Loading activity" forever
+      // (e.g. when an append or refresh re-runs the effect mid-request). The
+      // next run may re-request a hash whose response was discarded — a
+      // duplicate query is the cheap side of that trade.
+      for (const hash of wanted) inFlight.delete(hash);
     };
   }, [adminApp, hours, visibleHashes, byHash, retryToken]);
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/use-issue-data.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/issues/use-issue-data.ts
@@ -170,7 +170,7 @@ export function useIssueSparklines(
       try {
         const { query, params } = getIssueSparklineQuery(hours, wanted);
         const response = await queryObservability(adminApp, { query, params });
-        const parsed = parseIssueSparklineRows(response.result, wanted, hours, Date.now());
+        const parsed = parseIssueSparklineRows(response.result, wanted, hours, performance.timeOrigin + performance.now());
         if (cancelled) return;
         setError(null);
         setCache((current) => {

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/observability-links.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/observability-links.ts
@@ -14,21 +14,10 @@ export type TraceHighlight = {
   eventAtMs?: number | null,
 };
 
-export function issuesListHref(projectId: string): string {
-  return urlString`/projects/${projectId}/observability/issues`;
-}
-
-export function issueAlertRulesHref(projectId: string): string {
-  return urlString`/projects/${projectId}/observability/issues/alerts`;
-}
-
-export function issueSearchHref(projectId: string, search: string): string {
-  return `${issuesListHref(projectId)}?status=all&search=${encodeURIComponent(search)}`;
-}
-
-export function issueDetailHref(projectId: string, idOrShortId: string): string {
-  return urlString`/projects/${projectId}/observability/issues/${idOrShortId}`;
-}
+// Issue hrefs (issuesListHref, issueDetailHref, …) live in
+// ./issues/issue-links, which re-exports this module's traceDetailHref for the
+// Issues pages. They were briefly duplicated here as well; one home each keeps
+// the URL logic from silently diverging.
 
 export function tracesHref(projectId: string): string {
   return urlString`/projects/${projectId}/observability/traces`;

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/performance/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/performance/page-client.tsx
@@ -39,7 +39,7 @@ import { PageLayout } from "../../page-layout";
 import { StickyPageHeader } from "../../sticky-page-header";
 import { useAdminApp } from "../../use-admin-app";
 import { getBucketGranularity } from "../bucket-granularity";
-import { formatDuration } from "../format";
+import { formatCount, formatDuration } from "../format";
 import { traceDetailHref } from "../issues/issue-links";
 import {
   fetchPerformanceMetrics,
@@ -105,13 +105,9 @@ function customMetricCatalog(catalog: readonly PerformanceMetricCatalogEntry[]):
   return catalog.filter((entry) => !WEB_VITAL_METRICS.some((metric) => metric.metricName === entry.metric_name));
 }
 
-function formatCount(value: number): string {
-  if (!Number.isFinite(value)) throw new Error(`Cannot format a non-finite count: ${value}`);
-  if (value < 10_000) return value.toLocaleString();
-  if (value < 1_000_000) return `${(value / 1_000).toFixed(value < 100_000 ? 1 : 0)}k`;
-  return `${(value / 1_000_000).toFixed(value < 10_000_000 ? 1 : 0)}M`;
-}
-
+// Rounds to whole percents on purpose: these are coarse summary shares, not
+// the dense one-decimal cells the Services table renders. Count formatting, by
+// contrast, is shared — see `formatCount` in `../format`.
 function formatPercent(ratio: number): string {
   return `${Math.round(ratio * 100)}%`;
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/releases/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/releases/page-client.tsx
@@ -20,7 +20,7 @@ import {
   RocketLaunchIcon,
   UploadSimpleIcon,
 } from "@phosphor-icons/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import * as yup from "yup";
 import { AppEnabledGuard } from "../../app-enabled-guard";
 import { PageLayout } from "../../page-layout";
@@ -175,24 +175,33 @@ export default function PageClient() {
     };
   }, [adminApp, reloadToken]);
 
+  // Guards against out-of-order lookup responses: clicking release rows in
+  // quick succession keeps several fetches in flight, and without the sequence
+  // check the slowest response (or a late failure) would overwrite the
+  // selection the user actually made last.
+  const lookupSeqRef = useRef(0);
+
   const lookup = async (version: string) => {
     const nextVersion = version.trim();
     if (nextVersion === "") {
       setOperationError("Enter a release version to look up.");
       return;
     }
+    const seq = ++lookupSeqRef.current;
     setLookingUp(true);
     setOperationError(null);
     setNotice(null);
     try {
       const release = await fetchReleaseByVersion(adminApp, nextVersion);
+      if (seq !== lookupSeqRef.current) return;
       setSelectedRelease(release);
       setLookupVersion(release.version);
     } catch (caught) {
+      if (seq !== lookupSeqRef.current) return;
       setSelectedRelease(null);
       setOperationError(errorMessage(caught));
     } finally {
-      setLookingUp(false);
+      if (seq === lookupSeqRef.current) setLookingUp(false);
     }
   };
 
@@ -270,7 +279,12 @@ export default function PageClient() {
         next.set(commit.id, commit);
         return next;
       });
-      setSelectedRelease(await fetchReleaseByVersion(adminApp, selectedRelease.version));
+      // Apply the refreshed release only while it is still the selected one:
+      // the admin may have clicked another release while this request was in
+      // flight, and unconditionally setting would yank the view back to the
+      // release the commit was added to.
+      const refreshedRelease = await fetchReleaseByVersion(adminApp, selectedRelease.version);
+      setSelectedRelease((current) => (current?.id === refreshedRelease.id ? refreshedRelease : current));
       setCommitSha("");
       setCommitMessage("");
       setCommitPosition(String(position + 1));
@@ -318,7 +332,9 @@ export default function PageClient() {
         next.set(deployment.id, deployment);
         return next;
       });
-      setSelectedRelease(await fetchReleaseByVersion(adminApp, selectedRelease.version));
+      // Same stale-selection guard as addCommit above.
+      const refreshedRelease = await fetchReleaseByVersion(adminApp, selectedRelease.version);
+      setSelectedRelease((current) => (current?.id === refreshedRelease.id ? refreshedRelease : current));
       setDeploymentKey("");
       setDeploymentName("");
       setDeploymentUrl("");

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/releases/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/releases/page-client.tsx
@@ -138,6 +138,8 @@ export default function PageClient() {
   const [createReleasedAt, setCreateReleasedAt] = useState("");
   const [creating, setCreating] = useState(false);
   const [selectedRelease, setSelectedRelease] = useState<Release | null>(null);
+  const selectedReleaseRef = useRef<Release | null>(selectedRelease);
+  selectedReleaseRef.current = selectedRelease;
   const [operationError, setOperationError] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
   const [sessionCommits, setSessionCommits] = useState<Map<string, ReleaseCommit>>(() => new Map());
@@ -241,11 +243,20 @@ export default function PageClient() {
     }
   };
 
+  const refreshSelectedRelease = async (releaseId: string, version: string): Promise<boolean> => {
+    const refreshedRelease = await fetchReleaseByVersion(adminApp, version);
+    if (selectedReleaseRef.current?.id !== releaseId) return false;
+    setSelectedRelease((current) => current?.id === releaseId ? refreshedRelease : current);
+    return true;
+  };
+
   const addCommit = async () => {
     if (selectedRelease === null) {
       setOperationError("Select a release before adding a commit.");
       return;
     }
+    const selectedReleaseId = selectedRelease.id;
+    const selectedReleaseVersion = selectedRelease.version;
     const repository = commitRepository.trim();
     const sha = commitSha.trim();
     if (repository === "" || sha === "") {
@@ -266,7 +277,7 @@ export default function PageClient() {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          release_id: selectedRelease.id,
+          release_id: selectedReleaseId,
           repository,
           commit_sha: sha,
           position,
@@ -279,16 +290,12 @@ export default function PageClient() {
         next.set(commit.id, commit);
         return next;
       });
-      // Apply the refreshed release only while it is still the selected one:
-      // the admin may have clicked another release while this request was in
-      // flight, and unconditionally setting would yank the view back to the
-      // release the commit was added to.
-      const refreshedRelease = await fetchReleaseByVersion(adminApp, selectedRelease.version);
-      setSelectedRelease((current) => (current?.id === refreshedRelease.id ? refreshedRelease : current));
-      setCommitSha("");
-      setCommitMessage("");
-      setCommitPosition(String(position + 1));
-      setNotice(`Commit ${commit.commit_sha} is registered on ${selectedRelease.version}.`);
+      if (await refreshSelectedRelease(selectedReleaseId, selectedReleaseVersion)) {
+        setCommitSha("");
+        setCommitMessage("");
+        setCommitPosition(String(position + 1));
+        setNotice(`Commit ${commit.commit_sha} is registered on ${selectedReleaseVersion}.`);
+      }
     } catch (caught) {
       setOperationError(errorMessage(caught));
     } finally {
@@ -301,6 +308,8 @@ export default function PageClient() {
       setOperationError("Select a release before adding a deployment.");
       return;
     }
+    const selectedReleaseId = selectedRelease.id;
+    const selectedReleaseVersion = selectedRelease.version;
     const key = deploymentKey.trim();
     const environment = deploymentEnvironment.trim();
     if (key === "" || environment === "") {
@@ -317,7 +326,7 @@ export default function PageClient() {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          release_id: selectedRelease.id,
+          release_id: selectedReleaseId,
           deployment_key: key,
           environment,
           ...(name === undefined ? {} : { name }),
@@ -332,13 +341,12 @@ export default function PageClient() {
         next.set(deployment.id, deployment);
         return next;
       });
-      // Same stale-selection guard as addCommit above.
-      const refreshedRelease = await fetchReleaseByVersion(adminApp, selectedRelease.version);
-      setSelectedRelease((current) => (current?.id === refreshedRelease.id ? refreshedRelease : current));
-      setDeploymentKey("");
-      setDeploymentName("");
-      setDeploymentUrl("");
-      setNotice(`Deployment ${deployment.deployment_key} is registered on ${selectedRelease.version}.`);
+      if (await refreshSelectedRelease(selectedReleaseId, selectedReleaseVersion)) {
+        setDeploymentKey("");
+        setDeploymentName("");
+        setDeploymentUrl("");
+        setNotice(`Deployment ${deployment.deployment_key} is registered on ${selectedReleaseVersion}.`);
+      }
     } catch (caught) {
       setOperationError(errorMessage(caught));
     } finally {

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/service-identity.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/service-identity.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   conciseServiceIdentitySummary,
+  namespacedSelectValue,
   parseServiceIdentityRow,
+  selectValueToNamespacedValue,
   selectValueToServiceIdentity,
   serviceIdentitiesFromTraceRow,
   serviceIdentityLabel,
@@ -9,6 +11,15 @@ import {
 } from "./service-identity";
 
 describe("observability service identities", () => {
+  it("shares the namespaced codec with scalar filters", () => {
+    const value = "production/eu-west:1";
+    const encoded = namespacedSelectValue(value, "env:");
+    expect(encoded).toBe("env:production%2Feu-west%3A1");
+    expect(selectValueToNamespacedValue(encoded, "env:")).toBe(value);
+    expect(selectValueToNamespacedValue("all", "env:")).toBeNull();
+    expect(() => selectValueToNamespacedValue("service:web/app", "env:")).toThrow("Unexpected namespaced select value");
+  });
+
   it("keeps equal names in different namespaces distinct", () => {
     const dashboard = { namespace: "web", name: "app" };
     const backend = { namespace: "api", name: "app" };

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/service-identity.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/service-identity.ts
@@ -6,6 +6,21 @@ export type ServiceIdentity = {
 const ALL_SERVICES_SELECT_VALUE = "all";
 const SERVICE_SELECT_VALUE_PREFIX = "service:";
 
+/**
+ * Encode a scalar dropdown value with the same sentinel/prefix convention as
+ * service identities. Keeping this codec here prevents filters with a simpler
+ * value shape (such as environments) from reimplementing the collision rules.
+ */
+export function namespacedSelectValue(value: string | null, prefix: string): string {
+  return value == null ? ALL_SERVICES_SELECT_VALUE : `${prefix}${encodeURIComponent(value)}`;
+}
+
+export function selectValueToNamespacedValue(value: string, prefix: string): string | null {
+  if (value === ALL_SERVICES_SELECT_VALUE) return null;
+  if (!value.startsWith(prefix)) throw new Error(`Unexpected namespaced select value: ${value}`);
+  return decodeURIComponent(value.slice(prefix.length));
+}
+
 export function serviceIdentityEquals(left: ServiceIdentity, right: ServiceIdentity): boolean {
   return left.namespace === right.namespace && left.name === right.name;
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/services/services-format.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/services/services-format.ts
@@ -1,23 +1,15 @@
 import {
   formatAbsoluteTimeFromMillis,
+  formatCount,
   formatDuration,
   formatRelativeTimeFromMillis,
 } from "../format";
 import { parseServiceTimestamp, type ServiceAttentionReason } from "./services-data";
 
-export { formatDuration };
-
-/**
- * Compact count formatting for dense table cells. Values below 10k stay exact
- * because at that size the digits are still readable and the precision matters
- * when comparing two similar services; above that the magnitude is what counts.
- */
-export function formatCount(value: number): string {
-  if (!Number.isFinite(value)) throw new Error(`Cannot format a non-finite count: ${value}`);
-  if (value < 10_000) return value.toLocaleString();
-  if (value < 1_000_000) return `${(value / 1_000).toFixed(value < 100_000 ? 1 : 0)}k`;
-  return `${(value / 1_000_000).toFixed(value < 10_000_000 ? 1 : 0)}M`;
-}
+// Count/duration rendering rules live in `../format` so every Observability
+// page compacts the same value to the same string; this module only re-exports
+// them for its existing call sites.
+export { formatCount, formatDuration };
 
 export function formatPercent(ratio: number, fractionDigits = 1): string {
   return `${(ratio * 100).toFixed(fractionDigits)}%`;

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/source-maps/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/source-maps/page-client.tsx
@@ -21,7 +21,7 @@ import * as yup from "yup";
 import { AppEnabledGuard } from "../../app-enabled-guard";
 import { PageLayout } from "../../page-layout";
 import { useAdminApp } from "../../use-admin-app";
-import { prepareSourceMapUpload } from "./upload-source-map";
+import { prepareSourceMapUpload, putPresignedArtifact } from "./upload-source-map";
 
 const ReleaseSchema = yup.object({
   id: yup.string().defined(),
@@ -79,23 +79,6 @@ type UploadResult = {
 async function readJsonOrThrow(response: Response, what: string): Promise<unknown> {
   if (!response.ok) throw new HexclaveAssertionError(`${what} failed with status ${response.status}`);
   return await response.json();
-}
-
-async function putPresigned(
-  url: string,
-  body: Blob,
-  headers: HeadersInit,
-  what: string,
-): Promise<void> {
-  const response = await fetch(url, {
-    method: "PUT",
-    headers,
-    body,
-    credentials: "omit",
-  });
-  if (!response.ok) {
-    throw new HexclaveAssertionError(`${what} failed with status ${response.status}`);
-  }
 }
 
 function selectedFilePath(file: File): string {
@@ -189,13 +172,16 @@ export default function PageClient() {
         if (descriptor.source_map_upload_url === null) {
           throw new HexclaveAssertionError("Source map registration did not return a source map upload URL.");
         }
-        await putPresigned(
+        // A 412 ("already-uploaded") from either PUT is fine here: the objects
+        // are content-addressed, and the finalize step below confirms the
+        // digests regardless of who uploaded the bytes first.
+        await putPresignedArtifact(
           descriptor.bundle_upload_url,
           prepared.bundleUploadBody,
           { "content-type": "application/javascript" },
           "Uploading JavaScript bundle",
         );
-        await putPresigned(
+        await putPresignedArtifact(
           descriptor.source_map_upload_url,
           prepared.sourceMapUploadBody,
           {

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/source-maps/upload-source-map.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/source-maps/upload-source-map.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   appendDebugIdSnippet,
   deriveDebugId,
   normalizeArtifactPath,
   prepareSourceMapUpload,
+  putPresignedArtifact,
 } from "./upload-source-map";
 
 const bundleSource = "console.log(1);";
@@ -67,10 +68,85 @@ describe("browser source-map preparation", () => {
     expect(injected.endsWith("//# sourceMappingURL=app.min.js.map")).toBe(true);
   });
 
+  it("rejects only fully injected debug-ID identifiers, not the bare prefix literal", async () => {
+    const prepare = (source: string) => prepareSourceMapUpload({
+      projectId: "project-source-map-test",
+      release: null,
+      environment: null,
+      codeFile: "static/app.min.js",
+      sourceMapFile: "static/app.min.js.map",
+      bundleSource: source,
+      sourceMapSource,
+    });
+
+    // A legitimate bundle may mention the prefix (e.g. tooling that reads
+    // `_hexclaveDebugIdIdentifier` values); only prefix + UUID means injected.
+    await expect(prepare(`const prefix = "hexclave-dbid-";\n${bundleSource}`))
+      .resolves.toMatchObject({ codeFile: "static/app.min.js" });
+    await expect(prepare(`g._hexclaveDebugIdIdentifier="hexclave-dbid-fdecadcc-fcec-429d-868f-cb6db59cb599";\n${bundleSource}`))
+      .rejects.toThrow("already contains a Hexclave debug ID");
+    await expect(prepare(`// hexclave:debug-id-injection:start\n${bundleSource}`))
+      .rejects.toThrow("already contains a Hexclave debug ID");
+  });
+
   it("rejects unsafe artifact paths before registration", () => {
     expect(() => normalizeArtifactPath("static/app.js")).not.toThrow();
     expect(() => normalizeArtifactPath("../app.js")).toThrow("..");
     expect(() => normalizeArtifactPath("/static/app.js")).toThrow("relative POSIX path");
     expect(() => normalizeArtifactPath("https://example.test/app.js")).toThrow("relative POSIX path");
+  });
+});
+
+describe("presigned artifact upload", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const putBody = new Blob(["bytes"], { type: "application/javascript" });
+
+  it("sends the signed If-None-Match header alongside the content headers", async () => {
+    const fetchMock = vi.fn(async (_url: string, _init: RequestInit) => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(putPresignedArtifact(
+      "https://uploads.example.test/bundle",
+      putBody,
+      { "content-type": "application/javascript" },
+      "Uploading JavaScript bundle",
+    )).resolves.toBe("uploaded");
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://uploads.example.test/bundle");
+    expect(init.method).toBe("PUT");
+    expect(init.credentials).toBe("omit");
+    // The backend signs If-None-Match into the presigned URL, so the request
+    // is rejected as a signature mismatch if the header is missing.
+    expect(init.headers).toEqual({
+      "content-type": "application/javascript",
+      "If-None-Match": "*",
+    });
+  });
+
+  it("treats 412 Precondition Failed as the artifact already being uploaded", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(null, { status: 412 })));
+
+    await expect(putPresignedArtifact(
+      "https://uploads.example.test/bundle",
+      putBody,
+      { "content-type": "application/javascript" },
+      "Uploading JavaScript bundle",
+    )).resolves.toBe("already-uploaded");
+  });
+
+  it("still fails loudly on any other non-2xx status", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(null, { status: 403 })));
+
+    await expect(putPresignedArtifact(
+      "https://uploads.example.test/bundle",
+      putBody,
+      { "content-type": "application/javascript" },
+      "Uploading JavaScript bundle",
+    )).rejects.toThrow("Uploading JavaScript bundle failed with status 403");
   });
 });

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/source-maps/upload-source-map.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/source-maps/upload-source-map.ts
@@ -4,6 +4,14 @@ const SOURCE_MAP_EXTENSION_PATTERN = /\.map$/i;
 const URL_PATTERN = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//u;
 const CONTROL_CHARACTER_PATTERN = /[\u0000-\u001f\u007f]/u;
 const DEBUG_ID_IDENTIFIER_PREFIX = "hexclave-dbid-";
+// Matches only a COMPLETE injected identifier (prefix + UUID), mirroring the
+// CLI's detection in packages/cli/src/lib/source-maps.ts. A bare prefix
+// substring check would falsely reject a legitimate bundle that merely
+// mentions the literal "hexclave-dbid-" (e.g. tooling that reads
+// `_hexclaveDebugIdIdentifier`). The identifier check still matters alongside
+// the snippet marker: re-minifying an injected bundle strips the marker
+// comments but keeps the identifier string literal.
+const INJECTED_DEBUG_ID_IDENTIFIER_PATTERN = new RegExp(`${DEBUG_ID_IDENTIFIER_PREFIX}[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`);
 const SNIPPET_START_MARKER = "// hexclave:debug-id-injection:start";
 const SNIPPET_END_MARKER = "// hexclave:debug-id-injection:end";
 const SOURCE_MAPPING_URL_LINE_PATTERN = "^[ \\t]*\\/\\/[#@][ \\t]*sourceMappingURL=([^\\s]*)[ \\t]*$";
@@ -70,7 +78,7 @@ export async function prepareSourceMapUpload(input: {
   if (input.bundleSource.length === 0) {
     throw new Error("Bundle file must not be empty.");
   }
-  if (input.bundleSource.includes(SNIPPET_START_MARKER) || input.bundleSource.includes(`${DEBUG_ID_IDENTIFIER_PREFIX}`)) {
+  if (input.bundleSource.includes(SNIPPET_START_MARKER) || INJECTED_DEBUG_ID_IDENTIFIER_PATTERN.test(input.bundleSource)) {
     throw new Error("Bundle already contains a Hexclave debug ID. Choose the original bundle before debug-ID injection.");
   }
 
@@ -126,6 +134,41 @@ export async function prepareSourceMapUpload(input: {
     manifestJson,
     manifestSha256: await sha256Hex(encoder.encode(manifestJson)),
   };
+}
+
+export type PresignedArtifactPutResult = "uploaded" | "already-uploaded";
+
+/**
+ * PUTs one artifact to a backend-presigned URL.
+ *
+ * The backend signs `If-None-Match: *` into these URLs (see
+ * apps/backend/src/s3.tsx createPresignedUploadUrl) so a published artifact
+ * can never be overwritten. Two consequences for this client:
+ * - the header MUST be sent: it is part of the presigned signature, so
+ *   omitting it fails signature validation (and on URLs signed before that
+ *   change, sending it is harmless — unsigned extra headers are ignored by
+ *   SigV4 while S3/R2 still honor the conditional-write semantics);
+ * - a 412 Precondition Failed means the content-addressed object already
+ *   exists, which is success for this flow, not an error — the registration
+ *   and finalize steps verify the digests either way.
+ */
+export async function putPresignedArtifact(
+  url: string,
+  body: Blob,
+  headers: Record<string, string>,
+  what: string,
+): Promise<PresignedArtifactPutResult> {
+  const response = await fetch(url, {
+    method: "PUT",
+    headers: { ...headers, "If-None-Match": "*" },
+    body,
+    credentials: "omit",
+  });
+  if (response.status === 412) return "already-uploaded";
+  if (!response.ok) {
+    throw new Error(`${what} failed with status ${response.status}`);
+  }
+  return "uploaded";
 }
 
 export async function deriveDebugId(
@@ -193,6 +236,13 @@ async function sha256(bytes: Uint8Array<ArrayBuffer>): Promise<Uint8Array<ArrayB
 }
 
 async function gzip(bytes: Uint8Array<ArrayBuffer>): Promise<ArrayBuffer> {
+  // All current evergreen browsers ship CompressionStream; a JS gzip fallback
+  // would mean vendoring a compression library for browsers we don't support.
+  // Failing with a clear compatibility message beats the bare ReferenceError
+  // the constructor call would otherwise surface in the upload error alert.
+  if (typeof CompressionStream === "undefined") {
+    throw new Error("This browser does not support gzip compression (CompressionStream), which source map uploads require. Please use a current version of Chrome, Edge, Firefox, or Safari.");
+  }
   const compression = new CompressionStream("gzip");
   const compressed = new Response(compression.readable).arrayBuffer();
   const writer = compression.writable.getWriter();

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/page-client.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/page-client.test.ts
@@ -183,6 +183,7 @@ describe("analytics trace row parsing", () => {
     expect(linkQuery.params).toEqual({ traceId: "0123456789abcdef0123456789abcdef" });
     expect(linkQuery.query).toContain("FROM default.span_links");
     expect(linkQuery.query).toContain("target_is_same_scope");
+    expect(linkQuery.query).toContain("LIMIT 1001");
     expect(linkQuery.query).not.toContain("JOIN default.spans");
     expect(parseTraceLinkRow({
       owner_span_id: "1111111111111111",

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/page-client.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/page-client.test.ts
@@ -202,7 +202,7 @@ describe("analytics trace row parsing", () => {
   });
 
   it("selects the enclosing span and page-view correlation on events, not an ancestry array", () => {
-    const { query } = getSelectedTraceEventQuery("0123456789abcdef0123456789abcdef");
+    const { query } = getSelectedTraceEventQuery("0123456789abcdef0123456789abcdef", null, { startMs: 1_720_000_000_000, endMs: 1_720_000_100_000 });
     expect(query).toContain("trace_id, span_id, page_view_span_id");
     expect(query).toContain("message AS body");
     expect(query).toContain("severity_number");
@@ -212,11 +212,29 @@ describe("analytics trace row parsing", () => {
     expect(query).not.toContain("w3c_trace_id");
   });
 
+  it("bounds the event scan to the selected trace's interval, not the inbox window", () => {
+    // The telemetry tables are keyed (project_id, branch_id, event_at) with no
+    // trace_id index, so an unbounded trace_id filter would scan the project's
+    // whole retained history. The bound comes from the trace itself so a
+    // deep-linked event outside the inbox hours window still loads.
+    const { query, params } = getSelectedTraceEventQuery("0123456789abcdef0123456789abcdef", null, { startMs: 1_720_000_000_000, endMs: 1_720_000_100_000 });
+    expect(query).toContain("event_at >= fromUnixTimestamp64Milli({eventWindowStartMs:Int64})");
+    expect(query).toContain("event_at <= fromUnixTimestamp64Milli({eventWindowEndMs:Int64})");
+    expect(query).not.toContain("INTERVAL {hours:UInt32}");
+    expect(params).toEqual({
+      traceId: "0123456789abcdef0123456789abcdef",
+      eventWindowStartMs: 1_720_000_000_000,
+      eventWindowEndMs: 1_720_000_100_000,
+    });
+  });
+
   it("ranks a deep-linked event first so the 5000-row cap cannot hide it", () => {
-    const focused = getSelectedTraceEventQuery("0123456789abcdef0123456789abcdef", 1_720_000_000_000);
+    const focused = getSelectedTraceEventQuery("0123456789abcdef0123456789abcdef", 1_720_000_000_000, { startMs: 1_719_999_000_000, endMs: 1_720_000_100_000 });
     expect(focused.query).toContain("abs(toUnixTimestamp64Milli(event_at) - {focusEventAtMs:Int64})");
     expect(focused.params).toEqual({
       traceId: "0123456789abcdef0123456789abcdef",
+      eventWindowStartMs: 1_719_999_000_000,
+      eventWindowEndMs: 1_720_000_100_000,
       focusEventAtMs: 1_720_000_000_000,
     });
   });
@@ -303,7 +321,7 @@ describe("analytics trace row parsing", () => {
 
   it("loads the complete distributed trace after filtering the inbox by service", () => {
     const spans = getSelectedTraceSpanQuery("0123456789abcdef0123456789abcdef");
-    const events = getSelectedTraceEventQuery("0123456789abcdef0123456789abcdef");
+    const events = getSelectedTraceEventQuery("0123456789abcdef0123456789abcdef", null, { startMs: 1_720_000_000_000, endMs: 1_720_000_100_000 });
 
     expect(spans.query).not.toContain("{serviceName:String}");
     expect(events.query).not.toContain("{serviceName:String}");
@@ -312,7 +330,10 @@ describe("analytics trace row parsing", () => {
     });
     expect(events.params).toEqual({
       traceId: "0123456789abcdef0123456789abcdef",
+      eventWindowStartMs: 1_720_000_000_000,
+      eventWindowEndMs: 1_720_000_100_000,
     });
+    // The event bound derives from the trace's interval, never the inbox hours.
     expect(events.query).not.toContain("INTERVAL");
   });
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/page-client.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/page-client.test.ts
@@ -7,6 +7,7 @@ import {
   getSpanDetailQuery,
   parseEventRow,
   parseTraceLinkRow,
+  parseTraceLinkRows,
   parseUniqueTraceRootRows,
   parseUniqueSpanRows,
   SPAN_DETAIL_COLUMNS,
@@ -200,6 +201,19 @@ describe("analytics trace row parsing", () => {
       linkedBranchId: "main",
       targetIsSameScope: true,
     });
+  });
+
+  it("filters malformed links before applying the display cap", () => {
+    expect(parseTraceLinkRows([
+      {},
+      {
+        owner_span_id: "1111111111111111",
+        linked_trace_id: "22222222222222222222222222222222",
+        linked_span_id: "3333333333333333",
+        linked_project_id: "internal",
+        linked_branch_id: "main",
+      },
+    ])).toHaveLength(1);
   });
 
   it("selects the enclosing span and page-view correlation on events, not an ancestry array", () => {

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/page-client.tsx
@@ -546,6 +546,15 @@ export function parseTraceLinkRow(row: Record<string, unknown>): TraceLink | nul
   };
 }
 
+export function parseTraceLinkRows(rows: Record<string, unknown>[]): TraceLink[] {
+  // Apply the cap after parsing: malformed rows must not consume a display
+  // slot that the query deliberately fetched to surface the next valid link.
+  return rows
+    .map(parseTraceLinkRow)
+    .filter((link): link is TraceLink => link != null)
+    .slice(0, SPAN_LINKS_CAP);
+}
+
 type TraceRootSpan = SpanInput & {
   activityMs: number,
 };
@@ -810,9 +819,7 @@ export default function PageClient() {
       }
       setSelectedSpans(spans);
       setSelectedEvents(events);
-      setSelectedLinks(linksResponse.result.slice(0, SPAN_LINKS_CAP)
-        .map(parseTraceLinkRow)
-        .filter((link): link is TraceLink => link != null));
+      setSelectedLinks(parseTraceLinkRows(linksResponse.result));
       setTraceResultWasCapped(spansResponse.result.length >= TRACE_SPANS_CAP);
       setLinksResultWasCapped(linksResponse.result.length > SPAN_LINKS_CAP);
       setNowMs(Date.now());

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/page-client.tsx
@@ -270,6 +270,10 @@ LIMIT 10000
   };
 }
 
+// Safety cap for span links, mirroring the 10,000-span cap: hitting it is
+// surfaced in the UI (see linksResultWasCapped) instead of silently truncating.
+export const SPAN_LINKS_CAP = 1000;
+
 export function getSelectedTraceLinksQuery(traceId: string): {
   query: string,
   params: Record<string, string>,
@@ -287,7 +291,7 @@ SELECT
 FROM default.span_links
 WHERE trace_id = {traceId:String}
 ORDER BY owner_span_id ASC, linked_trace_id ASC, linked_span_id ASC
-LIMIT 1000
+LIMIT ${SPAN_LINKS_CAP}
 `,
     params: { traceId },
   };
@@ -376,7 +380,16 @@ LIMIT 1
   };
 }
 
-export function getSelectedTraceEventQuery(traceId: string, focusEventAtMs: number | null = null): {
+// Slack applied around the selected trace's own interval when fetching its
+// events. Events belong inside their trace's span intervals; the slack only
+// absorbs producer clock skew, so it can stay small.
+export const TRACE_EVENT_WINDOW_SLACK_MS = 15 * 60 * 1000;
+
+export function getSelectedTraceEventQuery(
+  traceId: string,
+  focusEventAtMs: number | null,
+  window: { startMs: number, endMs: number },
+): {
   query: string,
   params: Record<string, string | number>,
 } {
@@ -390,11 +403,16 @@ export function getSelectedTraceEventQuery(traceId: string, focusEventAtMs: numb
     // event-shaped views; OTel log/error branches provide their canonical body
     // and severity fields.
     //
-    // No time-range bound: this is a point lookup by trace_id. Bounding by the
-    // inbox hours window would drop a deep-linked custom event that happened
-    // just outside it, which is exactly the shareable URL this query exists to
-    // serve. The 5000-row cap is the safety; when a highlight timestamp is
-    // present we rank that event first so the cap cannot hide it.
+    // The time bound is derived from the SELECTED TRACE's interval (plus skew
+    // slack, plus the deep-linked highlight timestamp — see loadSelectedTrace),
+    // NOT from the inbox hours window: an inbox bound would drop a deep-linked
+    // custom event that happened just outside it, which is exactly the
+    // shareable URL this query exists to serve. Some bound is required though —
+    // the telemetry tables are keyed (project_id, branch_id, event_at) with no
+    // trace_id index, so an unbounded trace_id filter scans the project's whole
+    // retained history and can hit the 30s query timeout on busy projects. The
+    // 5000-row cap is the volume safety; when a highlight timestamp is present
+    // we rank that event first so the cap cannot hide it.
     query: `
 WITH correlated AS (
   SELECT event_type, event_at, data, message AS body, level,
@@ -424,10 +442,17 @@ SELECT event_type, event_at, data, body, level, severity_number, severity_text,
        refresh_token_id, session_replay_id, session_replay_segment_id
 FROM correlated
 WHERE trace_id = {traceId:String}
+  AND event_at >= fromUnixTimestamp64Milli({eventWindowStartMs:Int64})
+  AND event_at <= fromUnixTimestamp64Milli({eventWindowEndMs:Int64})
 ORDER BY ${focusEventAtMs == null ? "event_at ASC" : "abs(toUnixTimestamp64Milli(event_at) - {focusEventAtMs:Int64}) ASC, event_at ASC"}
 LIMIT 5000
 `,
-    params: { traceId, ...focusEventAtMs == null ? {} : { focusEventAtMs } },
+    params: {
+      traceId,
+      eventWindowStartMs: window.startMs,
+      eventWindowEndMs: window.endMs,
+      ...focusEventAtMs == null ? {} : { focusEventAtMs },
+    },
   };
 }
 
@@ -614,6 +639,7 @@ export default function PageClient() {
   const [traceLoading, setTraceLoading] = useState(false);
   const [traceError, setTraceError] = useState<string | null>(null);
   const [traceResultWasCapped, setTraceResultWasCapped] = useState(false);
+  const [linksResultWasCapped, setLinksResultWasCapped] = useState(false);
   const [traceVolume, setTraceVolume] = useState<TraceVolumeBucket[]>([]);
   const [traceVolumeLoading, setTraceVolumeLoading] = useState(true);
   const [traceVolumeError, setTraceVolumeError] = useState<string | null>(null);
@@ -738,28 +764,53 @@ export default function PageClient() {
     setTraceError(null);
     try {
       const spanQuery = getSelectedTraceSpanQuery(traceId, focusSpanId);
-      const eventQuery = getSelectedTraceEventQuery(traceId, highlightEventAtMs);
       const linksQuery = getSelectedTraceLinksQuery(traceId);
-      const [spansResponse, eventsResponse, linksResponse] = await Promise.all([
+      const [spansResponse, linksResponse] = await Promise.all([
         queryObservability(adminApp, {
           query: spanQuery.query,
           params: spanQuery.params,
         }),
-        queryObservability(adminApp, {
-          query: eventQuery.query,
-          params: eventQuery.params,
-        }),
         queryObservability(adminApp, linksQuery),
       ]);
       if (seq !== traceRequestSeqRef.current) return;
-      setSelectedSpans(parseUniqueSpanRows(spansResponse.result));
-      setSelectedEvents(eventsResponse.result
-        .map(parseEventRow)
-        .filter((event): event is EventInput => event != null));
+      const spans = parseUniqueSpanRows(spansResponse.result);
+      // The event fetch runs AFTER the spans so it can be bounded to the
+      // trace's own interval (see the comment on getSelectedTraceEventQuery).
+      // One extra serial round-trip buys a primary-key/partition-prunable scan
+      // instead of one over the project's entire retained event history. With
+      // no spans there is no waterfall to place events into, so the fetch is
+      // skipped entirely.
+      let events: EventInput[] = [];
+      if (spans.length > 0) {
+        const loadedAtMs = Date.now();
+        const spanStartMs = Math.min(...spans.map((span) => span.startMs));
+        // Open spans (endMs == null) extend the interval to "now". A capped
+        // trace can under-report its true end; the capped-trace alert already
+        // flags that view as partial.
+        const spanEndMs = Math.max(...spans.map((span) => span.endMs ?? loadedAtMs));
+        const eventQuery = getSelectedTraceEventQuery(traceId, highlightEventAtMs, {
+          // A deep-linked highlight timestamp widens the window so clock skew
+          // between the event and its trace's spans cannot hide the very event
+          // the shared URL points at.
+          startMs: (highlightEventAtMs == null ? spanStartMs : Math.min(spanStartMs, highlightEventAtMs)) - TRACE_EVENT_WINDOW_SLACK_MS,
+          endMs: (highlightEventAtMs == null ? spanEndMs : Math.max(spanEndMs, highlightEventAtMs)) + TRACE_EVENT_WINDOW_SLACK_MS,
+        });
+        const eventsResponse = await queryObservability(adminApp, {
+          query: eventQuery.query,
+          params: eventQuery.params,
+        });
+        if (seq !== traceRequestSeqRef.current) return;
+        events = eventsResponse.result
+          .map(parseEventRow)
+          .filter((event): event is EventInput => event != null);
+      }
+      setSelectedSpans(spans);
+      setSelectedEvents(events);
       setSelectedLinks(linksResponse.result
         .map(parseTraceLinkRow)
         .filter((link): link is TraceLink => link != null));
       setTraceResultWasCapped(spansResponse.result.length >= 10000);
+      setLinksResultWasCapped(linksResponse.result.length >= SPAN_LINKS_CAP);
       setNowMs(Date.now());
     } catch (e) {
       if (seq !== traceRequestSeqRef.current) return;
@@ -982,7 +1033,11 @@ export default function PageClient() {
           title={shareLinkCopied ? "Copied!" : "Copy link to this view"}
           onClick={() => runAsynchronouslyWithAlert(async () => {
             const viewedId = linkedSelection?.traceId ?? pinnedTraceId ?? selectedTraceId;
-            if (viewedId != null && pinnedTraceId == null) setPinnedTraceId(viewedId);
+            // Pin so the copied URL survives inbox churn — but not while
+            // following a span link: the URL already names the linked trace via
+            // linkedSelection, and pinning the linked trace would break "Back
+            // to originating trace" (the pin is what "back" returns to).
+            if (viewedId != null && pinnedTraceId == null && linkedSelection == null) setPinnedTraceId(viewedId);
             const params = serializeTracePageUrlState({
               hours,
               service,
@@ -1040,6 +1095,14 @@ export default function PageClient() {
             variant="warning"
             title="Selected trace is unusually large"
             description="Showing the earliest 10,000 spans in this trace."
+          />
+        )}
+
+        {linksResultWasCapped && !traceLoading && traceError == null && (
+          <DesignAlert
+            variant="warning"
+            title="Selected trace has an unusually large number of span links"
+            description={`Showing the first ${SPAN_LINKS_CAP.toLocaleString()} span links in this trace; further links exist but are not listed.`}
           />
         )}
 
@@ -1132,7 +1195,10 @@ export default function PageClient() {
               <div className="flex items-center justify-between gap-3 border-b border-border/50 bg-foreground/[0.03] px-3 py-2">
                 <div className="min-w-0 text-xs text-muted-foreground">
                   <span className="font-medium text-foreground">Following span link</span>{" "}
-                  <span className="font-mono">{selectedRootTraceId?.slice(0, 8) ?? "trace"}</span>{" → "}
+                  {/* The originating side is what "Back" returns to: the pinned
+                      trace when one exists (deep link / explicit click), else
+                      the auto-selected inbox root. */}
+                  <span className="font-mono">{(pinnedTraceId ?? selectedRootTraceId)?.slice(0, 8) ?? "trace"}</span>{" → "}
                   <span className="font-mono">{linkedSelection.traceId.slice(0, 8)}/{linkedSelection.spanId?.slice(0, 6) ?? "root"}</span>
                 </div>
                 <DesignButton
@@ -1188,11 +1254,12 @@ export default function PageClient() {
                   openEventDetail(event.raw);
                 }}
                 onOpenLink={(link) => {
+                  // The follow target lives ONLY in linkedSelection: selection,
+                  // URL, and highlight all read linkedSelection first, and
+                  // leaving pinned/highlight untouched is what lets "Back to
+                  // originating trace" restore the exact pre-follow view by
+                  // just clearing linkedSelection.
                   setLinkedSelection({ traceId: link.linkedTraceId, spanId: link.linkedSpanId });
-                  setPinnedTraceId(link.linkedTraceId);
-                  setHighlightSpanId(link.linkedSpanId);
-                  setHighlightEventType(null);
-                  setHighlightEventAtMs(null);
                 }}
               />
             )}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/page-client.tsx
@@ -272,6 +272,7 @@ LIMIT 10000
 
 // Safety cap for span links, mirroring the 10,000-span cap: hitting it is
 // surfaced in the UI (see linksResultWasCapped) instead of silently truncating.
+export const TRACE_SPANS_CAP = 10000;
 export const SPAN_LINKS_CAP = 1000;
 
 export function getSelectedTraceLinksQuery(traceId: string): {
@@ -291,7 +292,7 @@ SELECT
 FROM default.span_links
 WHERE trace_id = {traceId:String}
 ORDER BY owner_span_id ASC, linked_trace_id ASC, linked_span_id ASC
-LIMIT ${SPAN_LINKS_CAP}
+LIMIT ${SPAN_LINKS_CAP + 1}
 `,
     params: { traceId },
   };
@@ -787,7 +788,10 @@ export default function PageClient() {
         // Open spans (endMs == null) extend the interval to "now". A capped
         // trace can under-report its true end; the capped-trace alert already
         // flags that view as partial.
-        const spanEndMs = Math.max(...spans.map((span) => span.endMs ?? loadedAtMs));
+        const spansResultWasCapped = spansResponse.result.length >= TRACE_SPANS_CAP;
+        const spanEndMs = spansResultWasCapped
+          ? loadedAtMs
+          : Math.max(...spans.map((span) => span.endMs ?? loadedAtMs));
         const eventQuery = getSelectedTraceEventQuery(traceId, highlightEventAtMs, {
           // A deep-linked highlight timestamp widens the window so clock skew
           // between the event and its trace's spans cannot hide the very event
@@ -806,11 +810,11 @@ export default function PageClient() {
       }
       setSelectedSpans(spans);
       setSelectedEvents(events);
-      setSelectedLinks(linksResponse.result
+      setSelectedLinks(linksResponse.result.slice(0, SPAN_LINKS_CAP)
         .map(parseTraceLinkRow)
         .filter((link): link is TraceLink => link != null));
-      setTraceResultWasCapped(spansResponse.result.length >= 10000);
-      setLinksResultWasCapped(linksResponse.result.length >= SPAN_LINKS_CAP);
+      setTraceResultWasCapped(spansResponse.result.length >= TRACE_SPANS_CAP);
+      setLinksResultWasCapped(linksResponse.result.length > SPAN_LINKS_CAP);
       setNowMs(Date.now());
     } catch (e) {
       if (seq !== traceRequestSeqRef.current) return;

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/trace-url-state.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/trace-url-state.ts
@@ -8,7 +8,6 @@ import {
   serviceIdentityToSelectValue,
   type ServiceIdentity,
 } from "../service-identity";
-import type { TraceHighlight } from "../observability-links";
 
 /**
  * Traces page URL state: inbox filters plus the currently viewed trace/event.
@@ -97,14 +96,4 @@ export function serializeTracePageUrlState(state: TracePageUrlState, params: URL
   setOrDelete(PARAM_KEYS.eventType, state.eventType);
   setOrDelete(PARAM_KEYS.eventAtMs, state.eventAtMs == null ? null : String(state.eventAtMs));
   return params;
-}
-
-export function traceHighlightFromUrlState(state: TracePageUrlState): TraceHighlight | null {
-  if (state.traceId == null) return null;
-  return {
-    traceId: state.traceId,
-    spanId: state.spanId,
-    eventType: state.eventType,
-    eventAtMs: state.eventAtMs,
-  };
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/waterfall.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/waterfall.test.ts
@@ -9,7 +9,13 @@ import { computeRowOffsets, computeRowWindow, findHighlightedRowIndex, shouldSho
 afterEach(cleanup);
 
 beforeEach(() => {
-  window.scrollTo = vi.fn();
+  // Assigned via an intermediate on purpose: in assignment position, vi.fn()
+  // is contextually typed against the overloaded window.scrollTo and infers
+  // only the (x, y) overload, and that Mock<[number, number], void> then fails
+  // to satisfy the full overload intersection. Without the context it keeps
+  // its default loose signature, which satisfies every overload.
+  const scrollToMock = vi.fn();
+  window.scrollTo = scrollToMock;
 });
 
 function spanRow(id: string): WaterfallRow {

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/waterfall.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/observability/traces/waterfall.tsx
@@ -209,14 +209,20 @@ function flattenSignalTrace(
   linksByOwnerSpanId: ReadonlyMap<string, readonly TraceWaterfallLink[]>,
 ): TraceWaterfallRow[] {
   const signalIds = traceSignalSpanIds(trace, 20, needle);
-  const promoteLinkedOwners = (node: TraceNode, ancestors: readonly TraceNode[]) => {
+  // Shared push/pop ancestry stack instead of copying an ancestors array per
+  // child: copying makes the walk O(spans x depth), which is quadratic for the
+  // deep chains pathological traces produce.
+  const ancestry: TraceNode[] = [];
+  const promoteLinkedOwners = (node: TraceNode) => {
     if (linksByOwnerSpanId.has(node.span.id)) {
       signalIds.add(node.span.id);
-      for (const ancestor of ancestors) signalIds.add(ancestor.span.id);
+      for (const ancestor of ancestry) signalIds.add(ancestor.span.id);
     }
-    for (const child of node.children) promoteLinkedOwners(child, [...ancestors, node]);
+    ancestry.push(node);
+    for (const child of node.children) promoteLinkedOwners(child);
+    ancestry.pop();
   };
-  promoteLinkedOwners(trace.root, []);
+  promoteLinkedOwners(trace.root);
 
   const rows: TraceWaterfallRow[] = [];
   const walk = (node: TraceNode, visibleDepth: number) => {
@@ -372,6 +378,20 @@ export function TraceWaterfall({
   const signalSpanCount = signalRows.filter((row) => row.kind === "span").length;
   const hiddenSignalSpanCount = trace.spanCount - signalSpanCount;
   const errorCount = useMemo(() => traceErrorCount(trace), [trace]);
+  // Links whose owner span is not part of this tree (the owner fell outside the
+  // 10,000-span fetch cap, or belongs to a disconnected fragment of the same
+  // trace id) have no row to hang from. Like unattached events, they are
+  // surfaced as a count rather than silently dropped, so the page-level link
+  // total never claims links the waterfall cannot show.
+  const unplacedLinkCount = useMemo(() => {
+    const spanIds = new Set<string>();
+    const walk = (node: TraceNode) => {
+      spanIds.add(node.span.id);
+      for (const child of node.children) walk(child);
+    };
+    walk(trace.root);
+    return links.filter((link) => !spanIds.has(link.ownerSpanId)).length;
+  }, [links, trace.root]);
 
   // Windowed rendering: only the rows inside the scrollport (± overscan) are
   // mounted; spacer divs stand in for the rest so a 10k-span trace doesn't
@@ -611,6 +631,13 @@ export function TraceWaterfall({
                     label={`${unattachedEventCount} ${unattachedEventCount === 1 ? "event has" : "events have"} no enclosing span in this trace, so ${unattachedEventCount === 1 ? "it is" : "they are"} not placed in the waterfall`}
                   />
                 )}
+                {unplacedLinkCount > 0 && (
+                  <TraceHeaderStat
+                    icon={<LinkSimpleIcon className="h-3.5 w-3.5" />}
+                    value={`+${unplacedLinkCount}`}
+                    label={`${unplacedLinkCount} span ${unplacedLinkCount === 1 ? "link's owner span is" : "links' owner spans are"} not in the loaded waterfall (for example beyond the 10,000-span cap), so ${unplacedLinkCount === 1 ? "that link is" : "those links are"} not shown as rows`}
+                  />
+                )}
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="inline-flex items-center rounded p-1 text-muted-foreground">
@@ -776,7 +803,14 @@ export function TraceWaterfall({
               const isHighlighted = highlightedRowIndex === rowIndex;
               return (
                 <div
-                  key={`event-${event.spanId ?? "none"}-${event.eventType}-${event.atMs}`}
+                  // Keyed by the absolute row index, not the event's identity:
+                  // two events under one span can share type AND epoch-ms (a
+                  // burst of identical trackEvent calls), which made an
+                  // identity key collide. The absolute index is unique and
+                  // stays stable as the render window scrolls; it only shifts
+                  // when the rows array itself changes (mode/collapse/trace),
+                  // where remounting these stateless rows is fine.
+                  key={`event-${rowIndex}`}
                   aria-current={isHighlighted ? "true" : undefined}
                   className={cn(
                     "w-full grid gap-3 px-4 items-center h-7 border-b border-border/20 hover:bg-muted/30 transition-colors hover:transition-none text-left cursor-pointer",

--- a/apps/dashboard/src/lib/prefetch/url-prefetcher.tsx
+++ b/apps/dashboard/src/lib/prefetch/url-prefetcher.tsx
@@ -54,7 +54,11 @@ const urlPrefetchers: Record<string, UrlPrefetcher[]> = {
     // the project overview page renders the AnalyticsEventLimitBanner
     ...usageLimitBannerPrefetchers("analytics_events"),
   ],
-  "/projects/*/analytics/queries": [
+  // The queries/tables workspaces moved from /analytics to /warehouse (the old
+  // URLs are server-side redirects), so the banner prefetch keys must follow —
+  // keyed to the old paths they would never fire on the pages that render the
+  // banner.
+  "/projects/*/warehouse/queries": [
     ...usageLimitBannerPrefetchers("analytics_events"),
   ],
   "/projects/*/observability/traces": [
@@ -63,7 +67,7 @@ const urlPrefetchers: Record<string, UrlPrefetcher[]> = {
   "/projects/*/observability/logs": [
     ...usageLimitBannerPrefetchers("analytics_events"),
   ],
-  "/projects/*/analytics/tables": [
+  "/projects/*/warehouse/tables": [
     ...usageLimitBannerPrefetchers("analytics_events"),
   ],
   "/projects/*/session-replays": [

--- a/apps/e2e/tests/backend/endpoints/api/v1/analytics-events-batch.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/analytics-events-batch.test.ts
@@ -110,7 +110,7 @@ it("returns ACCESS_TYPE_REQUIRED instead of crashing when no project access is p
         "code": "ACCESS_TYPE_REQUIRED",
         "error": deindent\`
           You must specify an access level for this Hexclave project. Make sure project API keys are provided (eg. x-hexclave-publishable-client-key) and you set the x-hexclave-access-type header to 'client', 'server', or 'admin'. (The legacy x-stack-* equivalents are also accepted.)
-
+          
           For more information, see the docs on REST API authentication: https://docs.hexclave.com/api/overview#authentication
         \`,
       },

--- a/apps/e2e/tests/backend/endpoints/api/v1/analytics-sentry-envelope.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/analytics-sentry-envelope.test.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from "node:crypto";
+import { wait } from "@hexclave/shared/dist/utils/promises";
 import { it } from "../../../../helpers";
 import { Project, niceBackendFetch } from "../../../backend-helpers";
 
@@ -85,6 +86,23 @@ async function querySpansUntil(traceId: string): Promise<{ status: number, body:
   return response;
 }
 
+async function queryEnvelopeErrorsUntil(batchId: string): Promise<{ status: number, body: { result?: Record<string, unknown>[] } }> {
+  let response: { status: number, body: { result?: Record<string, unknown>[] } } = { status: 0, body: {} };
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    response = await niceBackendFetch("/api/v1/analytics/query", {
+      method: "POST",
+      accessType: "admin",
+      body: {
+        query: "SELECT occurrence_id FROM logs WHERE batch_id = {batchId:String} AND event_type = '$error' ORDER BY occurrence_id LIMIT 2",
+        params: { batchId },
+      },
+    });
+    if (response.status === 200 && response.body.result?.length === 1) return response;
+    await wait(250);
+  }
+  return response;
+}
+
 it("accepts an authenticated Sentry envelope and returns itemized outcomes", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Project.updateConfig({ apps: { installed: { observability: { enabled: true } } } });
@@ -130,6 +148,14 @@ it("accepts an authenticated Sentry envelope and returns itemized outcomes", asy
       idempotency_key: response.body.ingest.idempotency_key,
     },
   });
+
+  // The response is deterministic even if the retry writes a second row. Query
+  // the persisted view by the deterministic envelope batch id so this test
+  // proves ClickHouse deduplication, rather than only comparing recomputed
+  // response fields.
+  const persistedErrors = await queryEnvelopeErrorsUntil(response.body.batch_id);
+  expect(persistedErrors.status).toBe(200);
+  expect(persistedErrors.body.result).toHaveLength(1);
 
   const attachments = await niceBackendFetch(`/api/v1/analytics/attachments?event_id=${eventId}`, {
     method: "GET",

--- a/apps/e2e/tests/backend/endpoints/api/v1/issues.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/issues.test.ts
@@ -78,6 +78,8 @@ type ErrorEventOptions = {
   release?: string,
 };
 
+const ISSUE_TEST_TIMEOUT = 180_000;
+
 function errorEvent(options: ErrorEventOptions) {
   return {
     event_type: "$error",
@@ -376,7 +378,7 @@ it("rejects non-admin access to the issues endpoints", async ({ expect }) => {
 
 // ─── Grouping / ingest ──────────────────────────────────────────────────────
 
-it("stamps grouping columns and a deterministic occurrence_id onto ingested $error rows", async ({ expect }) => {
+it("stamps grouping columns and a deterministic occurrence_id onto ingested $error rows", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -480,7 +482,7 @@ it("stamps grouping columns and a deterministic occurrence_id onto ingested $err
   `);
 });
 
-it("collapses two occurrences of the same error into one issue", async ({ expect }) => {
+it("collapses two occurrences of the same error into one issue", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -516,7 +518,7 @@ it("collapses two occurrences of the same error into one issue", async ({ expect
  * from the same helper share every other leaf and collapse into one issue —
  * which is wrong, because they are different bugs with different fixes.
  */
-it("does not merge a TypeError and a RangeError thrown from the same frame", async ({ expect }) => {
+it("does not merge a TypeError and a RangeError thrown from the same frame", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -554,7 +556,7 @@ it("does not merge a TypeError and a RangeError thrown from the same frame", asy
  * every non-`Error` throw, so without the dedicated synthetic rule every
  * `throw "nope"` in a project would collapse into one useless issue.
  */
-it("does not merge two different non-Error (synthetic) throws", async ({ expect }) => {
+it("does not merge two different non-Error (synthetic) throws", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -592,7 +594,7 @@ it("does not merge two different non-Error (synthetic) throws", async ({ expect 
  * twice (a retry that ClickHouse deduplicated by insert token) must advance the
  * counters exactly once.
  */
-it("increments times_seen exactly once when the same batch_id is posted twice", async ({ expect }) => {
+it("increments times_seen exactly once when the same batch_id is posted twice", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -661,7 +663,7 @@ it.fails("does not inflate window_occurrences when the same batch is retried", a
   expect(onlyItem(await listIssues()).window_occurrences).toBe(1);
 });
 
-it("produces a byte-identical occurrence_id across retries of the same batch", async ({ expect }) => {
+it("produces a byte-identical occurrence_id across retries of the same batch", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -689,7 +691,7 @@ it("produces a byte-identical occurrence_id across retries of the same batch", a
 
 // ─── Lifecycle ──────────────────────────────────────────────────────────────
 
-it("reopens a resolved issue as regressed when a new occurrence arrives", async ({ expect }) => {
+it("reopens a resolved issue as regressed when a new occurrence arrives", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -733,7 +735,7 @@ it("reopens a resolved issue as regressed when a new occurrence arrives", async 
  * lifetime counters honour the client timestamps: `lastSeenAt` uses `GREATEST`
  * and therefore does not move backwards, and `firstSeenAt` uses `LEAST` and does.
  */
-it("regresses on server receipt time, not on the client clock, for a back-dated occurrence", async ({ expect }) => {
+it("regresses on server receipt time, not on the client clock, for a back-dated occurrence", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -765,7 +767,7 @@ it("regresses on server receipt time, not on the client clock, for a back-dated 
  * stay ignored and a cron waking them all up would be wrong. The read path
  * therefore has to compensate for the window in between.
  */
-it("reports an issue whose snooze has expired as unresolved before the next occurrence", async ({ expect }) => {
+it("reports an issue whose snooze has expired as unresolved before the next occurrence", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -822,7 +824,7 @@ it("reports an issue whose snooze has expired as unresolved before the next occu
  * decimal string, the very first list response 500s. This is that guard, not a
  * style assertion.
  */
-it("returns short_id and times_seen as strings, not numbers", async ({ expect }) => {
+it("returns short_id and times_seen as strings, not numbers", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -845,7 +847,7 @@ it("returns short_id and times_seen as strings, not numbers", async ({ expect })
   expect(typeof detail.body?.issue?.times_seen).toBe("string");
 });
 
-it("resolves the detail route by uuid, by numeric short id, and through an IssueRedirect", async ({ expect }) => {
+it("resolves the detail route by uuid, by numeric short id, and through an IssueRedirect", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -921,7 +923,7 @@ it("resolves the detail route by uuid, by numeric short id, and through an Issue
  * the failure mode to guard against is a 200 with another project's data — a 404
  * is the only acceptable answer, including for the write path.
  */
-it("cannot read or mutate another project's issue", async ({ expect }) => {
+it("cannot read or mutate another project's issue", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
   const now = Date.now();
   await postBatch({ events: [checkoutTypeError(now)] });
@@ -955,7 +957,7 @@ it("cannot read or mutate another project's issue", async ({ expect }) => {
   `);
 });
 
-it("filters the issue list by status, service, and environment", async ({ expect }) => {
+it("filters the issue list by status, service, and environment", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -1048,7 +1050,7 @@ it("validates issue list query parameters", async ({ expect }) => {
   expect((await listIssues({ hours: "720", status: "all", sort: "users", sort_dir: "asc", limit: "10", handled: "handled" })).status).toBe(200);
 });
 
-it("paginates the issue list with a keyset cursor", async ({ expect }) => {
+it("paginates the issue list with a keyset cursor", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -1072,7 +1074,7 @@ it("paginates the issue list with a keyset cursor", async ({ expect }) => {
   expect(second.body?.cursor).toBe(null);
 });
 
-it("navigates an issue's occurrences with the older/newer cursors", async ({ expect }) => {
+it("navigates an issue's occurrences with the older/newer cursors", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -1104,7 +1106,7 @@ it("navigates an issue's occurrences with the older/newer cursors", async ({ exp
 // (`IssueMergeRequestSchema` / `IssueUnmergeRequestSchema`) and should need
 // nothing but the `.todo` removed once the routes land.
 
-it("merges issues, picking the primary by (firstSeenAt asc, timesSeen desc, id asc) and summing lifetime counters", async ({ expect }) => {
+it("merges issues, picking the primary by (firstSeenAt asc, timesSeen desc, id asc) and summing lifetime counters", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -1147,7 +1149,7 @@ it("merges issues, picking the primary by (firstSeenAt asc, timesSeen desc, id a
   expect(redirected.body?.redirected_from_issue_id).toBe(newer.id);
 });
 
-it("merging into an already-merged issue follows the redirect and creates no chain", async ({ expect }) => {
+it("merging into an already-merged issue follows the redirect and creates no chain", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -1185,7 +1187,7 @@ it("merging into an already-merged issue follows the redirect and creates no cha
   expect(new Set(redirects.rows.map((row) => row.fromIssueId))).toEqual(new Set([second.id, third.id]));
 });
 
-it("unmerge is retroactive: historical occurrences owned by the split hash resolve to the new issue", async ({ expect }) => {
+it("unmerge is retroactive: historical occurrences owned by the split hash resolve to the new issue", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -1229,7 +1231,7 @@ it("unmerge is retroactive: historical occurrences owned by the split hash resol
   expect(sourceDetail.body?.issue?.issue_hashes).not.toContain(splitHash);
 });
 
-it("unmerge stamps counters_truncated_at_millis on the new issue", async ({ expect }) => {
+it("unmerge stamps counters_truncated_at_millis on the new issue", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();
@@ -1258,7 +1260,7 @@ it("unmerge stamps counters_truncated_at_millis on the new issue", async ({ expe
   expect(newIssue?.counters_truncated_at_millis).toBe(truncatedAt);
 });
 
-it("resolves a merged-away NUMERIC short id through IssueRedirect", async ({ expect }) => {
+it("resolves a merged-away NUMERIC short id through IssueRedirect", { timeout: ISSUE_TEST_TIMEOUT }, async ({ expect }) => {
   await setUpIssuesProject();
 
   const now = Date.now();

--- a/docs-mintlify/guides/apps/observability/overview.mdx
+++ b/docs-mintlify/guides/apps/observability/overview.mdx
@@ -37,7 +37,7 @@ Three properties of that pipeline are worth knowing, because they explain most o
 | Capturing Next.js request errors | Requires [`hexclaveInstrumentation`](/guides/apps/analytics/cross-tier-tracing#server-side-instrumentation) |
 | Stack parsing, grouping, and issue creation | Automatic, server-side |
 | Correlation to trace / session replay / user | Automatic |
-| `release` and `environment` on every occurrence | Automatic on Vercel; [set them explicitly](/guides/apps/analytics/errors-and-logs#configuration) elsewhere |
+| `release` and `environment` on every occurrence | Automatic on Vercel; elsewhere, [set `release` explicitly](/guides/apps/analytics/errors-and-logs#configuration) (`environment` falls back to `NODE_ENV`) |
 | Naming the service an error came from | Inferred; [set `telemetry.resource`](/guides/apps/analytics/overview#identify-every-service) when several apps share a project |
 | Dropping known-noisy errors | Opt-in via `observability.errorCapture.ignoreErrors` |
 | `issue.*` webhooks | Requires the Webhooks app enabled |

--- a/docs-mintlify/openapi/admin.json
+++ b/docs-mintlify/openapi/admin.json
@@ -3648,7 +3648,130 @@
                     "rules": {
                       "type": "array",
                       "items": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                          "database_id": {
+                            "type": "string"
+                          },
+                          "schemaVersion": {
+                            "type": "number"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "integer"
+                          },
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "filters": {
+                            "type": "object",
+                            "properties": {
+                              "projectIds": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "environments": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "releases": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "tags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string",
+                                      "enum": [
+                                        "equals",
+                                        "not_equals",
+                                        "contains",
+                                        "starts_with",
+                                        "in",
+                                        "exists",
+                                        "not_exists"
+                                      ]
+                                    },
+                                    "value": {
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": []
+                          },
+                          "conditions": {
+                            "type": "object",
+                            "properties": {
+                              "all": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "any": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              }
+                            },
+                            "required": []
+                          },
+                          "cooldown": {
+                            "type": "object",
+                            "properties": {
+                              "durationSeconds": {
+                                "type": "integer"
+                              },
+                              "keyBy": {
+                                "type": "string",
+                                "enum": [
+                                  "issue",
+                                  "issue_environment",
+                                  "issue_release",
+                                  "issue_environment_release"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "durationSeconds",
+                              "keyBy"
+                            ]
+                          },
+                          "action": {
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "database_id",
+                          "schemaVersion",
+                          "id",
+                          "version",
+                          "enabled",
+                          "conditions",
+                          "cooldown",
+                          "action"
+                        ]
                       }
                     },
                     "truncated": {
@@ -3677,7 +3800,126 @@
                 "type": "object",
                 "properties": {
                   "rule": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                      "schemaVersion": {
+                        "type": "number"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "integer"
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "filters": {
+                        "type": "object",
+                        "properties": {
+                          "projectIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "environments": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "releases": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "equals",
+                                    "not_equals",
+                                    "contains",
+                                    "starts_with",
+                                    "in",
+                                    "exists",
+                                    "not_exists"
+                                  ]
+                                },
+                                "value": {
+                                  "type": "object"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ]
+                            }
+                          }
+                        },
+                        "required": []
+                      },
+                      "conditions": {
+                        "type": "object",
+                        "properties": {
+                          "all": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            }
+                          },
+                          "any": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            }
+                          }
+                        },
+                        "required": []
+                      },
+                      "cooldown": {
+                        "type": "object",
+                        "properties": {
+                          "durationSeconds": {
+                            "type": "integer"
+                          },
+                          "keyBy": {
+                            "type": "string",
+                            "enum": [
+                              "issue",
+                              "issue_environment",
+                              "issue_release",
+                              "issue_environment_release"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "durationSeconds",
+                          "keyBy"
+                        ]
+                      },
+                      "action": {
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "schemaVersion",
+                      "id",
+                      "version",
+                      "enabled",
+                      "conditions",
+                      "cooldown",
+                      "action"
+                    ]
                   }
                 },
                 "required": [
@@ -3701,7 +3943,130 @@
                   "type": "object",
                   "properties": {
                     "rule": {
-                      "type": "object"
+                      "type": "object",
+                      "properties": {
+                        "database_id": {
+                          "type": "string"
+                        },
+                        "schemaVersion": {
+                          "type": "number"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "integer"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "filters": {
+                          "type": "object",
+                          "properties": {
+                            "projectIds": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "environments": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "releases": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string",
+                                    "enum": [
+                                      "equals",
+                                      "not_equals",
+                                      "contains",
+                                      "starts_with",
+                                      "in",
+                                      "exists",
+                                      "not_exists"
+                                    ]
+                                  },
+                                  "value": {
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ]
+                              }
+                            }
+                          },
+                          "required": []
+                        },
+                        "conditions": {
+                          "type": "object",
+                          "properties": {
+                            "all": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            },
+                            "any": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          "required": []
+                        },
+                        "cooldown": {
+                          "type": "object",
+                          "properties": {
+                            "durationSeconds": {
+                              "type": "integer"
+                            },
+                            "keyBy": {
+                              "type": "string",
+                              "enum": [
+                                "issue",
+                                "issue_environment",
+                                "issue_release",
+                                "issue_environment_release"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "durationSeconds",
+                            "keyBy"
+                          ]
+                        },
+                        "action": {
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "database_id",
+                        "schemaVersion",
+                        "id",
+                        "version",
+                        "enabled",
+                        "conditions",
+                        "cooldown",
+                        "action"
+                      ]
                     }
                   },
                   "required": [
@@ -3743,7 +4108,153 @@
                     "deliveries": {
                       "type": "array",
                       "items": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "rule_id": {
+                            "type": "string"
+                          },
+                          "issue_id": {
+                            "type": "string"
+                          },
+                          "canonical_issue_id": {
+                            "type": "string"
+                          },
+                          "redirected": {
+                            "type": "boolean"
+                          },
+                          "redirected_from_issue_id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "occurrence_id": {
+                            "type": "string"
+                          },
+                          "rule_version": {
+                            "type": "integer"
+                          },
+                          "event_kind": {
+                            "type": "string",
+                            "enum": [
+                              "new",
+                              "regression",
+                              "occurrence"
+                            ]
+                          },
+                          "deduplication_key": {
+                            "type": "string"
+                          },
+                          "cooldown_key": {
+                            "type": "string"
+                          },
+                          "cooldown_duration_seconds": {
+                            "type": "integer"
+                          },
+                          "cooldown_expires_at_millis": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "claimed",
+                              "suppressed",
+                              "enqueued",
+                              "delivered",
+                              "failed",
+                              "dropped"
+                            ]
+                          },
+                          "outcome": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "cooldown_active",
+                              "workflow_enqueued",
+                              "workflow_delivered",
+                              "workflow_failed",
+                              "workflow_dropped",
+                              "invalid_rule"
+                            ]
+                          },
+                          "workflow_event_id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "attempt_count": {
+                            "type": "integer"
+                          },
+                          "replay_count": {
+                            "type": "integer"
+                          },
+                          "last_attempt_at_millis": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "next_retry_at_millis": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "last_error": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "claimed_at_millis": {
+                            "type": "integer"
+                          },
+                          "enqueued_at_millis": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "completed_at_millis": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "created_at_millis": {
+                            "type": "integer"
+                          },
+                          "updated_at_millis": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "rule_id",
+                          "issue_id",
+                          "canonical_issue_id",
+                          "redirected",
+                          "occurrence_id",
+                          "rule_version",
+                          "event_kind",
+                          "deduplication_key",
+                          "cooldown_key",
+                          "cooldown_duration_seconds",
+                          "state",
+                          "outcome",
+                          "attempt_count",
+                          "replay_count",
+                          "claimed_at_millis",
+                          "created_at_millis",
+                          "updated_at_millis"
+                        ]
                       }
                     },
                     "truncated": {
@@ -3788,7 +4299,153 @@
                   "type": "object",
                   "properties": {
                     "delivery": {
-                      "type": "object"
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "rule_id": {
+                          "type": "string"
+                        },
+                        "issue_id": {
+                          "type": "string"
+                        },
+                        "canonical_issue_id": {
+                          "type": "string"
+                        },
+                        "redirected": {
+                          "type": "boolean"
+                        },
+                        "redirected_from_issue_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "occurrence_id": {
+                          "type": "string"
+                        },
+                        "rule_version": {
+                          "type": "integer"
+                        },
+                        "event_kind": {
+                          "type": "string",
+                          "enum": [
+                            "new",
+                            "regression",
+                            "occurrence"
+                          ]
+                        },
+                        "deduplication_key": {
+                          "type": "string"
+                        },
+                        "cooldown_key": {
+                          "type": "string"
+                        },
+                        "cooldown_duration_seconds": {
+                          "type": "integer"
+                        },
+                        "cooldown_expires_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "claimed",
+                            "suppressed",
+                            "enqueued",
+                            "delivered",
+                            "failed",
+                            "dropped"
+                          ]
+                        },
+                        "outcome": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "cooldown_active",
+                            "workflow_enqueued",
+                            "workflow_delivered",
+                            "workflow_failed",
+                            "workflow_dropped",
+                            "invalid_rule"
+                          ]
+                        },
+                        "workflow_event_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "attempt_count": {
+                          "type": "integer"
+                        },
+                        "replay_count": {
+                          "type": "integer"
+                        },
+                        "last_attempt_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "next_retry_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "last_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "claimed_at_millis": {
+                          "type": "integer"
+                        },
+                        "enqueued_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "completed_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "created_at_millis": {
+                          "type": "integer"
+                        },
+                        "updated_at_millis": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "rule_id",
+                        "issue_id",
+                        "canonical_issue_id",
+                        "redirected",
+                        "occurrence_id",
+                        "rule_version",
+                        "event_kind",
+                        "deduplication_key",
+                        "cooldown_key",
+                        "cooldown_duration_seconds",
+                        "state",
+                        "outcome",
+                        "attempt_count",
+                        "replay_count",
+                        "claimed_at_millis",
+                        "created_at_millis",
+                        "updated_at_millis"
+                      ]
                     }
                   },
                   "required": [
@@ -3828,7 +4485,153 @@
                   "type": "object",
                   "properties": {
                     "delivery": {
-                      "type": "object"
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "rule_id": {
+                          "type": "string"
+                        },
+                        "issue_id": {
+                          "type": "string"
+                        },
+                        "canonical_issue_id": {
+                          "type": "string"
+                        },
+                        "redirected": {
+                          "type": "boolean"
+                        },
+                        "redirected_from_issue_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "occurrence_id": {
+                          "type": "string"
+                        },
+                        "rule_version": {
+                          "type": "integer"
+                        },
+                        "event_kind": {
+                          "type": "string",
+                          "enum": [
+                            "new",
+                            "regression",
+                            "occurrence"
+                          ]
+                        },
+                        "deduplication_key": {
+                          "type": "string"
+                        },
+                        "cooldown_key": {
+                          "type": "string"
+                        },
+                        "cooldown_duration_seconds": {
+                          "type": "integer"
+                        },
+                        "cooldown_expires_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "claimed",
+                            "suppressed",
+                            "enqueued",
+                            "delivered",
+                            "failed",
+                            "dropped"
+                          ]
+                        },
+                        "outcome": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "cooldown_active",
+                            "workflow_enqueued",
+                            "workflow_delivered",
+                            "workflow_failed",
+                            "workflow_dropped",
+                            "invalid_rule"
+                          ]
+                        },
+                        "workflow_event_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "attempt_count": {
+                          "type": "integer"
+                        },
+                        "replay_count": {
+                          "type": "integer"
+                        },
+                        "last_attempt_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "next_retry_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "last_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "claimed_at_millis": {
+                          "type": "integer"
+                        },
+                        "enqueued_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "completed_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "created_at_millis": {
+                          "type": "integer"
+                        },
+                        "updated_at_millis": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "rule_id",
+                        "issue_id",
+                        "canonical_issue_id",
+                        "redirected",
+                        "occurrence_id",
+                        "rule_version",
+                        "event_kind",
+                        "deduplication_key",
+                        "cooldown_key",
+                        "cooldown_duration_seconds",
+                        "state",
+                        "outcome",
+                        "attempt_count",
+                        "replay_count",
+                        "claimed_at_millis",
+                        "created_at_millis",
+                        "updated_at_millis"
+                      ]
                     },
                     "replayed": {
                       "type": "boolean"
@@ -3872,7 +4675,130 @@
                   "type": "object",
                   "properties": {
                     "rule": {
-                      "type": "object"
+                      "type": "object",
+                      "properties": {
+                        "database_id": {
+                          "type": "string"
+                        },
+                        "schemaVersion": {
+                          "type": "number"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "integer"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "filters": {
+                          "type": "object",
+                          "properties": {
+                            "projectIds": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "environments": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "releases": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string",
+                                    "enum": [
+                                      "equals",
+                                      "not_equals",
+                                      "contains",
+                                      "starts_with",
+                                      "in",
+                                      "exists",
+                                      "not_exists"
+                                    ]
+                                  },
+                                  "value": {
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ]
+                              }
+                            }
+                          },
+                          "required": []
+                        },
+                        "conditions": {
+                          "type": "object",
+                          "properties": {
+                            "all": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            },
+                            "any": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          "required": []
+                        },
+                        "cooldown": {
+                          "type": "object",
+                          "properties": {
+                            "durationSeconds": {
+                              "type": "integer"
+                            },
+                            "keyBy": {
+                              "type": "string",
+                              "enum": [
+                                "issue",
+                                "issue_environment",
+                                "issue_release",
+                                "issue_environment_release"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "durationSeconds",
+                            "keyBy"
+                          ]
+                        },
+                        "action": {
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "database_id",
+                        "schemaVersion",
+                        "id",
+                        "version",
+                        "enabled",
+                        "conditions",
+                        "cooldown",
+                        "action"
+                      ]
                     }
                   },
                   "required": [
@@ -3912,7 +4838,130 @@
                   "type": "object",
                   "properties": {
                     "rule": {
-                      "type": "object"
+                      "type": "object",
+                      "properties": {
+                        "database_id": {
+                          "type": "string"
+                        },
+                        "schemaVersion": {
+                          "type": "number"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "integer"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "filters": {
+                          "type": "object",
+                          "properties": {
+                            "projectIds": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "environments": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "releases": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string",
+                                    "enum": [
+                                      "equals",
+                                      "not_equals",
+                                      "contains",
+                                      "starts_with",
+                                      "in",
+                                      "exists",
+                                      "not_exists"
+                                    ]
+                                  },
+                                  "value": {
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ]
+                              }
+                            }
+                          },
+                          "required": []
+                        },
+                        "conditions": {
+                          "type": "object",
+                          "properties": {
+                            "all": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            },
+                            "any": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          "required": []
+                        },
+                        "cooldown": {
+                          "type": "object",
+                          "properties": {
+                            "durationSeconds": {
+                              "type": "integer"
+                            },
+                            "keyBy": {
+                              "type": "string",
+                              "enum": [
+                                "issue",
+                                "issue_environment",
+                                "issue_release",
+                                "issue_environment_release"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "durationSeconds",
+                            "keyBy"
+                          ]
+                        },
+                        "action": {
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "database_id",
+                        "schemaVersion",
+                        "id",
+                        "version",
+                        "enabled",
+                        "conditions",
+                        "cooldown",
+                        "action"
+                      ]
                     },
                     "changed": {
                       "type": "boolean"
@@ -7507,7 +8556,43 @@
                     "items": {
                       "type": "array",
                       "items": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "actor_user_id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "idempotency_key": {
+                            "type": "string"
+                          },
+                          "data": {
+                            "type": [
+                              "object",
+                              "null"
+                            ]
+                          },
+                          "occurred_at": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "idempotency_key",
+                          "occurred_at",
+                          "created_at"
+                        ]
                       }
                     }
                   },
@@ -11827,6 +12912,136 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "commits": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "release_id": {
+                            "type": "string"
+                          },
+                          "repository": {
+                            "type": "string"
+                          },
+                          "commit_sha": {
+                            "type": "string"
+                          },
+                          "position": {
+                            "type": "integer"
+                          },
+                          "message": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "author_name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "author_email": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "committed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "url": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "release_id",
+                          "repository",
+                          "commit_sha",
+                          "position",
+                          "created_at",
+                          "updated_at"
+                        ]
+                      }
+                    },
+                    "deployments": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "release_id": {
+                            "type": "string"
+                          },
+                          "deployment_key": {
+                            "type": "string"
+                          },
+                          "environment": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "url": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "started_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "finished_at": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "type": [
+                              "object",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "release_id",
+                          "deployment_key",
+                          "environment",
+                          "finished_at",
+                          "created_at",
+                          "updated_at"
+                        ]
+                      }
+                    },
                     "id": {
                       "type": "string"
                     },
@@ -11884,6 +13099,8 @@
                     }
                   },
                   "required": [
+                    "commits",
+                    "deployments",
                     "id",
                     "version",
                     "status",
@@ -12836,6 +14053,117 @@
                     "finished_at",
                     "created_at",
                     "updated_at"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/releases/recent": {
+      "get": {
+        "summary": "List recent releases",
+        "description": "Returns recent releases for the authenticated tenant, project, and branch scope.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "tags": [
+          "Releases"
+        ],
+        "x-full-url": "https://api.hexclave.com/api/v1/releases/recent",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "open",
+                              "archived"
+                            ]
+                          },
+                          "ref": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "url": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "data": {
+                            "type": [
+                              "object",
+                              "null"
+                            ]
+                          },
+                          "date_added": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "date_started": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "date_released": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "version",
+                          "status",
+                          "created_at",
+                          "updated_at"
+                        ]
+                      }
+                    },
+                    "truncated": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "truncated"
                   ]
                 }
               }

--- a/docs-mintlify/openapi/server.json
+++ b/docs-mintlify/openapi/server.json
@@ -3608,7 +3608,130 @@
                     "rules": {
                       "type": "array",
                       "items": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                          "database_id": {
+                            "type": "string"
+                          },
+                          "schemaVersion": {
+                            "type": "number"
+                          },
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "integer"
+                          },
+                          "enabled": {
+                            "type": "boolean"
+                          },
+                          "filters": {
+                            "type": "object",
+                            "properties": {
+                              "projectIds": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "environments": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "releases": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              },
+                              "tags": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "operator": {
+                                      "type": "string",
+                                      "enum": [
+                                        "equals",
+                                        "not_equals",
+                                        "contains",
+                                        "starts_with",
+                                        "in",
+                                        "exists",
+                                        "not_exists"
+                                      ]
+                                    },
+                                    "value": {
+                                      "type": "object"
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "operator"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": []
+                          },
+                          "conditions": {
+                            "type": "object",
+                            "properties": {
+                              "all": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              },
+                              "any": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object"
+                                }
+                              }
+                            },
+                            "required": []
+                          },
+                          "cooldown": {
+                            "type": "object",
+                            "properties": {
+                              "durationSeconds": {
+                                "type": "integer"
+                              },
+                              "keyBy": {
+                                "type": "string",
+                                "enum": [
+                                  "issue",
+                                  "issue_environment",
+                                  "issue_release",
+                                  "issue_environment_release"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "durationSeconds",
+                              "keyBy"
+                            ]
+                          },
+                          "action": {
+                            "type": "object"
+                          }
+                        },
+                        "required": [
+                          "database_id",
+                          "schemaVersion",
+                          "id",
+                          "version",
+                          "enabled",
+                          "conditions",
+                          "cooldown",
+                          "action"
+                        ]
                       }
                     },
                     "truncated": {
@@ -3637,7 +3760,126 @@
                 "type": "object",
                 "properties": {
                   "rule": {
-                    "type": "object"
+                    "type": "object",
+                    "properties": {
+                      "schemaVersion": {
+                        "type": "number"
+                      },
+                      "id": {
+                        "type": "string"
+                      },
+                      "version": {
+                        "type": "integer"
+                      },
+                      "enabled": {
+                        "type": "boolean"
+                      },
+                      "filters": {
+                        "type": "object",
+                        "properties": {
+                          "projectIds": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "environments": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "releases": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "operator": {
+                                  "type": "string",
+                                  "enum": [
+                                    "equals",
+                                    "not_equals",
+                                    "contains",
+                                    "starts_with",
+                                    "in",
+                                    "exists",
+                                    "not_exists"
+                                  ]
+                                },
+                                "value": {
+                                  "type": "object"
+                                }
+                              },
+                              "required": [
+                                "key",
+                                "operator"
+                              ]
+                            }
+                          }
+                        },
+                        "required": []
+                      },
+                      "conditions": {
+                        "type": "object",
+                        "properties": {
+                          "all": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            }
+                          },
+                          "any": {
+                            "type": "array",
+                            "items": {
+                              "type": "object"
+                            }
+                          }
+                        },
+                        "required": []
+                      },
+                      "cooldown": {
+                        "type": "object",
+                        "properties": {
+                          "durationSeconds": {
+                            "type": "integer"
+                          },
+                          "keyBy": {
+                            "type": "string",
+                            "enum": [
+                              "issue",
+                              "issue_environment",
+                              "issue_release",
+                              "issue_environment_release"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "durationSeconds",
+                          "keyBy"
+                        ]
+                      },
+                      "action": {
+                        "type": "object"
+                      }
+                    },
+                    "required": [
+                      "schemaVersion",
+                      "id",
+                      "version",
+                      "enabled",
+                      "conditions",
+                      "cooldown",
+                      "action"
+                    ]
                   }
                 },
                 "required": [
@@ -3661,7 +3903,130 @@
                   "type": "object",
                   "properties": {
                     "rule": {
-                      "type": "object"
+                      "type": "object",
+                      "properties": {
+                        "database_id": {
+                          "type": "string"
+                        },
+                        "schemaVersion": {
+                          "type": "number"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "integer"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "filters": {
+                          "type": "object",
+                          "properties": {
+                            "projectIds": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "environments": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "releases": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string",
+                                    "enum": [
+                                      "equals",
+                                      "not_equals",
+                                      "contains",
+                                      "starts_with",
+                                      "in",
+                                      "exists",
+                                      "not_exists"
+                                    ]
+                                  },
+                                  "value": {
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ]
+                              }
+                            }
+                          },
+                          "required": []
+                        },
+                        "conditions": {
+                          "type": "object",
+                          "properties": {
+                            "all": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            },
+                            "any": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          "required": []
+                        },
+                        "cooldown": {
+                          "type": "object",
+                          "properties": {
+                            "durationSeconds": {
+                              "type": "integer"
+                            },
+                            "keyBy": {
+                              "type": "string",
+                              "enum": [
+                                "issue",
+                                "issue_environment",
+                                "issue_release",
+                                "issue_environment_release"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "durationSeconds",
+                            "keyBy"
+                          ]
+                        },
+                        "action": {
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "database_id",
+                        "schemaVersion",
+                        "id",
+                        "version",
+                        "enabled",
+                        "conditions",
+                        "cooldown",
+                        "action"
+                      ]
                     }
                   },
                   "required": [
@@ -3703,7 +4068,153 @@
                     "deliveries": {
                       "type": "array",
                       "items": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "rule_id": {
+                            "type": "string"
+                          },
+                          "issue_id": {
+                            "type": "string"
+                          },
+                          "canonical_issue_id": {
+                            "type": "string"
+                          },
+                          "redirected": {
+                            "type": "boolean"
+                          },
+                          "redirected_from_issue_id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "occurrence_id": {
+                            "type": "string"
+                          },
+                          "rule_version": {
+                            "type": "integer"
+                          },
+                          "event_kind": {
+                            "type": "string",
+                            "enum": [
+                              "new",
+                              "regression",
+                              "occurrence"
+                            ]
+                          },
+                          "deduplication_key": {
+                            "type": "string"
+                          },
+                          "cooldown_key": {
+                            "type": "string"
+                          },
+                          "cooldown_duration_seconds": {
+                            "type": "integer"
+                          },
+                          "cooldown_expires_at_millis": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "state": {
+                            "type": "string",
+                            "enum": [
+                              "claimed",
+                              "suppressed",
+                              "enqueued",
+                              "delivered",
+                              "failed",
+                              "dropped"
+                            ]
+                          },
+                          "outcome": {
+                            "type": "string",
+                            "enum": [
+                              "none",
+                              "cooldown_active",
+                              "workflow_enqueued",
+                              "workflow_delivered",
+                              "workflow_failed",
+                              "workflow_dropped",
+                              "invalid_rule"
+                            ]
+                          },
+                          "workflow_event_id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "attempt_count": {
+                            "type": "integer"
+                          },
+                          "replay_count": {
+                            "type": "integer"
+                          },
+                          "last_attempt_at_millis": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "next_retry_at_millis": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "last_error": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "claimed_at_millis": {
+                            "type": "integer"
+                          },
+                          "enqueued_at_millis": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "completed_at_millis": {
+                            "type": [
+                              "integer",
+                              "null"
+                            ]
+                          },
+                          "created_at_millis": {
+                            "type": "integer"
+                          },
+                          "updated_at_millis": {
+                            "type": "integer"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "rule_id",
+                          "issue_id",
+                          "canonical_issue_id",
+                          "redirected",
+                          "occurrence_id",
+                          "rule_version",
+                          "event_kind",
+                          "deduplication_key",
+                          "cooldown_key",
+                          "cooldown_duration_seconds",
+                          "state",
+                          "outcome",
+                          "attempt_count",
+                          "replay_count",
+                          "claimed_at_millis",
+                          "created_at_millis",
+                          "updated_at_millis"
+                        ]
                       }
                     },
                     "truncated": {
@@ -3748,7 +4259,153 @@
                   "type": "object",
                   "properties": {
                     "delivery": {
-                      "type": "object"
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "rule_id": {
+                          "type": "string"
+                        },
+                        "issue_id": {
+                          "type": "string"
+                        },
+                        "canonical_issue_id": {
+                          "type": "string"
+                        },
+                        "redirected": {
+                          "type": "boolean"
+                        },
+                        "redirected_from_issue_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "occurrence_id": {
+                          "type": "string"
+                        },
+                        "rule_version": {
+                          "type": "integer"
+                        },
+                        "event_kind": {
+                          "type": "string",
+                          "enum": [
+                            "new",
+                            "regression",
+                            "occurrence"
+                          ]
+                        },
+                        "deduplication_key": {
+                          "type": "string"
+                        },
+                        "cooldown_key": {
+                          "type": "string"
+                        },
+                        "cooldown_duration_seconds": {
+                          "type": "integer"
+                        },
+                        "cooldown_expires_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "claimed",
+                            "suppressed",
+                            "enqueued",
+                            "delivered",
+                            "failed",
+                            "dropped"
+                          ]
+                        },
+                        "outcome": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "cooldown_active",
+                            "workflow_enqueued",
+                            "workflow_delivered",
+                            "workflow_failed",
+                            "workflow_dropped",
+                            "invalid_rule"
+                          ]
+                        },
+                        "workflow_event_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "attempt_count": {
+                          "type": "integer"
+                        },
+                        "replay_count": {
+                          "type": "integer"
+                        },
+                        "last_attempt_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "next_retry_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "last_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "claimed_at_millis": {
+                          "type": "integer"
+                        },
+                        "enqueued_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "completed_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "created_at_millis": {
+                          "type": "integer"
+                        },
+                        "updated_at_millis": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "rule_id",
+                        "issue_id",
+                        "canonical_issue_id",
+                        "redirected",
+                        "occurrence_id",
+                        "rule_version",
+                        "event_kind",
+                        "deduplication_key",
+                        "cooldown_key",
+                        "cooldown_duration_seconds",
+                        "state",
+                        "outcome",
+                        "attempt_count",
+                        "replay_count",
+                        "claimed_at_millis",
+                        "created_at_millis",
+                        "updated_at_millis"
+                      ]
                     }
                   },
                   "required": [
@@ -3788,7 +4445,153 @@
                   "type": "object",
                   "properties": {
                     "delivery": {
-                      "type": "object"
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "rule_id": {
+                          "type": "string"
+                        },
+                        "issue_id": {
+                          "type": "string"
+                        },
+                        "canonical_issue_id": {
+                          "type": "string"
+                        },
+                        "redirected": {
+                          "type": "boolean"
+                        },
+                        "redirected_from_issue_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "occurrence_id": {
+                          "type": "string"
+                        },
+                        "rule_version": {
+                          "type": "integer"
+                        },
+                        "event_kind": {
+                          "type": "string",
+                          "enum": [
+                            "new",
+                            "regression",
+                            "occurrence"
+                          ]
+                        },
+                        "deduplication_key": {
+                          "type": "string"
+                        },
+                        "cooldown_key": {
+                          "type": "string"
+                        },
+                        "cooldown_duration_seconds": {
+                          "type": "integer"
+                        },
+                        "cooldown_expires_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "state": {
+                          "type": "string",
+                          "enum": [
+                            "claimed",
+                            "suppressed",
+                            "enqueued",
+                            "delivered",
+                            "failed",
+                            "dropped"
+                          ]
+                        },
+                        "outcome": {
+                          "type": "string",
+                          "enum": [
+                            "none",
+                            "cooldown_active",
+                            "workflow_enqueued",
+                            "workflow_delivered",
+                            "workflow_failed",
+                            "workflow_dropped",
+                            "invalid_rule"
+                          ]
+                        },
+                        "workflow_event_id": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "attempt_count": {
+                          "type": "integer"
+                        },
+                        "replay_count": {
+                          "type": "integer"
+                        },
+                        "last_attempt_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "next_retry_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "last_error": {
+                          "type": [
+                            "string",
+                            "null"
+                          ]
+                        },
+                        "claimed_at_millis": {
+                          "type": "integer"
+                        },
+                        "enqueued_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "completed_at_millis": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        },
+                        "created_at_millis": {
+                          "type": "integer"
+                        },
+                        "updated_at_millis": {
+                          "type": "integer"
+                        }
+                      },
+                      "required": [
+                        "id",
+                        "rule_id",
+                        "issue_id",
+                        "canonical_issue_id",
+                        "redirected",
+                        "occurrence_id",
+                        "rule_version",
+                        "event_kind",
+                        "deduplication_key",
+                        "cooldown_key",
+                        "cooldown_duration_seconds",
+                        "state",
+                        "outcome",
+                        "attempt_count",
+                        "replay_count",
+                        "claimed_at_millis",
+                        "created_at_millis",
+                        "updated_at_millis"
+                      ]
                     },
                     "replayed": {
                       "type": "boolean"
@@ -3832,7 +4635,130 @@
                   "type": "object",
                   "properties": {
                     "rule": {
-                      "type": "object"
+                      "type": "object",
+                      "properties": {
+                        "database_id": {
+                          "type": "string"
+                        },
+                        "schemaVersion": {
+                          "type": "number"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "integer"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "filters": {
+                          "type": "object",
+                          "properties": {
+                            "projectIds": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "environments": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "releases": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string",
+                                    "enum": [
+                                      "equals",
+                                      "not_equals",
+                                      "contains",
+                                      "starts_with",
+                                      "in",
+                                      "exists",
+                                      "not_exists"
+                                    ]
+                                  },
+                                  "value": {
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ]
+                              }
+                            }
+                          },
+                          "required": []
+                        },
+                        "conditions": {
+                          "type": "object",
+                          "properties": {
+                            "all": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            },
+                            "any": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          "required": []
+                        },
+                        "cooldown": {
+                          "type": "object",
+                          "properties": {
+                            "durationSeconds": {
+                              "type": "integer"
+                            },
+                            "keyBy": {
+                              "type": "string",
+                              "enum": [
+                                "issue",
+                                "issue_environment",
+                                "issue_release",
+                                "issue_environment_release"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "durationSeconds",
+                            "keyBy"
+                          ]
+                        },
+                        "action": {
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "database_id",
+                        "schemaVersion",
+                        "id",
+                        "version",
+                        "enabled",
+                        "conditions",
+                        "cooldown",
+                        "action"
+                      ]
                     }
                   },
                   "required": [
@@ -3872,7 +4798,130 @@
                   "type": "object",
                   "properties": {
                     "rule": {
-                      "type": "object"
+                      "type": "object",
+                      "properties": {
+                        "database_id": {
+                          "type": "string"
+                        },
+                        "schemaVersion": {
+                          "type": "number"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "integer"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "filters": {
+                          "type": "object",
+                          "properties": {
+                            "projectIds": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "environments": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "releases": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "tags": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "key": {
+                                    "type": "string"
+                                  },
+                                  "operator": {
+                                    "type": "string",
+                                    "enum": [
+                                      "equals",
+                                      "not_equals",
+                                      "contains",
+                                      "starts_with",
+                                      "in",
+                                      "exists",
+                                      "not_exists"
+                                    ]
+                                  },
+                                  "value": {
+                                    "type": "object"
+                                  }
+                                },
+                                "required": [
+                                  "key",
+                                  "operator"
+                                ]
+                              }
+                            }
+                          },
+                          "required": []
+                        },
+                        "conditions": {
+                          "type": "object",
+                          "properties": {
+                            "all": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            },
+                            "any": {
+                              "type": "array",
+                              "items": {
+                                "type": "object"
+                              }
+                            }
+                          },
+                          "required": []
+                        },
+                        "cooldown": {
+                          "type": "object",
+                          "properties": {
+                            "durationSeconds": {
+                              "type": "integer"
+                            },
+                            "keyBy": {
+                              "type": "string",
+                              "enum": [
+                                "issue",
+                                "issue_environment",
+                                "issue_release",
+                                "issue_environment_release"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "durationSeconds",
+                            "keyBy"
+                          ]
+                        },
+                        "action": {
+                          "type": "object"
+                        }
+                      },
+                      "required": [
+                        "database_id",
+                        "schemaVersion",
+                        "id",
+                        "version",
+                        "enabled",
+                        "conditions",
+                        "cooldown",
+                        "action"
+                      ]
                     },
                     "changed": {
                       "type": "boolean"
@@ -7467,7 +8516,43 @@
                     "items": {
                       "type": "array",
                       "items": {
-                        "type": "object"
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "actor_user_id": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "type": {
+                            "type": "string"
+                          },
+                          "idempotency_key": {
+                            "type": "string"
+                          },
+                          "data": {
+                            "type": [
+                              "object",
+                              "null"
+                            ]
+                          },
+                          "occurred_at": {
+                            "type": "string"
+                          },
+                          "created_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "type",
+                          "idempotency_key",
+                          "occurred_at",
+                          "created_at"
+                        ]
                       }
                     }
                   },
@@ -11124,6 +12209,136 @@
                 "schema": {
                   "type": "object",
                   "properties": {
+                    "commits": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "release_id": {
+                            "type": "string"
+                          },
+                          "repository": {
+                            "type": "string"
+                          },
+                          "commit_sha": {
+                            "type": "string"
+                          },
+                          "position": {
+                            "type": "integer"
+                          },
+                          "message": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "author_name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "author_email": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "committed_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "url": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "release_id",
+                          "repository",
+                          "commit_sha",
+                          "position",
+                          "created_at",
+                          "updated_at"
+                        ]
+                      }
+                    },
+                    "deployments": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "release_id": {
+                            "type": "string"
+                          },
+                          "deployment_key": {
+                            "type": "string"
+                          },
+                          "environment": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "url": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "started_at": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "finished_at": {
+                            "type": "string"
+                          },
+                          "metadata": {
+                            "type": [
+                              "object",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "release_id",
+                          "deployment_key",
+                          "environment",
+                          "finished_at",
+                          "created_at",
+                          "updated_at"
+                        ]
+                      }
+                    },
                     "id": {
                       "type": "string"
                     },
@@ -11181,6 +12396,8 @@
                     }
                   },
                   "required": [
+                    "commits",
+                    "deployments",
                     "id",
                     "version",
                     "status",
@@ -12133,6 +13350,117 @@
                     "finished_at",
                     "created_at",
                     "updated_at"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/releases/recent": {
+      "get": {
+        "summary": "List recent releases",
+        "description": "Returns recent releases for the authenticated tenant, project, and branch scope.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "tags": [
+          "Releases"
+        ],
+        "x-full-url": "https://api.hexclave.com/api/v1/releases/recent",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "version": {
+                            "type": "string"
+                          },
+                          "status": {
+                            "type": "string",
+                            "enum": [
+                              "open",
+                              "archived"
+                            ]
+                          },
+                          "ref": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "url": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "data": {
+                            "type": [
+                              "object",
+                              "null"
+                            ]
+                          },
+                          "date_added": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "date_started": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "date_released": {
+                            "type": [
+                              "string",
+                              "null"
+                            ]
+                          },
+                          "created_at": {
+                            "type": "string"
+                          },
+                          "updated_at": {
+                            "type": "string"
+                          }
+                        },
+                        "required": [
+                          "id",
+                          "version",
+                          "status",
+                          "created_at",
+                          "updated_at"
+                        ]
+                      }
+                    },
+                    "truncated": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "items",
+                    "truncated"
                   ]
                 }
               }

--- a/docs-mintlify/openapi/webhooks.json
+++ b/docs-mintlify/openapi/webhooks.json
@@ -1293,7 +1293,7 @@
                           "ongoing",
                           "regressed"
                         ],
-                        "example": "regressed",
+                        "example": "new",
                         "description": "A finer-grained view of an unresolved issue, derived from its timestamps"
                       },
                       "first_seen_at_millis": {
@@ -1601,7 +1601,7 @@
                           "resolved",
                           "ignored"
                         ],
-                        "example": "unresolved",
+                        "example": "resolved",
                         "description": "The lifecycle status of the issue"
                       },
                       "substatus": {
@@ -1611,7 +1611,7 @@
                           "ongoing",
                           "regressed"
                         ],
-                        "example": "regressed",
+                        "example": "ongoing",
                         "description": "A finer-grained view of an unresolved issue, derived from its timestamps"
                       },
                       "first_seen_at_millis": {
@@ -1760,7 +1760,7 @@
                           "resolved",
                           "ignored"
                         ],
-                        "example": "unresolved",
+                        "example": "ignored",
                         "description": "The lifecycle status of the issue"
                       },
                       "substatus": {
@@ -1770,7 +1770,7 @@
                           "ongoing",
                           "regressed"
                         ],
-                        "example": "regressed",
+                        "example": "ongoing",
                         "description": "A finer-grained view of an unresolved issue, derived from its timestamps"
                       },
                       "first_seen_at_millis": {
@@ -1929,7 +1929,7 @@
                           "ongoing",
                           "regressed"
                         ],
-                        "example": "regressed",
+                        "example": "ongoing",
                         "description": "A finer-grained view of an unresolved issue, derived from its timestamps"
                       },
                       "first_seen_at_millis": {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -286,12 +286,16 @@ async function uploadSource(uploadUrl: string, contentType: string, bytes: Uint8
       // This header is signed into the R2/S3 URL and must match exactly.
       "content-type": contentType,
       "content-length": bytes.length.toString(),
+      "if-none-match": "*",
     },
     // Copy into a plain ArrayBuffer: TS's BodyInit doesn't accept
     // Uint8Array<ArrayBufferLike>, and slicing also drops any surrounding
     // bytes of a shared buffer.
     body: new Uint8Array(bytes).slice().buffer,
   });
+  // A content-addressed object already present in storage is the desired
+  // result of a retry after a completed PUT whose response was lost.
+  if (response.status === 412) return;
   if (!response.ok) {
     const responseBody = await response.text();
     throw new CliError(`Source upload failed (${response.status} from object storage): ${responseBody.slice(0, 1000)}`);

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -293,9 +293,13 @@ async function uploadSource(uploadUrl: string, contentType: string, bytes: Uint8
     // bytes of a shared buffer.
     body: new Uint8Array(bytes).slice().buffer,
   });
-  // A content-addressed object already present in storage is the desired
-  // result of a retry after a completed PUT whose response was lost.
-  if (response.status === 412) return;
+  // Deployment upload keys are random rather than content-addressed, so a 412
+  // proves only that some caller populated this slot. Accepting it could deploy
+  // a different valid tarball uploaded through the same presigned URL.
+  if (response.status === 412) {
+    const responseBody = await response.text();
+    throw new CliError(`Source upload conflicted with an existing object (412 from object storage): ${responseBody.slice(0, 1000)}`);
+  }
   if (!response.ok) {
     const responseBody = await response.text();
     throw new CliError(`Source upload failed (${response.status} from object storage): ${responseBody.slice(0, 1000)}`);

--- a/packages/cli/src/commands/source-maps.ts
+++ b/packages/cli/src/commands/source-maps.ts
@@ -17,6 +17,7 @@ import {
   deriveBundleDebugId,
   findIntegrityManifests,
   findNextBuildRoots,
+  isInside,
   isDebugId,
   NEXT_SERVER_SOURCE_MAPS_CONFIG_HINT,
   normalizeArtifactRelativePath,
@@ -824,7 +825,21 @@ export function prepareArtifacts(candidates: readonly SourceMapArtifactCandidate
     let mapDir: string;
     if (candidate.sourceMapPath !== null) {
       try {
-        mapText = fs.readFileSync(candidate.sourceMapPath, "utf-8");
+        // Open the validated path before checking its real path again. The
+        // descriptor pins the bytes we read even if a local build watcher swaps
+        // the symlink after this check; reading the pathname directly would
+        // reopen the attacker-controlled target during that window.
+        const mapFd = fs.openSync(candidate.sourceMapPath, "r");
+        try {
+          const realMapPath = fs.realpathSync(candidate.sourceMapPath);
+          const realScanDir = fs.realpathSync(candidate.scanDir);
+          if (!isInside(realMapPath, realScanDir)) {
+            throw new CliError(`Source map ${candidate.sourceMapPath} is outside the scanned build directory.`);
+          }
+          mapText = fs.readFileSync(mapFd, "utf-8");
+        } finally {
+          fs.closeSync(mapFd);
+        }
       } catch (error) {
         throw new CliError(`Could not read source map ${candidate.sourceMapPath}: ${error instanceof Error ? error.message : String(error)}`);
       }
@@ -917,13 +932,6 @@ export function registerSourceMapsCommand(program: Command) {
       const release = normalizeOptionalMetadata(opts.release, "--release");
       const dist = normalizeOptionalMetadata(opts.dist, "--dist");
       const environment = normalizeOptionalMetadata(opts.environment, "--environment");
-      // Best-effort project id for the informational manifest that gets printed
-      // (dry-run, or a real run that prepared nothing). `resolveOptionalProjectId`
-      // never throws, so the printed manifest carries the resolved id in both
-      // cases instead of a bogus `null` on a real no-op run. The upload path does
-      // NOT use this — it re-resolves through `auth.projectId`, which is the
-      // authenticated tenancy.
-      const projectId = resolveOptionalProjectId(opts.cloudProjectId);
       if (dist !== null && release === null) {
         throw new CliError("Distribution is only meaningful with a release. Supply --release together with --dist.");
       }
@@ -1021,6 +1029,11 @@ export function registerSourceMapsCommand(program: Command) {
         // prepared). The upload path derives and validates its own plan inside
         // `uploadPreparedSourceMaps`, so computing the manifest there too would
         // validate, normalize and sort every artifact a second time.
+        // A real upload with prepared artifacts already resolved the project
+        // through authenticated credentials; a dry-run or no-op print still
+        // resolves the optional CLI/env value here, where a conflicting env
+        // configuration is relevant to the output and cannot affect uploads.
+        const projectId = auth === null ? resolveOptionalProjectId(opts.cloudProjectId) : auth.projectId;
         const manifest = createSourceMapManifest(artifacts, release, environment, {
           projectId,
           dist,

--- a/packages/cli/src/commands/source-maps.ts
+++ b/packages/cli/src/commands/source-maps.ts
@@ -824,18 +824,21 @@ export function prepareArtifacts(candidates: readonly SourceMapArtifactCandidate
     let mapText: string;
     let mapDir: string;
     if (candidate.sourceMapPath !== null) {
+      let realMapPath: string;
       try {
-        // Open the validated path before checking its real path again. The
-        // descriptor pins the bytes we read even if a local build watcher swaps
-        // the symlink after this check; reading the pathname directly would
-        // reopen the attacker-controlled target during that window.
-        const mapFd = fs.openSync(candidate.sourceMapPath, "r");
+        // Resolve and validate the canonical path before opening it. Opening
+        // the original symlink first lets a swap between openSync and
+        // realpathSync validate a different target from the bytes we read.
+        realMapPath = fs.realpathSync(candidate.sourceMapPath);
+        const realScanDir = fs.realpathSync(candidate.scanDir);
+        if (!isInside(realMapPath, realScanDir)) {
+          throw new CliError(`Source map ${candidate.sourceMapPath} is outside the scanned build directory.`);
+        }
+        // The final-component guard closes the remaining replacement window:
+        // a watcher may replace the canonical path with a symlink after
+        // realpathSync, but must not make this read escape the validated tree.
+        const mapFd = fs.openSync(realMapPath, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
         try {
-          const realMapPath = fs.realpathSync(candidate.sourceMapPath);
-          const realScanDir = fs.realpathSync(candidate.scanDir);
-          if (!isInside(realMapPath, realScanDir)) {
-            throw new CliError(`Source map ${candidate.sourceMapPath} is outside the scanned build directory.`);
-          }
           mapText = fs.readFileSync(mapFd, "utf-8");
         } finally {
           fs.closeSync(mapFd);
@@ -843,7 +846,7 @@ export function prepareArtifacts(candidates: readonly SourceMapArtifactCandidate
       } catch (error) {
         throw new CliError(`Could not read source map ${candidate.sourceMapPath}: ${error instanceof Error ? error.message : String(error)}`);
       }
-      mapDir = path.dirname(candidate.sourceMapPath);
+      mapDir = path.dirname(realMapPath);
     } else {
       const inline = readInlineSourceMap(source);
       if (inline === null) {

--- a/packages/cli/src/lib/source-maps.ts
+++ b/packages/cli/src/lib/source-maps.ts
@@ -56,6 +56,7 @@ const DEBUG_ID_IDENTIFIER_PREFIX = "hexclave-dbid-";
 // what makes `appendDebugIdSnippet` safe to call repeatedly on the same file.
 const SNIPPET_START_MARKER = "// hexclave:debug-id-injection:start";
 const SNIPPET_END_MARKER = "// hexclave:debug-id-injection:end";
+const SNIPPET_SEPARATOR_MARKER = "// hexclave:debug-id-injection:separator";
 
 /** The exact next.config line to print when a server chunk has no source map. */
 export const NEXT_SERVER_SOURCE_MAPS_CONFIG_HINT = "experimental: { serverSourceMaps: true }";
@@ -136,7 +137,7 @@ function buildDebugIdSnippet(debugId: string): string {
   return `${SNIPPET_START_MARKER}\n${snippet}\n//# debugId=${debugId}\n${SNIPPET_END_MARKER}\n`;
 }
 
-const SNIPPET_BLOCK_RE = new RegExp(`${SNIPPET_START_MARKER}\\n[\\s\\S]*?\\n${SNIPPET_END_MARKER}\\n?`, "g");
+const SNIPPET_BLOCK_RE = new RegExp(`(?:${SNIPPET_SEPARATOR_MARKER}\\n)?${SNIPPET_START_MARKER}\\n[\\s\\S]*?\\n${SNIPPET_END_MARKER}\\n?`, "g");
 
 // Matches a `//# sourceMappingURL=` / `//@ sourceMappingURL=` line. Anchored to
 // whole lines so a URL appearing inside a string literal cannot match.
@@ -181,7 +182,8 @@ export function appendDebugIdSnippet(source: string, debugId: string): string {
   const block = buildDebugIdSnippet(debugId);
   const sourceMappingUrl = findLastSourceMappingUrlMatch(stripped);
   if (sourceMappingUrl === null) {
-    return stripped.endsWith("\n") || stripped === "" ? `${stripped}${block}` : `${stripped}\n${block}`;
+    if (stripped.endsWith("\n") || stripped === "") return `${stripped}${block}`;
+    return `${stripped}\n${SNIPPET_SEPARATOR_MARKER}\n${block}`;
   }
   // `lineStart` is a line boundary (the regex is `^`-anchored with `m`), so the
   // slice before it already ends in a newline unless it is empty.
@@ -192,16 +194,13 @@ export function appendDebugIdSnippet(source: string, debugId: string): string {
  * The bundle as it was BEFORE any debug-id injection, normalized so that
  * `stripDebugIdSnippet(appendDebugIdSnippet(x, id))` round-trips exactly.
  *
- * `appendDebugIdSnippet` adds a trailing newline before its block only in the
- * EOF branch (a bundle with no `//# sourceMappingURL=` comment). Reproducing
- * that one normalization here is what lets `deriveBundleDebugId` derive the SAME
- * id on the first run and on every unchanged rerun — the derivation basis is
- * identical whether or not a previous run already injected a block.
+ * The EOF branch records a separator marker only when injection had to add a
+ * newline to a bundle that did not already end in one. Removing that marker
+ * with the block preserves the exact clean bytes, so bundles differing only by
+ * an EOF newline retain distinct ids on fallback-map uploads.
  */
 function canonicalCleanSource(source: string): string {
   const stripped = source.replace(SNIPPET_BLOCK_RE, "");
-  const hasSourceMappingUrl = findLastSourceMappingUrlMatch(stripped) !== null;
-  if (!hasSourceMappingUrl && stripped !== "" && !stripped.endsWith("\n")) return `${stripped}\n`;
   return stripped;
 }
 
@@ -262,7 +261,7 @@ export type DetermineSourceMapPathOptions = {
   containingDir?: string,
 };
 
-function isInside(candidate: string, containingDir: string): boolean {
+export function isInside(candidate: string, containingDir: string): boolean {
   const relative = path.relative(containingDir, candidate);
   return relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative);
 }

--- a/packages/dashboard-ui-components/src/components/badge.tsx
+++ b/packages/dashboard-ui-components/src/components/badge.tsx
@@ -13,7 +13,7 @@ const badgeStyles = new Map<DesignBadgeColor, string>([
   // locally, which is exactly what the Observability logs level chip used to
   // do. Same ring/bg/text ratios as the others so the two are metrically
   // identical when they sit in one row.
-  ["zinc", "text-zinc-600 dark:text-zinc-400 bg-zinc-500/15 dark:bg-zinc-500/10 ring-1 ring-zinc-500/25 dark:ring-zinc-500/20"],
+  ["zinc", "text-zinc-600 dark:text-zinc-400 bg-zinc-500/20 dark:bg-zinc-500/10 ring-1 ring-zinc-500/30 dark:ring-zinc-500/20"],
   ["blue", "text-blue-700 dark:text-blue-400 bg-blue-500/20 dark:bg-blue-500/10 ring-1 ring-blue-500/30 dark:ring-blue-500/20"],
   ["cyan", "text-cyan-700 dark:text-cyan-400 bg-cyan-500/20 dark:bg-cyan-500/10 ring-1 ring-cyan-500/30 dark:ring-cyan-500/20"],
   ["purple", "text-purple-700 dark:text-purple-400 bg-purple-500/20 dark:bg-purple-500/10 ring-1 ring-purple-500/30 dark:ring-purple-500/20"],

--- a/packages/dashboard-ui-components/src/components/data-grid/types.ts
+++ b/packages/dashboard-ui-components/src/components/data-grid/types.ts
@@ -260,6 +260,12 @@ export type DataGridCallbacks<TRow> = {
   /**
    * Fires when the row body is clicked. Selection checkboxes do not trigger
    * this — they only update `selection` — so it is safe to use for navigation.
+   *
+   * The handler is attached to the row-body wrapper (`[data-row-body]`), not
+   * the `role="row"` element, so a checkbox click can never bubble into it.
+   * Consequently `event.currentTarget` is that wrapper; use
+   * `event.currentTarget.closest('[role="row"]')` to reach row-level
+   * attributes such as `data-row-id` or to measure the full row.
    */
   onRowClick?: (row: TRow, rowId: RowId, event: React.MouseEvent) => void;
   onRowDoubleClick?: (row: TRow, rowId: RowId, event: React.MouseEvent) => void;

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -915,6 +915,12 @@ export function migrateConfigOverride(type: "project" | "branch" | "environment"
   // stricter schema validates the saved override. The generated ids are stable
   // and collision-safe so rerunning this migration is idempotent.
   if (isEnvironmentOrHigher) {
+    // Older override writes could flatten a selector below the record itself,
+    // for example `...dropKeys.user.email`. Reassemble those descendants under
+    // the record path before the record migrator turns selectors into rule ids;
+    // otherwise the current dotless-key schema sees the selector as a rule id
+    // and rejects a valid legacy override before migration can run.
+    res = reassembleFlattenedErrorIngestOverrideRecords(res);
     res = mapProperty(
       res,
       (path) => path.join(".") === "observability.errorIngest.finalScrub.dropKeys"
@@ -941,7 +947,15 @@ function migrateLegacyErrorIngestOverrideRecord(value: unknown): unknown {
       if (nestedValue === true) {
         legacySelectors.push(selectorPath.join("."));
       } else if (isObjectLike(nestedValue) && !Array.isArray(nestedValue)) {
-        collectLegacySelectors(nestedValue, selectorPath);
+        if (Object.keys(nestedValue).length === 0) {
+          // An empty nested object is still invalid under the current record
+          // schema. Preserve it so migration cannot turn malformed config into
+          // an apparently valid empty record by dropping the entry silently.
+          migrated[key] = nestedValue;
+          usedRuleIds.add(key);
+        } else {
+          collectLegacySelectors(nestedValue, selectorPath);
+        }
       } else if (typeof nestedValue === "string" && prefix.length === 0) {
         // New-format entries already have a dotless rule id and selector value.
         migrated[key] = nestedValue;
@@ -970,6 +984,44 @@ function migrateLegacyErrorIngestOverrideRecord(value: unknown): unknown {
   }
 
   return migrated;
+}
+
+const LEGACY_ERROR_INGEST_RECORD_PATHS = [
+  ["observability", "errorIngest", "finalScrub", "dropKeys"],
+  ["observability", "errorIngest", "finalScrub", "urlKeys"],
+] as const;
+
+function reassembleFlattenedErrorIngestOverrideRecords(value: unknown, path: string[] = []): unknown {
+  if (!isObjectLike(value) || Array.isArray(value)) return value;
+
+  const result: Record<string, unknown> = {};
+  const descendants = new Map<string, Record<string, unknown>>();
+  for (const [key, nestedValue] of Object.entries(value)) {
+    const fullPath = [...path, ...key.split(".")];
+    const targetPath = LEGACY_ERROR_INGEST_RECORD_PATHS.find((candidate) =>
+      fullPath.length >= candidate.length && candidate.every((segment, index) => fullPath[index] === segment),
+    );
+    if (targetPath !== undefined && fullPath.length > targetPath.length) {
+      const localTargetPath = targetPath.slice(path.length).join(".");
+      const record = descendants.get(localTargetPath) ?? {};
+      record[fullPath.slice(targetPath.length).join(".")] = nestedValue;
+      descendants.set(localTargetPath, record);
+      continue;
+    }
+
+    const isTargetPrefix = LEGACY_ERROR_INGEST_RECORD_PATHS.some((candidate) =>
+      fullPath.length < candidate.length && fullPath.every((segment, index) => candidate[index] === segment),
+    );
+    result[key] = isTargetPrefix ? reassembleFlattenedErrorIngestOverrideRecords(nestedValue, fullPath) : nestedValue;
+  }
+
+  for (const [targetPath, record] of descendants) {
+    const previous = result[targetPath];
+    result[targetPath] = isObjectLike(previous) && !Array.isArray(previous)
+      ? { ...previous, ...record }
+      : record;
+  }
+  return result;
 }
 
 import.meta.vitest?.test("migrateConfigOverride converts legacy error-ingest scrub override records", ({ expect }) => {
@@ -1003,6 +1055,30 @@ import.meta.vitest?.test("migrateConfigOverride converts legacy error-ingest scr
     },
   });
   expect(migrateConfigOverride("environment", migrated)).toEqual(migrated);
+});
+
+import.meta.vitest?.test("migrateConfigOverride reassembles flattened error-ingest selectors and preserves empty invalid entries", ({ expect }) => {
+  expect(migrateConfigOverride("environment", {
+    "observability.errorIngest.finalScrub.dropKeys.user.email": true,
+    observability: {
+      errorIngest: {
+        finalScrub: {
+          urlKeys: { tags: {} },
+        },
+      },
+    },
+  })).toEqual({
+    "observability.errorIngest.finalScrub.dropKeys": {
+      "legacy-user-email": "user.email",
+    },
+    observability: {
+      errorIngest: {
+        finalScrub: {
+          urlKeys: { tags: {} },
+        },
+      },
+    },
+  });
 });
 
 import.meta.vitest?.test("migrateConfigOverride removes legacy sourceOfTruth overrides", ({ expect }) => {

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -715,11 +715,11 @@ import.meta.vitest?.test("error-ingest policy schema matches the backend policy 
   const config = (errorIngest: unknown) => ({ observability: { errorIngest } });
 
   // `url` is a valid selector for URL scrubbing but reserved away from dropKeys.
-  await expect(environmentConfigSchema.validate(config({ finalScrub: { urlKeys: { url: true } } }))).resolves.toBeDefined();
-  await expect(environmentConfigSchema.validate(config({ finalScrub: { dropKeys: { url: true } } }))).rejects.toThrow("The url selector is only valid for URL scrubbing");
+  await expect(environmentConfigSchema.validate(config({ finalScrub: { urlKeys: { urlRule: "url" } } }))).resolves.toBeDefined();
+  await expect(environmentConfigSchema.validate(config({ finalScrub: { dropKeys: { urlRule: "url" } } }))).rejects.toThrow("The url selector is only valid for URL scrubbing");
 
   // At most 32 override keys per record, mirroring MAX_OVERRIDE_KEYS in the parser.
-  const manyKeys = Object.fromEntries(Array.from({ length: 33 }, (_, i) => [`tags.key-${i}`, true] as const));
+  const manyKeys = Object.fromEntries(Array.from({ length: 33 }, (_, i) => [`rule-${i}`, `tags.key-${i}`] as const));
   await expect(environmentConfigSchema.validate(config({ finalScrub: { dropKeys: manyKeys } }))).rejects.toThrow("must not contain more than 32 keys");
   await expect(environmentConfigSchema.validate(config({ finalScrub: { dropKeys: Object.fromEntries(Object.entries(manyKeys).slice(0, 32)) } }))).resolves.toBeDefined();
 
@@ -909,9 +909,101 @@ export function migrateConfigOverride(type: "project" | "branch" | "environment"
   }
   // END
 
+  // BEGIN 2026-08-15: error-ingest scrub overrides now use dotless rule ids as
+  // record keys because config-override path notation cannot represent dotted
+  // selectors as keys. Convert the old `{ selector: true }` shape before the
+  // stricter schema validates the saved override. The generated ids are stable
+  // and collision-safe so rerunning this migration is idempotent.
+  if (isEnvironmentOrHigher) {
+    res = mapProperty(
+      res,
+      (path) => path.join(".") === "observability.errorIngest.finalScrub.dropKeys"
+        || path.join(".") === "observability.errorIngest.finalScrub.urlKeys",
+      migrateLegacyErrorIngestOverrideRecord,
+    );
+  }
+  // END
+
   // return the result
   return res;
 };
+
+function migrateLegacyErrorIngestOverrideRecord(value: unknown): unknown {
+  if (!isObjectLike(value) || Array.isArray(value)) return value;
+
+  const migrated: Record<string, unknown> = {};
+  const usedRuleIds = new Set<string>();
+  const legacySelectors: string[] = [];
+
+  const collectLegacySelectors = (record: object, prefix: string[]): void => {
+    for (const [key, nestedValue] of Object.entries(record)) {
+      const selectorPath = [...prefix, ...key.split(".")];
+      if (nestedValue === true) {
+        legacySelectors.push(selectorPath.join("."));
+      } else if (isObjectLike(nestedValue) && !Array.isArray(nestedValue)) {
+        collectLegacySelectors(nestedValue, selectorPath);
+      } else if (typeof nestedValue === "string" && prefix.length === 0) {
+        // New-format entries already have a dotless rule id and selector value.
+        migrated[key] = nestedValue;
+        usedRuleIds.add(key);
+      } else {
+        // Preserve invalid values so the current schema still rejects malformed
+        // legacy data instead of silently dropping it during migration.
+        migrated[key] = nestedValue;
+        usedRuleIds.add(key);
+      }
+    }
+  };
+
+  collectLegacySelectors(value, []);
+  for (const selector of legacySelectors) {
+    const readableBase = `legacy-${selector.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 56) || "rule"}`;
+    let ruleId = readableBase;
+    let suffix = 2;
+    while (usedRuleIds.has(ruleId)) {
+      const suffixText = `-${suffix}`;
+      ruleId = `${readableBase.slice(0, 64 - suffixText.length)}${suffixText}`;
+      suffix += 1;
+    }
+    usedRuleIds.add(ruleId);
+    migrated[ruleId] = selector;
+  }
+
+  return migrated;
+}
+
+import.meta.vitest?.test("migrateConfigOverride converts legacy error-ingest scrub override records", ({ expect }) => {
+  const migrated = migrateConfigOverride("environment", {
+    observability: {
+      errorIngest: {
+        finalScrub: {
+          dropKeys: {
+            "legacy-user-email": "tags.existing",
+            "user.email": true,
+            tags: { "foo.bar": true },
+          },
+          urlKeys: { "request.url": true },
+        },
+      },
+    },
+  });
+
+  expect(migrated).toEqual({
+    observability: {
+      errorIngest: {
+        finalScrub: {
+          dropKeys: {
+            "legacy-user-email": "tags.existing",
+            "legacy-user-email-2": "user.email",
+            "legacy-tags-foo-bar": "tags.foo.bar",
+          },
+          urlKeys: { "legacy-request-url": "request.url" },
+        },
+      },
+    },
+  });
+  expect(migrateConfigOverride("environment", migrated)).toEqual(migrated);
+});
 
 import.meta.vitest?.test("migrateConfigOverride removes legacy sourceOfTruth overrides", ({ expect }) => {
   expect(migrateConfigOverride("project", {

--- a/packages/shared/src/utils/analytics-wire.test.ts
+++ b/packages/shared/src/utils/analytics-wire.test.ts
@@ -55,6 +55,10 @@ describe("truncateUtf8Bytes", () => {
     expect(truncateUtf8Bytes("", 0)).toBe("");
   });
 
+  it("rejects a NaN byte budget instead of bypassing the cap", () => {
+    expect(truncateUtf8Bytes("sensitive payload", Number.NaN)).toBe("");
+  });
+
   it("truncates by bytes, not characters", () => {
     // "€" is 3 UTF-8 bytes, so a 3000-char string is 9000 bytes. The result
     // is a prefix within budget; the 64-char chop step means the cut can land

--- a/packages/shared/src/utils/analytics-wire.tsx
+++ b/packages/shared/src/utils/analytics-wire.tsx
@@ -270,7 +270,9 @@ export const ERROR_MAX_DEBUG_IMAGES_BYTES = 4_096;
  * and edge runtimes, so this keeps the module dependency-free.
  */
 export function truncateUtf8Bytes(value: string, maxBytes: number): string {
-  if (maxBytes <= 0 || value === "") return "";
+  // NaN makes every `bytes + width > maxBytes` comparison false, which would
+  // otherwise let an invalid budget bypass the cap and return the full value.
+  if (Number.isNaN(maxBytes) || maxBytes <= 0 || value === "") return "";
 
   // Stop as soon as the prefix cannot fit. Encoding the entire public message
   // before truncating defeats the cap on exactly the oversized-input path this

--- a/packages/shared/src/utils/analytics-wire.tsx
+++ b/packages/shared/src/utils/analytics-wire.tsx
@@ -270,15 +270,42 @@ export const ERROR_MAX_DEBUG_IMAGES_BYTES = 4_096;
  * and edge runtimes, so this keeps the module dependency-free.
  */
 export function truncateUtf8Bytes(value: string, maxBytes: number): string {
-  const encoder = new TextEncoder();
-  if (encoder.encode(value).length <= maxBytes) return value;
-  // Chop from a chars-can't-be-shorter-than-bytes upper bound down to budget;
-  // the 64-char step keeps this O(few iterations) for realistic inputs.
-  let sliced = value.slice(0, maxBytes);
-  while (sliced.length > 0 && encoder.encode(sliced).length > maxBytes) {
-    sliced = sliced.slice(0, Math.max(0, sliced.length - 64));
+  if (maxBytes <= 0 || value === "") return "";
+
+  // Stop as soon as the prefix cannot fit. Encoding the entire public message
+  // before truncating defeats the cap on exactly the oversized-input path this
+  // helper protects, and slicing by UTF-16 units can leave a lone surrogate at
+  // the grouping boundary. Count the UTF-8 width of each code point instead;
+  // paired surrogates are admitted as one four-byte code point or rejected as a
+  // pair, so the persisted prefix and the grouping hash always agree.
+  let bytes = 0;
+  let index = 0;
+  while (index < value.length) {
+    const first = value.charCodeAt(index);
+    let width: number;
+    let units = 1;
+    if (first >= 0xd800 && first <= 0xdbff && index + 1 < value.length) {
+      const second = value.charCodeAt(index + 1);
+      if (second >= 0xdc00 && second <= 0xdfff) {
+        width = 4;
+        units = 2;
+      } else {
+        width = 3;
+      }
+    } else if (first >= 0xd800 && first <= 0xdfff) {
+      width = 3;
+    } else if (first <= 0x7f) {
+      width = 1;
+    } else if (first <= 0x7ff) {
+      width = 2;
+    } else {
+      width = 3;
+    }
+    if (bytes + width > maxBytes) break;
+    bytes += width;
+    index += units;
   }
-  return sliced;
+  return index === value.length ? value : value.slice(0, index);
 }
 
 // The one log-level vocabulary of the telemetry pipeline, ordered least to

--- a/packages/template/src/integrations/next.ts
+++ b/packages/template/src/integrations/next.ts
@@ -3,6 +3,7 @@ import { throwErr } from "@hexclave/shared/dist/utils/errors";
 import type { Instrumentation } from "@opentelemetry/instrumentation";
 import type { RequestLike } from "../lib/hexclave-app/common";
 import { getServerAppInstrumentation } from "../lib/hexclave-app/apps/implementations/server-app-impl";
+import { preCaught } from "../lib/hexclave-app/apps/implementations/telemetry-core";
 import { AdapterServerApp, AdapterTelemetryOptions, AdapterUser, HexclaveRequestContext, runGuardedCall, runGuardedRoute, UnauthorizedFactory } from "./adapter-core";
 
 /**
@@ -256,25 +257,23 @@ export function hexclaveInstrumentation(app: AdapterServerApp, options?: Hexclav
   }
   return {
     runWithTelemetrySuppressed: async (fn) => await instrumentation.runWithTelemetrySuppressed(fn),
-    // Returned directly (not wrapped in async/await): captureServerRequestError
-    // returns a PRE-CAUGHT promise, and an async wrapper would mint a new,
-    // un-caught promise whose rejection becomes an unhandled rejection for
-    // fire-and-forget callers. Callers that await it still observe failures.
-    captureHandledError: (error, info) => instrumentation.captureServerRequestError(error, {
+    // Promise.resolve().then() preserves the promise-returning contract even
+    // when the instrumentation seam throws synchronously. preCaught also
+    // covers callers that intentionally fire-and-forget this hook.
+    captureHandledError: (error, info) => preCaught(Promise.resolve().then(async () => await instrumentation.captureServerRequestError(error, {
       mechanism: "captured",
       handled: true,
       data: {
         ...info?.data ?? {},
         ...info?.location === undefined ? {} : { location: info.location },
-        // Re-asserted AFTER the user-data spread: captureServerRequestError
-        // merges `data` over the flattened $error payload, so without this a
-        // caller passing `data: { handled: false }` (or a custom
-        // mechanism_type) could flip the handled/unhandled classification
-        // that this API guarantees.
+        // Reserved mechanism fields are supplied separately below. The server
+        // capture seam also writes those authoritative fields after this
+        // metadata; keeping them here makes the adapter contract explicit even
+        // when the instrumentation seam is replaced by a structural test spy.
         mechanism_type: "captured",
         handled: true,
       },
-    }),
+    }))),
     register: async () => {
       instrumentation.ensureOpenTelemetryProvider();
       instrumentation.installServerErrorMonitor();

--- a/packages/template/src/lib/hexclave-app/apps/implementations/browser-otel-queue.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/browser-otel-queue.ts
@@ -51,7 +51,10 @@ export type BrowserOtlpOfflineQueue = {
 
 const AUTH_GENERATION_KEY = "auth-generation";
 const QUEUE_BYTES_KEY = "queue-bytes";
-const DATABASE_VERSION = 1;
+// Version 2 creates every signal store in a custom database. Version 1 used a
+// single literal custom dbName for all signals, so upgrading that database must
+// preserve its existing batches while adding the stores for the other signals.
+const DATABASE_VERSION = 2;
 
 function normalizeQueueNumber(value: unknown, fallback: number): number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : fallback;
@@ -205,11 +208,15 @@ function openDatabase(options: BrowserOtlpOfflineQueueOptions): Promise<IDBDatab
 
     request.onupgradeneeded = () => {
       const database = request.result;
-      if (!database.objectStoreNames.contains(options.storeName)) {
-        database.createObjectStore(options.storeName, { autoIncrement: true });
-      }
-      if (!database.objectStoreNames.contains(`${options.storeName}-meta`)) {
-        database.createObjectStore(`${options.storeName}-meta`);
+      const storeNames = new Set([options.storeName, "batches-traces", "batches-logs", "batches-metrics"]);
+      for (const storeName of storeNames) {
+        if (!database.objectStoreNames.contains(storeName)) {
+          database.createObjectStore(storeName, { autoIncrement: true });
+        }
+        const metaStoreName = `${storeName}-meta`;
+        if (!database.objectStoreNames.contains(metaStoreName)) {
+          database.createObjectStore(metaStoreName);
+        }
       }
     };
     request.onsuccess = () => {

--- a/packages/template/src/lib/hexclave-app/apps/implementations/browser-otel-queue.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/browser-otel-queue.ts
@@ -51,9 +51,9 @@ export type BrowserOtlpOfflineQueue = {
 
 const AUTH_GENERATION_KEY = "auth-generation";
 const QUEUE_BYTES_KEY = "queue-bytes";
-// Version 2 creates every signal store in a custom database. Version 1 used a
-// single literal custom dbName for all signals, so upgrading that database must
-// preserve its existing batches while adding the stores for the other signals.
+// Version 2 adds the stores for every signal to whichever database is opened.
+// Keeping the version bump also upgrades older per-signal databases without
+// changing their existing queue contents.
 const DATABASE_VERSION = 2;
 
 function normalizeQueueNumber(value: unknown, fallback: number): number {
@@ -224,8 +224,12 @@ function openDatabase(options: BrowserOtlpOfflineQueueOptions): Promise<IDBDatab
       database.onversionchange = () => database.close();
       resolve(database);
     };
+    // A previous SDK instance in another tab may still hold the old database
+    // version open. Do not reject here: IndexedDB keeps the request pending and
+    // fires `onsuccess` after that connection closes, which is the safe retry
+    // path. Leaving `onblocked` unset preserves that behavior; the caller's
+    // normal operation deadline remains the bound.
     request.onerror = () => reject(persistenceError("open", request.error));
-    request.onblocked = () => reject(new BrowserOtlpQueuePersistenceError("IndexedDB open was blocked by another connection"));
   });
 }
 

--- a/packages/template/src/lib/hexclave-app/apps/implementations/browser-otel-sdk.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/browser-otel-sdk.test.ts
@@ -116,6 +116,25 @@ describe("managed browser OpenTelemetry", () => {
     expect(inject().get("baggage")).toContain("segment-1");
   });
 
+  it("does not let same-project owners disagree about the page-global baggage policy", async () => {
+    const makeOptions = (correlationBaggage: boolean) => ({
+      analyticsBaseUrl: "https://analytics.example.test",
+      projectId: "project-shared",
+      clientVersion: "test",
+      traceSampleRate: 1,
+      resource: { service: { name: "storefront" } },
+      getRequestHeaders: async () => ({}),
+      networkCapture: { enabled: true, allowOrigins: null, denyOrigins: null, ignoreUrls: [] },
+      getPropagationPolicy: () => ({ allowedOrigins: [], allowLocalhost: false, correlationBaggage }),
+      getAmbientOtelContext: () => null,
+    });
+
+    registerManagedBrowserOtel(makeOptions(true));
+    expect(() => registerManagedBrowserOtel(makeOptions(false))).toThrow(
+      "Hexclave browser OpenTelemetry is already configured for a different project or resource on this page",
+    );
+  });
+
   it("resolves rotating credentials for each OTLP export", async () => {
     const receivedUrls: string[] = [];
     const receivedAccessTokens: string[] = [];

--- a/packages/template/src/lib/hexclave-app/apps/implementations/browser-otel-sdk.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/browser-otel-sdk.ts
@@ -243,8 +243,9 @@ export type HexclaveBrowserOtelExporterOptions = {
 
 export type BrowserOtlpOfflineQueueOptions = {
   /**
-   * IndexedDB database name PREFIX. Each signal (traces/logs/metrics) stores
-   * its queue in its own `${dbName}-${signal}` database.
+   * IndexedDB database name. The default uses one database per signal; a
+   * configured name remains the legacy shared database name so queued batches
+   * written by older SDK versions remain readable after upgrade.
    */
   dbName?: string,
   maxQueueSize?: number,
@@ -378,12 +379,10 @@ function queueOptionsForExporter(options: HexclaveBrowserOtelExporterOptions, si
 } {
   const projectKey = encodeURIComponent(options.projectId);
   return {
-    // A configured dbName is a PREFIX — one database per signal. All three
-    // signal queues sharing one literal database would break: IndexedDB runs
-    // onupgradeneeded only once per version, so whichever signal opened the
-    // shared database first would create only its own object stores and the
-    // other signals' transactions would fail with NotFoundError.
-    dbName: `${options.offlineQueue?.dbName ?? `hexclave-otlp-offline-${projectKey}`}-${signal}`,
+    // Custom names were literal database names before signal suffixes were
+    // introduced. Keep that name so old queued batches are drained; the queue
+    // schema upgrade creates all signal stores in the shared database.
+    dbName: options.offlineQueue?.dbName ?? `hexclave-otlp-offline-${projectKey}-${signal}`,
     storeName: `batches-${signal}`,
     maxQueueSize: normalizedPositiveInteger(options.offlineQueue?.maxQueueSize, OTLP_OFFLINE_QUEUE_MAX_SIZE),
     maxQueueBytes: normalizedPositiveInteger(options.offlineQueue?.maxQueueBytes, OTLP_OFFLINE_QUEUE_MAX_BYTES),
@@ -1555,6 +1554,10 @@ function registrationSignature(options: BrowserManagedOtelOptions): string {
     projectId: options.projectId,
     resource: options.resource,
     traceSampleRate: options.traceSampleRate,
+    // This policy is installed into the page-global propagator. Treat it as
+    // part of provider ownership so a second same-project app cannot silently
+    // inherit the first owner's baggage behavior.
+    correlationBaggage: options.getPropagationPolicy().correlationBaggage,
   });
 }
 

--- a/packages/template/src/lib/hexclave-app/apps/implementations/browser-otel-sdk.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/browser-otel-sdk.ts
@@ -243,9 +243,8 @@ export type HexclaveBrowserOtelExporterOptions = {
 
 export type BrowserOtlpOfflineQueueOptions = {
   /**
-   * IndexedDB database name. The default uses one database per signal; a
-   * configured name remains the legacy shared database name so queued batches
-   * written by older SDK versions remain readable after upgrade.
+   * IndexedDB database name prefix. Each signal stores its queue in its own
+   * `${dbName}-${signal}` database, preserving the naming used by older SDKs.
    */
   dbName?: string,
   maxQueueSize?: number,
@@ -379,10 +378,9 @@ function queueOptionsForExporter(options: HexclaveBrowserOtelExporterOptions, si
 } {
   const projectKey = encodeURIComponent(options.projectId);
   return {
-    // Custom names were literal database names before signal suffixes were
-    // introduced. Keep that name so old queued batches are drained; the queue
-    // schema upgrade creates all signal stores in the shared database.
-    dbName: options.offlineQueue?.dbName ?? `hexclave-otlp-offline-${projectKey}-${signal}`,
+    // Keep custom names as a prefix so upgrades continue reading the existing
+    // per-signal databases instead of silently starting a fresh queue.
+    dbName: `${options.offlineQueue?.dbName ?? `hexclave-otlp-offline-${projectKey}`}-${signal}`,
     storeName: `batches-${signal}`,
     maxQueueSize: normalizedPositiveInteger(options.offlineQueue?.maxQueueSize, OTLP_OFFLINE_QUEUE_MAX_SIZE),
     maxQueueBytes: normalizedPositiveInteger(options.offlineQueue?.maxQueueBytes, OTLP_OFFLINE_QUEUE_MAX_BYTES),

--- a/packages/template/src/lib/hexclave-app/apps/implementations/debug-ids.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/debug-ids.ts
@@ -169,7 +169,12 @@ function indexOfFrameLocation(stack: string, codeFile: string): number {
     const index = stack.indexOf(codeFile, from);
     if (index < 0) return -1;
     const end = index + codeFile.length;
-    if (stack.charCodeAt(end) === 0x3a /* ":" */) {
+    const lineStart = stack.lastIndexOf("\n", index - 1) + 1;
+    const linePrefix = stack.slice(lineStart, index);
+    const hasFrameDelimiter = linePrefix.endsWith("at ")
+      || linePrefix.endsWith("(")
+      || linePrefix.endsWith("@");
+    if (hasFrameDelimiter && stack.charCodeAt(end) === 0x3a /* ":" */) {
       const digit = stack.charCodeAt(end + 1);
       if (digit >= 0x30 && digit <= 0x39) return index;
     }

--- a/packages/template/src/lib/hexclave-app/apps/implementations/error-capture.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/error-capture.ts
@@ -181,16 +181,43 @@ const exceptionValueEncoder = new TextEncoder();
  * Frames are capped at the raw-stack frame budget for the same reason.
  */
 function boundExceptionValue(value: CapturedExceptionValue): CapturedExceptionValue {
+  const boundFrame = (frame: ErrorStackFrame): ErrorStackFrame => ({
+    ...frame.filename === undefined ? {} : { filename: truncateUtf8Bytes(frame.filename, ERROR_TEXT_MAX_BYTES) },
+    ...frame.absPath === undefined ? {} : { absPath: truncateUtf8Bytes(frame.absPath, ERROR_TEXT_MAX_BYTES) },
+    ...frame.function === undefined ? {} : { function: truncateUtf8Bytes(frame.function, ERROR_TEXT_MAX_BYTES) },
+    ...frame.module === undefined ? {} : { module: truncateUtf8Bytes(frame.module, ERROR_TEXT_MAX_BYTES) },
+    ...frame.lineno === undefined ? {} : { lineno: frame.lineno },
+    ...frame.colno === undefined ? {} : { colno: frame.colno },
+    ...frame.inApp === undefined ? {} : { inApp: frame.inApp },
+    ...frame.contextLine === undefined ? {} : { contextLine: truncateUtf8Bytes(frame.contextLine, ERROR_TEXT_MAX_BYTES) },
+  });
+  const boundMechanism = value.mechanism === undefined ? undefined : {
+    ...value.mechanism.type === undefined ? {} : { type: truncateUtf8Bytes(value.mechanism.type, ERROR_TEXT_MAX_BYTES) },
+    ...value.mechanism.handled === undefined ? {} : { handled: value.mechanism.handled },
+    ...value.mechanism.data === undefined ? {} : jsonSafeMechanismData(value.mechanism.data),
+  };
   const stacktrace = value.stacktrace === undefined ? undefined : {
     ...value.stacktrace.raw === undefined ? {} : { raw: truncateUtf8Bytes(value.stacktrace.raw, ERROR_TEXT_MAX_BYTES) },
-    ...value.stacktrace.frames === undefined ? {} : { frames: value.stacktrace.frames.slice(0, ERROR_STACK_TRACE_LIMIT) },
+    ...value.stacktrace.frames === undefined ? {} : { frames: value.stacktrace.frames.slice(0, ERROR_STACK_TRACE_LIMIT).map(boundFrame) },
   };
   return {
-    ...value,
     ...value.type === undefined ? {} : { type: truncateUtf8Bytes(value.type, ERROR_TEXT_MAX_BYTES) },
     ...value.value === undefined ? {} : { value: truncateUtf8Bytes(value.value, ERROR_TEXT_MAX_BYTES) },
+    ...boundMechanism === undefined ? {} : { mechanism: boundMechanism },
     ...stacktrace === undefined ? {} : { stacktrace },
   };
+}
+
+function jsonSafeMechanismData(data: Record<string, unknown>): { data?: Record<string, unknown> } {
+  // Adapter metadata is outside the typed scalar fields and may contain a
+  // cycle or BigInt. Validate it once here; dropping only that optional field
+  // keeps capture synchronous and preserves the bounded exception identity.
+  try {
+    JSON.stringify(data);
+    return { data };
+  } catch {
+    return {};
+  }
 }
 
 /**
@@ -202,8 +229,20 @@ function boundExceptionValue(value: CapturedExceptionValue): CapturedExceptionVa
  * cap. The root always survives, even alone over budget: an over-budget event
  * beats silently losing the primary identity.
  */
-function boundExceptionValues(values: readonly CapturedExceptionValue[]): CapturedExceptionValue[] {
+function boundExceptionValues(values: readonly CapturedExceptionValue[], primaryMechanism: { type: string, handled: boolean }): CapturedExceptionValue[] {
   const bounded = values.slice(-MAX_LINKED_ERROR_VALUES).map(boundExceptionValue);
+  const primaryIndex = bounded.length - 1;
+  if (primaryIndex >= 0) {
+    const primary = bounded[primaryIndex];
+    bounded[primaryIndex] = {
+      ...primary,
+      mechanism: {
+        ...primary.mechanism,
+        type: truncateUtf8Bytes(primaryMechanism.type, ERROR_TEXT_MAX_BYTES),
+        handled: primaryMechanism.handled,
+      },
+    };
+  }
   const kept: CapturedExceptionValue[] = [];
   // Byte accounting mirrors what JSON.stringify(values) actually costs: the
   // enclosing `[]` plus one `,` between entries.
@@ -353,18 +392,10 @@ export function buildErrorEventDataFromNormalized(normalized: NormalizedError, o
   // Bounded at the single choke point every capture path funnels through, so
   // neither a deep automatic cause chain nor an adapter-supplied chain can
   // push the event past the shared item-data budget.
-  const exceptionValues = boundExceptionValues(options.exceptionValues ?? [exceptionValueFromNormalized(normalized)]);
-  const primaryExceptionIndex = exceptionValues.length - 1;
-  const exceptions = exceptionValues.map((exception, index) => index === primaryExceptionIndex
-    ? {
-      ...exception,
-      mechanism: {
-        ...exception.mechanism,
-        type: options.mechanismType,
-        handled: options.handled,
-      },
-    }
-    : exception);
+  const exceptionValues = boundExceptionValues(options.exceptionValues ?? [exceptionValueFromNormalized(normalized)], {
+    type: options.mechanismType,
+    handled: options.handled,
+  });
   return {
     event_id: options.eventId ?? generateErrorEventId(),
     message,
@@ -374,7 +405,7 @@ export function buildErrorEventDataFromNormalized(normalized: NormalizedError, o
     mechanism_type: options.mechanismType,
     handled: options.handled,
     ...normalized.synthetic || options.synthetic === true ? { synthetic: 1 } : {},
-    exception: { values: exceptions },
+    exception: { values: exceptionValues },
     // Fingerprint over the UNTRUNCATED inputs would differ from what a reader
     // can recompute from the row, so hash the bounded values.
     fingerprint: computeErrorFingerprint(normalized.name, message, stack),

--- a/packages/template/src/lib/hexclave-app/apps/implementations/error-scope.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/error-scope.ts
@@ -37,7 +37,9 @@ function copyScopeData(data: ErrorScopeData | undefined): ErrorScopeData {
     ...data.breadcrumbs === undefined ? {} : { breadcrumbs: data.breadcrumbs.slice(-MAX_BREADCRUMBS).map((breadcrumb) => ({ ...breadcrumb, ...breadcrumb.data === undefined ? {} : { data: { ...breadcrumb.data } } })) },
     ...data.level === undefined ? {} : { level: data.level },
     ...data.fingerprint === undefined ? {} : { fingerprint: [...data.fingerprint] },
-    ...data.eventProcessors === undefined ? {} : { eventProcessors: [...data.eventProcessors] },
+    // Match addEventProcessor and preserve the newest processors when a
+    // caller seeds an oversized initial scope.
+    ...data.eventProcessors === undefined ? {} : { eventProcessors: data.eventProcessors.slice(-MAX_EVENT_PROCESSORS) },
     ...data.attachments === undefined ? {} : { attachments: cloneErrorAttachmentInputs(data.attachments) },
   };
 }

--- a/packages/template/src/lib/hexclave-app/apps/implementations/integration-registry.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/integration-registry.test.ts
@@ -380,6 +380,8 @@ describe("error integration registry", () => {
     fixture.xhrBreadcrumb?.handler({ method: "put", url: "blob:https://private.example.test/some-uuid", statusCode: 202 });
     fixture.xhrBreadcrumb?.handler({ method: "patch", url: "file:///Users/private/secret.txt", statusCode: 203 });
     fixture.xhrBreadcrumb?.handler({ method: "delete", url: "file://[private/secret", statusCode: 204 });
+    fixture.xhrBreadcrumb?.handler({ method: "head", url: "\u0000data:text/plain,secret", statusCode: 205 });
+    fixture.xhrBreadcrumb?.handler({ method: "options", url: "  javascript:alert(secret)", statusCode: 206 });
 
     expect(fixture.breadcrumbs).toEqual([
       { category: "xhr", level: "info", data: { method: "GET", url: "<data-url>", status_code: 200 } },
@@ -387,6 +389,8 @@ describe("error integration registry", () => {
       { category: "xhr", level: "info", data: { method: "PUT", url: "<blob-url>", status_code: 202 } },
       { category: "xhr", level: "info", data: { method: "PATCH", url: "<file-url>", status_code: 203 } },
       { category: "xhr", level: "info", data: { method: "DELETE", url: "<file-url>", status_code: 204 } },
+      { category: "xhr", level: "info", data: { method: "HEAD", url: "<data-url>", status_code: 205 } },
+      { category: "xhr", level: "info", data: { method: "OPTIONS", url: "<javascript-url>", status_code: 206 } },
     ]);
   });
 

--- a/packages/template/src/lib/hexclave-app/apps/implementations/integration-registry.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/integration-registry.test.ts
@@ -379,12 +379,14 @@ describe("error integration registry", () => {
     fixture.xhrBreadcrumb?.handler({ method: "post", url: "DATA:text/plain,secret", statusCode: 201 });
     fixture.xhrBreadcrumb?.handler({ method: "put", url: "blob:https://private.example.test/some-uuid", statusCode: 202 });
     fixture.xhrBreadcrumb?.handler({ method: "patch", url: "file:///Users/private/secret.txt", statusCode: 203 });
+    fixture.xhrBreadcrumb?.handler({ method: "delete", url: "file://[private/secret", statusCode: 204 });
 
     expect(fixture.breadcrumbs).toEqual([
       { category: "xhr", level: "info", data: { method: "GET", url: "<data-url>", status_code: 200 } },
       { category: "xhr", level: "info", data: { method: "POST", url: "<data-url>", status_code: 201 } },
       { category: "xhr", level: "info", data: { method: "PUT", url: "<blob-url>", status_code: 202 } },
       { category: "xhr", level: "info", data: { method: "PATCH", url: "<file-url>", status_code: 203 } },
+      { category: "xhr", level: "info", data: { method: "DELETE", url: "<file-url>", status_code: 204 } },
     ]);
   });
 

--- a/packages/template/src/lib/hexclave-app/apps/implementations/integration-registry.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/integration-registry.ts
@@ -295,8 +295,17 @@ function safeText(value: string, maxBytes: number): string {
 function safeUrlPath(value: string | undefined, maxBytes: number): string | undefined {
   if (value === undefined || value === "") return undefined;
 
+  // URL parsing ignores leading C0 controls and spaces, but the fallback
+  // relative-URL interpretation below would otherwise expose a non-HTTP
+  // payload as a pathname. Normalize that prefix before classifying the scheme.
+  const normalized = value.replace(/^[\u0000-\u0020]+/u, "");
+  const explicitScheme = /^([a-z][a-z\d+.-]*):/iu.exec(normalized)?.[1]?.toLowerCase();
+  if (explicitScheme !== undefined && explicitScheme !== "http" && explicitScheme !== "https") {
+    return truncateUtf8Bytes(`<${explicitScheme}-url>`, maxBytes);
+  }
+
   try {
-    const parsed = new URL(value, "https://hexclave.invalid");
+    const parsed = new URL(normalized, "https://hexclave.invalid");
     // Only http(s) pathnames are structural route information. For every other
     // scheme, `pathname` IS the URL's payload — a data: URL's inlined content,
     // a blob: URL's inner origin, a file: URL's local path, javascript: code —
@@ -307,10 +316,6 @@ function safeUrlPath(value: string | undefined, maxBytes: number): string | unde
     }
     return truncateUtf8Bytes(parsed.pathname || "/", maxBytes);
   } catch {
-    const scheme = /^([a-z][a-z\d+.-]*):/iu.exec(value)?.[1]?.toLowerCase();
-    if (scheme !== undefined && scheme !== "http" && scheme !== "https") {
-      return truncateUtf8Bytes(`<${scheme}-url>`, maxBytes);
-    }
     const queryStart = value.search(/[?#]/);
     return truncateUtf8Bytes(value.slice(0, queryStart === -1 ? value.length : queryStart), maxBytes);
   }

--- a/packages/template/src/lib/hexclave-app/apps/implementations/integration-registry.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/integration-registry.ts
@@ -307,6 +307,10 @@ function safeUrlPath(value: string | undefined, maxBytes: number): string | unde
     }
     return truncateUtf8Bytes(parsed.pathname || "/", maxBytes);
   } catch {
+    const scheme = /^([a-z][a-z\d+.-]*):/iu.exec(value)?.[1]?.toLowerCase();
+    if (scheme !== undefined && scheme !== "http" && scheme !== "https") {
+      return truncateUtf8Bytes(`<${scheme}-url>`, maxBytes);
+    }
     const queryStart = value.search(/[?#]/);
     return truncateUtf8Bytes(value.slice(0, queryStart === -1 ? value.length : queryStart), maxBytes);
   }

--- a/packages/template/src/lib/hexclave-app/apps/implementations/otel-log-facade.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/otel-log-facade.test.ts
@@ -134,6 +134,32 @@ describe("emitHexclaveOtelLog", () => {
     }]);
   });
 
+  it("passes each property's JSON key to toJSON", async () => {
+    const exporter = new InMemoryLogRecordExporter();
+    const provider = new LoggerProvider({ processors: [new SimpleLogRecordProcessor({ exporter })] });
+    providers.push(provider);
+    logs.setGlobalLoggerProvider(provider);
+    const keys: string[] = [];
+
+    emitHexclaveOtelLog({
+      message: "key-aware value",
+      level: "info",
+      data: {
+        custom: {
+          toJSON(key: string): string {
+            keys.push(key);
+            return key;
+          },
+        },
+      },
+      origin: "logger",
+    }, "test-version");
+    await provider.forceFlush();
+
+    expect(keys).toEqual(["custom"]);
+    expect(exporter.getFinishedLogRecords()[0]?.attributes["hexclave.data"]).toMatchObject({ custom: "custom" });
+  });
+
   it("emits product events as named OTel LogRecords with explicit parent context", async () => {
     const exporter = new InMemoryLogRecordExporter();
     const provider = new LoggerProvider({ processors: [new SimpleLogRecordProcessor({ exporter })] });

--- a/packages/template/src/lib/hexclave-app/apps/implementations/otel-log-facade.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/otel-log-facade.test.ts
@@ -134,6 +134,30 @@ describe("emitHexclaveOtelLog", () => {
     }]);
   });
 
+  it("omits undefined object values and writes null for undefined array values", async () => {
+    const exporter = new InMemoryLogRecordExporter();
+    const provider = new LoggerProvider({ processors: [new SimpleLogRecordProcessor({ exporter })] });
+    providers.push(provider);
+    logs.setGlobalLoggerProvider(provider);
+    const sparse: unknown[] = [];
+    sparse[1] = undefined;
+
+    emitHexclaveOtelLog({
+      message: "undefined values",
+      level: "info",
+      data: {
+        omitted: { toJSON: () => undefined },
+        values: [undefined, ...sparse, { toJSON: () => undefined }],
+      },
+      origin: "logger",
+    }, "test-version");
+    await provider.forceFlush();
+
+    expect(exporter.getFinishedLogRecords()[0]?.attributes["hexclave.data"]).toEqual({
+      values: [null, null, null, null],
+    });
+  });
+
   it("passes each property's JSON key to toJSON", async () => {
     const exporter = new InMemoryLogRecordExporter();
     const provider = new LoggerProvider({ processors: [new SimpleLogRecordProcessor({ exporter })] });

--- a/packages/template/src/lib/hexclave-app/apps/implementations/otel-log-facade.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/otel-log-facade.ts
@@ -13,14 +13,19 @@ const SEVERITY_NUMBERS = new Map<LogLevel, SeverityNumber>([
 
 function objectEntriesToAnyValueMap(value: object): AnyValueMap {
   const result: AnyValueMap = {};
-  for (const [key, child] of Object.entries(value)) result[key] = toOtelAnyValue(child);
+  for (const [key, child] of Object.entries(value)) {
+    // Match JSON.stringify: enumerable function and undefined properties are
+    // omitted from objects, rather than becoming an OTel `undefined` value.
+    if (typeof child === "function" || child === undefined) continue;
+    result[key] = toOtelAnyValue(child, key);
+  }
   return result;
 }
 
-function toOtelAnyValue(value: unknown): AnyValue {
+function toOtelAnyValue(value: unknown, key = ""): AnyValue {
   if (value === null || value === undefined || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
   if (value instanceof Uint8Array) return value;
-  if (Array.isArray(value)) return value.map(toOtelAnyValue);
+  if (Array.isArray(value)) return value.map((entry, index) => toOtelAnyValue(entry, String(index)));
   if (typeof value === "object") {
     // Follow JSON.stringify's semantics: the accepted-data contract is "JSON
     // serializable" (getCustomTelemetryDataError validates via stringify, which
@@ -28,7 +33,7 @@ function toOtelAnyValue(value: unknown): AnyValue {
     // properties instead would silently turn e.g. a Date into `{}`.
     const toJson: unknown = Reflect.get(value, "toJSON");
     if (typeof toJson === "function") {
-      const jsonValue: unknown = Reflect.apply(toJson, value, []);
+      const jsonValue: unknown = Reflect.apply(toJson, value, [key]);
       // Like JSON.stringify, toJSON is consulted once per level: converting an
       // object result through toOtelAnyValue again would loop forever when
       // toJSON returns `this`. Children still get their own toJSON treatment.

--- a/packages/template/src/lib/hexclave-app/apps/implementations/otel-log-facade.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/otel-log-facade.ts
@@ -17,15 +17,20 @@ function objectEntriesToAnyValueMap(value: object): AnyValueMap {
     // Match JSON.stringify: enumerable function and undefined properties are
     // omitted from objects, rather than becoming an OTel `undefined` value.
     if (typeof child === "function" || child === undefined) continue;
-    result[key] = toOtelAnyValue(child, key);
+    const converted = toOtelAnyValue(child, key);
+    if (converted !== undefined) result[key] = converted;
   }
   return result;
 }
 
-function toOtelAnyValue(value: unknown, key = ""): AnyValue {
+function toOtelAnyValue(value: unknown, key = ""): AnyValue | undefined {
   if (value === null || value === undefined || typeof value === "string" || typeof value === "number" || typeof value === "boolean") return value;
   if (value instanceof Uint8Array) return value;
-  if (Array.isArray(value)) return value.map((entry, index) => toOtelAnyValue(entry, String(index)));
+  if (Array.isArray(value)) {
+    // JSON.stringify turns undefined, functions, and sparse slots into null
+    // inside arrays. Array.from visits holes, unlike Array.prototype.map.
+    return Array.from(value, (entry, index) => toOtelAnyValue(entry, String(index)) ?? null);
+  }
   if (typeof value === "object") {
     // Follow JSON.stringify's semantics: the accepted-data contract is "JSON
     // serializable" (getCustomTelemetryDataError validates via stringify, which

--- a/packages/template/src/lib/hexclave-app/apps/implementations/otel-sdk.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/otel-sdk.test.ts
@@ -85,7 +85,7 @@ describe("Hexclave managed OTel SDK", () => {
     const eager = registerManagedOtel(options);
 
     const prisma = fakeInstrumentation("@prisma/instrumentation");
-    const late = registerManagedOtel({ ...options, instrumentations: [prisma] });
+    const late = registerManagedOtel({ ...options, instrumentations: [prisma, prisma] });
     expect(late).toBe(eager);
     expect(prisma.setTracerProvider).toHaveBeenCalledTimes(1);
 

--- a/packages/template/src/lib/hexclave-app/apps/implementations/otel-sdk.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/otel-sdk.test.ts
@@ -95,6 +95,38 @@ describe("Hexclave managed OTel SDK", () => {
     expect(prismaAgain.enable).not.toHaveBeenCalled();
   });
 
+  it("keeps successful instrumentation registrations marked when a later one fails", () => {
+    const fakeInstrumentation = (name: string, enable: () => void = () => {}) => ({
+      instrumentationName: name,
+      instrumentationVersion: "1.0.0",
+      enable: vi.fn(enable),
+      disable: vi.fn(),
+      setTracerProvider: vi.fn(),
+      setMeterProvider: vi.fn(),
+      setConfig: vi.fn(),
+      getConfig: vi.fn(() => ({})),
+    });
+    const options = {
+      analyticsBaseUrl: "http://127.0.0.1:8102",
+      projectId: "project",
+      secretServerKey: "secret",
+      clientVersion: "test",
+      traceSampleRate: 1,
+      resource: { serviceName: "checkout" },
+    };
+    registerManagedOtel(options);
+    const first = fakeInstrumentation("first");
+    const second = fakeInstrumentation("second", () => {
+      throw new Error("second instrumentation failed");
+    });
+
+    expect(() => registerManagedOtel({ ...options, instrumentations: [first, second] })).toThrow("second instrumentation failed");
+
+    const firstAgain = fakeInstrumentation("first");
+    registerManagedOtel({ ...options, instrumentations: [firstAgain] });
+    expect(firstAgain.enable).not.toHaveBeenCalled();
+  });
+
   it("still rejects a different project in the same process", () => {
     const options = {
       analyticsBaseUrl: "http://127.0.0.1:8102",

--- a/packages/template/src/lib/hexclave-app/apps/implementations/otel-sdk.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/otel-sdk.ts
@@ -266,13 +266,20 @@ export function registerManagedOtel(options: ManagedOtelOptions): ManagedOtelReg
   const installedInstrumentationNames = new Set<string>();
   const instrumentationDisposers: (() => void)[] = [];
   const installInstrumentations = (instrumentations: NonNullable<ManagedOtelOptions["instrumentations"]>): void => {
-    const missing = instrumentations.filter((instrumentation) => !installedInstrumentationNames.has(instrumentation.instrumentationName));
+    const requestedNames = new Set<string>();
+    const missing = instrumentations.filter((instrumentation) => {
+      if (installedInstrumentationNames.has(instrumentation.instrumentationName) || requestedNames.has(instrumentation.instrumentationName)) return false;
+      requestedNames.add(instrumentation.instrumentationName);
+      return true;
+    });
     if (missing.length === 0) return;
-    for (const instrumentation of missing) installedInstrumentationNames.add(instrumentation.instrumentationName);
     instrumentationDisposers.push(registerInstrumentations({
       instrumentations: missing,
       tracerProvider: provider,
     }));
+    // Only mark names after registration succeeds. A failed registration must
+    // remain retryable instead of permanently suppressing the instrumentation.
+    for (const instrumentation of missing) installedInstrumentationNames.add(instrumentation.instrumentationName);
   };
   installInstrumentations([httpInstrumentation, ...options.instrumentations ?? []]);
   const value: ManagedOtelRegistration = {

--- a/packages/template/src/lib/hexclave-app/apps/implementations/otel-sdk.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/otel-sdk.ts
@@ -273,13 +273,16 @@ export function registerManagedOtel(options: ManagedOtelOptions): ManagedOtelReg
       return true;
     });
     if (missing.length === 0) return;
-    instrumentationDisposers.push(registerInstrumentations({
-      instrumentations: missing,
-      tracerProvider: provider,
-    }));
-    // Only mark names after registration succeeds. A failed registration must
-    // remain retryable instead of permanently suppressing the instrumentation.
-    for (const instrumentation of missing) installedInstrumentationNames.add(instrumentation.instrumentationName);
+    // Register one at a time so a failure after an earlier enable cannot leave
+    // an enabled instrumentation unmarked. A later HMR retry must skip only the
+    // instrumentations that actually succeeded, or it will double-patch them.
+    for (const instrumentation of missing) {
+      instrumentationDisposers.push(registerInstrumentations({
+        instrumentations: [instrumentation],
+        tracerProvider: provider,
+      }));
+      installedInstrumentationNames.add(instrumentation.instrumentationName);
+    }
   };
   installInstrumentations([httpInstrumentation, ...options.instrumentations ?? []]);
   const value: ManagedOtelRegistration = {

--- a/packages/template/src/lib/hexclave-app/apps/implementations/otel-span-facade.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/otel-span-facade.test.ts
@@ -146,6 +146,24 @@ describe("OTel Span facade", () => {
     expect(exporter.getFinishedSpans().map((span) => span.name)).toEqual(["checkout"]);
   });
 
+  it("preserves the registration error when cleanup rejects", () => {
+    const { exporter, provider, capabilities } = fixture();
+    const registrationError = new Error("span registry unavailable");
+    const cleanupError = new Error("span cleanup unavailable");
+
+    expect(() => createOtelSpanFacade({
+      tracer: provider.getTracer("facade-test"),
+      spanType: "checkout",
+      capabilities: {
+        ...capabilities,
+        onStarted: () => { throw registrationError; },
+        onEnded: () => { throw cleanupError; },
+      },
+    })).toThrow(registrationError);
+
+    expect(exporter.getFinishedSpans().map((span) => span.name)).toEqual(["checkout"]);
+  });
+
   it("lets the official propagator preserve an upstream tracestate", async () => {
     const { provider, capabilities } = fixture();
     const span = createOtelSpanFacade({

--- a/packages/template/src/lib/hexclave-app/apps/implementations/otel-span-facade.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/otel-span-facade.test.ts
@@ -127,6 +127,25 @@ describe("OTel Span facade", () => {
     expect(started[1]?.spanId).toBe(child.spanId);
   });
 
+  it("ends and deregisters a span when onStarted rejects", () => {
+    const { exporter, provider, capabilities } = fixture();
+    const onEnded = vi.fn();
+    const registrationError = new Error("span registry unavailable");
+
+    expect(() => createOtelSpanFacade({
+      tracer: provider.getTracer("facade-test"),
+      spanType: "checkout",
+      capabilities: {
+        ...capabilities,
+        onStarted: () => { throw registrationError; },
+        onEnded,
+      },
+    })).toThrow(registrationError);
+
+    expect(onEnded).toHaveBeenCalledTimes(1);
+    expect(exporter.getFinishedSpans().map((span) => span.name)).toEqual(["checkout"]);
+  });
+
   it("lets the official propagator preserve an upstream tracestate", async () => {
     const { provider, capabilities } = fixture();
     const span = createOtelSpanFacade({

--- a/packages/template/src/lib/hexclave-app/apps/implementations/otel-span-facade.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/otel-span-facade.ts
@@ -199,7 +199,12 @@ export function createOtelSpanFacade(options: {
     // the registration failure for the caller.
     ended = true;
     otelSpan.end();
-    options.capabilities.onEnded?.(facade);
+    try {
+      options.capabilities.onEnded?.(facade);
+    } catch {
+      // Cleanup must not replace the registration failure that caused span
+      // creation to fail; callers need the original error for diagnosis.
+    }
     throw error;
   }
 

--- a/packages/template/src/lib/hexclave-app/apps/implementations/otel-span-facade.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/otel-span-facade.ts
@@ -190,7 +190,18 @@ export function createOtelSpanFacade(options: {
   // Fired LAST so the observer always receives a fully constructed handle
   // (including the trusted link writer). Child facades run through this same
   // factory, so every span in the tree announces itself here.
-  options.capabilities.onStarted?.(facade);
+  try {
+    options.capabilities.onStarted?.(facade);
+  } catch (error) {
+    // Registration is part of span creation. If it fails, do not leave an
+    // already-exportable span alive without a caller that can end it; close it
+    // through the same lifecycle hook used by ordinary callers, then preserve
+    // the registration failure for the caller.
+    ended = true;
+    otelSpan.end();
+    options.capabilities.onEnded?.(facade);
+    throw error;
+  }
 
   return facade;
 }

--- a/packages/template/src/lib/hexclave-app/apps/implementations/server-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/server-app-impl.ts
@@ -2655,14 +2655,20 @@ export class _HexclaveServerAppImplIncomplete<HasTokenStore extends boolean, Pro
       // it runs fire-and-forget — the record is emitted once (and only once)
       // from inside the resolved scope, or unattributed when resolution
       // degrades (see _runWithAmbientRequestScope's failure contract).
-      runAsynchronously(this._runWithAmbientRequestScope(null, async () => {
+      const ambientLog = this._runWithAmbientRequestScope(null, async () => {
         const resolved = getServerRequestContext();
         if (resolved !== null) {
           this._emitServerLogWithRequestContext(item, resolved);
         } else {
           emitHexclaveOtelLog(item, clientVersion);
         }
-      }));
+      });
+      registerTelemetryBackgroundTask(
+        this._telemetryOptions?.waitUntil ?? autoDetectedBackgroundTaskHook,
+        ambientLog,
+        "server ambient logger",
+      );
+      runAsynchronously(ambientLog);
       return "ok";
     }
     emitHexclaveOtelLog(item, clientVersion);


### PR DESCRIPTION
## Summary
- Align issue, trace, performance, source-map, and release dashboard surfaces.
- Harden analytics path visualization, shared formatting, navigation, and loading states.
- Update shared dashboard components, Playground coverage, and observability documentation.

## Stack
Base: [SDK and config contracts](https://github.com/hexclave/hexclave/pull/1974)
Final replacement PR in this stack.

## Test plan
- [ ] Run dashboard observability unit and component tests.
- [ ] Run dashboard lint and typecheck with the repository development environment.
- [ ] Verify the updated observability pages in the development environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates Observability UI and ingest around the new backend contracts and shared helpers. Also tightens issue identity/lifecycle semantics, artifact integrity reads, OTLP/public-search validation, and ClickHouse legacy-telemetry cutover.

- Issues UI
  - Detail/list links persist `?range=` (24h default via `DEFAULT_ISSUE_RANGE_HOURS`/`ISSUE_RANGE_PARAM_KEY` in `issues/issue-links`).
  - Sparklines return a dense, zero‑filled 24h grid and keep the chart’s `ariaLabel` when empty; timestamps parse via one helper.
  - Exception semantics match Sentry: hero stack and culprit use the LAST chain entry; causes list shows direct cause first (reversed).
  - Event search adds cursor pagination; whitespace‑only search is treated as the default.
  - Service/environment filters use a shared namespaced codec; stack snippets render valid inline elements in `pre` and show “Mapped” from frame symbolication; `formatCount` moved to `observability/format` and is used in Services, Performance, and Issues.

- Ingest, identity, and safety
  - Error‑ingest policy distinguishes `$log` vs `$error` items; legacy batch projection includes items that bypass policy so the durable client‑report ledger matches the batch; outcome counting is shared.
  - Rejects all‑zero W3C `trace_id`/`span_id`; validates `parent_span_id` as a W3C span id; tighter URL/password scrubbing and secret‑bearing client‑report idempotency keys.
  - Safe request context decodes percent‑encoded URL/cookie names before scrubbing; public search facets require a non‑empty key and cap identifiers at 128 characters.
  - Artifact reads use storage ETags to avoid integrity races; tar diagnostics forwarded only from a safe allowlist.
  - Customer request observability keeps the first trusted `userId`/`refreshTokenId` pair for a request.
  - Issue identity uses a stricter UUID check; public action routes share target resolution. Merges are idempotent (redirect detection with re‑enqueue); webhooks accept a provided `eventId`. Issue‑alert delivery verifies hash ownership in the same serializable transaction (FOR UPDATE) and guards updates with expected delivery state.

- OTLP, metrics, and legacy telemetry
  - Shared OTLP attribute limits; metric queries require `metric_name` when filtering by `metric_type`.
  - Legacy telemetry cutover adds a “fenced” phase and retiring suffix; `--min-drain-seconds` must be non‑negative and the ClickHouse client is closed after cutover.

- Source maps and artifacts
  - Presigned PUTs via `putPresignedArtifact`; source‑map uploads still reject fully injected debug‑IDs; archive error messages are sanitized.

Migration
- Use issue link helpers from `projects/[projectId]/observability/issues/issue-links` (`issuesListHref`, `issueDetailHref`, …); remove duplicates from `observability-links`.
- Import `formatCount` from `../format` instead of page‑local copies.
- Deploy the updated backend and shared contracts before merging (policy item types, W3C identity validation, public search facet rules). Backend Node engine now requires `>=22.13.0`.

<sup>Written for commit 904dc5c131514d62b2f3fbcabe8f708d7bb3ca60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

