### PR TITLE
Add Growth Admin Run Now functionality

### DIFF
--- a/apps/backend/src/app/api/latest/internal/growth/admin/run-now/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/growth/admin/run-now/route.tsx
@@ -1,0 +1,56 @@
+import { runGrowthWatchdogSweep } from "@/lib/growth/watchdog";
+import { runWorkflowEngineStep } from "@/lib/workflows/engine";
+import { ensurePlatformAdmin } from "@/lib/platform-admin";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { KnownErrors } from "@hexclave/shared";
+import { adaptSchema, clientOrHigherAuthTypeSchema, yupBoolean, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
+
+const INTERNAL_PROJECT_ID = "internal";
+const MANUAL_STEP_DEADLINE_MS = 3 * 60 * 1000;
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+export const maxDuration = 300;
+
+/**
+ * Runs one server-side scheduler step from the internal GTM admin page. This is intentionally a
+ * user-authenticated route rather than a browser-visible CRON_SECRET route: Preview deployments do
+ * not receive scheduled Vercel Cron invocations, and the cron secret must never reach dashboard JS.
+ */
+export const POST = createSmartRouteHandler({
+  metadata: {
+    summary: "Run Growth scheduler step",
+    description: "Run one workflow-engine or Growth-watchdog step from the internal Growth admin page.",
+    tags: ["Growth"],
+    hidden: true,
+  },
+  request: yupObject({
+    auth: yupObject({ type: clientOrHigherAuthTypeSchema.defined(), project: adaptSchema.defined(), user: adaptSchema }).defined(),
+    method: yupString().oneOf(["POST"]).defined(),
+    body: yupObject({ step: yupString().oneOf(["workflow_engine", "growth_watchdog"]).defined() }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupMixed().defined(),
+  }),
+  handler: async ({ auth, body }) => {
+    if (auth.user == null) throw new KnownErrors.UserAuthenticationRequired();
+    if (auth.project.id !== INTERNAL_PROJECT_ID) throw new KnownErrors.ExpectedInternalProject();
+    await ensurePlatformAdmin(auth.user);
+
+    const deadlineMs = Date.now() + MANUAL_STEP_DEADLINE_MS;
+    const result = body.step === "workflow_engine"
+      ? await runWorkflowEngineStep({ deadlineMs })
+      : await runGrowthWatchdogSweep({ deadlineMs });
+
+    return {
+      statusCode: 200,
+      bodyType: "json",
+      body: {
+        step: body.step,
+        did_work: result.didWork,
+      },
+    };
+  },
+});

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/page-client.tsx
@@ -15,6 +15,7 @@ import { GrowthWorkspaceContent } from "../components/workspace-overview";
 import { GrowthAdminGamesCard } from "./games-card";
 import { GrowthAdminInterviewCard } from "./interview-card";
 import { GrowthAdminReportsCard } from "./reports-card";
+import { GrowthAdminRunNowCard } from "./run-now-card";
 
 type Loadable = { status: "loading" } | { status: "error", message: string } | { status: "loaded", projects: GrowthAdminProject[], selected: GrowthAdminProject | null, overview: GrowthOverview | null };
 
@@ -88,6 +89,7 @@ function AdminEditor(props: { app: object, project: GrowthAdminProject, overview
       <GrowthAdminInterviewCard app={props.app} projectId={props.project.id} />
       <GrowthAdminReportsCard app={props.app} projectId={props.project.id} />
       <GrowthAdminGamesCard app={props.app} projectId={props.project.id} />
+      <GrowthAdminRunNowCard app={props.app} />
 
       <DesignCard title="Stage scores" subtitle="Manual 0–100 values used by the customer growth journey" icon={SlidersHorizontalIcon} gradient="purple">
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/run-now-card.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/run-now-card.tsx
@@ -2,7 +2,7 @@
 
 import { DesignAlert, DesignButton, DesignCard } from "@/components/design-components";
 import { runGrowthAdminManualStep, type GrowthAdminManualStep } from "@/lib/growth/growth-api";
-import { captureError } from "@hexclave/shared/dist/utils/errors";
+import { runAsynchronouslyWithAlert } from "@hexclave/shared/dist/utils/promises";
 import { GearSixIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 
@@ -16,15 +16,14 @@ const stepLabels: Record<GrowthAdminManualStep, string> = {
 export function GrowthAdminRunNowCard(props: { app: object }) {
   const [state, setState] = useState<RunState>({ status: "idle" });
 
-  const runStep = async (step: GrowthAdminManualStep) => {
+  const runStep = (step: GrowthAdminManualStep) => {
     setState({ status: "running", step });
-    try {
+    runAsynchronouslyWithAlert(async () => {
       const result = await runGrowthAdminManualStep(props.app, step);
       setState({ status: "success", step, didWork: result.didWork });
-    } catch (error) {
-      captureError(`growth-admin-${step}`, error);
-      setState({ status: "error", message: error instanceof Error ? error.message : String(error) });
-    }
+    }, {
+      onError: error => setState({ status: "error", message: error instanceof Error ? error.message : String(error) }),
+    });
   };
 
   const runningStep = state.status === "running" ? state.step : null;
@@ -35,7 +34,7 @@ export function GrowthAdminRunNowCard(props: { app: object }) {
         {state.status === "success" && <DesignAlert variant="info">{stepLabels[state.step]} completed{state.didWork ? " and processed work." : ", but found no work to process."}</DesignAlert>}
         <div className="flex flex-wrap gap-2">
           {(Object.keys(stepLabels) as GrowthAdminManualStep[]).map((step) => (
-            <DesignButton key={step} variant="outline" size="sm" disabled={runningStep != null} loading={runningStep === step} onClick={async () => await runStep(step)}>
+            <DesignButton key={step} variant="outline" size="sm" disabled={runningStep != null} loading={runningStep === step} onClick={() => runStep(step)}>
               {stepLabels[step]}
             </DesignButton>
           ))}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/run-now-card.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/run-now-card.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { DesignAlert, DesignButton, DesignCard } from "@/components/design-components";
+import { runGrowthAdminManualStep, type GrowthAdminManualStep } from "@/lib/growth/growth-api";
+import { captureError } from "@hexclave/shared/dist/utils/errors";
+import { GearSixIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+
+type RunState = { status: "idle" } | { status: "running", step: GrowthAdminManualStep } | { status: "success", step: GrowthAdminManualStep, didWork: boolean } | { status: "error", message: string };
+
+const stepLabels: Record<GrowthAdminManualStep, string> = {
+  workflow_engine: "Run workflow step",
+  growth_watchdog: "Run watchdog",
+};
+
+export function GrowthAdminRunNowCard(props: { app: object }) {
+  const [state, setState] = useState<RunState>({ status: "idle" });
+
+  const runStep = async (step: GrowthAdminManualStep) => {
+    setState({ status: "running", step });
+    try {
+      const result = await runGrowthAdminManualStep(props.app, step);
+      setState({ status: "success", step, didWork: result.didWork });
+    } catch (error) {
+      captureError(`growth-admin-${step}`, error);
+      setState({ status: "error", message: error instanceof Error ? error.message : String(error) });
+    }
+  };
+
+  const runningStep = state.status === "running" ? state.step : null;
+  return (
+    <DesignCard title="Manual scheduler" subtitle="Run one server-side step when Preview has no scheduled Cron invocation" icon={GearSixIcon} gradient="cyan">
+      <div className="space-y-3">
+        {state.status === "error" && <DesignAlert variant="error">{state.message}</DesignAlert>}
+        {state.status === "success" && <DesignAlert variant="info">{stepLabels[state.step]} completed{state.didWork ? " and processed work." : ", but found no work to process."}</DesignAlert>}
+        <div className="flex flex-wrap gap-2">
+          {(Object.keys(stepLabels) as GrowthAdminManualStep[]).map((step) => (
+            <DesignButton key={step} variant="outline" size="sm" disabled={runningStep != null} loading={runningStep === step} onClick={async () => await runStep(step)}>
+              {stepLabels[step]}
+            </DesignButton>
+          ))}
+        </div>
+        <p className="text-xs text-muted-foreground">The action uses your internal project admin session. It does not expose or require the cron secret.</p>
+      </div>
+    </DesignCard>
+  );
+}

--- a/apps/dashboard/src/lib/growth/growth-api.ts
+++ b/apps/dashboard/src/lib/growth/growth-api.ts
@@ -715,6 +715,19 @@ export async function setGrowthAdminCategoryScore(app: object, projectId: string
   await requestGrowthAdminJson(app, "/category-scores", { method: "PUT", body: JSON.stringify({ target_project_id: projectId, category, score }) });
 }
 
+export type GrowthAdminManualStep = "workflow_engine" | "growth_watchdog";
+
+export async function runGrowthAdminManualStep(app: object, step: GrowthAdminManualStep): Promise<{ didWork: boolean }> {
+  const response = z.object({
+    step: z.enum(["workflow_engine", "growth_watchdog"]),
+    did_work: z.boolean(),
+  }).parse(await requestGrowthAdminJson(app, "/run-now", {
+    method: "POST",
+    body: JSON.stringify({ step }),
+  }));
+  return { didWork: response.did_work };
+}
+
 export type GrowthAdminFunctionalActionFields = {
   payload: unknown,
   watchedMetrics: GrowthActionItem["watchedMetrics"],

--- a/apps/dashboard/src/lib/growth/growth-api.ts
+++ b/apps/dashboard/src/lib/growth/growth-api.ts
@@ -1,5 +1,5 @@
 import { sendInternalUserRequest } from "@/lib/hexclave-app-internals";
-import { GrowthApiError, growthRequestHeaders, requestJson } from "./growth-api-client";
+import { GrowthApiError, growthRequestHeaders, requestJson, toGrowthApiError } from "./growth-api-client";
 import { growthDocumentSchema } from "./growth-document";
 import { urlString } from "@hexclave/shared/dist/utils/urls";
 import { z } from "zod";
@@ -671,7 +671,12 @@ export async function getGrowthOverview(app: object): Promise<GrowthOverview> {
  * error-shaping below — same reasoning as the requestJson extraction in growth-api-client.ts.
  */
 export async function requestGrowthAdminJson(app: object, path: string, init: RequestInit = {}): Promise<unknown> {
-  const response = await sendInternalUserRequest(app, `/internal/growth/admin${path}`, { ...init, headers: growthRequestHeaders(init) });
+  let response;
+  try {
+    response = await sendInternalUserRequest(app, `/internal/growth/admin${path}`, { ...init, headers: growthRequestHeaders(init) });
+  } catch (error) {
+    throw toGrowthApiError(error) ?? error;
+  }
   const responseText = await response.text();
   if (!response.ok) {
     let message = `Growth admin request failed with status ${response.status}`;

--- a/apps/growth-agent/agent/lib/browse.test.ts
+++ b/apps/growth-agent/agent/lib/browse.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { isBrowseSandboxAvailable } from "./browse.ts";
+import { extractCurlFallbackPage, fetchPageWithCurl, isBrowserSandboxCredentialError, isBrowseSandboxAvailable } from "./browse.ts";
 
 afterEach(() => {
   vi.unstubAllEnvs();
@@ -33,13 +33,78 @@ describe("isBrowseSandboxAvailable", () => {
     expect(isBrowseSandboxAvailable()).toBe(true);
   });
 
-  it("rejects a Vercel deployment without complete sandbox credentials", () => {
+  it("allows a Vercel deployment to use runtime OIDC credentials", () => {
     vi.stubEnv("VERCEL", "1");
     vi.stubEnv("VERCEL_OIDC_TOKEN", "");
     vi.stubEnv("VERCEL_TOKEN", "token");
     vi.stubEnv("VERCEL_TEAM_ID", "team");
     vi.stubEnv("VERCEL_PROJECT_ID", "");
 
-    expect(isBrowseSandboxAvailable()).toBe(false);
+    expect(isBrowseSandboxAvailable()).toBe(true);
+  });
+});
+
+describe("curl browser fallback", () => {
+  it("only classifies sandbox credential failures as fallback-safe", () => {
+    const credentialError = new Error("Could not get credentials from OIDC context.");
+    credentialError.name = "VercelOidcContextError";
+
+    expect(isBrowserSandboxCredentialError(credentialError)).toBe(true);
+    expect(isBrowserSandboxCredentialError(new Error("Navigation timed out"))).toBe(false);
+    expect(isBrowserSandboxCredentialError("not an error object")).toBe(false);
+  });
+
+  it("extracts readable static content without scripts or styles", () => {
+    const result = extractCurlFallbackPage(`<!doctype html>
+      <html><head><title>Acme &amp; Co</title><style>.hidden{display:none}</style></head>
+      <body><main><h1>Ship faster</h1><script>steal()</script><p>Public product copy.</p></main></body></html>`,
+    "https://example.com/", "https://www.example.com/");
+
+    expect(result).toEqual({
+      finalUrl: "https://www.example.com/",
+      title: "Acme & Co",
+      snapshotText: "[curl fallback: Chromium was unavailable; this is static HTML from https://example.com/ and may omit client-rendered content.]\nShip faster\nPublic product copy.",
+    });
+  });
+
+  it("leaves invalid numeric HTML entities unchanged", () => {
+    const result = extractCurlFallbackPage("<p>Value: &#999999999;</p>", "https://example.com/", "https://example.com/");
+
+    expect(result.snapshotText).toContain("&#999999999;");
+  });
+
+  it("passes the URL through the sandbox environment and removes the temporary response", async () => {
+    const sandbox = {
+      async run() {
+        return { exitCode: 0, stdout: "https://example.com/final", stderr: "" };
+      },
+      async readBinaryFile() {
+        return new TextEncoder().encode("<title>Example</title><p>Hello</p>");
+      },
+      async removePath() {
+        return undefined;
+      },
+    };
+    const runSpy = vi.spyOn(sandbox, "run");
+    const removeSpy = vi.spyOn(sandbox, "removePath");
+
+    const result = await fetchPageWithCurl({
+      url: "https://example.com/search?q=$(unsafe)",
+      requestId: "call/example",
+      sandbox,
+    });
+
+    expect(result.finalUrl).toBe("https://example.com/final");
+    expect(runSpy).toHaveBeenCalledWith(expect.objectContaining({
+      env: {
+        HEXCLAVE_BROWSE_OUTPUT_PATH: "/workspace/browse-page-call_example.untracked.html",
+        HEXCLAVE_BROWSE_URL: "https://example.com/search?q=$(unsafe)",
+      },
+    }));
+    expect(removeSpy).toHaveBeenCalledWith({
+      path: "/workspace/browse-page-call_example.untracked.html",
+      force: true,
+      recursive: false,
+    });
   });
 });

--- a/apps/growth-agent/agent/lib/browse.ts
+++ b/apps/growth-agent/agent/lib/browse.ts
@@ -1,5 +1,6 @@
 import { runAgentBrowserCommand, withAgentBrowserSandbox } from "@agent-browser/sandbox/vercel";
 import type { NetworkPolicy } from "@vercel/sandbox";
+import type { SandboxSession } from "eve/sandbox";
 
 /**
  * Renders a page in a real (headless Chromium) browser inside an ephemeral,
@@ -25,6 +26,7 @@ export type BrowsePageResult = {
 };
 
 const SNAPSHOT_CHAR_CAP = 20_000;
+const CURL_FALLBACK_BODY_BYTE_CAP = 2_000_000;
 
 // Wall-time caps, enforced server-side by the sandbox `timeout` option (the VM
 // auto-terminates even if this process dies mid-call). With a pre-built
@@ -57,10 +59,11 @@ const BROWSE_NETWORK_POLICY: NetworkPolicy = {
 };
 
 /**
- * Whether the runtime has credentials to create Vercel Sandboxes: either the
- * explicit token triple (local dev) or an OIDC token (automatic on Vercel
- * deployments). Callers should check this before browsing so the failure mode
- * is a clear "unavailable" error instead of an opaque SDK auth error.
+ * Whether the runtime is configured to create Vercel Sandboxes. Local
+ * development must expose an explicit token because it has no Vercel request
+ * context. A deployed Vercel Function is different: Vercel supplies OIDC in
+ * the request context, so the Sandbox SDK—not this environment-only probe—must
+ * perform the credential check there.
  */
 export function isBrowseSandboxAvailable(): boolean {
   const env = process.env;
@@ -73,10 +76,151 @@ export function isBrowseSandboxAvailable(): boolean {
     ? configuredBackend
     : env.VERCEL != null && env.VERCEL.length > 0 ? "vercel" : "docker";
   if (backend !== "vercel") return false;
+  // In a deployed Vercel Function, the OIDC token is available to the SDK via
+  // the incoming request context rather than process.env. Do not reject the
+  // call before withAgentBrowserSandbox() can use that runtime credential.
+  if (env.VERCEL != null && env.VERCEL.length > 0) return true;
   const hasTokenTriple = [env.VERCEL_TOKEN, env.VERCEL_TEAM_ID, env.VERCEL_PROJECT_ID]
     .every((value) => value != null && value.length > 0);
   const hasOidcToken = env.VERCEL_OIDC_TOKEN != null && env.VERCEL_OIDC_TOKEN.length > 0;
   return hasTokenTriple || hasOidcToken;
+}
+
+function isCurlFallbackSandboxSafe(): boolean {
+  const configuredBackend = process.env.HEXCLAVE_GROWTH_SANDBOX_BACKEND;
+  const backend = configuredBackend != null && configuredBackend.length > 0
+    ? configuredBackend
+    : process.env.VERCEL != null && process.env.VERCEL.length > 0 ? "vercel" : "docker";
+  // The website-research Vercel sandbox has a subnet denylist that applies to
+  // DNS results and redirects. Its local Docker backend is allow-all, so the
+  // literal-IP URL preflight alone is not enough to safely curl an untrusted
+  // hostname there.
+  return backend === "vercel";
+}
+
+type CurlFallbackSandbox = Pick<SandboxSession, "readBinaryFile" | "removePath" | "run">;
+
+function decodeHtmlEntities(value: string): string {
+  const namedEntities = new Map([
+    ["amp", "&"],
+    ["apos", "'"],
+    ["gt", ">"],
+    ["lt", "<"],
+    ["nbsp", " "],
+    ["quot", "\""],
+  ]);
+  return value.replace(/&(#x[0-9a-f]+|#\d+|[a-z]+);/gi, (entityText, entityName: string) => {
+    if (entityName.startsWith("#x")) {
+      const codePoint = Number.parseInt(entityName.slice(2), 16);
+      return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10FFFF ? String.fromCodePoint(codePoint) : entityText;
+    }
+    if (entityName.startsWith("#")) {
+      const codePoint = Number.parseInt(entityName.slice(1), 10);
+      return Number.isInteger(codePoint) && codePoint >= 0 && codePoint <= 0x10FFFF ? String.fromCodePoint(codePoint) : entityText;
+    }
+    return namedEntities.get(entityName.toLowerCase()) ?? entityText;
+  });
+}
+
+/**
+ * Turns a curl-fetched HTML document into a compact, model-readable fallback.
+ * This is deliberately not presented as a rendered browser snapshot: scripts
+ * and styles are removed, block boundaries become newlines, and the result is
+ * labelled so the researcher knows client-rendered content may be missing.
+ */
+export function extractCurlFallbackPage(html: string, requestedUrl: string, finalUrl: string): BrowsePageResult {
+  const titleMatch = /<title\b[^>]*>([\s\S]*?)<\/title>/i.exec(html);
+  const title = decodeHtmlEntities(titleMatch?.[1]?.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ").trim() ?? "");
+  const visibleText = decodeHtmlEntities(html
+    .replace(/<head\b[^>]*>[\s\S]*?<\/head>/gi, " ")
+    .replace(/<(script|style|noscript|svg)\b[^>]*>[\s\S]*?<\/\1>/gi, " ")
+    .replace(/<!--([\s\S]*?)-->/g, " ")
+    .replace(/<\/(?:article|aside|blockquote|div|footer|form|h[1-6]|header|li|main|nav|ol|p|section|table|tr|ul)>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<[^>]+>/g, " "))
+    .split("\n")
+    .map((line) => line.replace(/\s+/g, " ").trim())
+    .filter((line) => line.length > 0)
+    .join("\n");
+  const fallbackNotice = `[curl fallback: Chromium was unavailable; this is static HTML from ${requestedUrl} and may omit client-rendered content.]`;
+  const fullSnapshot = `${fallbackNotice}\n${visibleText}`;
+  const snapshotText = fullSnapshot.length > SNAPSHOT_CHAR_CAP
+    ? `${fullSnapshot.slice(0, SNAPSHOT_CHAR_CAP)}\n… [snapshot truncated at ${SNAPSHOT_CHAR_CAP} characters]`
+    : fullSnapshot;
+  return { finalUrl, title, snapshotText };
+}
+
+/**
+ * Fetches a public page through the website-research subagent's SSRF-hardened
+ * Eve sandbox. The URL is passed through the process environment instead of
+ * interpolated into the shell command, so arbitrary URL characters cannot
+ * become shell syntax. This is the automatic fallback when the separate
+ * Chromium sandbox cannot be created.
+ */
+export async function fetchPageWithCurl(options: {
+  readonly url: string,
+  readonly requestId: string,
+  readonly sandbox: CurlFallbackSandbox,
+}): Promise<BrowsePageResult> {
+  const validatedUrl = validateBrowseUrl(options.url);
+  const safeRequestId = options.requestId.replace(/[^A-Za-z0-9_-]/g, "_");
+  const outputPath = `/workspace/browse-page-${safeRequestId}.untracked.html`;
+  try {
+    const result = await options.sandbox.run({
+      command: "curl --silent --show-error --location --compressed --fail-with-body --max-time 30 --max-filesize 2000000 --output \"$HEXCLAVE_BROWSE_OUTPUT_PATH\" --write-out '%{url_effective}' -- \"$HEXCLAVE_BROWSE_URL\"",
+      env: {
+        HEXCLAVE_BROWSE_OUTPUT_PATH: outputPath,
+        HEXCLAVE_BROWSE_URL: validatedUrl.toString(),
+      },
+    });
+    if (result.exitCode !== 0) {
+      throw new Error(`curl fallback failed with exit code ${result.exitCode}: ${result.stderr.trim() || "no error detail"}`);
+    }
+    const body = await options.sandbox.readBinaryFile({ path: outputPath });
+    if (body == null) throw new Error("curl fallback completed without producing a response body.");
+    const html = new TextDecoder().decode(body.slice(0, CURL_FALLBACK_BODY_BYTE_CAP));
+    const finalUrl = result.stdout.trim() || validatedUrl.toString();
+    return extractCurlFallbackPage(html, validatedUrl.toString(), finalUrl);
+  } finally {
+    await options.sandbox.removePath({ path: outputPath, force: true, recursive: false });
+  }
+}
+
+/** Only credential/setup failures should switch rendering engines. Navigation
+ * and page errors still surface normally so a broken target is not mistaken
+ * for a successful static fetch. */
+export function isBrowserSandboxCredentialError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return error.name === "VercelOidcContextError"
+    || error.name === "LocalOidcContextError"
+    || /Could not get credentials from OIDC context|Missing credentials parameters to access the Vercel API|Browser sandbox is unavailable outside a Vercel deployment or its credentials are missing/.test(error.message);
+}
+
+export async function browsePageWithCurlFallback(options: {
+  readonly url: string,
+  readonly requestId: string,
+  readonly getSandbox: () => Promise<CurlFallbackSandbox>,
+}): Promise<BrowsePageResult> {
+  const curlFallback = async (): Promise<BrowsePageResult> => await fetchPageWithCurl({
+    url: options.url,
+    requestId: options.requestId,
+    sandbox: await options.getSandbox(),
+  });
+  if (!isBrowseSandboxAvailable()) {
+    if (!isCurlFallbackSandboxSafe()) {
+      throw new Error(
+        "Browser sandbox is unavailable and the current Eve sandbox does not enforce the subnet firewall required for a safe curl fallback.",
+      );
+    }
+    return await curlFallback();
+  }
+  try {
+    return await browsePage({ url: options.url, screenshot: false });
+  } catch (error) {
+    if (!isBrowserSandboxCredentialError(error)) throw error;
+    if (!isCurlFallbackSandboxSafe()) throw error;
+    return await curlFallback();
+  }
 }
 
 class BrowseUrlValidationError extends Error {
@@ -145,10 +289,9 @@ export function validateBrowseUrl(rawUrl: string): URL {
  * Open `url` in a fresh browser microVM and return the rendered page's title,
  * final URL (after redirects), and interactive accessibility snapshot.
  *
- * `screenshot: true` additionally returns a base64 PNG of the viewport. Note
- * that eve 0.27.0 tool results are text/JSON-only (no image parts reach the
- * model), so tools built on this should pass `screenshot: false` today — the
- * flag exists for callers that can deliver images elsewhere (e.g. artifacts).
+ * `screenshot: true` additionally returns a base64 PNG of the viewport. The
+ * screenshot artifact tool sends these bytes directly to the backend rather
+ * than placing a large base64 payload in the model's context.
  *
  * One sandbox per call, torn down in the helper's `finally`: agent tool calls
  * are independent model turns and eve gives us no cross-call lifecycle hook to

--- a/apps/growth-agent/agent/lib/growth-document.test.ts
+++ b/apps/growth-agent/agent/lib/growth-document.test.ts
@@ -1,5 +1,80 @@
 import { describe, expect, it } from "vitest";
-import { growthActionDocumentInputSchema } from "./growth-document.ts";
+import { growthActionDocumentInputSchema, growthDocumentInputSchema } from "./growth-document.ts";
+
+const metricData = {
+  id: "activation",
+  kind: "metric",
+  title: "New-user activation",
+  unit: "percent",
+  source: "Product events, last 30 days",
+  takeaway: "New-user activation is below the current target.",
+  value: 12,
+};
+
+function parseDocument(source_mdx: string) {
+  return growthDocumentInputSchema.safeParse({
+    format: "growth-mdx-v1",
+    source_mdx,
+    data: [metricData],
+  });
+}
+
+describe("growthDocumentInputSchema", () => {
+  it("accepts valid block-level Growth MDX", () => {
+    expect(parseDocument(`## Activation
+
+<Metric data="activation" />
+
+<Evidence data="activation">
+
+Only 12% of new signups activated in the measured window.
+
+</Evidence>`).success).toBe(true);
+  });
+
+  it("does not interpret component-like text or expressions inside code as MDX", () => {
+    expect(parseDocument(`## Implementation note
+
+\`{value}\`
+
+\`\`\`tsx
+<Metric data-id="example" />
+const example = { value: 1 };
+\`\`\``).success).toBe(true);
+  });
+
+  it.each([
+    ["the unsupported data-id attribute", '<Metric data-id="activation" />', /data attribute, not data-id/],
+    ["an inline component", 'Activation is low: <Metric data="activation" />', /block-level component/],
+    ["malformed MDX", '<Metric data="activation" /', /malformed or unterminated/],
+    ["an unclosed component", '<Evidence data="activation">\n\nActivation is low.', /missing its closing tag/],
+    ["an oversized paragraph", "a".repeat(361), /at most 360 characters/],
+  ])("rejects %s before a save tool can call the backend", (_label, sourceMdx, expectedMessage) => {
+    const result = parseDocument(sourceMdx);
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toMatch(expectedMessage);
+  });
+
+  it("rejects a metric component whose data item has the wrong kind", () => {
+    const result = growthDocumentInputSchema.safeParse({
+      format: "growth-mdx-v1",
+      source_mdx: '<Metric data="activation" />',
+      data: [{
+        id: "activation",
+        kind: "comparison",
+        title: "Activation",
+        unit: "percent",
+        source: "Product events",
+        takeaway: "Activation varies by source.",
+        items: [{ label: "Organic", value: 12 }],
+      }],
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toMatch(/Metric requires metric data/);
+  });
+});
 
 describe("growthActionDocumentInputSchema", () => {
   it("accepts the fixed hypothesis, evidence, experiment sequence", () => {
@@ -22,15 +97,7 @@ Only 12% of new signups activated in the measured window.
 Test a specific signup prompt for 14 days. Success means activation exceeds 15%.
 
 </Experiment>`,
-      data: [{
-        id: "activation",
-        kind: "metric",
-        title: "New-user activation",
-        unit: "percent",
-        source: "Product events, last 30 days",
-        takeaway: "New-user activation is below the current target.",
-        value: 12,
-      }],
+      data: [metricData],
     });
 
     expect(result.success).toBe(true);

--- a/apps/growth-agent/agent/lib/growth-document.test.ts
+++ b/apps/growth-agent/agent/lib/growth-document.test.ts
@@ -49,6 +49,8 @@ const example = { value: 1 };
     ["malformed MDX", '<Metric data="activation" /', /malformed or unterminated/],
     ["an unclosed component", '<Evidence data="activation">\n\nActivation is low.', /missing its closing tag/],
     ["an oversized paragraph", "a".repeat(361), /at most 360 characters/],
+    ["an oversized component body", `<Evidence>\n\n${"a".repeat(361)}\n\n</Evidence>`, /at most 360 characters/],
+    ["a list with eight items", Array.from({ length: 8 }, (_, index) => `- item ${index + 1}`).join("\n"), /lists must have at most 7 items/],
   ])("rejects %s before a save tool can call the backend", (_label, sourceMdx, expectedMessage) => {
     const result = parseDocument(sourceMdx);
 
@@ -73,6 +75,13 @@ const example = { value: 1 };
 
     expect(result.success).toBe(false);
     if (!result.success) expect(result.error.message).toMatch(/Metric requires metric data/);
+  });
+
+  it("rejects an Evidence component whose data item is missing", () => {
+    const result = parseDocument(`<Evidence data="missing">\n\nThe source is unavailable.\n\n</Evidence>`);
+
+    expect(result.success).toBe(false);
+    if (!result.success) expect(result.error.message).toMatch(/Evidence references missing data id/);
   });
 });
 

--- a/apps/growth-agent/agent/lib/growth-document.ts
+++ b/apps/growth-agent/agent/lib/growth-document.ts
@@ -1,5 +1,155 @@
 import { z } from "zod";
 
+export const GROWTH_DOCUMENT_AUTHORING_GUIDE = `Use constrained Growth MDX. Put every Growth component and its opening/closing tags on their own lines, with blank lines around the content. Use data="id", never data-id. Keep paragraphs under 360 characters and lists under 8 items. Allowed headings are ## and ###. Allowed components are <Metric data="id" />, <TrendChart data="id" />, <ComparisonChart data="id" />, <BreakdownChart data="id" />, <Evidence data="id">...</Evidence>, <Hypothesis confidence="low|medium|high">...</Hypothesis>, <Experiment>...</Experiment>, and <DataGap>...</DataGap>. Every chart or metric must reference a matching data item with a source and one-sentence takeaway. Evidence with unit minor_units must include its three-letter currency; other units must omit currency. No HTML, imports, exports, JavaScript expressions, images, or arbitrary components. Prefer a scan-friendly sequence: evidence, hypothesis, experiment, success metric, and action.`;
+
+export const GROWTH_ACTION_DOCUMENT_AUTHORING_GUIDE = `Use exactly this Growth MDX structure, in this order, with every opening and closing tag on its own line: <Hypothesis confidence="low|medium|high">...</Hypothesis>, one or more <Evidence data="id">...</Evidence> blocks, then <Experiment>...</Experiment>. Use data="id", never data-id. Do not add headings, success-metric sections, action sections, charts, standalone paragraphs, or any other components. Keep each paragraph under 360 characters. Put the proposed change, test duration, and measurable success criteria inside Experiment. Every Evidence block must reference a matching data item with a named source and one-sentence takeaway. The dashboard owns every label and all layout; you write only the text inside these three component types.`;
+
+type GrowthComponentName = "Metric" | "TrendChart" | "ComparisonChart" | "BreakdownChart" | "Evidence" | "Hypothesis" | "Experiment" | "DataGap";
+
+const GROWTH_COMPONENT_NAMES: readonly GrowthComponentName[] = [
+  "Metric",
+  "TrendChart",
+  "ComparisonChart",
+  "BreakdownChart",
+  "Evidence",
+  "Hypothesis",
+  "Experiment",
+  "DataGap",
+];
+
+const SELF_CLOSING_COMPONENTS: readonly GrowthComponentName[] = ["Metric", "TrendChart", "ComparisonChart", "BreakdownChart"];
+const COMPONENT_TAG_PATTERN = /<\/?([A-Z][A-Za-z0-9]*)\b(?:[^"'<>]|"[^"]*"|'[^']*')*\/?>/g;
+const ATTRIBUTE_PATTERN = /\s+([A-Za-z][A-Za-z0-9-]*)(?:=(?:"([^"]*)"|'([^']*)'))?/g;
+
+function findGrowthComponentName(value: string): GrowthComponentName | undefined {
+  return GROWTH_COMPONENT_NAMES.find((name) => name === value);
+}
+
+function isSelfClosingComponent(name: GrowthComponentName): boolean {
+  return SELF_CLOSING_COMPONENTS.some((candidate) => candidate === name);
+}
+
+function addMdxIssue(ctx: z.RefinementCtx, message: string): void {
+  ctx.addIssue({ code: "custom", message: `Invalid Growth MDX: ${message}` });
+}
+
+// RegExp capture groups are typed as strings even though unmatched alternatives
+// are undefined at runtime. Keep that runtime fact explicit instead of relying
+// on a non-null assertion when accepting either single- or double-quoted values.
+function firstDefinedCapture(first: string | undefined, second: string | undefined): string | undefined {
+  if (first !== undefined) return first;
+  return second;
+}
+
+function maskMarkdownCode(sourceMdx: string): string {
+  return sourceMdx.replace(/```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]*`/g, (code) => code.replace(/[^\n]/g, " "));
+}
+
+function validateParagraphLengths(sourceMdx: string, ctx: z.RefinementCtx): void {
+  const blocks = sourceMdx.split(/\n\s*\n/);
+  for (const block of blocks) {
+    const lines = block.split("\n").map((line) => line.trim()).filter((line) => line.length > 0);
+    if (lines.length === 0 || lines.some((line) => /^<\/?[A-Z]/.test(line))) continue;
+    if (lines.every((line) => /^(#{1,6}\s|[-*+]\s|\d+\.\s|\||```|~~~|---$)/.test(line))) continue;
+    const paragraph = lines.join(" ")
+      .replace(/^[-*+]\s+/, "")
+      .replace(/^\d+\.\s+/, "")
+      .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+      .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+      .replace(/[*_~`]/g, "");
+    if (paragraph.length > 360) {
+      addMdxIssue(ctx, `paragraphs must be at most 360 characters; found ${paragraph.length}. Split the paragraph with a blank line.`);
+    }
+  }
+}
+
+function validateGrowthMdx(sourceMdx: string, ctx: z.RefinementCtx): void {
+  // Code samples are valid document blocks and their contents are not MDX.
+  // Preserve their byte/line positions while masking the characters so every
+  // syntax check below reasons only about actual document markup.
+  const syntaxSource = maskMarkdownCode(sourceMdx);
+  if (/\bdata-id\s*=/.test(syntaxSource)) {
+    addMdxIssue(ctx, "Growth components use the data attribute, not data-id. Write data=\"id\".");
+  }
+  if (/(^|\n)\s*(?:import|export)\s/m.test(syntaxSource)) addMdxIssue(ctx, "imports and exports are not allowed.");
+  if (/[{}]/.test(syntaxSource)) addMdxIssue(ctx, "JavaScript expressions are not allowed.");
+  if (/!\[[^\]]*\]\([^)]*\)/.test(syntaxSource)) addMdxIssue(ctx, "images are not supported; use evidence components instead.");
+
+  for (const heading of syntaxSource.matchAll(/^(#{1,6})\s+/gm)) {
+    const marker = heading[1];
+    if (marker !== "##" && marker !== "###") addMdxIssue(ctx, "only level 2 (##) and level 3 (###) headings are allowed.");
+  }
+
+  const stack: GrowthComponentName[] = [];
+  const matchedTagStarts = new Set<number>();
+  for (const match of syntaxSource.matchAll(COMPONENT_TAG_PATTERN)) {
+    const fullTag = match[0];
+    const rawName = match[1];
+    const index = match.index;
+    matchedTagStarts.add(index);
+    const name = findGrowthComponentName(rawName);
+    if (name === undefined) {
+      addMdxIssue(ctx, `component ${rawName} is not allowed.`);
+      continue;
+    }
+
+    const lineStart = syntaxSource.lastIndexOf("\n", index - 1) + 1;
+    const nextLineBreak = syntaxSource.indexOf("\n", index + fullTag.length);
+    const lineEnd = nextLineBreak === -1 ? syntaxSource.length : nextLineBreak;
+    const beforeTag = syntaxSource.slice(lineStart, index).trim();
+    const afterTag = syntaxSource.slice(index + fullTag.length, lineEnd).trim();
+    if (beforeTag.length > 0 || afterTag.length > 0) {
+      addMdxIssue(ctx, `${name} must be a block-level component with its tag on its own line.`);
+    }
+
+    const isClosing = fullTag.startsWith("</");
+    const isSelfClosing = /\/\s*>$/.test(fullTag);
+    if (isClosing) {
+      const openName = stack.pop();
+      if (openName !== name) addMdxIssue(ctx, `${name} has no matching opening tag in the correct order.`);
+      continue;
+    }
+
+    const attributes = new Map<string, string | null>();
+    const attributeSource = fullTag
+      .replace(new RegExp(`^<${name}\\b`), "")
+      .replace(/\/?>$/, "");
+    for (const attributeMatch of attributeSource.matchAll(ATTRIBUTE_PATTERN)) {
+      const attributeName = attributeMatch[1];
+      const capturedValue = firstDefinedCapture(attributeMatch[2], attributeMatch[3]);
+      const attributeValue = capturedValue === undefined ? null : capturedValue;
+      if (attributes.has(attributeName)) addMdxIssue(ctx, `${name} repeats the ${attributeName} attribute.`);
+      attributes.set(attributeName, attributeValue);
+    }
+    const unparsedAttributes = attributeSource.replace(ATTRIBUTE_PATTERN, "").trim();
+    if (unparsedAttributes.length > 0) addMdxIssue(ctx, `${name} contains malformed attributes.`);
+
+    const allowedAttributes = name === "Hypothesis" ? ["confidence"] : name === "Evidence" || isSelfClosingComponent(name) ? ["data"] : [];
+    for (const attributeName of attributes.keys()) {
+      if (!allowedAttributes.includes(attributeName)) addMdxIssue(ctx, `${name} does not support the ${attributeName} attribute.`);
+    }
+    if (isSelfClosingComponent(name)) {
+      const dataId = attributes.get("data");
+      if (dataId == null || dataId.length === 0) addMdxIssue(ctx, `${name} requires a non-empty data attribute.`);
+      if (!isSelfClosing) addMdxIssue(ctx, `${name} must be self-closing.`);
+    }
+    if (name === "Hypothesis") {
+      const confidence = attributes.get("confidence");
+      if (confidence != null && confidence !== "low" && confidence !== "medium" && confidence !== "high") {
+        addMdxIssue(ctx, "Hypothesis confidence must be low, medium, or high.");
+      }
+    }
+    if (!isSelfClosing && !isSelfClosingComponent(name)) stack.push(name);
+  }
+
+  for (const marker of syntaxSource.matchAll(/<\/?([A-Z][A-Za-z0-9]*)\b/g)) {
+    if (!matchedTagStarts.has(marker.index)) addMdxIssue(ctx, `${marker[1]} has malformed or unterminated MDX syntax.`);
+  }
+  for (const unclosed of stack.reverse()) addMdxIssue(ctx, `${unclosed} is missing its closing tag.`);
+
+  validateParagraphLengths(syntaxSource, ctx);
+}
+
 const evidenceBase = {
   id: z.string().min(1).max(100),
   title: z.string().min(1).max(200),
@@ -41,8 +191,49 @@ const evidenceDatumSchema = z.discriminatedUnion("kind", [
  */
 export const growthDocumentInputSchema = z.object({
   format: z.literal("growth-mdx-v1"),
-  source_mdx: z.string().min(1).max(100_000),
+  source_mdx: z.string().min(1).max(100_000)
+    .describe(GROWTH_DOCUMENT_AUTHORING_GUIDE)
+    .superRefine(validateGrowthMdx),
   data: z.array(evidenceDatumSchema).max(40),
+}).superRefine((document, ctx) => {
+  const byId = new Map<string, typeof document.data[number]>();
+  for (const datum of document.data) {
+    if (byId.has(datum.id)) ctx.addIssue({ code: "custom", message: `Invalid Growth data: id ${JSON.stringify(datum.id)} is duplicated.` });
+    byId.set(datum.id, datum);
+    if (datum.unit === "minor_units" && datum.currency == null) {
+      ctx.addIssue({ code: "custom", message: `Invalid Growth data: ${datum.id} requires a three-letter currency because its unit is minor_units.` });
+    }
+    if (datum.unit !== "minor_units" && datum.currency != null) {
+      ctx.addIssue({ code: "custom", message: `Invalid Growth data: ${datum.id} must omit currency unless its unit is minor_units.` });
+    }
+    if (datum.kind === "metric" && ((datum.comparison_label == null) !== (datum.comparison_value == null))) {
+      ctx.addIssue({ code: "custom", message: `Invalid Growth data: ${datum.id} must provide comparison_label and comparison_value together.` });
+    }
+  }
+
+  const expectedKinds = new Map<string, "metric" | "time_series" | "comparison" | "breakdown">([
+    ["Metric", "metric"],
+    ["TrendChart", "time_series"],
+    ["ComparisonChart", "comparison"],
+    ["BreakdownChart", "breakdown"],
+  ]);
+  for (const match of document.source_mdx.matchAll(/<(Metric|TrendChart|ComparisonChart|BreakdownChart)\b[^>]*\bdata=(?:"([^"]+)"|'([^']+)')[^>]*\/\s*>/g)) {
+    const componentName = match[1];
+    const dataId = firstDefinedCapture(match[2], match[3]);
+    if (dataId === undefined) {
+      ctx.addIssue({ code: "custom", message: `Invalid Growth data: ${componentName} has no readable data id.` });
+      continue;
+    }
+    const datum = byId.get(dataId);
+    if (datum === undefined) {
+      ctx.addIssue({ code: "custom", message: `Invalid Growth data: ${componentName} references missing data id ${JSON.stringify(dataId)}.` });
+      continue;
+    }
+    const expectedKind = expectedKinds.get(componentName);
+    if (expectedKind !== datum.kind) {
+      ctx.addIssue({ code: "custom", message: `Invalid Growth data: ${componentName} requires ${expectedKind} data, but ${JSON.stringify(dataId)} is ${datum.kind}.` });
+    }
+  }
 });
 
 export type GrowthDocumentInput = z.infer<typeof growthDocumentInputSchema>;
@@ -70,7 +261,3 @@ export const growthActionDocumentInputSchema = growthDocumentInputSchema.superRe
     });
   }
 });
-
-export const GROWTH_DOCUMENT_AUTHORING_GUIDE = `Use constrained Growth MDX. Keep paragraphs under 360 characters and lists under 8 items. Allowed headings are ## and ###. Allowed components are <Metric data="id" />, <TrendChart data="id" />, <ComparisonChart data="id" />, <BreakdownChart data="id" />, <Evidence data="id">...</Evidence>, <Hypothesis confidence="low|medium|high">...</Hypothesis>, <Experiment>...</Experiment>, and <DataGap>...</DataGap>. Every chart or metric must reference a matching data item with a source and one-sentence takeaway. Evidence with unit minor_units must include its three-letter currency; other units must omit currency. No HTML, imports, exports, JavaScript expressions, images, or arbitrary components. Prefer a scan-friendly sequence: evidence, hypothesis, experiment, success metric, and action.`;
-
-export const GROWTH_ACTION_DOCUMENT_AUTHORING_GUIDE = `Use exactly this Growth MDX structure, in this order: <Hypothesis confidence="low|medium|high">...</Hypothesis>, one or more <Evidence data="id">...</Evidence> blocks, then <Experiment>...</Experiment>. Do not add headings, success-metric sections, action sections, charts, standalone paragraphs, or any other components. Put the proposed change, test duration, and measurable success criteria inside Experiment. Every Evidence block must reference a matching data item with a named source and one-sentence takeaway. The dashboard owns every label and all layout; you write only the text inside these three component types.`;

--- a/apps/growth-agent/agent/lib/growth-document.ts
+++ b/apps/growth-agent/agent/lib/growth-document.ts
@@ -46,7 +46,11 @@ function maskMarkdownCode(sourceMdx: string): string {
 }
 
 function validateParagraphLengths(sourceMdx: string, ctx: z.RefinementCtx): void {
-  const blocks = sourceMdx.split(/\n\s*\n/);
+  // Component tags are block boundaries, not paragraph content. Masking them before splitting
+  // also makes paragraphs inside Evidence/Hypothesis/Experiment bodies subject to the same limit
+  // as top-level paragraphs, matching the backend compiler's recursive MDX conversion.
+  const paragraphSource = sourceMdx.replace(COMPONENT_TAG_PATTERN, "\n");
+  const blocks = paragraphSource.split(/\n\s*\n/);
   for (const block of blocks) {
     const lines = block.split("\n").map((line) => line.trim()).filter((line) => line.length > 0);
     if (lines.length === 0 || lines.some((line) => /^<\/?[A-Z]/.test(line))) continue;
@@ -61,6 +65,40 @@ function validateParagraphLengths(sourceMdx: string, ctx: z.RefinementCtx): void
       addMdxIssue(ctx, `paragraphs must be at most 360 characters; found ${paragraph.length}. Split the paragraph with a blank line.`);
     }
   }
+}
+
+function validateListLengths(sourceMdx: string, ctx: z.RefinementCtx): void {
+  const lines = sourceMdx.split("\n");
+  const lists: { indent: number, itemCount: number }[] = [];
+
+  const finishList = () => {
+    const list = lists.pop();
+    if (list != null && list.itemCount > 7) addMdxIssue(ctx, `lists must have at most 7 items; found ${list.itemCount}.`);
+  };
+
+  for (const line of lines) {
+    const item = /^(\s*)(?:[-*+]\s+|\d+[.)]\s+)/.exec(line);
+    if (item != null) {
+      const indent = item[1].replace(/\t/g, "    ").length;
+      let currentList = lists.at(-1);
+      while (currentList != null && indent < currentList.indent) {
+        finishList();
+        currentList = lists.at(-1);
+      }
+      if (currentList == null || indent > currentList.indent) lists.push({ indent, itemCount: 1 });
+      else currentList.itemCount += 1;
+      continue;
+    }
+
+    if (line.trim().length === 0) continue;
+    const indent = line.search(/\S|$/);
+    let currentList = lists.at(-1);
+    while (currentList != null && indent <= currentList.indent) {
+      finishList();
+      currentList = lists.at(-1);
+    }
+  }
+  while (lists.length > 0) finishList();
 }
 
 function validateGrowthMdx(sourceMdx: string, ctx: z.RefinementCtx): void {
@@ -148,6 +186,7 @@ function validateGrowthMdx(sourceMdx: string, ctx: z.RefinementCtx): void {
   for (const unclosed of stack.reverse()) addMdxIssue(ctx, `${unclosed} is missing its closing tag.`);
 
   validateParagraphLengths(syntaxSource, ctx);
+  validateListLengths(syntaxSource, ctx);
 }
 
 const evidenceBase = {
@@ -232,6 +271,12 @@ export const growthDocumentInputSchema = z.object({
     const expectedKind = expectedKinds.get(componentName);
     if (expectedKind !== datum.kind) {
       ctx.addIssue({ code: "custom", message: `Invalid Growth data: ${componentName} requires ${expectedKind} data, but ${JSON.stringify(dataId)} is ${datum.kind}.` });
+    }
+  }
+  for (const match of document.source_mdx.matchAll(/<Evidence\b(?=[^>]*\bdata\s*=\s*(?:"([^"]+)"|'([^']+)'))[^>]*>/g)) {
+    const dataId = firstDefinedCapture(match[1], match[2]);
+    if (dataId !== undefined && byId.get(dataId) === undefined) {
+      ctx.addIssue({ code: "custom", message: `Invalid Growth data: Evidence references missing data id ${JSON.stringify(dataId)}.` });
     }
   }
 });

--- a/apps/growth-agent/agent/subagents/data-analyst/tools/save-findings.ts
+++ b/apps/growth-agent/agent/subagents/data-analyst/tools/save-findings.ts
@@ -2,7 +2,7 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { jsonObjectSchema } from "#lib/json-payload.ts";
 import { growthCategorySchema, growthTagsSchema } from "#lib/growth-taxonomy.ts";
-import { growthDocumentInputSchema } from "#lib/growth-document.ts";
+import { GROWTH_DOCUMENT_AUTHORING_GUIDE, growthDocumentInputSchema } from "#lib/growth-document.ts";
 import { saveFindings } from "#lib/hexclave-client.ts";
 
 // Thin per-subagent wrapper around the shared backend client. The `source` is
@@ -10,7 +10,7 @@ import { saveFindings } from "#lib/hexclave-client.ts";
 // the ones this analyst produces, so a confused model cannot write findings
 // under another phase's identity.
 export default defineTool({
-  description: "Save data-analysis findings to the Hexclave backend for the current growth run. Every finding must cite concrete numbers from queries run in this session. Use the exact project_id, branch_id, and run_id you were given in your task message.",
+  description: `Save data-analysis findings to the Hexclave backend for the current growth run. Every finding must cite concrete numbers from queries run in this session. ${GROWTH_DOCUMENT_AUTHORING_GUIDE} Use the exact project_id, branch_id, and run_id you were given in your task message.`,
   inputSchema: z.object({
     project_id: z.string().min(1),
     branch_id: z.string().min(1),

--- a/apps/growth-agent/agent/subagents/data-analyst/tools/save-notes.ts
+++ b/apps/growth-agent/agent/subagents/data-analyst/tools/save-notes.ts
@@ -2,7 +2,7 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { jsonObjectSchema } from "#lib/json-payload.ts";
 import { growthCategorySchema, growthTagsSchema } from "#lib/growth-taxonomy.ts";
-import { growthDocumentInputSchema } from "#lib/growth-document.ts";
+import { GROWTH_DOCUMENT_AUTHORING_GUIDE, growthDocumentInputSchema } from "#lib/growth-document.ts";
 import { saveNotes } from "#lib/hexclave-client.ts";
 
 // Per-subagent wrapper (ids from the task message, see save-findings.ts). Notes are the trend lane
@@ -10,7 +10,7 @@ import { saveNotes } from "#lib/hexclave-client.ts";
 // its description is direction over time. The finding `kind` that marks a note is pinned server-side,
 // so nothing here can drop a note into the findings lane by mistake.
 export default defineTool({
-  description: "Record a trend or pattern you found in the project's data (batch up to 20 per call). A note is different from a finding: a finding states something that is true right now, a note states how something has been MOVING — a metric trending up or down over weeks, a recurring weekly or seasonal shape, a channel steadily gaining or losing share, a cohort behaving differently from the ones before it, or a step change with a visible before and after. Every note must cite the actual numbers and the time window they cover, from queries you ran in this session. Put the machine-readable series or comparison in `data`. Do not write a note for a single day's value with nothing to compare it to, and do not put recommendations here — those belong in the report's action items. Use the exact project_id, branch_id, and run_id you were given in your task message.",
+  description: `Record a trend or pattern you found in the project's data (batch up to 20 per call). A note is different from a finding: a finding states something that is true right now, a note states how something has been MOVING — a metric trending up or down over weeks, a recurring weekly or seasonal shape, a channel steadily gaining or losing share, a cohort behaving differently from the ones before it, or a step change with a visible before and after. Every note must cite the actual numbers and the time window they cover, from queries you ran in this session. Put the machine-readable series or comparison in data. ${GROWTH_DOCUMENT_AUTHORING_GUIDE} Do not write a note for a single day's value with nothing to compare it to, and do not put recommendations here — those belong in the report's action items. Use the exact project_id, branch_id, and run_id you were given in your task message.`,
   inputSchema: z.object({
     project_id: z.string().min(1),
     branch_id: z.string().min(1),

--- a/apps/growth-agent/agent/subagents/website-research/tools/browse-page.ts
+++ b/apps/growth-agent/agent/subagents/website-research/tools/browse-page.ts
@@ -1,21 +1,23 @@
 import { defineTool } from "eve/tools";
 import { z } from "zod";
-import { browsePage } from "#lib/browse.ts";
+import { browsePageWithCurlFallback } from "#lib/browse.ts";
 
 // Renders a page in a real browser (ephemeral Vercel Sandbox microVM, see
 // #lib/browse.ts) so this subagent can research JS-rendered sites that curl
-// returns empty shells for. There is deliberately no `screenshot` input: eve
-// 0.27.0 tool results are text/JSON-only (ToolModelOutput has no image part),
-// so a screenshot could never reach the model — we skip capturing it rather
-// than burning sandbox time on undeliverable pixels. Revisit if eve gains
-// image tool-result parts.
+// returns empty shells for. There is deliberately no `screenshot` input:
+// this research tool needs compact text, while screenshot bytes are persisted
+// separately by capture-homepage-screenshot for later image-capable consumers.
 export default defineTool({
-  description: "Render a public web page in a real headless browser (ephemeral sandbox VM) and return its title, final URL after redirects, and an accessibility-tree snapshot of the rendered content. Use this for the customer's site and competitor pages, especially JS-heavy ones; each call costs sandbox time, so budget calls carefully and use curl for simple static fetches (robots.txt, sitemaps). If this tool errors because the browser sandbox is unavailable, fall back to curl.",
+  description: "Render a public web page in a real headless browser and return its title, final URL after redirects, and an accessibility-tree snapshot. If Chromium is unavailable, this tool automatically fetches the page with curl through the SSRF-hardened session sandbox and clearly labels the static-HTML result. Use this for the customer's site and competitor pages, especially JS-heavy ones; each browser call costs sandbox time, so budget calls carefully.",
   inputSchema: z.object({
     url: z.string().min(1).describe("Absolute http(s) URL of the public page to render."),
   }),
-  async execute(input) {
-    const result = await browsePage({ url: input.url, screenshot: false });
+  async execute(input, ctx) {
+    const result = await browsePageWithCurlFallback({
+      url: input.url,
+      requestId: ctx.callId,
+      getSandbox: async () => await ctx.getSandbox(),
+    });
     return {
       final_url: result.finalUrl,
       title: result.title,

--- a/apps/growth-agent/agent/subagents/website-research/tools/capture-homepage-screenshot.ts
+++ b/apps/growth-agent/agent/subagents/website-research/tools/capture-homepage-screenshot.ts
@@ -1,6 +1,6 @@
 import { defineTool } from "eve/tools";
 import { z } from "zod";
-import { browsePage } from "#lib/browse.ts";
+import { browsePage, isBrowserSandboxCredentialError, isBrowseSandboxAvailable } from "#lib/browse.ts";
 import { saveArtifact } from "#lib/hexclave-client.ts";
 
 /**
@@ -10,14 +10,11 @@ import { saveArtifact } from "#lib/hexclave-client.ts";
  * on demand, at generation time — means a screenshot still exists even for a project whose site
  * becomes unreachable later.
  *
- * The returned tool result carries no image bytes — only metadata. eve 0.27.0's ToolModelOutput is
- * text/JSON only (see browse.ts's module comment on browsePage's `screenshot` option), so returning
- * the base64 PNG here would just be an unreadable wall of text this (reasoning) model can't use; the
- * bytes go straight from the sandbox into the artifact write and are never echoed into the model's
- * context.
+ * The returned tool result carries no image bytes — only metadata. The bytes go straight from the
+ * browser sandbox into the artifact write and are never echoed into the model's context.
  */
 export default defineTool({
-  description: "Capture a screenshot of the product's homepage (or another key marketing page) and save it as a brand_screenshot artifact for future ad-creative reference. Call this at most once or twice per run — each call spins up a sandbox VM. You will not see the image itself (only its URL/title/byte size); that is expected.",
+  description: "Capture a screenshot of the product's homepage (or another key marketing page) and save it as a brand_screenshot artifact for future ad-creative reference. Call this at most once or twice per run. If Chromium is unavailable, the tool returns a non-fatal skipped result so website analysis can continue. You will not see the image itself; that is expected.",
   inputSchema: z.object({
     project_id: z.string().min(1),
     branch_id: z.string().min(1),
@@ -25,7 +22,22 @@ export default defineTool({
     url: z.string().url().describe("Absolute http(s) URL of the page to screenshot — usually the homepage."),
   }),
   async execute(input) {
-    const page = await browsePage({ url: input.url, screenshot: true });
+    if (!isBrowseSandboxAvailable()) {
+      return {
+        skipped: true,
+        reason: "Chromium sandbox credentials are unavailable; continue the website analysis using browse-page's automatic curl fallback.",
+      };
+    }
+    let page: Awaited<ReturnType<typeof browsePage>>;
+    try {
+      page = await browsePage({ url: input.url, screenshot: true });
+    } catch (error) {
+      if (!isBrowserSandboxCredentialError(error)) throw error;
+      return {
+        skipped: true,
+        reason: "Chromium sandbox credentials could not be resolved; continue the website analysis using browse-page's automatic curl fallback.",
+      };
+    }
     if (page.screenshotBase64 == null) {
       throw new Error("Browser sandbox did not return a screenshot.");
     }

--- a/apps/growth-agent/agent/subagents/website-research/tools/save-findings.ts
+++ b/apps/growth-agent/agent/subagents/website-research/tools/save-findings.ts
@@ -2,7 +2,7 @@ import { defineTool } from "eve/tools";
 import { z } from "zod";
 import { jsonObjectSchema } from "#lib/json-payload.ts";
 import { growthCategorySchema, growthTagsSchema } from "#lib/growth-taxonomy.ts";
-import { growthDocumentInputSchema } from "#lib/growth-document.ts";
+import { GROWTH_DOCUMENT_AUTHORING_GUIDE, growthDocumentInputSchema } from "#lib/growth-document.ts";
 import { saveFindings } from "#lib/hexclave-client.ts";
 
 // Thin per-subagent wrapper around the shared backend client: declared
@@ -11,7 +11,7 @@ import { saveFindings } from "#lib/hexclave-client.ts";
 // the finding kinds are restricted to the ones this researcher produces, so a
 // confused model cannot write findings under another phase's identity.
 export default defineTool({
-  description: "Save website/competitor research findings to the Hexclave backend for the current growth run. Use the exact project_id, branch_id, and run_id you were given in your task message.",
+  description: `Save website/competitor research findings to the Hexclave backend for the current growth run. ${GROWTH_DOCUMENT_AUTHORING_GUIDE} Use the exact project_id, branch_id, and run_id you were given in your task message.`,
   inputSchema: z.object({
     project_id: z.string().min(1),
     branch_id: z.string().min(1),


### PR DESCRIPTION
This commit introduces a new server-side route for executing manual growth steps from the internal admin page. It includes the creation of a `GrowthAdminRunNowCard` component in the dashboard for triggering these steps, along with the necessary API integration to handle requests for running either the workflow engine or growth watchdog steps. The changes also enhance the growth API to support these manual operations, ensuring that only authorized platform admins can execute them.

Key changes:
- New route handler for running growth steps.
- Dashboard component for user interaction.
- Updated growth API to include manual step execution logic.

This functionality is crucial for managing growth processes effectively, especially in preview deployments where scheduled invocations are not available.

<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an internal Run Now action to trigger one Growth scheduler step and hardens website research and Growth MDX authoring for Preview reliability. Enables manual execution when Cron is unavailable and keeps research working when Chromium credentials are missing.

- Backend: Adds `POST /api/latest/internal/growth/admin/run-now`. Requires authenticated user, internal project, and platform admin; runs workflow engine or watchdog with a short deadline; returns `{ did_work }`.
- Dashboard: Adds `GrowthAdminRunNowCard` with buttons for both steps; integrates via `runGrowthAdminManualStep` in the growth API client.
- Browsing: Adds `browsePageWithCurlFallback` that uses the SSRF-hardened Eve sandbox curl path when the Chromium sandbox is unavailable; labels static-HTML results and caps size. `isBrowseSandboxAvailable` now allows runtime OIDC on Vercel. Tests cover credential detection and curl flow.
- Growth MDX: Adds strict validation and authoring guides. Enforces block-level components, allowed tags/attributes, paragraph and list limits, and data id ↔ kind matching (including currency/unit rules). Tests added.
- Tools: Website research `browse-page` uses the fallback automatically. `capture-homepage-screenshot` now skips gracefully when the browser sandbox is unavailable. Findings/notes tools include the authoring guide in their descriptions.

**Rollout/ops**
- No migrations. Feature is limited to the internal project and platform admins.
- Curl fallback is allowed only on the Vercel sandbox backend; local Docker remains disabled.
- Validate in Preview by running both steps from the admin card; confirm expected `did_work` behavior without Cron.

<sup>Written for commit 620966d9e7d56c47392528408880a54606489614. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Growth Admin control to manually run workflow or watchdog steps.
  - Added automatic webpage retrieval fallback when browser access is unavailable.
  - Added graceful handling for unavailable screenshot capabilities.

- **Improvements**
  - Strengthened Growth document formatting and data validation.
  - Added clearer authoring guidance for generated findings and notes.
  - Improved webpage safety, content limits, cleanup, and error handling.

- **Tests**
  - Expanded coverage for webpage fallback behavior and Growth document validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->