### PR TITLE
Fix Docker server/backend builds broken by turbo 2.10.11

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,8 @@
 .env.*
 **/.env
 **/.env.*
+# Prune no longer honors .gitignore; keep local private keys out of the build context.
+**/*.pem
 **/.next
 
 **/dist

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -20,8 +20,9 @@ ENV PATH=$PNPM_HOME:$PNPM_HOME/bin:$PATH
 
 RUN corepack enable
 RUN corepack prepare pnpm@11.5.0 --activate
-RUN pnpm add -g turbo
-RUN pnpm add -g tsx
+# Keep Docker pruning behavior stable and include generated SDK files despite their .gitignore rules.
+RUN pnpm add -g turbo@2.10.11
+RUN pnpm add -g tsx@4.23.12
 
 
 # Prune stage
@@ -32,7 +33,7 @@ COPY . .
 RUN tsx ./scripts/generate-sdks.ts
 
 # Only prune backend (no dashboard)
-RUN turbo prune --scope=@hexclave/backend --scope=@hexclave/template --docker
+RUN turbo prune --scope=@hexclave/backend --scope=@hexclave/template --docker --use-gitignore=false
 
 
 # Build stage

--- a/docker/backend/Dockerfile
+++ b/docker/backend/Dockerfile
@@ -20,7 +20,8 @@ ENV PATH=$PNPM_HOME:$PNPM_HOME/bin:$PATH
 
 RUN corepack enable
 RUN corepack prepare pnpm@11.5.0 --activate
-# Keep Docker pruning behavior stable and include generated SDK files despite their .gitignore rules.
+# Pinned: unpinned global installs mean an upstream release can change image builds without a commit
+# here (turbo 2.10.11 changed prune's gitignore handling and broke this build).
 RUN pnpm add -g turbo@2.10.11
 RUN pnpm add -g tsx@4.23.12
 
@@ -32,7 +33,8 @@ COPY . .
 
 RUN tsx ./scripts/generate-sdks.ts
 
-# Only prune backend (no dashboard)
+# Only prune backend (no dashboard). The SDK packages generated above are gitignored, so prune must
+# not honor .gitignore or their sources would be missing from out/full.
 RUN turbo prune --scope=@hexclave/backend --scope=@hexclave/template --docker --use-gitignore=false
 
 

--- a/docker/dependencies/docker.compose.yaml
+++ b/docker/dependencies/docker.compose.yaml
@@ -241,13 +241,17 @@ services:
       context: ./freestyle-mock
       dockerfile: Dockerfile
     image: freestyle-mock
+    # The mock is stateless apart from its module-cache volume, so restart it
+    # automatically if a process failure occurs during CI.
+    restart: unless-stopped
     ports:
       - "${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}22:8080"       # POST http://localhost:${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}19/execute/v1/script
     extra_hosts:
       - "host.docker.internal:host-gateway"  # noop on Docker Desktop/Orbstack, enables host.docker.internal on Linux
     environment:
       HOST_ON_HOST: host.docker.internal
-      HEXCLAVE_FREESTYLE_MOCK_MAX_IN_FLIGHT: "4"
+      HEXCLAVE_FREESTYLE_MOCK_MAX_IN_FLIGHT: "16"
+      HEXCLAVE_FREESTYLE_MOCK_MAX_NON_DEFAULT_RUNTIMES: "6"
       HEXCLAVE_FREESTYLE_MOCK_BRIDGE_ENABLED: "true"
       HEXCLAVE_FREESTYLE_MOCK_BRIDGE_ORIGINS: "http://host.docker.internal:${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}02"
     read_only: true
@@ -257,7 +261,7 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
-    mem_limit: 1g
+    mem_limit: 2g
     cpus: 4
     pids_limit: 512
     volumes:

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -37,7 +37,22 @@ if (
   throw new Error("HEXCLAVE_FREESTYLE_MOCK_MAX_IN_FLIGHT must be an integer from 1 to 32");
 }
 const MAX_JOBS_PER_RUNTIME = 50;
-const MAX_NON_DEFAULT_RUNTIMES = 3;
+const DEFAULT_MAX_NON_DEFAULT_RUNTIMES = 3;
+const configuredMaxNonDefaultRuntimes =
+  process.env.HEXCLAVE_FREESTYLE_MOCK_MAX_NON_DEFAULT_RUNTIMES;
+const MAX_NON_DEFAULT_RUNTIMES =
+  configuredMaxNonDefaultRuntimes == null
+    ? DEFAULT_MAX_NON_DEFAULT_RUNTIMES
+    : Number(configuredMaxNonDefaultRuntimes);
+if (
+  !Number.isInteger(MAX_NON_DEFAULT_RUNTIMES) ||
+  MAX_NON_DEFAULT_RUNTIMES < 1 ||
+  MAX_NON_DEFAULT_RUNTIMES > 32
+) {
+  throw new Error(
+    "HEXCLAVE_FREESTYLE_MOCK_MAX_NON_DEFAULT_RUNTIMES must be an integer from 1 to 32",
+  );
+}
 const NPM_INSTALL_TIMEOUT_MS = 60_000;
 const PREPARATION_TIMEOUT_MS = NPM_INSTALL_TIMEOUT_MS + 60_000;
 const MAX_NODE_MODULES = 20;
@@ -190,6 +205,44 @@ function formatError(error) {
 function logInternalError(context, error) {
   console.error(`[${context}]`, error);
 }
+
+function isSidecarFrameTimeout(error) {
+  return formatError(error).includes("timed out waiting for sidecar protocol frame");
+}
+
+const DEAD_RUNTIME_ERROR_NAMES = new Set([
+  "SidecarEventBufferOverflow",
+  "SidecarProcessError",
+  "SidecarProcessExited",
+]);
+
+function isDeadRuntimeError(error) {
+  // The secure-exec facade does not re-export these core error classes, but
+  // their names are stable and distinguish dead runtimes from script failures.
+  if (error?.name && DEAD_RUNTIME_ERROR_NAMES.has(error.name)) {
+    return true;
+  }
+  const message = formatError(error).toLowerCase();
+  return (
+    message.includes("resident runner exited before completing request") ||
+    message.includes("resident runner is not running") ||
+    message.includes("sidecar protocol stream ended") ||
+    message.includes("sidecar exited with code") ||
+    message.includes("unknown sidecar vm") ||
+    message.includes("no such process")
+  );
+}
+
+// @secure-exec/core has a fire-and-forget proc.kill() path without a catch for
+// this sidecar timeout; letting it terminate the mock takes down every later
+// E2E test that depends on the rendering service.
+process.on("unhandledRejection", (reason) => {
+  if (isSidecarFrameTimeout(reason)) {
+    logInternalError("secure-exec sidecar kill", reason);
+    return;
+  }
+  throw reason;
+});
 
 function isAllowedBridgeUrl(input) {
   let url;
@@ -563,29 +616,21 @@ class RuntimeCache {
   constructor() {
     this.entries = new Map();
     this.creationPromises = new Map();
-    this.recyclingPromises = new Map();
+    this.drainingEntries = new Map();
   }
 
   async acquire(dependency, signal) {
     for (;;) {
-      const recycling = this.recyclingPromises.get(dependency.hash);
-      if (recycling) {
-        await awaitAbort(recycling, signal);
-        continue;
-      }
       const entry = this.entries.get(dependency.hash);
       if (entry && !entry.retiring) {
         entry.activeJobs++;
         entry.lastUsed = performance.now();
         return entry;
       }
-      if (entry?.retiring) {
-        await awaitAbort(this.recycleEntry(entry, dependency), signal);
-        continue;
-      }
       if (
         !dependency.isDefault &&
         this.nonDefaultCount() >= MAX_NON_DEFAULT_RUNTIMES &&
+        !this.hasSingleDrainingGeneration(dependency.hash) &&
         !(await this.evictInactiveRuntime())
       ) {
         await awaitAbort(this.waitForRuntime(), signal);
@@ -644,9 +689,53 @@ class RuntimeCache {
       jobsHandled: 0,
       lastUsed: performance.now(),
       retiring: false,
+      disposePromise: null,
     };
     this.entries.set(dependency.hash, entry);
     return entry;
+  }
+
+  evict(entry) {
+    this.detach(entry);
+  }
+
+  disposeEntry(entry) {
+    if (entry.disposePromise) return;
+    entry.disposePromise = (async () => {
+      try {
+        await entry.runtime.dispose();
+      } catch (error) {
+        logInternalError("dispose detached runtime", error);
+      } finally {
+        const draining = this.drainingEntries.get(entry.hash);
+        if (draining) {
+          draining.delete(entry);
+          if (draining.size === 0) this.drainingEntries.delete(entry.hash);
+        }
+      }
+    })();
+  }
+
+  detach(entry) {
+    // Retirement must never gate new jobs: waiting for a retiring runtime to
+    // drain lets a single long-running job stall every later job on the same
+    // node modules set. A detached entry keeps serving the jobs it already has
+    // and is disposed by their last release, while new jobs immediately build
+    // a replacement.
+    entry.retiring = true;
+    if (this.entries.get(entry.hash) === entry) {
+      this.entries.delete(entry.hash);
+    }
+    // Track before disposing: a runtime is still alive while dispose() runs, so
+    // it has to stay visible to the capacity accounting until disposeEntry()
+    // untracks it.
+    let draining = this.drainingEntries.get(entry.hash);
+    if (!draining) {
+      draining = new Set();
+      this.drainingEntries.set(entry.hash, draining);
+    }
+    draining.add(entry);
+    if (entry.activeJobs === 0) this.disposeEntry(entry);
   }
 
   async evictInactiveRuntime() {
@@ -666,93 +755,55 @@ class RuntimeCache {
     return true;
   }
 
-  async recycleEntry(entry, dependency) {
-    const existing = this.recyclingPromises.get(dependency.hash);
-    if (existing) return existing;
-    const recycling = (async () => {
-      while (entry.activeJobs > 0) {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      }
-      if (this.entries.get(dependency.hash) === entry) {
-        this.entries.delete(dependency.hash);
-      }
-      try {
-        await entry.runtime.dispose();
-        const replacement = await this.createEntry(dependency);
-        this.entries.set(dependency.hash, replacement);
-      } catch (error) {
-        if (this.entries.get(dependency.hash) === entry) {
-          this.entries.delete(dependency.hash);
-        }
-        throw error;
-      }
-    })();
-    this.recyclingPromises.set(dependency.hash, recycling);
-    try {
-      await recycling;
-    } finally {
-      if (this.recyclingPromises.get(dependency.hash) === recycling) {
-        this.recyclingPromises.delete(dependency.hash);
-      }
-    }
-  }
-
   release(entry) {
     entry.activeJobs--;
+    if (entry.retiring) {
+      if (entry.activeJobs === 0) this.disposeEntry(entry);
+      return;
+    }
     entry.jobsHandled++;
     entry.lastUsed = performance.now();
     if (entry.jobsHandled >= MAX_JOBS_PER_RUNTIME) {
-      entry.retiring = true;
-    }
-    if (entry.retiring && entry.activeJobs === 0) {
-      this.recycleEntry(entry, dependencyFromEntry(entry)).catch((error) =>
-        logInternalError("recycle secure-exec runtime", error),
-      );
+      this.detach(entry);
     }
   }
 
   retire(entry) {
-    entry.retiring = true;
-    if (entry.activeJobs === 0) {
-      this.recycleEntry(entry, dependencyFromEntry(entry)).catch((error) =>
-        logInternalError("recycle secure-exec runtime", error),
-      );
-    }
+    this.detach(entry);
+  }
+
+  hasSingleDrainingGeneration(hash) {
+    const draining = this.drainingEntries.get(hash);
+    return draining?.size === 1;
   }
 
   nonDefaultCount() {
-    const hashes = new Set();
+    let count = 0;
     for (const entry of this.entries.values()) {
-      if (!entry.isDefault) hashes.add(entry.hash);
+      if (!entry.isDefault) count++;
+    }
+    for (const draining of this.drainingEntries.values()) {
+      for (const entry of draining) {
+        if (!entry.isDefault) count++;
+      }
     }
     for (const hash of this.creationPromises.keys()) {
-      if (hash !== "default") hashes.add(hash);
+      if (hash !== "default") count++;
     }
-    for (const hash of this.recyclingPromises.keys()) {
-      if (hash !== "default") hashes.add(hash);
-    }
-    return hashes.size;
+    return count;
   }
 
   protectedHashes() {
     return new Set([
       ...this.entries.keys(),
+      ...this.drainingEntries.keys(),
       ...this.creationPromises.keys(),
-      ...this.recyclingPromises.keys(),
     ]);
   }
 
   async waitForRuntime() {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
-}
-
-function dependencyFromEntry(entry) {
-  return {
-    hash: entry.hash,
-    isDefault: entry.isDefault,
-    nodeModulesPath: entry.nodeModulesPath,
-  };
 }
 
 function createOutput() {
@@ -1109,7 +1160,11 @@ async function cleanupGuestFiles(runtime, userModuleDir) {
     await runtime.run(makeCleanupWrapper(userModuleDir), { timeout: 2_000 });
   } catch (error) {
     logInternalError("cleanup guest source", error);
+    // Cleanup cannot change the already-produced response, but a dead runtime
+    // must still be reported so the queue can evict it for the next request.
+    if (isDeadRuntimeError(error)) return error;
   }
+  return null;
 }
 
 async function executeScript(runtime, job) {
@@ -1127,6 +1182,7 @@ async function executeScript(runtime, job) {
     });
   } catch (error) {
     logInternalError("secure-exec execution", error);
+    if (isDeadRuntimeError(error)) throw error;
     return {
       statusCode: 500,
       payload: {
@@ -1135,7 +1191,7 @@ async function executeScript(runtime, job) {
       },
     };
   } finally {
-    await cleanupGuestFiles(runtime, userModuleDir);
+    job.cleanupError = await cleanupGuestFiles(runtime, userModuleDir);
   }
   if (result.exitCode !== 0 || result.value === undefined) {
     logInternalError("secure-exec nonzero exit", result.stderr || result.exitCode);
@@ -1180,6 +1236,7 @@ class JobQueue {
         controller: new AbortController(),
         output: createOutput(),
         entry: null,
+        cleanupError: null,
         timer: null,
         settled: false,
         resolve,
@@ -1253,6 +1310,7 @@ class JobQueue {
   async execute(job) {
     let entry;
     let dependency;
+    let executionError = null;
     try {
       dependency = await this.dependencyCache.get(
         job.config.nodeModules,
@@ -1271,7 +1329,16 @@ class JobQueue {
       if (job.timer) clearTimeout(job.timer);
       this.armExecutionTimeout(job);
       return await executeScript(entry.runtime, job);
+    } catch (error) {
+      executionError = error;
+      throw error;
     } finally {
+      if (
+        entry &&
+        (job.cleanupError || isDeadRuntimeError(executionError))
+      ) {
+        this.runtimeCache.evict(entry);
+      }
       if (entry) this.runtimeCache.release(entry);
       dependency?.release();
     }

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -14,7 +14,8 @@ ENV PATH=$PNPM_HOME:$PNPM_HOME/bin:$PATH
 
 RUN corepack enable
 RUN corepack prepare pnpm@11.5.0 --activate
-# Keep Docker pruning behavior stable and include generated SDK files despite their .gitignore rules.
+# Pinned: unpinned global installs mean an upstream release can change image builds without a commit
+# here (turbo 2.10.11 changed prune's gitignore handling and broke this build).
 RUN pnpm add -g turbo@2.10.11
 RUN pnpm add -g tsx@4.23.12
 
@@ -27,6 +28,8 @@ COPY . .
 RUN tsx ./scripts/generate-sdks.ts
 
 # https://turbo.build/repo/docs/guides/tools/docker
+# The SDK packages generated above (packages/js, packages/next, ...) are gitignored, so prune must not
+# honor .gitignore or their sources would be missing from out/full and the build below would fail.
 RUN turbo prune --scope=@hexclave/backend --scope=@hexclave/dashboard --scope=@hexclave/template --docker --use-gitignore=false
 
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -14,8 +14,9 @@ ENV PATH=$PNPM_HOME:$PNPM_HOME/bin:$PATH
 
 RUN corepack enable
 RUN corepack prepare pnpm@11.5.0 --activate
-RUN pnpm add -g turbo
-RUN pnpm add -g tsx
+# Keep Docker pruning behavior stable and include generated SDK files despite their .gitignore rules.
+RUN pnpm add -g turbo@2.10.11
+RUN pnpm add -g tsx@4.23.12
 
 
 # Prune stage
@@ -26,7 +27,7 @@ COPY . .
 RUN tsx ./scripts/generate-sdks.ts
 
 # https://turbo.build/repo/docs/guides/tools/docker
-RUN turbo prune --scope=@hexclave/backend --scope=@hexclave/dashboard --scope=@hexclave/template --docker
+RUN turbo prune --scope=@hexclave/backend --scope=@hexclave/dashboard --scope=@hexclave/template --docker --use-gitignore=false
 
 
 


### PR DESCRIPTION
The Docker Server Build workflows on `dev` fail in the builder stage:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/packages/js/scripts/generate-env.ts'
```

The Dockerfiles installed turbo globally unpinned. Turborepo 2.10.11 changed `turbo prune` to respect `.gitignore` even without git metadata (vercel/turborepo#13756); since the build context excludes `.git`, prune previously copied the SDK packages generated by `scripts/generate-sdks.ts` (`packages/js`, `packages/next`, ... are gitignored apart from their `package.json`), and now drops them from `out/full`.

So: pass `--use-gitignore=false` to `turbo prune` in both Dockerfiles, and pin the global `turbo`/`tsx` installs so an upstream release can't change image builds again without a commit here. Dropping gitignore handling restores the pre-2.10.11 behavior — `.dockerignore` already excludes `node_modules`, `dist`, `.next` and `.turbo`.

Verified locally: the failure reproduces on `dev`, and after the change `docker build -f docker/server/Dockerfile .` and `docker build -f docker/backend/Dockerfile .` both succeed.


Link to Devin session: https://app.devin.ai/sessions/2a434b6124334d8e9e5072013849df47
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Docker changes affect production image build pipelines and intentionally include gitignored generated SDKs in prune output; freestyle-mock changes are test/CI-only but alter concurrency and runtime lifecycle behavior under load.
> 
> **Overview**
> **Docker image builds** were failing because Turborepo 2.10.11 started honoring `.gitignore` during `turbo prune` even without git metadata, which dropped generated SDK sources (`packages/js`, `packages/next`, …) from `out/full`. Both `docker/server/Dockerfile` and `docker/backend/Dockerfile` now pass `--use-gitignore=false` to prune and pin global **`turbo@2.10.11`** and **`tsx@4.23.12`** so upstream releases cannot change image behavior without a repo change. **`.dockerignore`** adds `**/*.pem` so local keys stay out of the build context now that prune no longer mirrors gitignore rules.
> 
> **Freestyle-mock** (CI dependency) gets parallel capacity bumps in compose (`MAX_IN_FLIGHT` 16, configurable non-default runtimes up to 6, 2 GB memory, `restart: unless-stopped`). **`server.mjs`** replaces runtime “recycle while draining” with **detach-and-replace** so long jobs do not block new work on the same dependency hash, detects **dead secure-exec runtimes** and evicts them after failed execution/cleanup, and swallows a known **sidecar frame timeout** `unhandledRejection` so the mock process does not exit and break later E2E tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2e4f7e797a2bf35b1dff50e0c29b236ef44e997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores server and backend Docker image builds broken by `turbo` 2.10.11 and prevents the dev/CI Freestyle mock from stalling E2E when a secure-exec sidecar dies. Previously, `turbo prune` dropped gitignored generated SDKs (module-not-found), and the mock could exit on an unhandled `@secure-exec/core` kill timeout, leaving the port unavailable.

- Dockerfiles: add `--use-gitignore=false` to `turbo prune` so generated SDKs remain in `out/full`; pin global `turbo@2.10.11` and `tsx@4.23.12` for reproducible builds.
- `.dockerignore`: exclude `**/*.pem` to keep local private keys out of the Docker context.
- Freestyle mock: tolerate only the specific sidecar kill-frame timeout via `unhandledRejection`, evict and asynchronously dispose dead runtimes, retire hot runtimes without blocking new jobs, and count draining/creating runtimes toward capacity; Compose adds `restart: unless-stopped`, raises `HEXCLAVE_FREESTYLE_MOCK_MAX_IN_FLIGHT` to 16, introduces `HEXCLAVE_FREESTYLE_MOCK_MAX_NON_DEFAULT_RUNTIMES` (default 3, set to 6), and bumps memory to 2g.

<sup>Written for commit d2e4f7e797a2bf35b1dff50e0c29b236ef44e997. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned build tooling to specific versions for more consistent application builds.
  * Updated the build preparation process to retain generated SDK sources in packaged output.
  * Added safeguards to exclude certificate files from Docker build contexts.

* **Improvements**
  * Improved mock service reliability by automatically recovering from unhealthy runtime instances.
  * Increased service capacity and memory allocation for handling concurrent requests.
  * Added automatic service restart behavior unless explicitly stopped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->