### PR TITLE
Start Marshal in the DB migration compat workflow

### DIFF
--- a/.github/workflows/db-migration-backwards-compatibility.yaml
+++ b/.github/workflows/db-migration-backwards-compatibility.yaml
@@ -157,6 +157,20 @@ jobs:
       - name: Wait on ClickHouse
         run: pnpm exec wait-on http://localhost:8136/ping
 
+      # The deployments e2e tests hit s3mock and fly-mock directly; marshal's /health does
+      # not touch either, so wait on them explicitly when the base branch provides them.
+      - name: Wait on s3mock
+        run: |
+          if grep -q '^  s3mock:' docker/dependencies/docker.compose.yaml; then
+            pnpm exec wait-on http://localhost:8121/
+          fi
+
+      - name: Wait on fly-mock
+        run: |
+          if grep -q '^  fly-mock:' docker/dependencies/docker.compose.yaml; then
+            pnpm exec wait-on http://localhost:8148/health
+          fi
+
       - name: Initialize database
         run: pnpm run db:init
 
@@ -188,6 +202,19 @@ jobs:
       - name: Backfill Bulldozer from Postgres
         if: ${{ hashFiles('apps/bulldozer-js/package.json') != '' }}
         run: pnpm run db:backfill-bulldozer-from-prisma
+
+      # Marshal (the deployments runtime) talks to the fly-mock + s3mock
+      # containers; the deployments e2e tests drive it through the backend.
+      - name: Start marshal in background
+        if: ${{ hashFiles('apps/marshal/package.json') != '' }}
+        uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635 # v1.0.7
+        with:
+          run: NODE_ENV=test pnpm run start:marshal &
+          wait-on: |
+            http://localhost:8147/health
+          tail: true
+          wait-for: 30s
+          log-output-if: true
 
       - name: Start stack-backend in background
         uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635 # v1.0.7
@@ -408,6 +435,14 @@ jobs:
       - name: Wait on ClickHouse
         run: pnpm exec wait-on http://localhost:8136/ping
 
+      # The deployments e2e tests hit s3mock and fly-mock directly; marshal's /health does
+      # not touch either, so wait on them explicitly (fly-mock is a build:-from-context image).
+      - name: Wait on s3mock
+        run: pnpm exec wait-on http://localhost:8121/
+
+      - name: Wait on fly-mock
+        run: pnpm exec wait-on http://localhost:8148/health
+
       - name: Initialize database
         run: pnpm run db:init
   
@@ -434,6 +469,18 @@ jobs:
       # fresh bulldozer-js store so the backend's payment reads aren't empty.
       - name: Backfill Bulldozer from Postgres
         run: pnpm run db:backfill-bulldozer-from-prisma
+
+      # Marshal (the deployments runtime) talks to the fly-mock + s3mock
+      # containers; the deployments e2e tests drive it through the backend.
+      - name: Start marshal in background
+        uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635 # v1.0.7
+        with:
+          run: NODE_ENV=test pnpm run start:marshal &
+          wait-on: |
+            http://localhost:8147/health
+          tail: true
+          wait-for: 30s
+          log-output-if: true
 
       - name: Start stack-backend in background
         uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635 # v1.0.7

--- a/.github/workflows/db-migration-backwards-compatibility.yaml
+++ b/.github/workflows/db-migration-backwards-compatibility.yaml
@@ -158,16 +158,17 @@ jobs:
         run: pnpm exec wait-on http://localhost:8136/ping
 
       # The deployments e2e tests hit s3mock and fly-mock directly; marshal's /health does
-      # not touch either, so wait on them explicitly when the base branch provides them.
+      # not touch either, so wait on them explicitly. This job runs base-branch code, so the
+      # containers only exist once the base branch's compose file declares them.
       - name: Wait on s3mock
         run: |
-          if grep -q '^  s3mock:' docker/dependencies/docker.compose.yaml; then
+          if docker compose -f docker/dependencies/docker.compose.yaml config --services | grep -qx s3mock; then
             pnpm exec wait-on http://localhost:8121/
           fi
 
       - name: Wait on fly-mock
         run: |
-          if grep -q '^  fly-mock:' docker/dependencies/docker.compose.yaml; then
+          if docker compose -f docker/dependencies/docker.compose.yaml config --services | grep -qx fly-mock; then
             pnpm exec wait-on http://localhost:8148/health
           fi
 


### PR DESCRIPTION
The DB migration compat workflow runs `pnpm test` but never starts Marshal, so every deployments test fails there with `POST /api/v1/deployments/uploads` → 500 `TypeError: fetch failed` / `ECONNREFUSED` (24 failed tests). `e2e-api-tests.yaml` and `fast-fail-tests.yaml` already start it.

Both jobs now wait on s3mock/fly-mock and start Marshal (health on `8147`) after the Bulldozer backfill, before the backend. The back-compat job runs base-branch code, so the Marshal step is `hashFiles`-guarded like the existing Bulldozer/cron steps, and the two container waits are skipped unless the base branch's compose file declares those services.

Verified locally: `deployments.test.ts` fails 23/45 without Marshal with the same signature, and passes (44 passed, 1 skipped) with it; `cli.test.ts` passes too.


Link to Devin session: https://app.devin.ai/sessions/141c01979cc94c3588a304e666ceed5e
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes with no application or migration logic touched; slightly longer job startup when Marshal and mocks are present.
> 
> **Overview**
> The **DB migration backwards/forward compatibility** workflow now brings up the same deployment test dependencies as `e2e-api-tests` and `fast-fail-tests`, so `pnpm test` no longer fails on deployments APIs with connection refused when Marshal is down.
> 
> Both jobs **wait on `s3mock` and `fly-mock`** before DB init, because deployments tests hit those services directly and Marshal’s `/health` does not cover them. The **back-compat** job only waits if the **base branch** compose file defines those services.
> 
> Each job **starts Marshal in the background** (health on port **8147**) after the Bulldozer backfill and **before** the backend. On back-compat, the Marshal step is **`hashFiles`-guarded** on `apps/marshal/package.json`, matching how optional Bulldozer steps behave when the checked-out base branch may not ship Marshal yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad0fd36d5389f0c51521584cb5b2bf2e368d1aea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Start Marshal in the DB migration compatibility workflow and wait for s3mock/fly-mock, fixing deployments e2e tests that previously failed when `pnpm test` ran without Marshal (ECONNREFUSED/500s). New behavior starts Marshal after the Bulldozer backfill and before the backend; this may add slight CI time but makes tests deterministic.

- Start Marshal via `JarvusInnovations/background-action` with `NODE_ENV=test pnpm run start:marshal` and wait on `http://localhost:8147/health`.
- Wait for s3mock and fly-mock; in the base-branch job these waits run only if the base compose declares the services, otherwise they are skipped.
- Order: DB init → Bulldozer backfill (`db:backfill-bulldozer-from-prisma`) → Marshal → backend, matching how deployments tests drive the runtime through the API.
- Guard Marshal in the base-branch job with `hashFiles('apps/marshal/package.json')` to avoid failures when Marshal does not exist on the base branch.
- No app code changes; resolves `POST /api/v1/deployments/uploads` connection errors in CI.

<sup>Written for commit ad0fd36d5389f0c51521584cb5b2bf2e368d1aea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility checks to reliably wait for required mock services and health checks before initializing databases and application stacks.
  * Prevented compatibility jobs from starting before dependent services are ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->