### PR TITLE
Fix three stale growth e2e expectations

### DIFF
--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
@@ -95,6 +95,13 @@ function getRunPhase(run: AdminRunBody, phaseKey: string): AdminRunPhase {
   return phase;
 }
 
+async function waitForSettledIntegrationsPhase(expect: ExpectStatic, runId: string): Promise<void> {
+  await pollWithTicks(expect, async () => {
+    const phase = getRunPhase(await getRun(runId), "integrations");
+    return phase.status === "completed" || phase.status === "skipped" ? phase : null;
+  });
+}
+
 type AgentScope = { project_id: string, branch_id: string };
 
 async function agentPhaseCall(runId: string, phaseKey: string, action: "start" | "heartbeat" | "complete" | "fail", scope: AgentScope, attempt: number, extraBody: Record<string, unknown> = {}) {
@@ -159,9 +166,9 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
       const activationLeg = await pollWithTicks(expect, async () => await findAnalysisLegRun(runId, ANALYSIS_ACTIVATED_EVENT_TYPE), { timeoutMs: 120_000 });
       expect(activationLeg).toMatchObject({ run_key: `${runId}:${ANALYSIS_ACTIVATED_EVENT_TYPE}` });
 
-      // The workflow tick auto-skips integrations as soon as compute-metrics settles, so the
-      // explicit answer route can lose this race by design; keep the route for future integration
-      // flows while pinning that the analysis is already unblocked.
+      // The leg row appears before the workflow's first advance step ticks the bridge, so drive
+      // until integrations settles before asserting the explicit route's CAS response.
+      await waitForSettledIntegrationsPhase(expect, runId);
       const skipIntegrations = await niceBackendFetch(`${ADMIN_BASE}/runs/${runId}/integrations`, {
         accessType: "admin",
         method: "POST",
@@ -414,9 +421,10 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
         predicate: (dispatch) => dispatch.path === "/runs/analysis-phase" && dispatch.body.project_id === projectId,
       });
       const runId = await completeOnboarding();
-      // The first tick computes metrics and auto-skips integrations. The explicit answer route can
-      // lose this race by design; keep it for future integration flows and pin the settled state.
+      // The first tick creates the leg row before its first advance step ticks the bridge, so drive
+      // until integrations settles before asserting the explicit route's CAS response.
       expect((await bridgeCall("analysis/tick", { run_id: runId })).status).toBe(200);
+      await waitForSettledIntegrationsPhase(expect, runId);
       const skipIntegrations = await niceBackendFetch(`${ADMIN_BASE}/runs/${runId}/integrations`, {
         accessType: "admin",
         method: "POST",

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
@@ -421,8 +421,9 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
         predicate: (dispatch) => dispatch.path === "/runs/analysis-phase" && dispatch.body.project_id === projectId,
       });
       const runId = await completeOnboarding();
-      // The first tick creates the leg row before its first advance step ticks the bridge, so drive
-      // until integrations settles before asserting the explicit route's CAS response.
+      // One bridge tick computes metrics, which is what makes integrations auto-skippable; the skip
+      // itself lands on a following tick, so drive until it settles before asserting the explicit
+      // route's CAS response.
       expect((await bridgeCall("analysis/tick", { run_id: runId })).status).toBe(200);
       await waitForSettledIntegrationsPhase(expect, runId);
       const skipIntegrations = await niceBackendFetch(`${ADMIN_BASE}/runs/${runId}/integrations`, {

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
@@ -159,15 +159,16 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
       const activationLeg = await pollWithTicks(expect, async () => await findAnalysisLegRun(runId, ANALYSIS_ACTIVATED_EVENT_TYPE), { timeoutMs: 120_000 });
       expect(activationLeg).toMatchObject({ run_key: `${runId}:${ANALYSIS_ACTIVATED_EVENT_TYPE}` });
 
-      // A fresh project has no ad-platform connection, so make the test's human choice explicit
-      // and unblock the analysis phases. The integrations route also enqueues the resume boundary
-      // event, which is part of the production lifecycle this full-path scenario is exercising.
+      // The workflow tick auto-skips integrations as soon as compute-metrics settles, so the
+      // explicit answer route can lose this race by design; keep the route for future integration
+      // flows while pinning that the analysis is already unblocked.
       const skipIntegrations = await niceBackendFetch(`${ADMIN_BASE}/runs/${runId}/integrations`, {
         accessType: "admin",
         method: "POST",
         body: { action: "skip" },
       });
-      expect(skipIntegrations.status).toBe(200);
+      expect(skipIntegrations.status).toBe(409);
+      expect(getRunPhase(await getRun(runId), "integrations")).toMatchObject({ status: "skipped" });
 
       // The workflow's bridge ticks dispatch the 6 immediate phases (attempt 1) to Eve.
       for (const phaseKey of IMMEDIATE_PHASE_KEYS) {
@@ -413,15 +414,16 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
         predicate: (dispatch) => dispatch.path === "/runs/analysis-phase" && dispatch.body.project_id === projectId,
       });
       const runId = await completeOnboarding();
-      // The first tick computes metrics and leaves the run resting for its integrations choice.
-      // Skip it explicitly so the six immediate agent phases become ready for the failure waves.
+      // The first tick computes metrics and auto-skips integrations. The explicit answer route can
+      // lose this race by design; keep it for future integration flows and pin the settled state.
       expect((await bridgeCall("analysis/tick", { run_id: runId })).status).toBe(200);
       const skipIntegrations = await niceBackendFetch(`${ADMIN_BASE}/runs/${runId}/integrations`, {
         accessType: "admin",
         method: "POST",
         body: { action: "skip" },
       });
-      expect(skipIntegrations.status).toBe(200);
+      expect(skipIntegrations.status).toBe(409);
+      expect(getRunPhase(await getRun(runId), "integrations")).toMatchObject({ status: "skipped" });
       for (let attempt = 1; attempt <= 3; attempt++) {
         const tick = await bridgeCall("analysis/tick", { run_id: runId });
         expect(tick.status).toBe(200);

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/interview.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/interview.test.ts
@@ -2,7 +2,6 @@ import { describe, type ExpectStatic } from "vitest";
 import { it } from "../../../../../../helpers";
 import { Project, niceBackendFetch } from "../../../../../backend-helpers";
 import { GROWTH_AGENT_AUTH, createGrowthProject, releaseGrowthInterviewAsStaff, requireRunId } from "./growth-helpers";
-import { urlString } from "@hexclave/shared/dist/utils/urls";
 
 const ADMIN_BASE = "/api/latest/internal/growth";
 const AGENT_BASE = "/api/latest/internal/growth-agent";
@@ -473,7 +472,7 @@ describe("internal growth interview (no mock Eve)", { timeout: 90_000 }, () => {
     expect(researchPhases.every((phase) => phase.status === "completed" || phase.status === "skipped")).toBe(true);
 
     // The finding is untouched.
-    const findings = await niceBackendFetch(urlString`${AGENT_BASE}/context-bundle?project_id=${scope.project_id}&branch_id=${scope.branch_id}`, {
+    const findings = await niceBackendFetch(`${AGENT_BASE}/context-bundle?project_id=${encodeURIComponent(scope.project_id)}&branch_id=${encodeURIComponent(scope.branch_id)}`, {
       method: "GET",
       headers: GROWTH_AGENT_AUTH,
     });


### PR DESCRIPTION
Three growth e2e tests fail on `dev`; all three are test-side, no product behavior changes.

**interview.test.ts — context-bundle GET 404s.** The URL was built as ``urlString`${AGENT_BASE}/context-bundle?...` ``, and `urlString` runs `encodeURIComponent` over every interpolated value — including the base path, so the request went to `%2Fapi%2Flatest%2Finternal%2Fgrowth-agent/context-bundle?...`, which matches no route. (Hitting the correct path returns 401, the encoded one 404.) Now only the query values are encoded.

**growth-workflows.test.ts — two `POST runs/:id/integrations` sites expected 200, got 409.** The orchestration tick auto-skips a pending integrations phase once compute-metrics settles (`autoSettleIntegrationsPhaseForRun`), and both tests drive exactly those ticks before answering, so the route's CAS correctly reports "already been answered". The tests now assert the 409 *and* that the phase is settled as `skipped`, which is the contract they actually care about (the analysis gets unblocked).

The remaining growth-workflows failures on `dev` are unrelated to these: they wait on workflow sources that never get compiled, because the workflow sandbox fails in CI (`Workflow sandbox invocation exceeded the 60s engine-side backstop timeout`, which also breaks the growth-unrelated `internal/workflows.test.ts` suite).

Verified: `interview.test.ts` passes locally (4/4); both workflow tests now get past the integrations assertion and stop at the sandbox-dependent step; `apps/e2e` lint and typecheck clean.


Link to Devin session: https://app.devin.ai/sessions/a0a79a13a8a34b80b048944a2487e099
Requested by: @aadesh18

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores three growth E2E tests by fixing context-bundle URL encoding and aligning integrations-phase expectations with auto-skip after metrics. No product behavior changes; tests now proceed to the sandbox-dependent steps.

- Interview test: build the `/context-bundle` URL directly and encode only `project_id` and `branch_id`; stop using `@hexclave/shared`’s `urlString`, which encoded the base path and produced a 404.
- Growth workflows tests: wait until the integrations phase settles before calling `POST /runs/:id/integrations`; expect 409 when already skipped and assert the phase is `skipped` (adds `waitForSettledIntegrationsPhase` to avoid races).

<sup>Written for commit 657f752c3bca8fa342dc95d042a4a20b99ecb708. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved coverage for workflow lifecycle scenarios where integrations are automatically skipped.
  * Added validation that explicit skip requests return the expected conflict response and affected phases are marked as skipped.
  * Strengthened interview workflow request handling by safely encoding project and branch identifiers.
  * Removed unused test code to improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->