### PR TITLE
[Fix] Logging to Sentry on Backend Now Reports Extradata

### DIFF
--- a/apps/backend/src/instrument.ts
+++ b/apps/backend/src/instrument.ts
@@ -9,7 +9,7 @@ import backendPackageJson from "../package.json";
 import { createBackendInstrumentationPlan } from "./instrumentation-plan";
 import { initPerfStats } from "./lib/dev-perf-stats";
 import { getSentryRelease } from "./sentry-release";
-import { sanitizeBackendSentryEvent, sanitizeBackendSentrySpan } from "./sentry-scrubbing";
+import { prepareBackendSentryEvent, sanitizeBackendSentrySpan } from "./sentry-scrubbing";
 
 globalThis.global = globalThis;
 // The Elysia process is the Node runtime; set the marker before shared helpers that still ask for Next runtime metadata.
@@ -70,9 +70,9 @@ export function registerBackendInstrumentation() {
       packageName: backendPackageJson.name,
       packageVersion: backendPackageJson.version,
     }),
-    beforeSend: sanitizeBackendSentryEvent,
+    beforeSend: prepareBackendSentryEvent,
     beforeSendSpan: sanitizeBackendSentrySpan,
-    beforeSendTransaction: sanitizeBackendSentryEvent,
+    beforeSendTransaction: prepareBackendSentryEvent,
   });
 }
 

--- a/apps/backend/src/sentry-scrubbing.test.ts
+++ b/apps/backend/src/sentry-scrubbing.test.ts
@@ -3,6 +3,14 @@ import type { Event } from "@sentry/node";
 import { describe, expect, it } from "vitest";
 import { prepareBackendSentryEvent, sanitizeBackendSentryEvent } from "./sentry-scrubbing";
 
+function requireEventExtra(event: Event) {
+  const extra = event.extra;
+  if (extra == null) {
+    throw new Error("expected Sentry extra to be set");
+  }
+  return extra;
+}
+
 describe("sanitizeBackendSentryEvent", () => {
   it("removes request and trace data that can contain credentials or PII", () => {
     const event: Event = {
@@ -329,7 +337,7 @@ describe("prepareBackendSentryEvent", () => {
       }),
     }));
     expect(JSON.stringify(result)).not.toContain("hunter2");
-    const nicifiedError = result.extra.nicifiedError;
+    const nicifiedError = requireEventExtra(result).nicifiedError;
     expect(nicifiedError).toEqual(expect.stringContaining("innerCode"));
     expect(nicifiedError).toEqual(expect.not.stringContaining("hunter2"));
   });
@@ -399,8 +407,8 @@ describe("prepareBackendSentryEvent", () => {
       { originalException: new HexclaveAssertionError("deep extraData", { nested }) },
     );
 
-    expect(JSON.stringify(result.extra.errorProps)).toContain("[truncated]");
-    expect(JSON.stringify(result.extra.errorProps)).not.toContain("leaf");
+    expect(JSON.stringify(requireEventExtra(result).errorProps)).toContain("[truncated]");
+    expect(JSON.stringify(requireEventExtra(result).errorProps)).not.toContain("leaf");
   });
 
   it("truncates oversized diagnostic collections before nicify", () => {
@@ -464,7 +472,7 @@ describe("prepareBackendSentryEvent", () => {
         }),
       }),
     }));
-    expect(JSON.stringify(result.extra.errorProps)).not.toContain("field50");
+    expect(JSON.stringify(requireEventExtra(result).errorProps)).not.toContain("field50");
   });
 
   it("does not invoke throwing enumerable getters while building extras", () => {
@@ -498,5 +506,152 @@ describe("prepareBackendSentryEvent", () => {
         },
       }),
     }));
+  });
+
+  it("dumps a shared nested object on every path, not as circular", () => {
+    const shared = { leaf: "shared-value" };
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "diamond" } },
+      {
+        originalException: new HexclaveAssertionError("diamond extraData", {
+          a: shared,
+          b: shared,
+        }),
+      },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      errorProps: expect.objectContaining({
+        extraData: {
+          a: { leaf: "shared-value" },
+          b: { leaf: "shared-value" },
+        },
+      }),
+    }));
+  });
+
+  it("still marks true cycles as circular", () => {
+    const extraData: Record<string, unknown> = { name: "cycle-root" };
+    extraData.self = extraData;
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "cycle" } },
+      { originalException: new HexclaveAssertionError("cycle extraData", extraData) },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      errorProps: expect.objectContaining({
+        extraData: {
+          name: "cycle-root",
+          self: "[circular]",
+        },
+      }),
+    }));
+  });
+
+  it("does not treat a host followed by a prose email as URL userinfo", () => {
+    const prose = "failed to reach https://api.example.com, page ops@company.com";
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "url-prose" } },
+      {
+        originalException: new HexclaveAssertionError("url extraData", { note: prose }),
+      },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      errorProps: expect.objectContaining({
+        extraData: {
+          note: prose,
+        },
+      }),
+    }));
+    expect(JSON.stringify(result)).toContain("api.example.com");
+    expect(JSON.stringify(result)).toContain("ops@company.com");
+  });
+
+  it("caps oversized diagnostic strings and nicify output", () => {
+    const huge = "x".repeat(8_000);
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "huge-string" } },
+      { originalException: new HexclaveAssertionError("huge extraData", { dump: huge }) },
+    );
+
+    const extra = requireEventExtra(result);
+    expect(extra.errorProps).toEqual(expect.objectContaining({
+      extraData: {
+        dump: `${"x".repeat(5_000)}…`,
+      },
+    }));
+    expect(JSON.stringify(result)).not.toContain("x".repeat(5_001));
+    expect(typeof extra.nicifiedError).toBe("string");
+    expect((extra.nicifiedError as string).length).toBeLessThanOrEqual(20_000 + 1);
+  });
+
+  it("redacts backend admin keys and extra credential-shaped fields", () => {
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "admin-key" } },
+      {
+        originalException: new HexclaveAssertionError("key extraData", {
+          note: "issued sak_abcdefghijklmnopqrstuvwxyz",
+          pwd: "hunter2",
+          jwt: "header.payload.sig",
+          otp: "123456",
+          signature: "sig-value",
+        }),
+      },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      errorProps: expect.objectContaining({
+        extraData: {
+          note: "issued [redacted]",
+          pwd: "[redacted]",
+          jwt: "[redacted]",
+          otp: "[redacted]",
+          signature: "[redacted]",
+        },
+      }),
+    }));
+    expect(JSON.stringify(result)).not.toContain("sak_abcdefghijklmnopqrstuvwxyz");
+    expect(JSON.stringify(result)).not.toContain("hunter2");
+    expect(JSON.stringify(result)).not.toContain("123456");
+  });
+
+  it("serializes Dates and dumps non-Error throws", () => {
+    const occurredAt = new Date("2026-08-18T12:00:00.000Z");
+    const dateResult = prepareBackendSentryEvent(
+      { extra: { location: "date" } },
+      { originalException: new HexclaveAssertionError("date extraData", { occurredAt }) },
+    );
+    expect(dateResult.extra).toEqual(expect.objectContaining({
+      errorProps: expect.objectContaining({
+        extraData: {
+          occurredAt: "2026-08-18T12:00:00.000Z",
+        },
+      }),
+    }));
+
+    const thrownResult = prepareBackendSentryEvent(
+      { extra: { location: "non-error" } },
+      { originalException: { reason: "sandbox-timeout", attempt: 2 } },
+    );
+    expect(thrownResult.extra).toEqual(expect.objectContaining({
+      location: "non-error",
+      errorProps: {
+        reason: "sandbox-timeout",
+        attempt: 2,
+      },
+      nicifiedError: expect.stringContaining("sandbox-timeout"),
+    }));
+  });
+
+  it("omits empty errorProps for Errors with no enumerable own data", () => {
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "plain-error" } },
+      { originalException: new Error("plain") },
+    );
+
+    expect(result.extra).toEqual({
+      location: "plain-error",
+    });
   });
 });

--- a/apps/backend/src/sentry-scrubbing.test.ts
+++ b/apps/backend/src/sentry-scrubbing.test.ts
@@ -334,6 +334,51 @@ describe("prepareBackendSentryEvent", () => {
     expect(nicifiedError).toEqual(expect.not.stringContaining("hunter2"));
   });
 
+  it("redacts plural credential keys", () => {
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "plural-keys" } },
+      {
+        originalException: new HexclaveAssertionError("plural extraData", {
+          tokens: ["rawTokenValue"],
+          passwords: ["hunter2"],
+          secrets: ["shh"],
+        }),
+      },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      errorProps: expect.objectContaining({
+        extraData: {
+          tokens: "[redacted]",
+          passwords: "[redacted]",
+          secrets: "[redacted]",
+        },
+      }),
+    }));
+    expect(JSON.stringify(result)).not.toContain("rawTokenValue");
+    expect(JSON.stringify(result)).not.toContain("hunter2");
+  });
+
+  it("redacts URL userinfo even under a non-sensitive key", () => {
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "url-userinfo" } },
+      {
+        originalException: new HexclaveAssertionError("url extraData", {
+          url: "postgres://user:hunter2@db/app",
+        }),
+      },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      errorProps: expect.objectContaining({
+        extraData: {
+          url: "postgres://[redacted]@db/app",
+        },
+      }),
+    }));
+    expect(JSON.stringify(result)).not.toContain("hunter2");
+  });
+
   it("ignores non-string location values", () => {
     const result = prepareBackendSentryEvent({
       extra: {

--- a/apps/backend/src/sentry-scrubbing.test.ts
+++ b/apps/backend/src/sentry-scrubbing.test.ts
@@ -1,6 +1,7 @@
+import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import type { Event } from "@sentry/node";
 import { describe, expect, it } from "vitest";
-import { sanitizeBackendSentryEvent } from "./sentry-scrubbing";
+import { prepareBackendSentryEvent, sanitizeBackendSentryEvent } from "./sentry-scrubbing";
 
 describe("sanitizeBackendSentryEvent", () => {
   it("removes request and trace data that can contain credentials or PII", () => {
@@ -94,9 +95,7 @@ describe("sanitizeBackendSentryEvent", () => {
             "trace_id": "0123456789abcdef0123456789abcdef",
           },
         },
-        "extra": {
-          "location": "backend-global-error",
-        },
+        "extra": undefined,
         "request": {
           "method": "POST",
         },
@@ -232,5 +231,116 @@ describe("sanitizeBackendSentryEvent", () => {
       },
     });
     expect(JSON.stringify(result)).not.toContain("customer-secret");
+  });
+
+  it("clears all extras, including ones that look like diagnostics", () => {
+    const result = sanitizeBackendSentryEvent({
+      extra: {
+        location: "js-execution-freestyle-failed",
+        connectionString: "postgres://secret",
+        nicifiedError: "should not survive sanitize alone",
+      },
+    });
+
+    expect(result.extra).toBeUndefined();
+    expect(JSON.stringify(result)).not.toContain("postgres://secret");
+  });
+});
+
+describe("prepareBackendSentryEvent", () => {
+  it("rebuilds extra from location + exception diagnostics after scrubbing", () => {
+    const cause = new Error("upstream sandbox failure");
+    const error = new HexclaveAssertionError(
+      "JS execution freestyle engine failed, falling back to vercel sandbox engine",
+      { cause, innerCode: "<redacted workflow>", innerOptions: { timeoutMs: 1_000 } },
+    );
+
+    const result = prepareBackendSentryEvent(
+      {
+        request: {
+          method: "POST",
+          url: "https://api.example.com/api/latest/users?token=secret",
+          data: { password: "secret" },
+        },
+        extra: {
+          location: "js-execution-freestyle-failed",
+          connectionString: "postgres://secret",
+        },
+      },
+      { originalException: error },
+    );
+
+    expect(result.request).toEqual({ method: "POST" });
+    expect(result.extra).toEqual(expect.objectContaining({
+      location: "js-execution-freestyle-failed",
+      cause: {
+        name: "Error",
+        message: "upstream sandbox failure",
+      },
+      errorProps: expect.objectContaining({
+        extraData: {
+          cause: {
+            name: "Error",
+            message: "upstream sandbox failure",
+          },
+          innerCode: "<redacted workflow>",
+          innerOptions: { timeoutMs: 1_000 },
+        },
+      }),
+      nicifiedError: expect.stringContaining("innerCode"),
+    }));
+    expect(JSON.stringify(result)).not.toContain("postgres://secret");
+    expect(JSON.stringify(result)).not.toContain("token=secret");
+  });
+
+  it("redacts credential-shaped keys in the dashboard dump", () => {
+    const error = new HexclaveAssertionError(
+      "OAuth callback failed",
+      {
+        innerCode: "<safe>",
+        password: "hunter2",
+        connectionString: "postgres://user:hunter2@db/app",
+        authorization: "Bearer hunter2",
+        oauth: {
+          accessToken: "hunter2-token",
+          timeoutMs: 1_000,
+        },
+      },
+    );
+
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "oauth-callback" } },
+      { originalException: error },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      location: "oauth-callback",
+      errorProps: expect.objectContaining({
+        extraData: {
+          innerCode: "<safe>",
+          password: "[redacted]",
+          connectionString: "[redacted]",
+          authorization: "[redacted]",
+          oauth: {
+            accessToken: "[redacted]",
+            timeoutMs: 1_000,
+          },
+        },
+      }),
+    }));
+    expect(JSON.stringify(result)).not.toContain("hunter2");
+    const nicifiedError = result.extra.nicifiedError;
+    expect(nicifiedError).toEqual(expect.stringContaining("innerCode"));
+    expect(nicifiedError).toEqual(expect.not.stringContaining("hunter2"));
+  });
+
+  it("ignores non-string location values", () => {
+    const result = prepareBackendSentryEvent({
+      extra: {
+        location: { spoofed: true },
+      },
+    });
+
+    expect(result.extra).toBeUndefined();
   });
 });

--- a/apps/backend/src/sentry-scrubbing.test.ts
+++ b/apps/backend/src/sentry-scrubbing.test.ts
@@ -3,14 +3,6 @@ import type { Event } from "@sentry/node";
 import { describe, expect, it } from "vitest";
 import { prepareBackendSentryEvent, sanitizeBackendSentryEvent } from "./sentry-scrubbing";
 
-function requireEventExtra(event: Event) {
-  const extra = event.extra;
-  if (extra == null) {
-    throw new Error("expected Sentry extra to be set");
-  }
-  return extra;
-}
-
 describe("sanitizeBackendSentryEvent", () => {
   it("removes request and trace data that can contain credentials or PII", () => {
     const event: Event = {
@@ -246,7 +238,7 @@ describe("sanitizeBackendSentryEvent", () => {
       extra: {
         location: "js-execution-freestyle-failed",
         connectionString: "postgres://secret",
-        nicifiedError: "should not survive sanitize alone",
+        leftover: "should not survive sanitize alone",
       },
     });
 
@@ -285,7 +277,7 @@ describe("prepareBackendSentryEvent", () => {
         name: "Error",
         message: "upstream sandbox failure",
       },
-      errorProps: expect.objectContaining({
+      errorProps: {
         extraData: {
           cause: {
             name: "Error",
@@ -294,14 +286,13 @@ describe("prepareBackendSentryEvent", () => {
           innerCode: "<redacted workflow>",
           innerOptions: { timeoutMs: 1_000 },
         },
-      }),
-      nicifiedError: expect.stringContaining("innerCode"),
+      },
     }));
     expect(JSON.stringify(result)).not.toContain("postgres://secret");
     expect(JSON.stringify(result)).not.toContain("token=secret");
   });
 
-  it("redacts credential-shaped keys in the dashboard dump", () => {
+  it("redacts credential-shaped keys in extraData", () => {
     const error = new HexclaveAssertionError(
       "OAuth callback failed",
       {
@@ -323,7 +314,7 @@ describe("prepareBackendSentryEvent", () => {
 
     expect(result.extra).toEqual(expect.objectContaining({
       location: "oauth-callback",
-      errorProps: expect.objectContaining({
+      errorProps: {
         extraData: {
           innerCode: "<safe>",
           password: "[redacted]",
@@ -334,12 +325,9 @@ describe("prepareBackendSentryEvent", () => {
             timeoutMs: 1_000,
           },
         },
-      }),
+      },
     }));
     expect(JSON.stringify(result)).not.toContain("hunter2");
-    const nicifiedError = requireEventExtra(result).nicifiedError;
-    expect(nicifiedError).toEqual(expect.stringContaining("innerCode"));
-    expect(nicifiedError).toEqual(expect.not.stringContaining("hunter2"));
   });
 
   it("redacts plural credential keys", () => {
@@ -355,13 +343,13 @@ describe("prepareBackendSentryEvent", () => {
     );
 
     expect(result.extra).toEqual(expect.objectContaining({
-      errorProps: expect.objectContaining({
+      errorProps: {
         extraData: {
           tokens: "[redacted]",
           passwords: "[redacted]",
           secrets: "[redacted]",
         },
-      }),
+      },
     }));
     expect(JSON.stringify(result)).not.toContain("rawTokenValue");
     expect(JSON.stringify(result)).not.toContain("hunter2");
@@ -378,11 +366,11 @@ describe("prepareBackendSentryEvent", () => {
     );
 
     expect(result.extra).toEqual(expect.objectContaining({
-      errorProps: expect.objectContaining({
+      errorProps: {
         extraData: {
           url: "postgres://[redacted]@db/app",
         },
-      }),
+      },
     }));
     expect(JSON.stringify(result)).not.toContain("hunter2");
   });
@@ -397,40 +385,19 @@ describe("prepareBackendSentryEvent", () => {
     expect(result.extra).toBeUndefined();
   });
 
-  it("truncates deeply nested diagnostic values before nicify", () => {
+  it("truncates deeply nested diagnostic values", () => {
     let nested: unknown = "leaf";
     for (let depth = 0; depth < 20; depth++) {
       nested = { child: nested };
     }
-    const result = prepareBackendSentryEvent(
+    const result: Event = prepareBackendSentryEvent(
       { extra: { location: "deep-error" } },
       { originalException: new HexclaveAssertionError("deep extraData", { nested }) },
     );
 
-    expect(JSON.stringify(requireEventExtra(result).errorProps)).toContain("[truncated]");
-    expect(JSON.stringify(requireEventExtra(result).errorProps)).not.toContain("leaf");
-  });
-
-  it("truncates oversized diagnostic collections before nicify", () => {
-    const result = prepareBackendSentryEvent(
-      { extra: { location: "wide-error" } },
-      {
-        originalException: new HexclaveAssertionError("wide extraData", {
-          items: Array.from({ length: 80 }, (_, index) => index),
-        }),
-      },
-    );
-
-    expect(result.extra).toEqual(expect.objectContaining({
-      errorProps: expect.objectContaining({
-        extraData: expect.objectContaining({
-          items: [
-            ...Array.from({ length: 50 }, (_, index) => index),
-            "[truncated]",
-          ],
-        }),
-      }),
-    }));
+    const errorProps = result.extra?.errorProps;
+    expect(JSON.stringify(errorProps)).toContain("[truncated]");
+    expect(JSON.stringify(errorProps)).not.toContain("leaf");
   });
 
   it("redacts URL userinfo when the password contains @ or space", () => {
@@ -444,108 +411,13 @@ describe("prepareBackendSentryEvent", () => {
     );
 
     expect(result.extra).toEqual(expect.objectContaining({
-      errorProps: expect.objectContaining({
+      errorProps: {
         extraData: {
           url: "postgres://[redacted]@db/app",
         },
-      }),
+      },
     }));
     expect(JSON.stringify(result)).not.toContain("p@ss word");
-  });
-
-  it("stops after 50 enumerable own keys on a wide diagnostic object", () => {
-    const wide: Record<string, number> = {};
-    for (let index = 0; index < 80; index++) {
-      wide[`field${index}`] = index;
-    }
-    const result = prepareBackendSentryEvent(
-      { extra: { location: "wide-object" } },
-      { originalException: new HexclaveAssertionError("wide extraData", wide) },
-    );
-
-    expect(result.extra).toEqual(expect.objectContaining({
-      errorProps: expect.objectContaining({
-        extraData: expect.objectContaining({
-          field0: 0,
-          field49: 49,
-          "[truncated]": true,
-        }),
-      }),
-    }));
-    expect(JSON.stringify(requireEventExtra(result).errorProps)).not.toContain("field50");
-  });
-
-  it("does not invoke throwing enumerable getters while building extras", () => {
-    const extraData = { innerCode: "<safe>" };
-    const error = new HexclaveAssertionError("accessor extraData", extraData);
-    Object.defineProperty(extraData, "boom", {
-      enumerable: true,
-      get() {
-        throw new Error("diagnostic getter should not run");
-      },
-    });
-    Object.defineProperty(error, "explode", {
-      enumerable: true,
-      get() {
-        throw new Error("error getter should not run");
-      },
-    });
-
-    const result = prepareBackendSentryEvent(
-      { extra: { location: "throwing-getter" } },
-      { originalException: error },
-    );
-
-    expect(result.extra).toEqual(expect.objectContaining({
-      location: "throwing-getter",
-      errorProps: expect.objectContaining({
-        explode: "[accessor]",
-        extraData: {
-          innerCode: "<safe>",
-          boom: "[accessor]",
-        },
-      }),
-    }));
-  });
-
-  it("dumps a shared nested object on every path, not as circular", () => {
-    const shared = { leaf: "shared-value" };
-    const result = prepareBackendSentryEvent(
-      { extra: { location: "diamond" } },
-      {
-        originalException: new HexclaveAssertionError("diamond extraData", {
-          a: shared,
-          b: shared,
-        }),
-      },
-    );
-
-    expect(result.extra).toEqual(expect.objectContaining({
-      errorProps: expect.objectContaining({
-        extraData: {
-          a: { leaf: "shared-value" },
-          b: { leaf: "shared-value" },
-        },
-      }),
-    }));
-  });
-
-  it("still marks true cycles as circular", () => {
-    const extraData: Record<string, unknown> = { name: "cycle-root" };
-    extraData.self = extraData;
-    const result = prepareBackendSentryEvent(
-      { extra: { location: "cycle" } },
-      { originalException: new HexclaveAssertionError("cycle extraData", extraData) },
-    );
-
-    expect(result.extra).toEqual(expect.objectContaining({
-      errorProps: expect.objectContaining({
-        extraData: {
-          name: "cycle-root",
-          self: "[circular]",
-        },
-      }),
-    }));
   });
 
   it("does not treat a host followed by a prose email as URL userinfo", () => {
@@ -558,32 +430,14 @@ describe("prepareBackendSentryEvent", () => {
     );
 
     expect(result.extra).toEqual(expect.objectContaining({
-      errorProps: expect.objectContaining({
+      errorProps: {
         extraData: {
           note: prose,
         },
-      }),
+      },
     }));
     expect(JSON.stringify(result)).toContain("api.example.com");
     expect(JSON.stringify(result)).toContain("ops@company.com");
-  });
-
-  it("caps oversized diagnostic strings and nicify output", () => {
-    const huge = "x".repeat(8_000);
-    const result = prepareBackendSentryEvent(
-      { extra: { location: "huge-string" } },
-      { originalException: new HexclaveAssertionError("huge extraData", { dump: huge }) },
-    );
-
-    const extra = requireEventExtra(result);
-    expect(extra.errorProps).toEqual(expect.objectContaining({
-      extraData: {
-        dump: `${"x".repeat(5_000)}…`,
-      },
-    }));
-    expect(JSON.stringify(result)).not.toContain("x".repeat(5_001));
-    expect(typeof extra.nicifiedError).toBe("string");
-    expect((extra.nicifiedError as string).length).toBeLessThanOrEqual(20_000 + 1);
   });
 
   it("redacts backend admin keys and extra credential-shaped fields", () => {
@@ -601,7 +455,7 @@ describe("prepareBackendSentryEvent", () => {
     );
 
     expect(result.extra).toEqual(expect.objectContaining({
-      errorProps: expect.objectContaining({
+      errorProps: {
         extraData: {
           note: "issued [redacted]",
           pwd: "[redacted]",
@@ -609,49 +463,172 @@ describe("prepareBackendSentryEvent", () => {
           otp: "[redacted]",
           signature: "[redacted]",
         },
-      }),
+      },
     }));
     expect(JSON.stringify(result)).not.toContain("sak_abcdefghijklmnopqrstuvwxyz");
     expect(JSON.stringify(result)).not.toContain("hunter2");
     expect(JSON.stringify(result)).not.toContain("123456");
   });
 
-  it("serializes Dates and dumps non-Error throws", () => {
-    const occurredAt = new Date("2026-08-18T12:00:00.000Z");
-    const dateResult = prepareBackendSentryEvent(
-      { extra: { location: "date" } },
-      { originalException: new HexclaveAssertionError("date extraData", { occurredAt }) },
+  it("caps oversized diagnostic strings", () => {
+    const huge = "x".repeat(8_000);
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "huge-string" } },
+      { originalException: new HexclaveAssertionError("huge extraData", { dump: huge }) },
     );
-    expect(dateResult.extra).toEqual(expect.objectContaining({
-      errorProps: expect.objectContaining({
-        extraData: {
-          occurredAt: "2026-08-18T12:00:00.000Z",
-        },
-      }),
-    }));
 
-    const thrownResult = prepareBackendSentryEvent(
-      { extra: { location: "non-error" } },
-      { originalException: { reason: "sandbox-timeout", attempt: 2 } },
-    );
-    expect(thrownResult.extra).toEqual(expect.objectContaining({
-      location: "non-error",
+    expect(result.extra).toEqual(expect.objectContaining({
       errorProps: {
-        reason: "sandbox-timeout",
-        attempt: 2,
+        extraData: {
+          dump: `${"x".repeat(5_000)}…`,
+        },
       },
-      nicifiedError: expect.stringContaining("sandbox-timeout"),
+    }));
+    expect(JSON.stringify(result)).not.toContain("x".repeat(5_001));
+  });
+
+  it("still serializes cyclic extraData", () => {
+    const extraData: Record<string, unknown> = { name: "cycle-root" };
+    extraData.self = extraData;
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "cycle" } },
+      { originalException: new HexclaveAssertionError("cycle extraData", extraData) },
+    );
+
+    const extra = result.extra;
+    expect(JSON.stringify(extra)).toContain("cycle-root");
+    expect(JSON.stringify(extra)).toContain("[truncated]");
+    expect(() => JSON.stringify(extra)).not.toThrow();
+  });
+
+  it("JSON.stringify of extra does not throw on bigint, Date, Buffer, or URL", () => {
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "exotic-types" } },
+      {
+        originalException: new HexclaveAssertionError("exotic extraData", {
+          id: 1n,
+          occurredAt: new Date("2026-08-19T12:00:00.000Z"),
+          payload: Buffer.from("secret-bytes"),
+          href: new URL("postgres://user:hunter2@db/app"),
+        }),
+      },
+    );
+
+    expect(() => JSON.stringify(result.extra)).not.toThrow();
+    expect(result.extra).toEqual(expect.objectContaining({
+      errorProps: {
+        extraData: {
+          id: "1",
+          occurredAt: {},
+          payload: "[bytes 12]",
+          href: {},
+        },
+      },
+    }));
+    expect(JSON.stringify(result)).not.toContain("hunter2");
+    expect(JSON.stringify(result)).not.toContain("secret-bytes");
+  });
+
+  it("redacts userinfo in redis URLs and in query-embedded URLs", () => {
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "url-variants" } },
+      {
+        originalException: new HexclaveAssertionError("url extraData", {
+          redis: "redis://:hunter2@localhost:6379/0",
+          redirect: "https://app.example.com/oauth?next=https://user:hunter2@evil.example.com/cb",
+          pathAt: "https://example.com/@aman",
+        }),
+      },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      errorProps: {
+        extraData: {
+          redis: "redis://[redacted]@localhost:6379/0",
+          redirect: "https://app.example.com/oauth?next=https://[redacted]@evil.example.com/cb",
+          pathAt: "https://example.com/@aman",
+        },
+      },
+    }));
+    expect(JSON.stringify(result)).not.toContain("hunter2");
+  });
+
+  it("redacts credential keys inside webhook-shaped nested data", () => {
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "webhook" } },
+      {
+        originalException: new HexclaveAssertionError("Error sending Svix webhook!", {
+          event: "user.created",
+          data: {
+            id: "user_123",
+            authorization: "Bearer hunter2",
+            client_secret: "shhh",
+          },
+        }),
+      },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      errorProps: {
+        extraData: {
+          event: "user.created",
+          data: {
+            id: "user_123",
+            authorization: "[redacted]",
+            client_secret: "[redacted]",
+          },
+        },
+      },
+    }));
+    expect(JSON.stringify(result)).not.toContain("hunter2");
+    expect(JSON.stringify(result)).not.toContain("shhh");
+  });
+
+  it("scrubs credential-shaped text in Error messages", () => {
+    const cause = new Error("upstream postgres://user:hunter2@db/app sak_abcdefghijklmnopqrstuvwxyz");
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "cause-message" } },
+      { originalException: new HexclaveAssertionError("wrapped", { cause }) },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      cause: {
+        name: "Error",
+        message: "upstream postgres://[redacted]@db/app [redacted]",
+      },
+    }));
+    expect(JSON.stringify(result)).not.toContain("hunter2");
+    expect(JSON.stringify(result)).not.toContain("sak_abcdefghijklmnopqrstuvwxyz");
+  });
+
+  it("dumps a cause chain, not only the first Error", () => {
+    const root = new Error("root failure");
+    const mid = new Error("mid failure", { cause: root });
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "cause-chain" } },
+      { originalException: new HexclaveAssertionError("wrapped", { cause: mid }) },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      cause: {
+        name: "Error",
+        message: "mid failure",
+        cause: {
+          name: "Error",
+          message: "root failure",
+        },
+      },
     }));
   });
 
-  it("omits empty errorProps for Errors with no enumerable own data", () => {
+  it("does not dump extra for non-Error throws", () => {
     const result = prepareBackendSentryEvent(
-      { extra: { location: "plain-error" } },
-      { originalException: new Error("plain") },
+      { extra: { location: "non-error" } },
+      { originalException: { reason: "sandbox-timeout" } },
     );
 
     expect(result.extra).toEqual({
-      location: "plain-error",
+      location: "non-error",
     });
   });
 });

--- a/apps/backend/src/sentry-scrubbing.test.ts
+++ b/apps/backend/src/sentry-scrubbing.test.ts
@@ -424,4 +424,79 @@ describe("prepareBackendSentryEvent", () => {
       }),
     }));
   });
+
+  it("redacts URL userinfo when the password contains @ or space", () => {
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "url-userinfo-special-chars" } },
+      {
+        originalException: new HexclaveAssertionError("url extraData", {
+          url: "postgres://user:p@ss word@db/app",
+        }),
+      },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      errorProps: expect.objectContaining({
+        extraData: {
+          url: "postgres://[redacted]@db/app",
+        },
+      }),
+    }));
+    expect(JSON.stringify(result)).not.toContain("p@ss word");
+  });
+
+  it("stops after 50 enumerable own keys on a wide diagnostic object", () => {
+    const wide: Record<string, number> = {};
+    for (let index = 0; index < 80; index++) {
+      wide[`field${index}`] = index;
+    }
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "wide-object" } },
+      { originalException: new HexclaveAssertionError("wide extraData", wide) },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      errorProps: expect.objectContaining({
+        extraData: expect.objectContaining({
+          field0: 0,
+          field49: 49,
+          "[truncated]": true,
+        }),
+      }),
+    }));
+    expect(JSON.stringify(result.extra.errorProps)).not.toContain("field50");
+  });
+
+  it("does not invoke throwing enumerable getters while building extras", () => {
+    const extraData = { innerCode: "<safe>" };
+    const error = new HexclaveAssertionError("accessor extraData", extraData);
+    Object.defineProperty(extraData, "boom", {
+      enumerable: true,
+      get() {
+        throw new Error("diagnostic getter should not run");
+      },
+    });
+    Object.defineProperty(error, "explode", {
+      enumerable: true,
+      get() {
+        throw new Error("error getter should not run");
+      },
+    });
+
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "throwing-getter" } },
+      { originalException: error },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      location: "throwing-getter",
+      errorProps: expect.objectContaining({
+        explode: "[accessor]",
+        extraData: {
+          innerCode: "<safe>",
+          boom: "[accessor]",
+        },
+      }),
+    }));
+  });
 });

--- a/apps/backend/src/sentry-scrubbing.test.ts
+++ b/apps/backend/src/sentry-scrubbing.test.ts
@@ -343,4 +343,40 @@ describe("prepareBackendSentryEvent", () => {
 
     expect(result.extra).toBeUndefined();
   });
+
+  it("truncates deeply nested diagnostic values before nicify", () => {
+    let nested: unknown = "leaf";
+    for (let depth = 0; depth < 20; depth++) {
+      nested = { child: nested };
+    }
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "deep-error" } },
+      { originalException: new HexclaveAssertionError("deep extraData", { nested }) },
+    );
+
+    expect(JSON.stringify(result.extra.errorProps)).toContain("[truncated]");
+    expect(JSON.stringify(result.extra.errorProps)).not.toContain("leaf");
+  });
+
+  it("truncates oversized diagnostic collections before nicify", () => {
+    const result = prepareBackendSentryEvent(
+      { extra: { location: "wide-error" } },
+      {
+        originalException: new HexclaveAssertionError("wide extraData", {
+          items: Array.from({ length: 80 }, (_, index) => index),
+        }),
+      },
+    );
+
+    expect(result.extra).toEqual(expect.objectContaining({
+      errorProps: expect.objectContaining({
+        extraData: expect.objectContaining({
+          items: [
+            ...Array.from({ length: 50 }, (_, index) => index),
+            "[truncated]",
+          ],
+        }),
+      }),
+    }));
+  });
 });

--- a/apps/backend/src/sentry-scrubbing.ts
+++ b/apps/backend/src/sentry-scrubbing.ts
@@ -83,11 +83,14 @@ export function sanitizeBackendSentrySpan(span: BackendSentrySpan): BackendSentr
 const sensitiveDiagnosticKeySegments = new Set([
   "password",
   "passwd",
+  "pwd",
   "secret",
   "authorization",
   "cookie",
   "cookies",
   "token",
+  "jwt",
+  "otp",
   "key",
   "dsn",
   "accesstoken",
@@ -101,10 +104,19 @@ const sensitiveDiagnosticKeySegments = new Set([
   "bearer",
   "credential",
   "credentials",
+  "signature",
 ]);
 
 const maxDiagnosticDepth = 8;
 const maxDiagnosticCollectionSize = 50;
+// Sentry does not apply maxValueLength to extras we attach in beforeSend.
+const maxDiagnosticStringLength = 5_000;
+const maxDiagnosticNicifyLength = 20_000;
+const maxDiagnosticPayloadBytes = 100_000;
+
+type DiagnosticBudget = {
+  used: number,
+};
 
 function matchesSensitiveDiagnosticSegment(part: string): boolean {
   if (sensitiveDiagnosticKeySegments.has(part)) {
@@ -133,15 +145,39 @@ function isSensitiveDiagnosticKey(key: string): boolean {
   return normalized.split("_").some((part) => part !== "" && matchesSensitiveDiagnosticSegment(part));
 }
 
-function scrubDiagnosticString(value: string): string {
-  return value
+function scrubDiagnosticString(value: string, budget: DiagnosticBudget): string {
+  if (budget.used >= maxDiagnosticPayloadBytes) {
+    return "[truncated]";
+  }
+  let scrubbed = value
     .replaceAll(
-      /\b(sk_[A-Za-z0-9_-]+|pk_[A-Za-z0-9_-]+|pck_[A-Za-z0-9_-]+|stk_[A-Za-z0-9_-]+|ssk_[A-Za-z0-9_-]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b/g,
+      /\b(sk_[A-Za-z0-9_-]+|pk_[A-Za-z0-9_-]+|pck_[A-Za-z0-9_-]+|sak_[A-Za-z0-9_-]+|ssk_[A-Za-z0-9_-]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b/g,
       "[redacted]",
     )
-    // Userinfo is everything between :// and the last @ before path/query/hash,
-    // so passwords may contain @ or space (the previous [^/@\s]+ cut those short).
-    .replaceAll(/:\/\/[^/?#]*@/g, "://[redacted]@");
+    // Pass 1: user:password@, including passwords that contain @ or space.
+    // Pass 2: user@ with no password. `[^\s/?#]*@` would also eat prose like
+    // `https://api.example.com, page ops@company.com`.
+    .replaceAll(/:\/\/[^\s/?#]*:[^/?#]*@/g, "://[redacted]@")
+    .replaceAll(/:\/\/[^\s/?#@]*@/g, "://[redacted]@");
+  if (scrubbed.length > maxDiagnosticStringLength) {
+    scrubbed = `${scrubbed.slice(0, maxDiagnosticStringLength)}…`;
+  }
+  budget.used += scrubbed.length;
+  if (budget.used > maxDiagnosticPayloadBytes) {
+    return "[truncated]";
+  }
+  return scrubbed;
+}
+
+function takeIterable<T>(value: Iterable<T>, limit: number): T[] {
+  const items: T[] = [];
+  for (const item of value) {
+    items.push(item);
+    if (items.length >= limit) {
+      break;
+    }
+  }
+  return items;
 }
 
 function readOwnDataProperty(object: object, key: string): { kind: "missing" } | { kind: "accessor" } | { kind: "value", value: unknown } {
@@ -162,48 +198,62 @@ function scrubOwnEnumerableFields(
   value: object,
   seen: WeakSet<object>,
   depth: number,
+  budget: DiagnosticBudget,
 ): unknown {
-  if (depth >= maxDiagnosticDepth) {
+  if (depth >= maxDiagnosticDepth || budget.used >= maxDiagnosticPayloadBytes) {
     return "[truncated]";
   }
   if (seen.has(value)) {
     return "[circular]";
   }
   seen.add(value);
-  if (Array.isArray(value)) {
-    const entries = value.slice(0, maxDiagnosticCollectionSize).map((entry) => (
-      scrubDiagnosticValue(entry, undefined, seen, depth + 1)
-    ));
-    if (value.length > maxDiagnosticCollectionSize) {
-      entries.push("[truncated]");
+  try {
+    if (Array.isArray(value)) {
+      const entries: unknown[] = [];
+      const limit = Math.min(value.length, maxDiagnosticCollectionSize);
+      for (let index = 0; index < limit; index++) {
+        if (budget.used >= maxDiagnosticPayloadBytes) {
+          entries.push("[truncated]");
+          break;
+        }
+        entries.push(scrubDiagnosticValue(value[index], undefined, seen, depth + 1, budget));
+      }
+      if (value.length > maxDiagnosticCollectionSize && entries.at(-1) !== "[truncated]") {
+        entries.push("[truncated]");
+      }
+      return entries;
     }
-    return entries;
+    const scrubbed = new Map<string, unknown>();
+    let enumerableCount = 0;
+    let truncated = false;
+    for (const nestedKey in value) {
+      if (!Object.prototype.hasOwnProperty.call(value, nestedKey)) {
+        continue;
+      }
+      enumerableCount += 1;
+      if (enumerableCount > maxDiagnosticCollectionSize || budget.used >= maxDiagnosticPayloadBytes) {
+        truncated = true;
+        break;
+      }
+      const own = readOwnDataProperty(value, nestedKey);
+      if (own.kind === "accessor") {
+        scrubbed.set(nestedKey, isSensitiveDiagnosticKey(nestedKey) ? "[redacted]" : "[accessor]");
+        continue;
+      }
+      if (own.kind === "value") {
+        scrubbed.set(nestedKey, scrubDiagnosticValue(own.value, nestedKey, seen, depth + 1, budget));
+      }
+    }
+    if (truncated) {
+      scrubbed.set("[truncated]", true);
+    }
+    return Object.fromEntries(scrubbed);
+  } finally {
+    // Path-local `seen`: diamonds (`{ a: shared, b: shared }`) must dump twice,
+    // not mark the second edge `[circular]`. True cycles still hit `seen` on the
+    // way down, before this unwind.
+    seen.delete(value);
   }
-  const scrubbed = new Map<string, unknown>();
-  let enumerableCount = 0;
-  let truncated = false;
-  for (const nestedKey in value) {
-    if (!Object.prototype.hasOwnProperty.call(value, nestedKey)) {
-      continue;
-    }
-    enumerableCount += 1;
-    if (enumerableCount > maxDiagnosticCollectionSize) {
-      truncated = true;
-      break;
-    }
-    const own = readOwnDataProperty(value, nestedKey);
-    if (own.kind === "accessor") {
-      scrubbed.set(nestedKey, isSensitiveDiagnosticKey(nestedKey) ? "[redacted]" : "[accessor]");
-      continue;
-    }
-    if (own.kind === "value") {
-      scrubbed.set(nestedKey, scrubDiagnosticValue(own.value, nestedKey, seen, depth + 1));
-    }
-  }
-  if (truncated) {
-    scrubbed.set("[truncated]", true);
-  }
-  return Object.fromEntries(scrubbed);
 }
 
 function scrubDiagnosticValue(
@@ -211,6 +261,7 @@ function scrubDiagnosticValue(
   key?: string,
   seen: WeakSet<object> = new WeakSet(),
   depth = 0,
+  budget: DiagnosticBudget = { used: 0 },
 ): unknown {
   if (key != null && isSensitiveDiagnosticKey(key) && value != null) {
     return "[redacted]";
@@ -219,10 +270,10 @@ function scrubDiagnosticValue(
     return value;
   }
   if (typeof value === "string") {
-    return scrubDiagnosticString(value);
+    return scrubDiagnosticString(value, budget);
   }
   if (typeof value === "bigint") {
-    return scrubDiagnosticString(value.toString());
+    return scrubDiagnosticString(value.toString(), budget);
   }
   if (typeof value === "symbol" || typeof value === "function") {
     return `[${typeof value}]`;
@@ -232,35 +283,97 @@ function scrubDiagnosticValue(
     const message = readOwnDataProperty(value, "message");
     return {
       name: name.kind === "accessor" ? "[accessor]" : name.kind === "value" && typeof name.value === "string" ? name.value : value.constructor.name,
-      message: message.kind === "accessor" ? "[accessor]" : message.kind === "value" && typeof message.value === "string" ? scrubDiagnosticString(message.value) : "",
+      message: message.kind === "accessor" ? "[accessor]" : message.kind === "value" && typeof message.value === "string" ? scrubDiagnosticString(message.value, budget) : "",
     };
+  }
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? "[Invalid Date]" : scrubDiagnosticString(value.toISOString(), budget);
+  }
+  if (value instanceof URL) {
+    return scrubDiagnosticString(value.href, budget);
+  }
+  if (value instanceof RegExp) {
+    return scrubDiagnosticString(value.toString(), budget);
+  }
+  if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
+    return `[bytes ${value.byteLength}]`;
   }
   if (typeof value !== "object") {
     return value;
   }
-  return scrubOwnEnumerableFields(value, seen, depth);
+  // Map/Set don't enumerate entries via for-in. Mark the original in `seen`
+  // before converting so a collection that contains itself stays `[circular]`.
+  // Copy at most cap+1 entries so a huge collection cannot allocate unbounded
+  // intermediates; the enumerable walk then applies the usual 50-item truncation.
+  if (value instanceof Map || value instanceof Set) {
+    if (seen.has(value)) {
+      return "[circular]";
+    }
+    seen.add(value);
+    try {
+      const converted = value instanceof Map
+        ? Object.fromEntries(takeIterable(value.entries(), maxDiagnosticCollectionSize + 1).map(([mapKey, mapValue]) => [
+          typeof mapKey === "string" ? mapKey : String(mapKey),
+          mapValue,
+        ]))
+        : takeIterable(value, maxDiagnosticCollectionSize + 1);
+      return scrubOwnEnumerableFields(converted, seen, depth, budget);
+    } finally {
+      seen.delete(value);
+    }
+  }
+  return scrubOwnEnumerableFields(value, seen, depth, budget);
+}
+
+function capNicifiedError(value: string): string {
+  if (value.length <= maxDiagnosticNicifyLength) {
+    return value;
+  }
+  return `${value.slice(0, maxDiagnosticNicifyLength)}…`;
+}
+
+function extrasFromDumpedProps(errorProps: unknown): Record<string, unknown> {
+  if (
+    errorProps != null
+    && typeof errorProps === "object"
+    && !Array.isArray(errorProps)
+    && Object.keys(errorProps).length === 0
+  ) {
+    return {};
+  }
+  return {
+    errorProps,
+    nicifiedError: capNicifiedError(nicify(errorProps, { maxDepth: maxDiagnosticDepth })),
+  };
 }
 
 /**
  * Dashboard dump (cause, enumerable error props, nicify), then key-scrub.
  * Root errorProps walks enumerable own data (extraData) without spreading the
- * Error. Nested Error values stay name/message only.
+ * Error. Nested Error values stay name/message only. nicify runs on the
+ * already-scrubbed tree so its cycle handling stays in the readable dump
+ * without re-walking live getters.
  */
 function getExceptionExtra(error: unknown): Record<string, unknown> {
-  if (!(error instanceof Error)) {
+  if (error === undefined) {
     return {};
   }
+  const budget: DiagnosticBudget = { used: 0 };
+  const seen = new WeakSet<object>();
+  if (!(error instanceof Error)) {
+    return extrasFromDumpedProps(scrubDiagnosticValue(error, undefined, seen, 0, budget));
+  }
 
-  const errorProps = scrubOwnEnumerableFields(error, new WeakSet(), 0);
+  const errorProps = scrubOwnEnumerableFields(error, seen, 0, budget);
   const causeProperty = readOwnDataProperty(error, "cause");
+  const cause = causeProperty.kind === "accessor"
+    ? "[accessor]"
+    : causeProperty.kind === "value"
+      ? scrubDiagnosticValue(causeProperty.value, undefined, seen, 0, budget)
+      : undefined;
   return {
-    cause: causeProperty.kind === "accessor"
-      ? "[accessor]"
-      : causeProperty.kind === "value"
-        ? scrubDiagnosticValue(causeProperty.value)
-        : undefined,
-    errorProps,
-    nicifiedError: nicify(errorProps, { maxDepth: 8 }),
+    ...(cause !== undefined ? { cause } : {}),
+    ...extrasFromDumpedProps(errorProps),
   };
 }
 
@@ -268,7 +381,10 @@ function getExceptionExtra(error: unknown): Record<string, unknown> {
  * Keep the minimum metadata needed to correlate a backend error while ensuring
  * request bodies, credentials, query values, customer identities, and SQL never
  * cross the Sentry boundary. Clears `extra` entirely — callers that need
- * diagnostics should go through prepareBackendSentryEvent, which rebuilds it.
+ * diagnostics should go through prepareBackendSentryEvent, which rebuilds a
+ * scrubbed dump. extraData on HexclaveAssertionError can still mention
+ * identities if a caller put them there; this sanitizer only default-denies
+ * the request/span/user envelope.
  */
 export function sanitizeBackendSentryEvent<T extends Event>(event: T): T {
   if (event.request != null) {

--- a/apps/backend/src/sentry-scrubbing.ts
+++ b/apps/backend/src/sentry-scrubbing.ts
@@ -1,5 +1,6 @@
 import { httpMethodNames } from "@/generated/route-modules";
-import type { Event } from "@sentry/node";
+import { nicify } from "@hexclave/shared/dist/utils/strings";
+import type { Event, EventHint } from "@sentry/node";
 
 const knownHttpMethods = new Set<string>(httpMethodNames);
 
@@ -77,10 +78,112 @@ export function sanitizeBackendSentrySpan(span: BackendSentrySpan): BackendSentr
   return span;
 }
 
+// Dashboard dump, then CLI-style extra scrub. Segment-split so "timeout" does
+// not match "token". Nested secrets under boring keys can still leak.
+const sensitiveDiagnosticKeySegments = new Set([
+  "password",
+  "passwd",
+  "secret",
+  "authorization",
+  "cookie",
+  "cookies",
+  "token",
+  "key",
+  "dsn",
+  "accesstoken",
+  "refreshtoken",
+  "idtoken",
+  "apikey",
+  "connectionstring",
+  "clientsecret",
+  "privatekey",
+  "setcookie",
+  "bearer",
+  "credential",
+  "credentials",
+]);
+
+function isSensitiveDiagnosticKey(key: string): boolean {
+  const normalized = key
+    .replaceAll(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .replaceAll(/[^A-Za-z0-9]+/g, "_")
+    .toLowerCase();
+  const compact = normalized.replaceAll("_", "");
+  if (sensitiveDiagnosticKeySegments.has(compact)) {
+    return true;
+  }
+  return normalized.split("_").some((part) => part !== "" && sensitiveDiagnosticKeySegments.has(part));
+}
+
+function scrubDiagnosticString(value: string): string {
+  return value.replaceAll(
+    /\b(sk_[A-Za-z0-9_-]+|pk_[A-Za-z0-9_-]+|pck_[A-Za-z0-9_-]+|stk_[A-Za-z0-9_-]+|ssk_[A-Za-z0-9_-]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b/g,
+    "[redacted]",
+  );
+}
+
+function scrubDiagnosticValue(value: unknown, key?: string, seen: WeakSet<object> = new WeakSet()): unknown {
+  if (key != null && isSensitiveDiagnosticKey(key) && value != null) {
+    return "[redacted]";
+  }
+  if (value == null || typeof value === "boolean" || typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string") {
+    return scrubDiagnosticString(value);
+  }
+  if (typeof value === "bigint") {
+    return scrubDiagnosticString(value.toString());
+  }
+  if (typeof value === "symbol" || typeof value === "function") {
+    return `[${typeof value}]`;
+  }
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: scrubDiagnosticString(value.message),
+    };
+  }
+  if (typeof value !== "object") {
+    return value;
+  }
+  if (seen.has(value)) {
+    return "[circular]";
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.map((entry) => scrubDiagnosticValue(entry, undefined, seen));
+  }
+  const scrubbed = new Map<string, unknown>();
+  for (const [nestedKey, nestedValue] of Object.entries(value)) {
+    scrubbed.set(nestedKey, scrubDiagnosticValue(nestedValue, nestedKey, seen));
+  }
+  return Object.fromEntries(scrubbed);
+}
+
+/**
+ * Dashboard dump (cause, enumerable error props, nicify), then key-scrub.
+ * nicify runs on already-scrubbed errorProps so the string dump does not
+ * re-introduce redacted values.
+ */
+function getExceptionExtra(error: unknown): Record<string, unknown> {
+  if (!(error instanceof Error)) {
+    return {};
+  }
+
+  const errorProps = scrubDiagnosticValue({ ...error });
+  return {
+    cause: scrubDiagnosticValue(error.cause),
+    errorProps,
+    nicifiedError: nicify(errorProps, { maxDepth: 8 }),
+  };
+}
+
 /**
  * Keep the minimum metadata needed to correlate a backend error while ensuring
  * request bodies, credentials, query values, customer identities, and SQL never
- * cross the Sentry boundary.
+ * cross the Sentry boundary. Clears `extra` entirely — callers that need
+ * diagnostics should go through prepareBackendSentryEvent, which rebuilds it.
  */
 export function sanitizeBackendSentryEvent<T extends Event>(event: T): T {
   if (event.request != null) {
@@ -90,9 +193,7 @@ export function sanitizeBackendSentryEvent<T extends Event>(event: T): T {
   }
   event.user = undefined;
   event.tags = undefined;
-
-  const location = event.extra?.location;
-  event.extra = typeof location === "string" ? { location } : undefined;
+  event.extra = undefined;
 
   event.breadcrumbs = event.breadcrumbs?.map((breadcrumb) => ({
     type: breadcrumb.type,
@@ -159,5 +260,21 @@ export function sanitizeBackendSentryEvent<T extends Event>(event: T): T {
       ...(safeRequestContext == null ? {} : { "stack-request": safeRequestContext }),
     };
 
+  return event;
+}
+
+/**
+ * beforeSend entrypoint: scrub request/span PII, then rebuild `extra` as the
+ * dashboard dump plus captureError's `location`, then key-scrub that dump.
+ */
+export function prepareBackendSentryEvent<T extends Event>(event: T, hint?: EventHint): T {
+  const location = typeof event.extra?.location === "string" ? event.extra.location : undefined;
+  sanitizeBackendSentryEvent(event);
+
+  const extra = {
+    ...(location != null ? { location } : {}),
+    ...getExceptionExtra(hint?.originalException),
+  };
+  event.extra = Object.keys(extra).length > 0 ? extra : undefined;
   return event;
 }

--- a/apps/backend/src/sentry-scrubbing.ts
+++ b/apps/backend/src/sentry-scrubbing.ts
@@ -139,8 +139,71 @@ function scrubDiagnosticString(value: string): string {
       /\b(sk_[A-Za-z0-9_-]+|pk_[A-Za-z0-9_-]+|pck_[A-Za-z0-9_-]+|stk_[A-Za-z0-9_-]+|ssk_[A-Za-z0-9_-]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b/g,
       "[redacted]",
     )
-    // postgres://user:pass@host and the same userinfo shape on other URLs
-    .replaceAll(/:\/\/[^/@\s]+:[^/@\s]+@/g, "://[redacted]@");
+    // Userinfo is everything between :// and the last @ before path/query/hash,
+    // so passwords may contain @ or space (the previous [^/@\s]+ cut those short).
+    .replaceAll(/:\/\/[^/?#]*@/g, "://[redacted]@");
+}
+
+function readOwnDataProperty(object: object, key: string): { kind: "missing" } | { kind: "accessor" } | { kind: "value", value: unknown } {
+  const descriptor = Object.getOwnPropertyDescriptor(object, key);
+  if (descriptor == null) {
+    return { kind: "missing" };
+  }
+  if (descriptor.get != null) {
+    return { kind: "accessor" };
+  }
+  if (Object.prototype.hasOwnProperty.call(descriptor, "value")) {
+    return { kind: "value", value: descriptor.value };
+  }
+  return { kind: "missing" };
+}
+
+function scrubOwnEnumerableFields(
+  value: object,
+  seen: WeakSet<object>,
+  depth: number,
+): unknown {
+  if (depth >= maxDiagnosticDepth) {
+    return "[truncated]";
+  }
+  if (seen.has(value)) {
+    return "[circular]";
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const entries = value.slice(0, maxDiagnosticCollectionSize).map((entry) => (
+      scrubDiagnosticValue(entry, undefined, seen, depth + 1)
+    ));
+    if (value.length > maxDiagnosticCollectionSize) {
+      entries.push("[truncated]");
+    }
+    return entries;
+  }
+  const scrubbed = new Map<string, unknown>();
+  let enumerableCount = 0;
+  let truncated = false;
+  for (const nestedKey in value) {
+    if (!Object.prototype.hasOwnProperty.call(value, nestedKey)) {
+      continue;
+    }
+    enumerableCount += 1;
+    if (enumerableCount > maxDiagnosticCollectionSize) {
+      truncated = true;
+      break;
+    }
+    const own = readOwnDataProperty(value, nestedKey);
+    if (own.kind === "accessor") {
+      scrubbed.set(nestedKey, isSensitiveDiagnosticKey(nestedKey) ? "[redacted]" : "[accessor]");
+      continue;
+    }
+    if (own.kind === "value") {
+      scrubbed.set(nestedKey, scrubDiagnosticValue(own.value, nestedKey, seen, depth + 1));
+    }
+  }
+  if (truncated) {
+    scrubbed.set("[truncated]", true);
+  }
+  return Object.fromEntries(scrubbed);
 }
 
 function scrubDiagnosticValue(
@@ -165,54 +228,37 @@ function scrubDiagnosticValue(
     return `[${typeof value}]`;
   }
   if (value instanceof Error) {
+    const name = readOwnDataProperty(value, "name");
+    const message = readOwnDataProperty(value, "message");
     return {
-      name: value.name,
-      message: scrubDiagnosticString(value.message),
+      name: name.kind === "accessor" ? "[accessor]" : name.kind === "value" && typeof name.value === "string" ? name.value : value.constructor.name,
+      message: message.kind === "accessor" ? "[accessor]" : message.kind === "value" && typeof message.value === "string" ? scrubDiagnosticString(message.value) : "",
     };
   }
   if (typeof value !== "object") {
     return value;
   }
-  if (depth >= maxDiagnosticDepth) {
-    return "[truncated]";
-  }
-  if (seen.has(value)) {
-    return "[circular]";
-  }
-  seen.add(value);
-  if (Array.isArray(value)) {
-    const entries = value.slice(0, maxDiagnosticCollectionSize).map((entry) => (
-      scrubDiagnosticValue(entry, undefined, seen, depth + 1)
-    ));
-    if (value.length > maxDiagnosticCollectionSize) {
-      entries.push("[truncated]");
-    }
-    return entries;
-  }
-  const keys = Object.keys(value);
-  const scrubbed = new Map<string, unknown>();
-  for (const nestedKey of keys.slice(0, maxDiagnosticCollectionSize)) {
-    scrubbed.set(nestedKey, scrubDiagnosticValue(Reflect.get(value, nestedKey), nestedKey, seen, depth + 1));
-  }
-  if (keys.length > maxDiagnosticCollectionSize) {
-    scrubbed.set("[truncated]", true);
-  }
-  return Object.fromEntries(scrubbed);
+  return scrubOwnEnumerableFields(value, seen, depth);
 }
 
 /**
  * Dashboard dump (cause, enumerable error props, nicify), then key-scrub.
- * nicify runs on already-scrubbed errorProps so the string dump does not
- * re-introduce redacted values.
+ * Root errorProps walks enumerable own data (extraData) without spreading the
+ * Error. Nested Error values stay name/message only.
  */
 function getExceptionExtra(error: unknown): Record<string, unknown> {
   if (!(error instanceof Error)) {
     return {};
   }
 
-  const errorProps = scrubDiagnosticValue({ ...error });
+  const errorProps = scrubOwnEnumerableFields(error, new WeakSet(), 0);
+  const causeProperty = readOwnDataProperty(error, "cause");
   return {
-    cause: scrubDiagnosticValue(error.cause),
+    cause: causeProperty.kind === "accessor"
+      ? "[accessor]"
+      : causeProperty.kind === "value"
+        ? scrubDiagnosticValue(causeProperty.value)
+        : undefined,
     errorProps,
     nicifiedError: nicify(errorProps, { maxDepth: 8 }),
   };

--- a/apps/backend/src/sentry-scrubbing.ts
+++ b/apps/backend/src/sentry-scrubbing.ts
@@ -106,23 +106,41 @@ const sensitiveDiagnosticKeySegments = new Set([
 const maxDiagnosticDepth = 8;
 const maxDiagnosticCollectionSize = 50;
 
+function matchesSensitiveDiagnosticSegment(part: string): boolean {
+  if (sensitiveDiagnosticKeySegments.has(part)) {
+    return true;
+  }
+  // tokens / passwords / secrets / dsns / apiKeys — same as the singular forms
+  // already in the set (credential/credentials were listed explicitly).
+  if (part.length > 3 && part.endsWith("es") && sensitiveDiagnosticKeySegments.has(part.slice(0, -2))) {
+    return true;
+  }
+  if (part.length > 2 && part.endsWith("s") && sensitiveDiagnosticKeySegments.has(part.slice(0, -1))) {
+    return true;
+  }
+  return false;
+}
+
 function isSensitiveDiagnosticKey(key: string): boolean {
   const normalized = key
     .replaceAll(/([a-z0-9])([A-Z])/g, "$1_$2")
     .replaceAll(/[^A-Za-z0-9]+/g, "_")
     .toLowerCase();
   const compact = normalized.replaceAll("_", "");
-  if (sensitiveDiagnosticKeySegments.has(compact)) {
+  if (matchesSensitiveDiagnosticSegment(compact)) {
     return true;
   }
-  return normalized.split("_").some((part) => part !== "" && sensitiveDiagnosticKeySegments.has(part));
+  return normalized.split("_").some((part) => part !== "" && matchesSensitiveDiagnosticSegment(part));
 }
 
 function scrubDiagnosticString(value: string): string {
-  return value.replaceAll(
-    /\b(sk_[A-Za-z0-9_-]+|pk_[A-Za-z0-9_-]+|pck_[A-Za-z0-9_-]+|stk_[A-Za-z0-9_-]+|ssk_[A-Za-z0-9_-]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b/g,
-    "[redacted]",
-  );
+  return value
+    .replaceAll(
+      /\b(sk_[A-Za-z0-9_-]+|pk_[A-Za-z0-9_-]+|pck_[A-Za-z0-9_-]+|stk_[A-Za-z0-9_-]+|ssk_[A-Za-z0-9_-]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b/g,
+      "[redacted]",
+    )
+    // postgres://user:pass@host and the same userinfo shape on other URLs
+    .replaceAll(/:\/\/[^/@\s]+:[^/@\s]+@/g, "://[redacted]@");
 }
 
 function scrubDiagnosticValue(

--- a/apps/backend/src/sentry-scrubbing.ts
+++ b/apps/backend/src/sentry-scrubbing.ts
@@ -1,5 +1,5 @@
 import { httpMethodNames } from "@/generated/route-modules";
-import { nicify } from "@hexclave/shared/dist/utils/strings";
+import { sentryBaseConfig } from "@hexclave/shared/dist/utils/sentry";
 import type { Event, EventHint } from "@sentry/node";
 
 const knownHttpMethods = new Set<string>(httpMethodNames);
@@ -78,8 +78,8 @@ export function sanitizeBackendSentrySpan(span: BackendSentrySpan): BackendSentr
   return span;
 }
 
-// Dashboard dump, then CLI-style extra scrub. Segment-split so "timeout" does
-// not match "token". Nested secrets under boring keys can still leak.
+// Segment-split so "timeout" does not match "token". Nested secrets under
+// boring keys can still leak.
 const sensitiveDiagnosticKeySegments = new Set([
   "password",
   "passwd",
@@ -108,22 +108,11 @@ const sensitiveDiagnosticKeySegments = new Set([
 ]);
 
 const maxDiagnosticDepth = 8;
-const maxDiagnosticCollectionSize = 50;
-// Sentry does not apply maxValueLength to extras we attach in beforeSend.
-const maxDiagnosticStringLength = 5_000;
-const maxDiagnosticNicifyLength = 20_000;
-const maxDiagnosticPayloadBytes = 100_000;
-
-type DiagnosticBudget = {
-  used: number,
-};
 
 function matchesSensitiveDiagnosticSegment(part: string): boolean {
   if (sensitiveDiagnosticKeySegments.has(part)) {
     return true;
   }
-  // tokens / passwords / secrets / dsns / apiKeys — same as the singular forms
-  // already in the set (credential/credentials were listed explicitly).
   if (part.length > 3 && part.endsWith("es") && sensitiveDiagnosticKeySegments.has(part.slice(0, -2))) {
     return true;
   }
@@ -145,11 +134,8 @@ function isSensitiveDiagnosticKey(key: string): boolean {
   return normalized.split("_").some((part) => part !== "" && matchesSensitiveDiagnosticSegment(part));
 }
 
-function scrubDiagnosticString(value: string, budget: DiagnosticBudget): string {
-  if (budget.used >= maxDiagnosticPayloadBytes) {
-    return "[truncated]";
-  }
-  let scrubbed = value
+function scrubDiagnosticString(value: string): string {
+  const scrubbed = value
     .replaceAll(
       /\b(sk_[A-Za-z0-9_-]+|pk_[A-Za-z0-9_-]+|pck_[A-Za-z0-9_-]+|sak_[A-Za-z0-9_-]+|ssk_[A-Za-z0-9_-]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+)\b/g,
       "[redacted]",
@@ -159,232 +145,65 @@ function scrubDiagnosticString(value: string, budget: DiagnosticBudget): string 
     // `https://api.example.com, page ops@company.com`.
     .replaceAll(/:\/\/[^\s/?#]*:[^/?#]*@/g, "://[redacted]@")
     .replaceAll(/:\/\/[^\s/?#@]*@/g, "://[redacted]@");
-  if (scrubbed.length > maxDiagnosticStringLength) {
-    scrubbed = `${scrubbed.slice(0, maxDiagnosticStringLength)}…`;
+  // extras attached in beforeSend skip Sentry's maxValueLength truncation.
+  if (scrubbed.length <= sentryBaseConfig.maxValueLength) {
+    return scrubbed;
   }
-  budget.used += scrubbed.length;
-  if (budget.used > maxDiagnosticPayloadBytes) {
-    return "[truncated]";
-  }
-  return scrubbed;
+  return `${scrubbed.slice(0, sentryBaseConfig.maxValueLength)}…`;
 }
 
-function takeIterable<T>(value: Iterable<T>, limit: number): T[] {
-  const items: T[] = [];
-  for (const item of value) {
-    items.push(item);
-    if (items.length >= limit) {
-      break;
-    }
-  }
-  return items;
-}
-
-function readOwnDataProperty(object: object, key: string): { kind: "missing" } | { kind: "accessor" } | { kind: "value", value: unknown } {
-  const descriptor = Object.getOwnPropertyDescriptor(object, key);
-  if (descriptor == null) {
-    return { kind: "missing" };
-  }
-  if (descriptor.get != null) {
-    return { kind: "accessor" };
-  }
-  if (Object.prototype.hasOwnProperty.call(descriptor, "value")) {
-    return { kind: "value", value: descriptor.value };
-  }
-  return { kind: "missing" };
-}
-
-function scrubOwnEnumerableFields(
-  value: object,
-  seen: WeakSet<object>,
-  depth: number,
-  budget: DiagnosticBudget,
-): unknown {
-  if (depth >= maxDiagnosticDepth || budget.used >= maxDiagnosticPayloadBytes) {
-    return "[truncated]";
-  }
-  if (seen.has(value)) {
-    return "[circular]";
-  }
-  seen.add(value);
-  try {
-    if (Array.isArray(value)) {
-      const entries: unknown[] = [];
-      const limit = Math.min(value.length, maxDiagnosticCollectionSize);
-      for (let index = 0; index < limit; index++) {
-        if (budget.used >= maxDiagnosticPayloadBytes) {
-          entries.push("[truncated]");
-          break;
-        }
-        entries.push(scrubDiagnosticValue(value[index], undefined, seen, depth + 1, budget));
-      }
-      if (value.length > maxDiagnosticCollectionSize && entries.at(-1) !== "[truncated]") {
-        entries.push("[truncated]");
-      }
-      return entries;
-    }
-    const scrubbed = new Map<string, unknown>();
-    let enumerableCount = 0;
-    let truncated = false;
-    for (const nestedKey in value) {
-      if (!Object.prototype.hasOwnProperty.call(value, nestedKey)) {
-        continue;
-      }
-      enumerableCount += 1;
-      if (enumerableCount > maxDiagnosticCollectionSize || budget.used >= maxDiagnosticPayloadBytes) {
-        truncated = true;
-        break;
-      }
-      const own = readOwnDataProperty(value, nestedKey);
-      if (own.kind === "accessor") {
-        scrubbed.set(nestedKey, isSensitiveDiagnosticKey(nestedKey) ? "[redacted]" : "[accessor]");
-        continue;
-      }
-      if (own.kind === "value") {
-        scrubbed.set(nestedKey, scrubDiagnosticValue(own.value, nestedKey, seen, depth + 1, budget));
-      }
-    }
-    if (truncated) {
-      scrubbed.set("[truncated]", true);
-    }
-    return Object.fromEntries(scrubbed);
-  } finally {
-    // Path-local `seen`: diamonds (`{ a: shared, b: shared }`) must dump twice,
-    // not mark the second edge `[circular]`. True cycles still hit `seen` on the
-    // way down, before this unwind.
-    seen.delete(value);
-  }
-}
-
-function scrubDiagnosticValue(
-  value: unknown,
-  key?: string,
-  seen: WeakSet<object> = new WeakSet(),
-  depth = 0,
-  budget: DiagnosticBudget = { used: 0 },
-): unknown {
+function scrubValue(value: unknown, key: string | undefined, depth: number): unknown {
   if (key != null && isSensitiveDiagnosticKey(key) && value != null) {
     return "[redacted]";
   }
-  if (value == null || typeof value === "boolean" || typeof value === "number") {
-    return value;
-  }
   if (typeof value === "string") {
-    return scrubDiagnosticString(value, budget);
+    return scrubDiagnosticString(value);
   }
   if (typeof value === "bigint") {
-    return scrubDiagnosticString(value.toString(), budget);
+    return scrubDiagnosticString(value.toString());
   }
-  if (typeof value === "symbol" || typeof value === "function") {
-    return `[${typeof value}]`;
+  if (value == null || typeof value !== "object") {
+    return value;
+  }
+  if (depth >= maxDiagnosticDepth) {
+    return "[truncated]";
   }
   if (value instanceof Error) {
-    const name = readOwnDataProperty(value, "name");
-    const message = readOwnDataProperty(value, "message");
     return {
-      name: name.kind === "accessor" ? "[accessor]" : name.kind === "value" && typeof name.value === "string" ? name.value : value.constructor.name,
-      message: message.kind === "accessor" ? "[accessor]" : message.kind === "value" && typeof message.value === "string" ? scrubDiagnosticString(message.value, budget) : "",
+      name: value.name,
+      message: scrubDiagnosticString(value.message),
+      ...(value.cause !== undefined ? { cause: scrubValue(value.cause, undefined, depth + 1) } : {}),
     };
-  }
-  if (value instanceof Date) {
-    return Number.isNaN(value.getTime()) ? "[Invalid Date]" : scrubDiagnosticString(value.toISOString(), budget);
-  }
-  if (value instanceof URL) {
-    return scrubDiagnosticString(value.href, budget);
-  }
-  if (value instanceof RegExp) {
-    return scrubDiagnosticString(value.toString(), budget);
   }
   if (ArrayBuffer.isView(value) || value instanceof ArrayBuffer) {
     return `[bytes ${value.byteLength}]`;
   }
-  if (typeof value !== "object") {
-    return value;
+  if (Array.isArray(value)) {
+    return value.map((entry) => scrubValue(entry, undefined, depth + 1));
   }
-  // Map/Set don't enumerate entries via for-in. Mark the original in `seen`
-  // before converting so a collection that contains itself stays `[circular]`.
-  // Copy at most cap+1 entries so a huge collection cannot allocate unbounded
-  // intermediates; the enumerable walk then applies the usual 50-item truncation.
-  if (value instanceof Map || value instanceof Set) {
-    if (seen.has(value)) {
-      return "[circular]";
-    }
-    seen.add(value);
-    try {
-      const converted = value instanceof Map
-        ? Object.fromEntries(takeIterable(value.entries(), maxDiagnosticCollectionSize + 1).map(([mapKey, mapValue]) => [
-          typeof mapKey === "string" ? mapKey : String(mapKey),
-          mapValue,
-        ]))
-        : takeIterable(value, maxDiagnosticCollectionSize + 1);
-      return scrubOwnEnumerableFields(converted, seen, depth, budget);
-    } finally {
-      seen.delete(value);
-    }
-  }
-  return scrubOwnEnumerableFields(value, seen, depth, budget);
-}
-
-function capNicifiedError(value: string): string {
-  if (value.length <= maxDiagnosticNicifyLength) {
-    return value;
-  }
-  return `${value.slice(0, maxDiagnosticNicifyLength)}…`;
-}
-
-function extrasFromDumpedProps(errorProps: unknown): Record<string, unknown> {
-  if (
-    errorProps != null
-    && typeof errorProps === "object"
-    && !Array.isArray(errorProps)
-    && Object.keys(errorProps).length === 0
-  ) {
-    return {};
-  }
-  return {
-    errorProps,
-    nicifiedError: capNicifiedError(nicify(errorProps, { maxDepth: maxDiagnosticDepth })),
-  };
+  return Object.fromEntries(Object.entries(value).map(([nestedKey, nestedValue]) => [
+    nestedKey,
+    scrubValue(nestedValue, nestedKey, depth + 1),
+  ]));
 }
 
 /**
- * Dashboard dump (cause, enumerable error props, nicify), then key-scrub.
- * Root errorProps walks enumerable own data (extraData) without spreading the
- * Error. Nested Error values stay name/message only. nicify runs on the
- * already-scrubbed tree so its cycle handling stays in the readable dump
- * without re-walking live getters.
+ * `cause` plus `{ ...error }` — extraData is the enumerable own field — then redact.
  */
 function getExceptionExtra(error: unknown): Record<string, unknown> {
-  if (error === undefined) {
+  if (!(error instanceof Error)) {
     return {};
   }
-  const budget: DiagnosticBudget = { used: 0 };
-  const seen = new WeakSet<object>();
-  if (!(error instanceof Error)) {
-    return extrasFromDumpedProps(scrubDiagnosticValue(error, undefined, seen, 0, budget));
-  }
-
-  const errorProps = scrubOwnEnumerableFields(error, seen, 0, budget);
-  const causeProperty = readOwnDataProperty(error, "cause");
-  const cause = causeProperty.kind === "accessor"
-    ? "[accessor]"
-    : causeProperty.kind === "value"
-      ? scrubDiagnosticValue(causeProperty.value, undefined, seen, 0, budget)
-      : undefined;
   return {
-    ...(cause !== undefined ? { cause } : {}),
-    ...extrasFromDumpedProps(errorProps),
+    ...(error.cause !== undefined ? { cause: scrubValue(error.cause, undefined, 0) } : {}),
+    errorProps: scrubValue({ ...error }, undefined, 0),
   };
 }
 
 /**
- * Keep the minimum metadata needed to correlate a backend error while ensuring
- * request bodies, credentials, query values, customer identities, and SQL never
- * cross the Sentry boundary. Clears `extra` entirely — callers that need
- * diagnostics should go through prepareBackendSentryEvent, which rebuilds a
- * scrubbed dump. extraData on HexclaveAssertionError can still mention
- * identities if a caller put them there; this sanitizer only default-denies
- * the request/span/user envelope.
+ * Default-deny the request/span/user envelope. extra is cleared here;
+ * prepareBackendSentryEvent rebuilds a redacted dump. extraData can still
+ * mention identities if a caller put them there.
  */
 export function sanitizeBackendSentryEvent<T extends Event>(event: T): T {
   if (event.request != null) {
@@ -465,8 +284,8 @@ export function sanitizeBackendSentryEvent<T extends Event>(event: T): T {
 }
 
 /**
- * beforeSend entrypoint: scrub request/span PII, then rebuild `extra` as the
- * dashboard dump plus captureError's `location`, then key-scrub that dump.
+ * beforeSend entrypoint: scrub the request/span envelope, then rebuild `extra` from
+ * captureError's `location` plus the redacted exception dump.
  */
 export function prepareBackendSentryEvent<T extends Event>(event: T, hint?: EventHint): T {
   const location = typeof event.extra?.location === "string" ? event.extra.location : undefined;

--- a/apps/backend/src/sentry-scrubbing.ts
+++ b/apps/backend/src/sentry-scrubbing.ts
@@ -103,6 +103,9 @@ const sensitiveDiagnosticKeySegments = new Set([
   "credentials",
 ]);
 
+const maxDiagnosticDepth = 8;
+const maxDiagnosticCollectionSize = 50;
+
 function isSensitiveDiagnosticKey(key: string): boolean {
   const normalized = key
     .replaceAll(/([a-z0-9])([A-Z])/g, "$1_$2")
@@ -122,7 +125,12 @@ function scrubDiagnosticString(value: string): string {
   );
 }
 
-function scrubDiagnosticValue(value: unknown, key?: string, seen: WeakSet<object> = new WeakSet()): unknown {
+function scrubDiagnosticValue(
+  value: unknown,
+  key?: string,
+  seen: WeakSet<object> = new WeakSet(),
+  depth = 0,
+): unknown {
   if (key != null && isSensitiveDiagnosticKey(key) && value != null) {
     return "[redacted]";
   }
@@ -147,16 +155,29 @@ function scrubDiagnosticValue(value: unknown, key?: string, seen: WeakSet<object
   if (typeof value !== "object") {
     return value;
   }
+  if (depth >= maxDiagnosticDepth) {
+    return "[truncated]";
+  }
   if (seen.has(value)) {
     return "[circular]";
   }
   seen.add(value);
   if (Array.isArray(value)) {
-    return value.map((entry) => scrubDiagnosticValue(entry, undefined, seen));
+    const entries = value.slice(0, maxDiagnosticCollectionSize).map((entry) => (
+      scrubDiagnosticValue(entry, undefined, seen, depth + 1)
+    ));
+    if (value.length > maxDiagnosticCollectionSize) {
+      entries.push("[truncated]");
+    }
+    return entries;
   }
+  const keys = Object.keys(value);
   const scrubbed = new Map<string, unknown>();
-  for (const [nestedKey, nestedValue] of Object.entries(value)) {
-    scrubbed.set(nestedKey, scrubDiagnosticValue(nestedValue, nestedKey, seen));
+  for (const nestedKey of keys.slice(0, maxDiagnosticCollectionSize)) {
+    scrubbed.set(nestedKey, scrubDiagnosticValue(Reflect.get(value, nestedKey), nestedKey, seen, depth + 1));
+  }
+  if (keys.length > maxDiagnosticCollectionSize) {
+    scrubbed.set("[truncated]", true);
   }
   return Object.fromEntries(scrubbed);
 }


### PR DESCRIPTION
### Summary of Changes
This was a regression with the elysia migration. Should now be fixed, errors are logging to sentry with the full context.
This change should be safe because it is a) still sanitized and b) in line with how the dashboard and CLI log errors

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores backend Sentry diagnostics while keeping PII out. Previously `beforeSend`/`beforeSendTransaction` sanitized events and dropped `extra`; now `prepareBackendSentryEvent` scrubs first and then rebuilds a safe `extra` from `extra.location` and the exception.

- Replace `beforeSend` and `beforeSendTransaction` with `prepareBackendSentryEvent`; keep `beforeSendSpan` unchanged.
- `sanitizeBackendSentryEvent` default-denies envelopes: keeps `request.method` only; clears `user`, `tags`, and `extra`; trims breadcrumbs/trace.
- `prepareBackendSentryEvent` reconstructs `extra` with a string `location`, a redacted `cause` chain, and enumerable error fields under `errorProps`; for non-Error throws, only `location` is kept.
- Redacts credential-shaped keys (incl. plurals) and token/connection-string patterns; scrubs URL userinfo (handles @/spaces) without redacting prose emails.
- Bounds diagnostics: truncate nesting at depth 8, cap strings to `sentryBaseConfig.maxValueLength`, and render binary data as `[bytes N]`.

<sup>Written for commit e6596b5e4219de189a07078eb00fb01a392b4df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backend error reporting while preventing sensitive request data, connection strings, passwords, and credential-like values from being included.
  * Preserved approved diagnostic details and validated location information in prepared error events.
  * Removed unintended additional data from sanitized error reports.
  * Improved handling of nested, token-like, circular, and unsupported diagnostic values to keep reported errors safe and consistent.
  * Added safeguards for oversized diagnostic data and unusual error values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->