### PR TITLE
Fix ClickHouse OOM in the newly-created-projects user counts

### DIFF
--- a/apps/backend/src/app/api/latest/internal/newly-created-projects/helpers.tsx
+++ b/apps/backend/src/app/api/latest/internal/newly-created-projects/helpers.tsx
@@ -285,24 +285,20 @@ export async function loadProjectActivityMetrics(projectIds: string[]): Promise<
       async (projectIdChunk) => {
         const [userRowsResult, activityRowsResult] = await Promise.all([
           clickhouse.query({
-            // Deduplicate the ReplacingMergeTree rows to each user's latest
-            // version with `FINAL` rather than an explicit argMax GROUP BY on
-            // the dedup key. The argMax approach materializes one aggregation
-            // state per user; over user-heavy projects those per-user states
-            // exceed the per-query max_memory_usage cap regardless of
-            // max_bytes_before_external_group_by (pre-aggregation spills to
-            // disk, but the post-spill merge of millions of UUID-keyed groups
-            // does not stay under the cap, and the in-order pipeline cannot
-            // spill at all). `FINAL` instead deduplicates as a streaming merge
-            // of sorted parts — memory scales with part count, not user count —
-            // and the outer GROUP BY only has one group per project. FINAL over
-            // the *unbatched* candidate window was too heavy historically, but
-            // combined with the project-ID batching below it stays far below
-            // the cap (validated empirically on a 5M-row seeded table under a
-            // 300 MB cap: every argMax variant OOMs, FINAL passes with
-            // headroom and identical results). This also matches the dedup
-            // semantics of the public `default.users` view, which reads the
-            // same table with FINAL.
+            // Deduplicate the ReplacingMergeTree rows with `FINAL` instead of
+            // an explicit argMax GROUP BY on the dedup key: argMax needs one
+            // aggregation state per user, which exceeds the per-query memory
+            // cap on user-heavy batches (even with external group-by spill),
+            // while FINAL is a streaming merge of sorted parts whose memory
+            // scales with part count, not user count. Combined with the
+            // project-ID batching below it stays far under the cap, and it
+            // matches the dedup semantics of the public `default.users` view.
+            // Note that deletion tombstones carry deletedAt as signed_up_at
+            // and thus usually live in a later monthly partition than the
+            // live row; FINAL still collapses the pair because it merges
+            // across partitions by default — so never enable
+            // do_not_merge_across_partitions_select_final on this table, or
+            // deleted users would be counted again (validated empirically).
             query: `
               SELECT
                 project_id AS projectId,

--- a/apps/backend/src/app/api/latest/internal/newly-created-projects/helpers.tsx
+++ b/apps/backend/src/app/api/latest/internal/newly-created-projects/helpers.tsx
@@ -286,36 +286,35 @@ export async function loadProjectActivityMetrics(projectIds: string[]): Promise<
         const [userRowsResult, activityRowsResult] = await Promise.all([
           clickhouse.query({
             // Deduplicate the ReplacingMergeTree rows to each user's latest
-            // version with an explicit argMax GROUP BY instead of `FINAL`.
-            // `FINAL` merges parts outside the aggregation pipeline. The
-            // candidate window can therefore exceed the per-query
-            // max_memory_usage cap even though a manual argMax dedup can spill
-            // to disk. Batching project IDs bounds the number of groups in
-            // each query; `(project_id, branch_id, id)` is the table's ORDER BY
-            // / dedup key, so grouping by it reproduces FINAL exactly. Since
-            // the grouping key matches that ORDER BY, this setting also lets
-            // ClickHouse stream the inner aggregation in order.
-            // Re-seeded rows can share a version, so break ties by insertion time.
+            // version with `FINAL` rather than an explicit argMax GROUP BY on
+            // the dedup key. The argMax approach materializes one aggregation
+            // state per user; over user-heavy projects those per-user states
+            // exceed the per-query max_memory_usage cap regardless of
+            // max_bytes_before_external_group_by (pre-aggregation spills to
+            // disk, but the post-spill merge of millions of UUID-keyed groups
+            // does not stay under the cap, and the in-order pipeline cannot
+            // spill at all). `FINAL` instead deduplicates as a streaming merge
+            // of sorted parts — memory scales with part count, not user count —
+            // and the outer GROUP BY only has one group per project. FINAL over
+            // the *unbatched* candidate window was too heavy historically, but
+            // combined with the project-ID batching below it stays far below
+            // the cap (validated empirically on a 5M-row seeded table under a
+            // 300 MB cap: every argMax variant OOMs, FINAL passes with
+            // headroom and identical results). This also matches the dedup
+            // semantics of the public `default.users` view, which reads the
+            // same table with FINAL.
             query: `
               SELECT
                 project_id AS projectId,
-                countIf(isAnonymous = 0) AS nonAnon,
-                countIf(isAnonymous = 1) AS anon
-              FROM (
-                SELECT
-                  project_id,
-                  argMax(is_anonymous, (sync_sequence_id, sync_created_at)) AS isAnonymous,
-                  argMax(sync_is_deleted, (sync_sequence_id, sync_created_at)) AS syncIsDeleted
-                FROM analytics_internal.users
-                WHERE branch_id = {branchId:String}
-                  AND project_id IN {projectIds:Array(String)}
-                GROUP BY project_id, branch_id, id
-              )
-              WHERE syncIsDeleted = 0
+                countIf(is_anonymous = 0) AS nonAnon,
+                countIf(is_anonymous = 1) AS anon
+              FROM analytics_internal.users FINAL
+              WHERE branch_id = {branchId:String}
+                AND project_id IN {projectIds:Array(String)}
+                AND sync_is_deleted = 0
               GROUP BY project_id
             `,
             query_params: { branchId, projectIds: projectIdChunk },
-            clickhouse_settings: { optimize_aggregation_in_order: 1 },
             format: "JSONEachRow",
           }),
           clickhouse.query({


### PR DESCRIPTION
The `/internal/newly-created-projects` endpoint kept failing with `MEMORY_LIMIT_EXCEEDED` in `loadProjectActivityMetrics` despite earlier batching fixes.

Root cause: the argMax-dedup subquery (`GROUP BY project_id, branch_id, id`) materializes one aggregation state per user, so user-heavy batches blow past the per-query `max_memory_usage` cap no matter what — the in-order pipeline (`AggregatingInOrderTransform`) can't spill to disk at all, and even regular hash aggregation with `max_bytes_before_external_group_by` OOMs in the post-spill merge.

Fix: dedup with `FINAL` instead:

```sql
SELECT project_id, countIf(is_anonymous = 0), countIf(is_anonymous = 1)
FROM analytics_internal.users FINAL
WHERE branch_id = {...} AND project_id IN {...} AND sync_is_deleted = 0
GROUP BY project_id
```

`FINAL` dedups as a streaming merge of sorted parts (memory ∝ parts, not users). It was too heavy back when the query ran over the whole unbatched candidate window (#1873), but with the 200-project batching from #1886 it stays far under the cap.

Validated empirically on a 5M-row seeded `ReplacingMergeTree` (with duplicate row versions) under a 300 MB cap: every argMax variant (in-order, hash+spill, hash+spill+`max_threads=1`) OOMs; the FINAL query passes in ~0.6–1s with results identical to the uncapped ground truth. This also matches the dedup semantics of the `default.users` view.

Backend lint, typecheck, and the `newly-created-projects` helper tests pass.

Link to Devin session: https://app.devin.ai/sessions/dda1473bce7247328a1ef156ee7c5465
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ClickHouse dedup semantics for an internal metrics path; behavior should match `default.users` and prior uncapped results, but counts could diverge if FINAL + batching assumptions are wrong.
> 
> **Overview**
> Fixes **`MEMORY_LIMIT_EXCEEDED`** in `loadProjectActivityMetrics` for `/internal/newly-created-projects` by changing how `analytics_internal.users` is deduplicated before per-project anonymous/non-anonymous counts.
> 
> The user-metrics query no longer uses an inner **`argMax` + `GROUP BY project_id, branch_id, id`** subquery (which held one aggregation state per user and OOM’d on user-heavy batches). It now reads **`analytics_internal.users FINAL`**, filters deleted rows in the `WHERE` clause, and **`GROUP BY project_id`** only. **`optimize_aggregation_in_order`** was dropped with the argMax path. Project-ID batching and concurrent chunk execution are unchanged; the activity (`$token-refresh`) query is untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08dbf36bf80d1a9bf087093ce9403f2886be9e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops OOMs in `/internal/newly-created-projects` by switching user deduplication from an argMax GROUP BY to `FINAL` on `analytics_internal.users`. Previously we held one aggregation state per user and exceeded `max_memory_usage`; now dedup happens as a streaming part merge and we group by `project_id`, keeping memory bounded with identical counts.

- Query now uses: `FROM analytics_internal.users FINAL WHERE branch_id = ? AND project_id IN (?) AND sync_is_deleted = 0 GROUP BY project_id` with `countIf(is_anonymous = 0/1)`.
- Removes ClickHouse setting `optimize_aggregation_in_order`.
- Relies on `FINAL` merging across partitions so deletions collapse with live rows; do not enable `do_not_merge_across_partitions_select_final` or deleted users may be counted again.
- Expect much lower memory usage; slight CPU increase stays within limits due to project-ID batching.
- No migrations or config changes required.

<sup>Written for commit 8fa50d30a97408c69042e22fd9841929f2d93f56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and consistency of user metrics by using deduplicated analytics data.
  * Updated counts for anonymous and non-anonymous users to reflect the latest available records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->