### PR TITLE
[Dopcs] update payments docs with recent changes

### DIFF
--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -141,6 +141,7 @@
                   "guides/apps/payments/checkout",
                   "guides/apps/payments/subscriptions",
                   "guides/apps/payments/billing-and-invoices",
+                  "guides/apps/payments/refunds",
                   "guides/apps/payments/granting-products",
                   "guides/apps/payments/customers"
                 ]

--- a/docs-mintlify/guides/apps/emails/guide.mdx
+++ b/docs-mintlify/guides/apps/emails/guide.mdx
@@ -75,7 +75,7 @@ Per-send overrides: `themeId: "your-theme-id"`, `themeId: null` for the project 
 
 ## 4. Create a template
 
-Built-in templates already cover verification, password reset, magic link, invitations, and payment receipts — Hexclave sends those automatically when those flows run. Customize them under **Emails → Templates**.
+Built-in templates already cover verification, password reset, magic link, invitations, payment receipts, payment failures, and trial-ending notices — Hexclave sends those automatically when those flows run. Customize them under **Emails → Templates**.
 
 For your own product email, create a React Email template in the dashboard (or start from a clone). A minimal template looks like this:
 

--- a/docs-mintlify/guides/apps/emails/templates-and-themes.mdx
+++ b/docs-mintlify/guides/apps/emails/templates-and-themes.mdx
@@ -52,7 +52,7 @@ Key concepts:
 
 ### Built-in templates
 
-Hexclave ships with templates for common auth flows. These are used automatically by the built-in authentication components:
+Hexclave ships with templates for common auth and payment flows. These are sent automatically when the matching event happens:
 
 | Template | Trigger |
 |---|---|
@@ -63,6 +63,7 @@ Hexclave ships with templates for common auth flows. These are used automaticall
 | **Sign In Invitation** | User is invited to create an account |
 | **Payment Receipt** | A payment succeeds (one-time or subscription) |
 | **Payment Failed** | A payment fails |
+| **Trial Ending Soon** | A [Payments free trial](/guides/apps/payments/products-and-pricing#free-trials) is about to end |
 
 You can customize any built-in template from the dashboard under **Emails → Templates**.
 

--- a/docs-mintlify/guides/apps/payments/billing-and-invoices.mdx
+++ b/docs-mintlify/guides/apps/payments/billing-and-invoices.mdx
@@ -61,7 +61,10 @@ const secondPage = await user.listInvoices({
   Billing and invoices are available for user and team customers only, not custom customers (see [Customer Types](./customers)).
 </Info>
 
+To reverse a charge, see [Refunds](./refunds). Refunds are issued from **Payments -> Transactions**, not from the customer invoice list.
+
 ## Related
 
 - [Subscriptions](./subscriptions) - switching plans requires a saved payment method
 - [Checkout & Purchases](./checkout) - sell a product
+- [Refunds](./refunds) - reverse a charge and optionally end access

--- a/docs-mintlify/guides/apps/payments/checkout.mdx
+++ b/docs-mintlify/guides/apps/payments/checkout.mdx
@@ -58,6 +58,38 @@ const checkoutUrl = await team.createCheckoutUrl({ productId });
   If you're using a non-JS backend (Python, Go, etc.), call the REST API directly: `POST /api/v1/payments/purchases/create-purchase-url` with `customer_type`, `customer_id`, and `product_id`. See the [REST API overview](/api/overview) for details.
 </Info>
 
+On the **server**, you can also pass an inline product definition instead of `productId`, or create a URL for a [custom customer](./customers):
+
+```typescript
+import { hexclaveServerApp } from "@/hexclave/server";
+
+const checkoutUrl = await hexclaveServerApp.createCheckoutUrl({
+  customCustomerId: "external-org-123",
+  productId: "prod_enterprise",
+  returnUrl: "https://example.com/billing",
+});
+```
+
+## Hosted checkout
+
+`createCheckoutUrl` returns a hosted Hexclave page (`/purchase/{code}`). Price and quantity are chosen **on that page**, not in the URL. Stackable products show a quantity selector.
+
+Checkout URLs expire after **24 hours**. If **Block new purchases** is on in **Payments -> Settings**, creating a URL and completing checkout both fail; existing subscriptions keep renewing.
+
+A **$0 recurring** price activates without collecting a card. One-time $0 prices cannot go through checkout.
+
+[Free trials](./products-and-pricing#free-trials) collect a card up front and charge it when the trial ends. In **test mode**, checkout grants the product immediately and skips the trial.
+
+## Creating a checkout URL from the dashboard
+
+You don't have to generate URLs in code. **Create checkout** is available from:
+
+- **Payments -> Customers** (user, team, or custom)
+- A product's detail page, and product cards in **Payments -> Product Lines**
+- The **Users** and **Teams** tables
+
+The URL still expires in 24 hours. Send it to the customer, or open it yourself while testing.
+
 ## Checking what a customer owns
 
 After a purchase, you'll want to know what the customer has. Check their product list, or check a specific [item balance](./items-and-entitlements).
@@ -82,4 +114,5 @@ Each product in the list includes:
 
 - [Items & Entitlements](./items-and-entitlements) - read and consume credits, seats, and quota
 - [Subscriptions](./subscriptions) - manage recurring plans after purchase
+- [Refunds](./refunds) - reverse a purchase from the dashboard
 - [Granting Products](./granting-products) - give access without checkout

--- a/docs-mintlify/guides/apps/payments/customers.mdx
+++ b/docs-mintlify/guides/apps/payments/customers.mdx
@@ -7,12 +7,14 @@ A **customer** is whoever owns a purchase. Hexclave supports three types:
 
 - **Users** - Individual user accounts. Users can manage their own purchases, billing, and invoices from the client SDK.
 - **Teams** - Team or organization accounts. Team admins can create checkouts, switch plans, and cancel subscriptions for their team.
-- **Custom customers** - External entities identified by an arbitrary string ID. Useful for integrations with external systems. Custom customers are managed only via the server SDK and do not support billing or invoices.
+- **Custom customers** - External entities identified by an arbitrary string ID. Useful for integrations with external systems. They do not support billing, invoices, or plan switching; checkout and grants go through the server SDK or the dashboard.
 
 ## Where each method lives
 
 The full billing surface - [`createCheckoutUrl`](./checkout), [`useProducts`](./checkout#checking-what-a-customer-owns), [`useItem`](./items-and-entitlements), [`switchSubscription`](./subscriptions), [`useBilling` and `useInvoices`](./billing-and-invoices) - is available on both **user** and **team** objects.
 
-For **custom customers**, use the top-level `hexclaveServerApp` methods with `customCustomerId` (for example [`grantProduct`](./granting-products), `getItem`, and `listProducts`). Billing, invoices, and subscription switching are not available for custom customers.
+For **custom customers**, use the top-level `hexclaveServerApp` methods with `customCustomerId` (for example [`createCheckoutUrl`](./checkout), [`grantProduct`](./granting-products), `getItem`, and `listProducts`). Billing, invoices, payment methods, and subscription switching are not available for custom customers.
 
 Every product declares a **customer type** when you [define it](./products-and-pricing#defining-products), which determines who can purchase it.
+
+From the dashboard, **Payments -> Customers** lists users, teams, and custom customers (custom IDs appear after they have transactions). You can adjust item balances and [create a checkout URL](./checkout#creating-a-checkout-url-from-the-dashboard) for any of them. Granting a product without checkout is [SDK/API only](./granting-products).

--- a/docs-mintlify/guides/apps/payments/granting-products.mdx
+++ b/docs-mintlify/guides/apps/payments/granting-products.mdx
@@ -3,7 +3,9 @@ title: "Granting Products"
 description: "Give a customer a product without going through checkout"
 ---
 
-Sometimes you need to give a customer a product without charging them - free trials, admin grants, promotional offers, support credits. Use `grantProduct` on the server.
+Sometimes you need to give a customer a product without charging them - comps, promotional offers, or support access. Use `grantProduct` on the server. There is **no grant-product button** in the dashboard — from the dashboard, use [Create checkout](./checkout#creating-a-checkout-url-from-the-dashboard) (even in test mode) or adjust item quantities.
+
+A grant creates a real subscription or one-time product on the customer. It does **not** honor a configured [free trial](./products-and-pricing#free-trials) — access starts immediately. Pass `quantity` for stackable products (defaults to `1`).
 
 ## Granting a configured product
 
@@ -14,6 +16,7 @@ import { hexclaveServerApp } from "@/hexclave/server";
 await hexclaveServerApp.grantProduct({
   userId: "user-id",
   productId: "prod_premium",
+  quantity: 1,
 });
 
 // Grant to a team
@@ -29,7 +32,7 @@ await hexclaveServerApp.grantProduct({
 });
 ```
 
-If you already have a reference to a **server** user or team object (for example from `hexclaveServerApp.getUser(userId)`), you can also call `user.grantProduct({ productId })` directly. This method is server-only.
+If you already have a reference to a **server** user or team object (for example from `hexclaveServerApp.getUser(userId)`), you can also call `user.grantProduct({ productId, quantity })` directly. This method is server-only.
 
 ## Inline products
 
@@ -58,4 +61,5 @@ await hexclaveServerApp.grantProduct({
 ## Related
 
 - [Items & Entitlements](./items-and-entitlements) - the credits and seats a grant hands out
+- [Checkout & Purchases](./checkout) - charge the customer instead
 - [Customer Types](./customers) - grant to users, teams, or custom customers

--- a/docs-mintlify/guides/apps/payments/items-and-entitlements.mdx
+++ b/docs-mintlify/guides/apps/payments/items-and-entitlements.mdx
@@ -75,7 +75,7 @@ You can also increase a balance with `credits.increaseQuantity(amount)` or decre
 
 ## Adjusting balances from the dashboard
 
-In **Payments -> Customers** you can view item balances per customer and manually adjust quantities (with an optional expiration) - useful for support credits, comps, or corrections.
+In **Payments -> Customers** you can view item balances per customer and manually adjust quantities (plus or minus, with an optional description) - useful for support credits, comps, or corrections. The dashboard dialog does not set an expiration on those adjustments.
 
 ## Related
 

--- a/docs-mintlify/guides/apps/payments/overview.mdx
+++ b/docs-mintlify/guides/apps/payments/overview.mdx
@@ -6,7 +6,7 @@ sidebarTitle: "Overview"
 
 <Visibility for="agents">
 <Note>
-  **For agents/LLMs:** This is a high-level *marketing* overview of the Payments app, not an implementation reference. To actually build with payments, start at [Payments setup](./setup), then use the concept pages: [Products & Pricing](./products-and-pricing), [Items & Entitlements](./items-and-entitlements), [Checkout & Purchases](./checkout), [Subscriptions](./subscriptions), [Billing & Invoices](./billing-and-invoices), [Granting Products](./granting-products), and [Customer Types](./customers).
+  **For agents/LLMs:** This is a high-level *marketing* overview of the Payments app, not an implementation reference. To actually build with payments, start at [Payments setup](./setup), then use the concept pages: [Products & Pricing](./products-and-pricing), [Items & Entitlements](./items-and-entitlements), [Checkout & Purchases](./checkout), [Subscriptions](./subscriptions), [Billing & Invoices](./billing-and-invoices), [Refunds](./refunds), [Granting Products](./granting-products), and [Customer Types](./customers).
 </Note>
 </Visibility>
 
@@ -28,7 +28,7 @@ window.location.href = checkoutUrl;
 
 <PricingSkeleton />
 
-Group products into a **product line** to make them mutually exclusive - Free, Pro, and Enterprise where a customer can only hold one at a time. Upgrades, downgrades, and proration on plan switches are handled for you.
+Group products into a **product line** to make them mutually exclusive - Free, Pro, and Enterprise where a customer can only hold one at a time. Upgrades, downgrades, and proration on plan switches are handled for you. Recurring prices can include a **free trial** — the card is collected at checkout and charged when the trial ends. See [Products & Pricing](./products-and-pricing#free-trials).
 
 ## Can I sell credits, seats, or API quota?
 
@@ -65,7 +65,7 @@ With a raw payment processor you build and maintain the glue: webhook handlers, 
 - **Grants & revokes** - products and items are applied on payment and removed when a subscription ends or a refund is issued
 - **Subscription lifecycle** - status, renewals, cancellations, and period ends tracked automatically
 - **Proration** - handled automatically on plan switches, triggered through one SDK call
-- **Refunds** - issued from the dashboard, with entitlements revoked in step
+- **Refunds** - issued from the dashboard (partial or full), with optional entitlement revocation. See [Refunds](./refunds).
 - **Sync** - entitlement and subscription state stays consistent without a database to babysit
 
 <TransactionsSkeleton />
@@ -108,4 +108,4 @@ Straight answers so there are no surprises:
 2. Connect your payment account under **Payments → Settings**, and turn on **test mode** while you build.
 3. Define a product (with items, if you want entitlements), then call `user.createCheckoutUrl(...)`.
 
-Ready for the details - products, items, subscriptions, billing, invoices, and grants? Start with [Payments setup](./setup).
+Ready for the details - products, items, subscriptions, billing, invoices, refunds, and grants? Start with [Payments setup](./setup).

--- a/docs-mintlify/guides/apps/payments/products-and-pricing.mdx
+++ b/docs-mintlify/guides/apps/payments/products-and-pricing.mdx
@@ -3,7 +3,7 @@ title: "Products & Pricing"
 description: "Define what you sell - products, prices, product lines, add-ons, and trials"
 ---
 
-A **product** is anything a customer can buy: a subscription plan, a one-time purchase, or a credit pack. Configure your products in **Payments -> Products & Items**.
+A **product** is anything a customer can buy: a subscription plan, a one-time purchase, or a credit pack. Configure your products in **Payments -> Products & Items**, or in `hexclave.config.ts` under `payments.products`.
 
 ## Defining products
 
@@ -11,15 +11,17 @@ Each product has:
 
 - **Display name** - What the customer sees
 - **Customer type** - Whether this product is for users, teams, or custom customers (see [Customer Types](./customers))
-- **Prices** - One or more prices, each with a currency amount and an optional billing interval (day, week, month, or year). Amounts are **decimal strings** like `"9.99"` or `"1000"` — not cent integers. Payments are processed in **USD**.
+- **Prices** - One or more prices, each with a currency amount and an optional billing interval (day, week, month, or year). Amounts are **decimal strings** like `"9.99"` or `"1000"` — not cent integers. Live charges are processed in **USD**.
 - **Included items** - Items granted when the product is purchased, with configurable quantity, repeat schedule, and expiration behavior (see [Items & Entitlements](./items-and-entitlements))
 
 A few additional options:
 
-- **Free trial** - Give customers a trial period before charging. Can be set on the product or on individual prices.
-- **Add-ons** - Set **isAddOnTo** to require the customer to already own a specific base product before purchasing this one.
-- **Server-only** - Hide the product from client SDK responses. Useful for products that should only be granted programmatically.
-- **Stackable** - Allow multiple purchases of the same product (default is one per customer).
+- **Free trial** - Give customers a trial period before charging. Prefer setting this **on the price**; a product-level trial is a fallback. See [Free trials](#free-trials).
+- **Add-ons** - Set **isAddOnTo** to require the customer to already own a specific base product before purchasing this one. Every add-on base must live in the **same product line**.
+- **Server-only** - Hide the product (or an individual price) from client SDK responses. Useful for products that should only be granted programmatically.
+- **Stackable** - Allow multiple purchases of the same product (default is one per customer). Quantity is chosen on the [hosted checkout](./checkout#hosted-checkout) page.
+
+A recurring price can be **$0** (a free plan in a product line). One-time $0 prices are not sold through checkout — use [grantProduct](./granting-products) or test mode instead.
 
 ## Product lines
 
@@ -31,7 +33,22 @@ Assign products to a product line to power plan tiers and enable [subscription s
   Add-ons are exempt from product-line exclusivity - a customer can own an add-on alongside their base product in the same line.
 </Info>
 
+## Free trials
+
+A free trial defers the first charge on a **recurring** price. Checkout still collects a card; it is not charged until the trial ends, and the billing cycle starts from that date. Customers get a **Trial Ending Soon** email beforehand.
+
+Configure the trial **on the price** in the price editor. A product-level trial still works as a fallback, but the price-level value wins when both are set.
+
+Trials cannot be combined with:
+
+- One-time (non-recurring) prices
+- $0 recurring prices
+- Durations longer than **730 days** (a processor limit)
+
+They also **do not run in test mode** — the product is granted immediately with no trial. [Plan switches](./subscriptions) do not start a new trial on the destination product. [grantProduct](./granting-products) also skips trials and creates an active subscription.
+
 ## Related
 
 - [Items & Entitlements](./items-and-entitlements) - attach credits, seats, and quota to a product
 - [Checkout & Purchases](./checkout) - sell a product once it's defined
+- [Subscriptions](./subscriptions) - switching plans after a trial or paid period

--- a/docs-mintlify/guides/apps/payments/refunds.mdx
+++ b/docs-mintlify/guides/apps/payments/refunds.mdx
@@ -1,0 +1,38 @@
+---
+title: "Refunds"
+description: "Reverse a charge from the dashboard, and optionally end the customer's access"
+---
+
+Refunds are issued from **Payments -> Transactions**. Open a **purchase** row and choose **Refund**. You can return money, end the product, or both.
+
+## Dashboard refunds
+
+Each refund has two knobs:
+
+1. **Amount (USD)** - Partial or full. Leave at `0` to change access without returning money (for example after a prior partial refund, or for a test-mode purchase).
+2. **Product / subscription lifecycle**
+   - **End now** - Revoke the product immediately and expire item grants that were tied to the purchase (`when-purchase-expires` or `when-repeated`). Permanent grants (`expires: never`) stay.
+   - **End at period end** - Subscriptions only. Access continues until the current period ends.
+   - **No change** - Refund money only; the customer keeps the product.
+
+You must set a non-zero amount **or** change the lifecycle. Multiple partial refunds are allowed until the original charge is fully returned.
+
+<Info>
+  The dashboard refunds the **original purchase**, not later **subscription-renewal** rows. One-time purchases only support **End now** (they have no period).
+</Info>
+
+### Test mode
+
+Test-mode purchases never charged a card, so money refunds are disabled. You can still choose **End now** to revoke access.
+
+### Platform fee
+
+Hexclave's **0.9%** platform fee is not returned when you refund a charge. Processor fees follow the processor's own refund rules.
+
+Subscriptions created with [`grantProduct`](./granting-products) have no processor charge, so a refund can only change lifecycle — not return money.
+
+## Related
+
+- [Billing & Invoices](./billing-and-invoices) - invoices and saved payment methods
+- [Subscriptions](./subscriptions) - cancel without a refund
+- [Items & Entitlements](./items-and-entitlements) - what happens to credits when access ends

--- a/docs-mintlify/guides/apps/payments/setup.mdx
+++ b/docs-mintlify/guides/apps/payments/setup.mdx
@@ -53,6 +53,7 @@ Each step has its own guide:
 - [Checkout & Purchases](./checkout) - sell a product and read what a customer owns
 - [Subscriptions](./subscriptions) - switching plans and cancellation
 - [Billing & Invoices](./billing-and-invoices) - payment methods and billing history
+- [Refunds](./refunds) - partial or full refunds, and ending access
 - [Granting Products](./granting-products) - give access without checkout
 - [Customer Types](./customers) - users, teams, and custom customers
 
@@ -61,6 +62,12 @@ Each step has its own guide:
 While you're building, turn on **test mode** in **Payments -> Settings**. With test mode on, purchases skip the payment processor entirely: products and items are granted instantly, no card is collected, and no money moves. It's on by default in development environments.
 
 This lets you wire up checkout, entitlements, and subscription logic end to end without touching real money. When you're confident everything works, turn test mode off - at which point purchases go through the payment processor and **charge real money**.
+
+Test mode does **not** simulate every live behavior:
+
+- **Free trials are skipped.** The product is granted immediately; there is no trial period and no deferred first charge. Turn test mode off to exercise the real trial checkout.
+- **Catalog edits still apply to production.** Test mode only changes how purchases run, not which products exist.
+- **Money refunds are not available.** You can still end access from a refund dialog; you cannot return money that was never charged. See [Refunds](./refunds).
 
 <Warning>
   There's no "live but free" middle ground. With test mode **off**, every purchase is a real, billable charge. Keep test mode on until you're ready to take real payments.
@@ -72,10 +79,10 @@ The dashboard gives you full visibility and control over your payments:
 
 - **Product Lines** - Group products into mutually exclusive tiers. In **Payments -> Product Lines**.
 - **Products & Items** - Create and edit products, set pricing, and configure included items. In **Payments -> Products & Items**.
-- **Customers** - View item balances per customer, manually adjust quantities (with optional expiration), and grant products directly. In **Payments -> Customers**.
-- **Transactions** - See all payment activity, filter by type and customer, view details, and issue refunds. In **Payments -> Transactions**.
-- **Payouts** - View payout information. In **Payments -> Payouts**.
-- **Settings** - Connect your payment account, toggle test mode, configure payment methods, and block new purchases. In **Payments -> Settings**.
+- **Customers** - View item balances per customer, manually adjust quantities, and create checkout URLs. In **Payments -> Customers**. Granting a product without checkout is [SDK/API only](./granting-products).
+- **Transactions** - See all payment activity, filter by type and customer, export CSV, and issue [refunds](./refunds) on purchase rows. In **Payments -> Transactions**.
+- **Payouts** - View payout information. In **Payments -> Payouts**. Unavailable in development environments.
+- **Settings** - Connect your payment account, toggle test mode, configure payment methods, and **block new purchases** (existing subscriptions keep renewing). In **Payments -> Settings**.
 
 ### Payment emails
 
@@ -83,5 +90,6 @@ Email notifications are sent automatically on payment events:
 
 - **Payment Receipt** - Sent on successful payment with product details, amount, and receipt link
 - **Payment Failed** - Sent on failed payment with product name, amount, and failure reason
+- **Trial Ending Soon** - Sent before a [free trial](./products-and-pricing#free-trials) ends, so the customer knows the saved payment method will be charged
 
-These apply to both one-time purchases and subscription renewals. Customize them in **Emails -> Templates** (see the [Emails guide](/guides/apps/emails/guide)).
+These apply to both one-time purchases and subscription renewals (receipts and failures). Customize them in **Emails -> Templates** (see the [Emails guide](/guides/apps/emails/guide)).

--- a/docs-mintlify/guides/apps/payments/subscriptions.mdx
+++ b/docs-mintlify/guides/apps/payments/subscriptions.mdx
@@ -21,6 +21,7 @@ export default function UpgradeButton() {
       await user.switchSubscription({
         fromProductId: "prod_pro",
         toProductId: "prod_enterprise",
+        // optional: priceId, quantity (quantity > 1 requires a stackable product)
       });
     }}>
       Upgrade to Enterprise
@@ -30,7 +31,7 @@ export default function UpgradeButton() {
 ```
 
 <Info>
-  Switching plans requires the customer to have a default payment method saved (see [Billing & Invoices](./billing-and-invoices)). The switch happens immediately and the charge is prorated automatically.
+  Switching plans requires the customer to have a default payment method saved (see [Billing & Invoices](./billing-and-invoices)). The switch happens immediately and the charge is prorated automatically. You cannot switch to an add-on, and a [free trial](./products-and-pricing#free-trials) on the destination product is not applied.
 </Info>
 
 ## Canceling a subscription
@@ -71,6 +72,10 @@ export default function UpgradeButton() {
   </Tab>
 </Tabs>
 
+`cancelSubscription` is **immediate** for live, processor-backed subscriptions — access ends now. Subscriptions created in **test mode** or via [grantProduct](./granting-products) (no processor subscription) are marked to end at the current period end, so access continues until then.
+
+Pass `subscriptionId` when canceling an [inline product](./granting-products#inline-products) that has no catalog `productId`. One-time purchases cannot be canceled; [refund](./refunds) them instead.
+
 ## Reading subscription state
 
 Each subscription product returned by [`useProducts` / `listProducts`](./checkout#checking-what-a-customer-owns) carries a `subscription` field with the current period end and cancellation state, plus `switchOptions` listing the other products in the same product line the customer can switch to.
@@ -79,3 +84,4 @@ Each subscription product returned by [`useProducts` / `listProducts`](./checkou
 
 - [Checkout & Purchases](./checkout) - start a subscription
 - [Billing & Invoices](./billing-and-invoices) - payment methods and billing history
+- [Refunds](./refunds) - reverse a charge and optionally end the subscription

--- a/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/docs-json.generated.ts
+++ b/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/docs-json.generated.ts
@@ -143,6 +143,7 @@ const docsJson = {
                   "guides/apps/payments/checkout",
                   "guides/apps/payments/subscriptions",
                   "guides/apps/payments/billing-and-invoices",
+                  "guides/apps/payments/refunds",
                   "guides/apps/payments/granting-products",
                   "guides/apps/payments/customers"
                 ]


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Refunds guide and updates Payments docs to reflect current behavior for checkout, trials, subscriptions, and dashboard actions. This matters because it clarifies how access changes on refunds, how test mode differs from live, and how to create checkout links in code and the dashboard.

**Key updates**
- New Refunds guide; linked across Payments pages and added to navigation (`docs.json`, generated docs JSON). Dashboard refunds support partial/full amounts and lifecycle options (end now, end at period end, or no change). Platform fee isn’t returned; test mode disables money refunds.
- Checkout: server `createCheckoutUrl` supports inline products and `customCustomerId`. Hosted checkout sets quantity on the page, expires in 24h, respects “Block new purchases.” $0 recurring is allowed; one-time $0 is not. Trials collect a card; in test mode trials are skipped. “Create checkout” is available from Customers, Product pages/cards, and Users/Teams.
- Products & Pricing: prefer price-level free trials; constraints include no one-time or $0 recurring, max 730 days, and no trials in test mode. Add-ons must share a product line with their base. Stackable quantity is chosen at checkout.
- Subscriptions: switches require a saved payment method and do not apply a new trial. Cancellation is immediate for live processor subs; test-mode or granted subs end at period end. Pass `subscriptionId` for inline products; one-time purchases can’t be canceled—refund instead.
- Granting products: grants create real access, skip trials, and accept `quantity`. No dashboard grant button; use checkout links or adjust item balances.
- Customers: custom customers use top-level server methods (`createCheckoutUrl`, `grantProduct`, etc.) and don’t support billing, invoices, payment methods, or plan switching. Dashboard lists them after transactions and can create checkout URLs.
- Emails: built-in templates now include payment failures and trial-ending notices.

**Review notes**
- Verify new links resolve to `guides/apps/payments/refunds` and that sidebar/nav include Refunds.
- Docs-only change; no SDK/API behavior change in this PR. No migration required.

<sup>Written for commit 2df4a41066d4822bbcc54705066f709e251901f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive Refunds guide covering full and partial refunds, entitlement handling, fees, validation, and test-mode behavior.
  - Expanded payment documentation with guidance on checkout, customers, subscriptions, products, free trials, grants, and test mode.
  - Documented payment-failure and trial-ending email templates and automatic delivery behavior.
  - Clarified dashboard workflows, refund access, customer capabilities, and transaction management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->