### PR TITLE
Improve growth admin recovery flow

### DIFF
--- a/apps/backend/src/app/api/latest/internal/growth/admin/run-now/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/growth/admin/run-now/route.tsx
@@ -2,7 +2,7 @@ import { repairGrowthProject, runGrowthProjectAnalysisStep } from "@/lib/growth/
 import { requireGrowthAdminTenancy } from "@/lib/growth/admin";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { KnownErrors } from "@hexclave/shared";
-import { adaptSchema, clientOrHigherAuthTypeSchema, yupBoolean, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
+import { adaptSchema, clientOrHigherAuthTypeSchema, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
 
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";

--- a/apps/backend/src/app/api/latest/internal/growth/admin/run-now/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/growth/admin/run-now/route.tsx
@@ -1,12 +1,8 @@
-import { runGrowthWatchdogSweep } from "@/lib/growth/watchdog";
-import { runWorkflowEngineStep } from "@/lib/workflows/engine";
-import { ensurePlatformAdmin } from "@/lib/platform-admin";
+import { repairGrowthProject, runGrowthProjectAnalysisStep } from "@/lib/growth/admin-recovery";
+import { requireGrowthAdminTenancy } from "@/lib/growth/admin";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { KnownErrors } from "@hexclave/shared";
 import { adaptSchema, clientOrHigherAuthTypeSchema, yupBoolean, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
-
-const INTERNAL_PROJECT_ID = "internal";
-const MANUAL_STEP_DEADLINE_MS = 3 * 60 * 1000;
 
 export const dynamic = "force-dynamic";
 export const fetchCache = "force-no-store";
@@ -20,14 +16,14 @@ export const maxDuration = 300;
 export const POST = createSmartRouteHandler({
   metadata: {
     summary: "Run Growth scheduler step",
-    description: "Run one workflow-engine or Growth-watchdog step from the internal Growth admin page.",
+    description: "Advance or repair one selected project's Growth analysis from the internal Growth admin page.",
     tags: ["Growth"],
     hidden: true,
   },
   request: yupObject({
     auth: yupObject({ type: clientOrHigherAuthTypeSchema.defined(), project: adaptSchema.defined(), user: adaptSchema }).defined(),
     method: yupString().oneOf(["POST"]).defined(),
-    body: yupObject({ step: yupString().oneOf(["workflow_engine", "growth_watchdog"]).defined() }).defined(),
+    body: yupObject({ step: yupString().oneOf(["analysis_tick", "project_recovery"]).defined(), target_project_id: yupString().defined() }).defined(),
   }),
   response: yupObject({
     statusCode: yupNumber().oneOf([200]).defined(),
@@ -36,13 +32,10 @@ export const POST = createSmartRouteHandler({
   }),
   handler: async ({ auth, body }) => {
     if (auth.user == null) throw new KnownErrors.UserAuthenticationRequired();
-    if (auth.project.id !== INTERNAL_PROJECT_ID) throw new KnownErrors.ExpectedInternalProject();
-    await ensurePlatformAdmin(auth.user);
-
-    const deadlineMs = Date.now() + MANUAL_STEP_DEADLINE_MS;
-    const result = body.step === "workflow_engine"
-      ? await runWorkflowEngineStep({ deadlineMs })
-      : await runGrowthWatchdogSweep({ deadlineMs });
+    const tenancy = await requireGrowthAdminTenancy(auth.project.id, auth.user, body.target_project_id);
+    const result = body.step === "analysis_tick"
+      ? await runGrowthProjectAnalysisStep(tenancy)
+      : await repairGrowthProject(tenancy);
 
     return {
       statusCode: 200,

--- a/apps/backend/src/lib/growth/admin-recovery.test.ts
+++ b/apps/backend/src/lib/growth/admin-recovery.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test, vi } from "vitest";
+
+const { findFirst } = vi.hoisted(() => ({ findFirst: vi.fn() }));
+
+vi.mock("@/prisma-client", () => ({
+  globalPrismaClient: {
+    workflowEvent: { findFirst },
+  },
+}));
+
+import { hasPendingGrowthBoundaryEvent } from "./admin-recovery";
+import { GROWTH_EVENT_TYPES } from "./workflows";
+
+describe("hasPendingGrowthBoundaryEvent", () => {
+  test("finds an unprocessed boundary event for the same tenancy, run, and leg", async () => {
+    findFirst.mockResolvedValueOnce({ id: "event-1" });
+
+    await expect(hasPendingGrowthBoundaryEvent({
+      tenancyId: "tenancy-1",
+      growthRunId: "run-1",
+      type: GROWTH_EVENT_TYPES.analysisRunActivated,
+    })).resolves.toBe(true);
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        tenancyId: "tenancy-1",
+        type: GROWTH_EVENT_TYPES.analysisRunActivated,
+        processedAt: null,
+        payload: { path: ["growth_run_id"], equals: "run-1" },
+      },
+      select: { id: true },
+    });
+  });
+
+  test("allows recovery when no matching event remains in the outbox", async () => {
+    findFirst.mockResolvedValueOnce(null);
+
+    await expect(hasPendingGrowthBoundaryEvent({
+      tenancyId: "tenancy-1",
+      growthRunId: "run-1",
+      type: GROWTH_EVENT_TYPES.interviewFinished,
+    })).resolves.toBe(false);
+  });
+});

--- a/apps/backend/src/lib/growth/admin-recovery.ts
+++ b/apps/backend/src/lib/growth/admin-recovery.ts
@@ -1,0 +1,77 @@
+import { GrowthRunStatus, WorkflowRunState } from "@/generated/prisma/enums";
+import type { Tenancy } from "@/lib/tenancies";
+import { enqueueWorkflowEvent } from "@/lib/workflows/events";
+import { globalPrismaClient } from "@/prisma-client";
+import { getGrowthAnalysisSnapshot, tickGrowthAnalysisRun } from "./orchestration";
+import { GROWTH_ANALYSIS_WORKFLOW_ID } from "./workflow-sources";
+import { ensureGrowthWorkflows, getGrowthAnalysisLegRunKeys, GROWTH_EVENT_TYPES } from "./workflows";
+
+async function findActiveGrowthRun(tenancy: Tenancy) {
+  return await globalPrismaClient.growthAnalysisRun.findFirst({
+    where: {
+      projectId: tenancy.project.id,
+      branchId: tenancy.branchId,
+      status: { in: [GrowthRunStatus.PENDING, GrowthRunStatus.RUNNING, GrowthRunStatus.AWAITING_INTERVIEW, GrowthRunStatus.COMPOSING_REPORT] },
+    },
+    orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+    select: {
+      id: true,
+      status: true,
+      trigger: true,
+      interview: { select: { status: true } },
+    },
+  });
+}
+
+/** Advances the selected project's active Growth run without touching the shared workflow engine. */
+export async function runGrowthProjectAnalysisStep(tenancy: Tenancy): Promise<{ didWork: boolean }> {
+  const run = await findActiveGrowthRun(tenancy);
+  if (run == null) return { didWork: false };
+  const scope = { projectId: tenancy.project.id, branchId: tenancy.branchId, runId: run.id };
+  const before = await getGrowthAnalysisSnapshot(scope);
+  const after = await tickGrowthAnalysisRun(scope);
+  return { didWork: before?.fingerprint !== after?.fingerprint };
+}
+
+export async function repairGrowthProject(tenancy: Tenancy): Promise<{ didWork: boolean }> {
+  let didWork = false;
+  const workflowResults = await ensureGrowthWorkflows(tenancy);
+  didWork = [...workflowResults.values()].some((result) => result.created) || didWork;
+
+  const run = await findActiveGrowthRun(tenancy);
+  if (run == null) return { didWork };
+
+  const leg = run.status === GrowthRunStatus.PENDING || run.status === GrowthRunStatus.RUNNING
+    ? "activation"
+    : run.status === GrowthRunStatus.AWAITING_INTERVIEW && (run.interview?.status === "completed" || run.interview?.status === "skipped")
+      ? "interview"
+      : run.status === GrowthRunStatus.COMPOSING_REPORT
+        ? "interview"
+        : null;
+  if (leg == null) {
+    const tick = await runGrowthProjectAnalysisStep(tenancy);
+    return { didWork: tick.didWork || didWork };
+  }
+
+  const activeLeg = await globalPrismaClient.workflowRun.findFirst({
+    where: {
+      tenancyId: tenancy.id,
+      workflowId: GROWTH_ANALYSIS_WORKFLOW_ID,
+      runKey: { in: getGrowthAnalysisLegRunKeys(run.id) },
+      state: { in: [WorkflowRunState.QUEUED, WorkflowRunState.RUNNING, WorkflowRunState.SLEEPING] },
+    },
+    select: { id: true },
+  });
+  if (activeLeg != null) {
+    const tick = await runGrowthProjectAnalysisStep(tenancy);
+    return { didWork: tick.didWork || didWork };
+  }
+
+  const enqueued = await enqueueWorkflowEvent(globalPrismaClient, {
+    tenancy,
+    type: leg === "activation" ? GROWTH_EVENT_TYPES.analysisRunActivated : GROWTH_EVENT_TYPES.interviewFinished,
+    payload: leg === "activation" ? { growth_run_id: run.id, trigger: run.trigger } : { growth_run_id: run.id },
+  });
+  const tick = await runGrowthProjectAnalysisStep(tenancy);
+  return { didWork: tick.didWork || enqueued != null || didWork };
+}

--- a/apps/backend/src/lib/growth/admin-recovery.ts
+++ b/apps/backend/src/lib/growth/admin-recovery.ts
@@ -23,6 +23,23 @@ async function findActiveGrowthRun(tenancy: Tenancy) {
   });
 }
 
+export async function hasPendingGrowthBoundaryEvent(options: {
+  tenancyId: string,
+  growthRunId: string,
+  type: typeof GROWTH_EVENT_TYPES.analysisRunActivated | typeof GROWTH_EVENT_TYPES.interviewFinished,
+}): Promise<boolean> {
+  const event = await globalPrismaClient.workflowEvent.findFirst({
+    where: {
+      tenancyId: options.tenancyId,
+      type: options.type,
+      processedAt: null,
+      payload: { path: ["growth_run_id"], equals: options.growthRunId },
+    },
+    select: { id: true },
+  });
+  return event != null;
+}
+
 /** Advances the selected project's active Growth run without touching the shared workflow engine. */
 export async function runGrowthProjectAnalysisStep(tenancy: Tenancy): Promise<{ didWork: boolean }> {
   const run = await findActiveGrowthRun(tenancy);
@@ -67,9 +84,18 @@ export async function repairGrowthProject(tenancy: Tenancy): Promise<{ didWork: 
     return { didWork: tick.didWork || didWork };
   }
 
+  const eventType = leg === "activation" ? GROWTH_EVENT_TYPES.analysisRunActivated : GROWTH_EVENT_TYPES.interviewFinished;
+  // A boundary event is durable before its WorkflowRun is materialized. Treat that pending event
+  // as an active leg: enqueueing a second event here can leave it behind the original until after
+  // the first leg completes, at which point runKey's active-only conflict check no longer dedupes it.
+  if (await hasPendingGrowthBoundaryEvent({ tenancyId: tenancy.id, growthRunId: run.id, type: eventType })) {
+    const tick = await runGrowthProjectAnalysisStep(tenancy);
+    return { didWork: tick.didWork || didWork };
+  }
+
   const enqueued = await enqueueWorkflowEvent(globalPrismaClient, {
     tenancy,
-    type: leg === "activation" ? GROWTH_EVENT_TYPES.analysisRunActivated : GROWTH_EVENT_TYPES.interviewFinished,
+    type: eventType,
     payload: leg === "activation" ? { growth_run_id: run.id, trigger: run.trigger } : { growth_run_id: run.id },
   });
   const tick = await runGrowthProjectAnalysisStep(tenancy);

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/interview-card.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/interview-card.tsx
@@ -2,6 +2,7 @@
 
 import { DesignAlert, DesignBadge, DesignButton, DesignCard } from "@/components/design-components";
 import { formatGrowthRelativeTime } from "@/lib/growth/growth-format";
+import { GrowthApiError } from "@/lib/growth/growth-api";
 import {
   deleteGrowthAdminInterviewQuestion,
   getGrowthAdminInterview,
@@ -34,6 +35,14 @@ type CardState =
   | { status: "loading" }
   | { status: "error", message: string }
   | { status: "loaded", interview: GrowthAdminInterview };
+
+const NO_INTERVIEW_MESSAGE = "This project has no interview to review yet.";
+
+function interviewLoadErrorMessage(error: unknown): string {
+  return error instanceof GrowthApiError && error.statusCode === 404
+    ? NO_INTERVIEW_MESSAGE
+    : error instanceof Error ? error.message : String(error);
+}
 
 /** Serialized so a draft can be compared against what the server holds without a deep-equal helper. */
 function optionsKey(options: GrowthAdminInterviewOption[]): string {
@@ -180,7 +189,7 @@ export function GrowthAdminInterviewCard(props: { app: object, projectId: string
       setState({ status: "loaded", interview: await getGrowthAdminInterview(props.app, props.projectId) });
     } catch (error) {
       captureError("growth-admin-interview-load", error);
-      setState({ status: "error", message: error instanceof Error ? error.message : String(error) });
+      setState({ status: "error", message: interviewLoadErrorMessage(error) });
     }
   }, [props.app, props.projectId]);
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/page-client.tsx
@@ -89,7 +89,7 @@ function AdminEditor(props: { app: object, project: GrowthAdminProject, overview
       <GrowthAdminInterviewCard app={props.app} projectId={props.project.id} />
       <GrowthAdminReportsCard app={props.app} projectId={props.project.id} />
       <GrowthAdminGamesCard app={props.app} projectId={props.project.id} />
-      <GrowthAdminRunNowCard app={props.app} />
+      <GrowthAdminRunNowCard app={props.app} projectId={props.project.id} projectName={props.project.displayName} />
 
       <DesignCard title="Stage scores" subtitle="Manual 0–100 values used by the customer growth journey" icon={SlidersHorizontalIcon} gradient="purple">
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/page-client.tsx
@@ -89,7 +89,7 @@ function AdminEditor(props: { app: object, project: GrowthAdminProject, overview
       <GrowthAdminInterviewCard app={props.app} projectId={props.project.id} />
       <GrowthAdminReportsCard app={props.app} projectId={props.project.id} />
       <GrowthAdminGamesCard app={props.app} projectId={props.project.id} />
-      <GrowthAdminRunNowCard app={props.app} projectId={props.project.id} projectName={props.project.displayName} />
+      <GrowthAdminRunNowCard app={props.app} projectId={props.project.id} projectName={props.project.displayName} onCompleted={props.refresh} />
 
       <DesignCard title="Stage scores" subtitle="Manual 0–100 values used by the customer growth journey" icon={SlidersHorizontalIcon} gradient="purple">
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/run-now-card.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/run-now-card.tsx
@@ -13,13 +13,14 @@ const stepLabels: Record<GrowthAdminManualStep, string> = {
   project_recovery: "Repair selected project",
 };
 
-export function GrowthAdminRunNowCard(props: { app: object, projectId: string, projectName: string }) {
+export function GrowthAdminRunNowCard(props: { app: object, projectId: string, projectName: string, onCompleted: () => Promise<void> }) {
   const [state, setState] = useState<RunState>({ status: "idle" });
 
   const runStep = (step: GrowthAdminManualStep) => {
     setState({ status: "running", step });
     runAsynchronouslyWithAlert(async () => {
       const result = await runGrowthAdminManualStep(props.app, props.projectId, step);
+      await props.onCompleted();
       setState({ status: "success", step, didWork: result.didWork });
     }, {
       onError: error => setState({ status: "error", message: error instanceof Error ? error.message : String(error) }),

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/run-now-card.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/run-now-card.tsx
@@ -9,17 +9,17 @@ import { useState } from "react";
 type RunState = { status: "idle" } | { status: "running", step: GrowthAdminManualStep } | { status: "success", step: GrowthAdminManualStep, didWork: boolean } | { status: "error", message: string };
 
 const stepLabels: Record<GrowthAdminManualStep, string> = {
-  workflow_engine: "Run workflow step",
-  growth_watchdog: "Run watchdog",
+  analysis_tick: "Advance selected analysis",
+  project_recovery: "Repair selected project",
 };
 
-export function GrowthAdminRunNowCard(props: { app: object }) {
+export function GrowthAdminRunNowCard(props: { app: object, projectId: string, projectName: string }) {
   const [state, setState] = useState<RunState>({ status: "idle" });
 
   const runStep = (step: GrowthAdminManualStep) => {
     setState({ status: "running", step });
     runAsynchronouslyWithAlert(async () => {
-      const result = await runGrowthAdminManualStep(props.app, step);
+      const result = await runGrowthAdminManualStep(props.app, props.projectId, step);
       setState({ status: "success", step, didWork: result.didWork });
     }, {
       onError: error => setState({ status: "error", message: error instanceof Error ? error.message : String(error) }),
@@ -28,7 +28,7 @@ export function GrowthAdminRunNowCard(props: { app: object }) {
 
   const runningStep = state.status === "running" ? state.step : null;
   return (
-    <DesignCard title="Manual scheduler" subtitle="Run one server-side step when Preview has no scheduled Cron invocation" icon={GearSixIcon} gradient="cyan">
+    <DesignCard title={`Manual scheduler · ${props.projectName}`} subtitle="Run a server-side step for this project when Preview has no scheduled Cron invocation" icon={GearSixIcon} gradient="cyan">
       <div className="space-y-3">
         {state.status === "error" && <DesignAlert variant="error">{state.message}</DesignAlert>}
         {state.status === "success" && <DesignAlert variant="info">{stepLabels[state.step]} completed{state.didWork ? " and processed work." : ", but found no work to process."}</DesignAlert>}
@@ -39,7 +39,7 @@ export function GrowthAdminRunNowCard(props: { app: object }) {
             </DesignButton>
           ))}
         </div>
-        <p className="text-xs text-muted-foreground">The action uses your internal project admin session. It does not expose or require the cron secret.</p>
+        <p className="text-xs text-muted-foreground">Both actions target only this selected project. The internal admin session is used; the cron secret is not exposed.</p>
       </div>
     </DesignCard>
   );

--- a/apps/dashboard/src/lib/growth/growth-api.ts
+++ b/apps/dashboard/src/lib/growth/growth-api.ts
@@ -720,15 +720,15 @@ export async function setGrowthAdminCategoryScore(app: object, projectId: string
   await requestGrowthAdminJson(app, "/category-scores", { method: "PUT", body: JSON.stringify({ target_project_id: projectId, category, score }) });
 }
 
-export type GrowthAdminManualStep = "workflow_engine" | "growth_watchdog";
+export type GrowthAdminManualStep = "analysis_tick" | "project_recovery";
 
-export async function runGrowthAdminManualStep(app: object, step: GrowthAdminManualStep): Promise<{ didWork: boolean }> {
+export async function runGrowthAdminManualStep(app: object, projectId: string, step: GrowthAdminManualStep): Promise<{ didWork: boolean }> {
   const response = z.object({
-    step: z.enum(["workflow_engine", "growth_watchdog"]),
+    step: z.enum(["analysis_tick", "project_recovery"]),
     did_work: z.boolean(),
   }).parse(await requestGrowthAdminJson(app, "/run-now", {
     method: "POST",
-    body: JSON.stringify({ step }),
+    body: JSON.stringify({ step, target_project_id: projectId }),
   }));
   return { didWork: response.did_work };
 }

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/admin-overview.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/admin-overview.test.ts
@@ -71,6 +71,16 @@ describe("internal Growth admin", { timeout: 90_000 }, () => {
     expect(customerRequest.body).toMatchObject({ code: "EXPECTED_INTERNAL_PROJECT" });
   });
 
+  it("requires the selected project for manual scheduler actions", async ({ expect }) => {
+    await signInAsInternalAdmin();
+    const response = await niceBackendFetch(`${ADMIN_BASE}/run-now`, {
+      accessType: "client",
+      method: "POST",
+      body: { step: "analysis_tick" },
+    });
+    expect(response.status).toBe(400);
+  });
+
   it("edits customer-visible Growth data without bypassing action lifecycle rules", async ({ expect }) => {
     const { projectId, actionId } = await createOnboardedProjectWithAction();
     await signInAsInternalAdmin();


### PR DESCRIPTION
## What changed

- Add shared growth-admin recovery handling for run-now operations.
- Improve dashboard run-now and interview-card state handling.
- Extend the growth admin overview E2E coverage.

## Why

This makes the growth admin recovery path more reliable and keeps the dashboard state aligned with backend responses.

## Validation

- Focused E2E command attempted: `pnpm test run apps/e2e/tests/backend/endpoints/api/v1/internal/growth/admin-overview.test.ts`
- Blocked in the sandbox during the repository pre-hook because `tsx` could not create its IPC pipe (`listen EPERM`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Growth Admins can manually advance project analysis or initiate project recovery.
  * Manual actions report whether work was completed and refresh project information afterward.
  * Duplicate recovery actions are prevented when work is already pending or active.

* **Bug Fixes**
  * Improved interview loading errors, including a clear message when no interview exists.
  * Added validation requiring a project selection before running manual actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->