### PR TITLE
Stop the Freestyle mock from stalling the E2E suite (non-blocking runtime retirement + capacity)

### DIFF
--- a/docker/dependencies/docker.compose.yaml
+++ b/docker/dependencies/docker.compose.yaml
@@ -241,6 +241,9 @@ services:
       context: ./freestyle-mock
       dockerfile: Dockerfile
     image: freestyle-mock
+    # The mock is stateless apart from its module-cache volume, so restart it
+    # automatically if a process failure occurs during CI.
+    restart: unless-stopped
     ports:
       - "${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}22:8080"       # POST http://localhost:${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}19/execute/v1/script
     extra_hosts:

--- a/docker/dependencies/docker.compose.yaml
+++ b/docker/dependencies/docker.compose.yaml
@@ -250,7 +250,8 @@ services:
       - "host.docker.internal:host-gateway"  # noop on Docker Desktop/Orbstack, enables host.docker.internal on Linux
     environment:
       HOST_ON_HOST: host.docker.internal
-      HEXCLAVE_FREESTYLE_MOCK_MAX_IN_FLIGHT: "4"
+      HEXCLAVE_FREESTYLE_MOCK_MAX_IN_FLIGHT: "16"
+      HEXCLAVE_FREESTYLE_MOCK_MAX_NON_DEFAULT_RUNTIMES: "6"
       HEXCLAVE_FREESTYLE_MOCK_BRIDGE_ENABLED: "true"
       HEXCLAVE_FREESTYLE_MOCK_BRIDGE_ORIGINS: "http://host.docker.internal:${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}02"
     read_only: true
@@ -260,7 +261,7 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
-    mem_limit: 1g
+    mem_limit: 2g
     cpus: 4
     pids_limit: 512
     volumes:

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -690,12 +690,14 @@ class RuntimeCache {
   }
 
   evict(entry) {
-    if (this.entries.get(entry.hash) !== entry) return;
-    // Remove it before disposal so the next acquire can create a replacement;
-    // release must not recycle an entry already known to be unusable.
-    this.entries.delete(entry.hash);
+    // Mark before the map check: an entry that was already replaced in the
+    // cache still must not be recycled once we know its runtime is unusable.
     entry.evicted = true;
     entry.retiring = true;
+    // Remove it before disposal so the next acquire can create a replacement.
+    if (this.entries.get(entry.hash) === entry) {
+      this.entries.delete(entry.hash);
+    }
     this.disposeEntry(entry);
   }
 

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -191,6 +191,28 @@ function logInternalError(context, error) {
   console.error(`[${context}]`, error);
 }
 
+function isSidecarFrameTimeout(error) {
+  return formatError(error).includes("timed out waiting for sidecar protocol frame");
+}
+
+function isPreparationAbort(job) {
+  return (
+    job.controller.signal.aborted &&
+    formatError(job.controller.signal.reason) === "Dependency preparation timed out"
+  );
+}
+
+// @secure-exec/core has a fire-and-forget proc.kill() path without a catch for
+// this sidecar timeout; letting it terminate the mock takes down every later
+// E2E test that depends on the rendering service.
+process.on("unhandledRejection", (reason) => {
+  if (isSidecarFrameTimeout(reason)) {
+    logInternalError("secure-exec sidecar kill", reason);
+    return;
+  }
+  throw reason;
+});
+
 function isAllowedBridgeUrl(input) {
   let url;
   try {
@@ -593,20 +615,25 @@ class RuntimeCache {
       }
       let creation = this.creationPromises.get(dependency.hash);
       if (!creation) {
-        creation = this.createEntry(dependency);
+        const creationState = {
+          discarded: false,
+          promise: null,
+        };
+        creationState.promise = this.createEntry(dependency, creationState);
+        creation = creationState;
         this.creationPromises.set(dependency.hash, creation);
         const clearCreation = () => {
           if (this.creationPromises.get(dependency.hash) === creation) {
             this.creationPromises.delete(dependency.hash);
           }
         };
-        creation.then(clearCreation, clearCreation);
+        creation.promise.then(clearCreation, clearCreation);
       }
-      await awaitAbort(creation, signal);
+      await awaitAbort(creation.promise, signal);
     }
   }
 
-  async createEntry(dependency) {
+  async createEntry(dependency, creationState) {
     const options = {
       nodeModules: dependency.nodeModulesPath,
       permissions: {
@@ -635,6 +662,14 @@ class RuntimeCache {
       };
     }
     const runtime = await NodeRuntime.create(options);
+    if (creationState?.discarded) {
+      try {
+        await runtime.dispose();
+      } catch (error) {
+        logInternalError("dispose discarded runtime", error);
+      }
+      throw new Error("Secure-exec runtime creation was discarded");
+    }
     const entry = {
       hash: dependency.hash,
       isDefault: dependency.isDefault,
@@ -644,9 +679,36 @@ class RuntimeCache {
       jobsHandled: 0,
       lastUsed: performance.now(),
       retiring: false,
+      discarded: false,
+      disposePromise: null,
     };
     this.entries.set(dependency.hash, entry);
     return entry;
+  }
+
+  discardCreation(dependency) {
+    const creation = this.creationPromises.get(dependency.hash);
+    if (!creation) return;
+    creation.discarded = true;
+    this.creationPromises.delete(dependency.hash);
+  }
+
+  discard(entry) {
+    entry.discarded = true;
+    entry.retiring = true;
+    if (this.entries.get(entry.hash) === entry) {
+      this.entries.delete(entry.hash);
+    }
+    if (entry.activeJobs === 0) this.disposeEntry(entry);
+  }
+
+  disposeEntry(entry) {
+    if (!entry.disposePromise) {
+      entry.disposePromise = entry.runtime
+        .dispose()
+        .catch((error) => logInternalError("dispose discarded runtime", error));
+    }
+    return entry.disposePromise;
   }
 
   async evictInactiveRuntime() {
@@ -701,6 +763,10 @@ class RuntimeCache {
     entry.activeJobs--;
     entry.jobsHandled++;
     entry.lastUsed = performance.now();
+    if (entry.discarded) {
+      if (entry.activeJobs === 0) this.disposeEntry(entry);
+      return;
+    }
     if (entry.jobsHandled >= MAX_JOBS_PER_RUNTIME) {
       entry.retiring = true;
     }
@@ -1127,6 +1193,9 @@ async function executeScript(runtime, job) {
     });
   } catch (error) {
     logInternalError("secure-exec execution", error);
+    if (isSidecarFrameTimeout(error) || isPreparationAbort(job)) {
+      throw error;
+    }
     return {
       statusCode: 500,
       payload: {
@@ -1253,16 +1322,20 @@ class JobQueue {
   async execute(job) {
     let entry;
     let dependency;
+    let acquiringRuntime = false;
+    let runningRuntime = false;
     try {
       dependency = await this.dependencyCache.get(
         job.config.nodeModules,
         job.controller.signal,
       );
       if (job.settled || job.controller.signal.aborted) return null;
+      acquiringRuntime = true;
       entry = await this.runtimeCache.acquire(
         dependency,
         job.controller.signal,
       );
+      acquiringRuntime = false;
       // Preparation can finish after the preparation watchdog already settled
       // the response; never hand a settled job to the guest or arm a timer for
       // it, or a late timer would retire a healthy runtime.
@@ -1270,7 +1343,19 @@ class JobQueue {
       job.entry = entry;
       if (job.timer) clearTimeout(job.timer);
       this.armExecutionTimeout(job);
+      runningRuntime = true;
       return await executeScript(entry.runtime, job);
+    } catch (error) {
+      const sidecarFailure =
+        isSidecarFrameTimeout(error) &&
+        (acquiringRuntime || runningRuntime || entry);
+      const preparationAbort =
+        isPreparationAbort(job) && (acquiringRuntime || runningRuntime);
+      if (sidecarFailure || preparationAbort) {
+        if (entry) this.runtimeCache.discard(entry);
+        else if (dependency) this.runtimeCache.discardCreation(dependency);
+      }
+      throw error;
     } finally {
       if (entry) this.runtimeCache.release(entry);
       dependency?.release();

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -616,7 +616,7 @@ class RuntimeCache {
   constructor() {
     this.entries = new Map();
     this.creationPromises = new Map();
-    this.drainingEntries = new Set();
+    this.drainingEntries = new Map();
   }
 
   async acquire(dependency, signal) {
@@ -630,7 +630,7 @@ class RuntimeCache {
       if (
         !dependency.isDefault &&
         this.nonDefaultCount() >= MAX_NON_DEFAULT_RUNTIMES &&
-        !this.hasDraining(dependency.hash) &&
+        !this.hasSingleDrainingGeneration(dependency.hash) &&
         !(await this.evictInactiveRuntime())
       ) {
         await awaitAbort(this.waitForRuntime(), signal);
@@ -707,7 +707,11 @@ class RuntimeCache {
       } catch (error) {
         logInternalError("dispose detached runtime", error);
       } finally {
-        this.drainingEntries.delete(entry);
+        const draining = this.drainingEntries.get(entry.hash);
+        if (draining) {
+          draining.delete(entry);
+          if (draining.size === 0) this.drainingEntries.delete(entry.hash);
+        }
       }
     })();
   }
@@ -726,7 +730,12 @@ class RuntimeCache {
       this.disposeEntry(entry);
       return;
     }
-    this.drainingEntries.add(entry);
+    let draining = this.drainingEntries.get(entry.hash);
+    if (!draining) {
+      draining = new Set();
+      this.drainingEntries.set(entry.hash, draining);
+    }
+    draining.add(entry);
   }
 
   async evictInactiveRuntime() {
@@ -763,11 +772,9 @@ class RuntimeCache {
     this.detach(entry);
   }
 
-  hasDraining(hash) {
-    for (const entry of this.drainingEntries) {
-      if (entry.hash === hash) return true;
-    }
-    return false;
+  hasSingleDrainingGeneration(hash) {
+    const draining = this.drainingEntries.get(hash);
+    return draining?.size === 1;
   }
 
   nonDefaultCount() {
@@ -775,8 +782,10 @@ class RuntimeCache {
     for (const entry of this.entries.values()) {
       if (!entry.isDefault) count++;
     }
-    for (const entry of this.drainingEntries) {
-      if (!entry.isDefault) count++;
+    for (const draining of this.drainingEntries.values()) {
+      for (const entry of draining) {
+        if (!entry.isDefault) count++;
+      }
     }
     for (const hash of this.creationPromises.keys()) {
       if (hash !== "default") count++;
@@ -787,7 +796,7 @@ class RuntimeCache {
   protectedHashes() {
     return new Set([
       ...this.entries.keys(),
-      ...[...this.drainingEntries].map((entry) => entry.hash),
+      ...this.drainingEntries.keys(),
       ...this.creationPromises.keys(),
     ]);
   }

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -37,7 +37,22 @@ if (
   throw new Error("HEXCLAVE_FREESTYLE_MOCK_MAX_IN_FLIGHT must be an integer from 1 to 32");
 }
 const MAX_JOBS_PER_RUNTIME = 50;
-const MAX_NON_DEFAULT_RUNTIMES = 3;
+const DEFAULT_MAX_NON_DEFAULT_RUNTIMES = 3;
+const configuredMaxNonDefaultRuntimes =
+  process.env.HEXCLAVE_FREESTYLE_MOCK_MAX_NON_DEFAULT_RUNTIMES;
+const MAX_NON_DEFAULT_RUNTIMES =
+  configuredMaxNonDefaultRuntimes == null
+    ? DEFAULT_MAX_NON_DEFAULT_RUNTIMES
+    : Number(configuredMaxNonDefaultRuntimes);
+if (
+  !Number.isInteger(MAX_NON_DEFAULT_RUNTIMES) ||
+  MAX_NON_DEFAULT_RUNTIMES < 1 ||
+  MAX_NON_DEFAULT_RUNTIMES > 32
+) {
+  throw new Error(
+    "HEXCLAVE_FREESTYLE_MOCK_MAX_NON_DEFAULT_RUNTIMES must be an integer from 1 to 32",
+  );
+}
 const NPM_INSTALL_TIMEOUT_MS = 60_000;
 const PREPARATION_TIMEOUT_MS = NPM_INSTALL_TIMEOUT_MS + 60_000;
 const MAX_NODE_MODULES = 20;
@@ -601,29 +616,21 @@ class RuntimeCache {
   constructor() {
     this.entries = new Map();
     this.creationPromises = new Map();
-    this.recyclingPromises = new Map();
+    this.drainingEntries = new Set();
   }
 
   async acquire(dependency, signal) {
     for (;;) {
-      const recycling = this.recyclingPromises.get(dependency.hash);
-      if (recycling) {
-        await awaitAbort(recycling, signal);
-        continue;
-      }
       const entry = this.entries.get(dependency.hash);
       if (entry && !entry.retiring) {
         entry.activeJobs++;
         entry.lastUsed = performance.now();
         return entry;
       }
-      if (entry?.retiring) {
-        await awaitAbort(this.recycleEntry(entry, dependency), signal);
-        continue;
-      }
       if (
         !dependency.isDefault &&
         this.nonDefaultCount() >= MAX_NON_DEFAULT_RUNTIMES &&
+        !this.hasDraining(dependency.hash) &&
         !(await this.evictInactiveRuntime())
       ) {
         await awaitAbort(this.waitForRuntime(), signal);
@@ -682,7 +689,6 @@ class RuntimeCache {
       jobsHandled: 0,
       lastUsed: performance.now(),
       retiring: false,
-      evicted: false,
       disposePromise: null,
     };
     this.entries.set(dependency.hash, entry);
@@ -690,15 +696,7 @@ class RuntimeCache {
   }
 
   evict(entry) {
-    // Mark before the map check: an entry that was already replaced in the
-    // cache still must not be recycled once we know its runtime is unusable.
-    entry.evicted = true;
-    entry.retiring = true;
-    // Remove it before disposal so the next acquire can create a replacement.
-    if (this.entries.get(entry.hash) === entry) {
-      this.entries.delete(entry.hash);
-    }
-    if (entry.activeJobs === 0) this.disposeEntry(entry);
+    this.detach(entry);
   }
 
   disposeEntry(entry) {
@@ -707,9 +705,28 @@ class RuntimeCache {
       try {
         await entry.runtime.dispose();
       } catch (error) {
-        logInternalError("dispose evicted runtime", error);
+        logInternalError("dispose detached runtime", error);
+      } finally {
+        this.drainingEntries.delete(entry);
       }
     })();
+  }
+
+  detach(entry) {
+    // Retirement must never gate new jobs: waiting for a retiring runtime to
+    // drain lets a single long-running job stall every later job on the same
+    // node modules set. A detached entry keeps serving the jobs it already has
+    // and is disposed by their last release, while new jobs immediately build
+    // a replacement.
+    entry.retiring = true;
+    if (this.entries.get(entry.hash) === entry) {
+      this.entries.delete(entry.hash);
+    }
+    if (entry.activeJobs === 0) {
+      this.disposeEntry(entry);
+      return;
+    }
+    this.drainingEntries.add(entry);
   }
 
   async evictInactiveRuntime() {
@@ -729,97 +746,55 @@ class RuntimeCache {
     return true;
   }
 
-  async recycleEntry(entry, dependency) {
-    const existing = this.recyclingPromises.get(dependency.hash);
-    if (existing) return existing;
-    const recycling = (async () => {
-      while (entry.activeJobs > 0) {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      }
-      if (this.entries.get(dependency.hash) === entry) {
-        this.entries.delete(dependency.hash);
-      }
-      try {
-        await entry.runtime.dispose();
-        const replacement = await this.createEntry(dependency);
-        this.entries.set(dependency.hash, replacement);
-      } catch (error) {
-        if (this.entries.get(dependency.hash) === entry) {
-          this.entries.delete(dependency.hash);
-        }
-        throw error;
-      }
-    })();
-    this.recyclingPromises.set(dependency.hash, recycling);
-    try {
-      await recycling;
-    } finally {
-      if (this.recyclingPromises.get(dependency.hash) === recycling) {
-        this.recyclingPromises.delete(dependency.hash);
-      }
-    }
-  }
-
   release(entry) {
     entry.activeJobs--;
-    if (entry.evicted) {
+    if (entry.retiring) {
       if (entry.activeJobs === 0) this.disposeEntry(entry);
       return;
     }
     entry.jobsHandled++;
     entry.lastUsed = performance.now();
     if (entry.jobsHandled >= MAX_JOBS_PER_RUNTIME) {
-      entry.retiring = true;
-    }
-    if (entry.retiring && entry.activeJobs === 0) {
-      this.recycleEntry(entry, dependencyFromEntry(entry)).catch((error) =>
-        logInternalError("recycle secure-exec runtime", error),
-      );
+      this.detach(entry);
     }
   }
 
   retire(entry) {
-    entry.retiring = true;
-    if (entry.activeJobs === 0) {
-      this.recycleEntry(entry, dependencyFromEntry(entry)).catch((error) =>
-        logInternalError("recycle secure-exec runtime", error),
-      );
+    this.detach(entry);
+  }
+
+  hasDraining(hash) {
+    for (const entry of this.drainingEntries) {
+      if (entry.hash === hash) return true;
     }
+    return false;
   }
 
   nonDefaultCount() {
-    const hashes = new Set();
+    let count = 0;
     for (const entry of this.entries.values()) {
-      if (!entry.isDefault) hashes.add(entry.hash);
+      if (!entry.isDefault) count++;
+    }
+    for (const entry of this.drainingEntries) {
+      if (!entry.isDefault) count++;
     }
     for (const hash of this.creationPromises.keys()) {
-      if (hash !== "default") hashes.add(hash);
+      if (hash !== "default") count++;
     }
-    for (const hash of this.recyclingPromises.keys()) {
-      if (hash !== "default") hashes.add(hash);
-    }
-    return hashes.size;
+    return count;
   }
 
   protectedHashes() {
     return new Set([
       ...this.entries.keys(),
+      ...[...this.drainingEntries].map((entry) => entry.hash),
       ...this.creationPromises.keys(),
-      ...this.recyclingPromises.keys(),
     ]);
   }
 
   async waitForRuntime() {
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
-}
-
-function dependencyFromEntry(entry) {
-  return {
-    hash: entry.hash,
-    isDefault: entry.isDefault,
-    nodeModulesPath: entry.nodeModulesPath,
-  };
 }
 
 function createOutput() {

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -209,7 +209,6 @@ function isDeadRuntimeError(error) {
   }
   const message = formatError(error).toLowerCase();
   return (
-    message.includes("timed out waiting for sidecar protocol frame") ||
     message.includes("resident runner exited before completing request") ||
     message.includes("resident runner is not running") ||
     message.includes("sidecar protocol stream ended") ||
@@ -1324,6 +1323,7 @@ class JobQueue {
   async execute(job) {
     let entry;
     let dependency;
+    let executionError = null;
     try {
       dependency = await this.dependencyCache.get(
         job.config.nodeModules,
@@ -1341,15 +1341,17 @@ class JobQueue {
       job.entry = entry;
       if (job.timer) clearTimeout(job.timer);
       this.armExecutionTimeout(job);
-      const result = await executeScript(entry.runtime, job);
-      if (job.cleanupError) this.runtimeCache.evict(entry);
-      return result;
+      return await executeScript(entry.runtime, job);
     } catch (error) {
-      if (entry && isDeadRuntimeError(error)) {
-        this.runtimeCache.evict(entry);
-      }
+      executionError = error;
       throw error;
     } finally {
+      if (
+        entry &&
+        (job.cleanupError || isDeadRuntimeError(executionError))
+      ) {
+        this.runtimeCache.evict(entry);
+      }
       if (entry) this.runtimeCache.release(entry);
       dependency?.release();
     }

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -209,6 +209,7 @@ function isDeadRuntimeError(error) {
   }
   const message = formatError(error).toLowerCase();
   return (
+    message.includes("timed out waiting for sidecar protocol frame") ||
     message.includes("resident runner exited before completing request") ||
     message.includes("resident runner is not running") ||
     message.includes("sidecar protocol stream ended") ||
@@ -1173,7 +1174,11 @@ async function cleanupGuestFiles(runtime, userModuleDir) {
     await runtime.run(makeCleanupWrapper(userModuleDir), { timeout: 2_000 });
   } catch (error) {
     logInternalError("cleanup guest source", error);
+    // Cleanup cannot change the already-produced response, but a dead runtime
+    // must still be reported so the queue can evict it for the next request.
+    if (isDeadRuntimeError(error)) return error;
   }
+  return null;
 }
 
 async function executeScript(runtime, job) {
@@ -1200,7 +1205,7 @@ async function executeScript(runtime, job) {
       },
     };
   } finally {
-    await cleanupGuestFiles(runtime, userModuleDir);
+    job.cleanupError = await cleanupGuestFiles(runtime, userModuleDir);
   }
   if (result.exitCode !== 0 || result.value === undefined) {
     logInternalError("secure-exec nonzero exit", result.stderr || result.exitCode);
@@ -1245,6 +1250,7 @@ class JobQueue {
         controller: new AbortController(),
         output: createOutput(),
         entry: null,
+        cleanupError: null,
         timer: null,
         settled: false,
         resolve,
@@ -1335,7 +1341,9 @@ class JobQueue {
       job.entry = entry;
       if (job.timer) clearTimeout(job.timer);
       this.armExecutionTimeout(job);
-      return await executeScript(entry.runtime, job);
+      const result = await executeScript(entry.runtime, job);
+      if (job.cleanupError) this.runtimeCache.evict(entry);
+      return result;
     } catch (error) {
       if (entry && isDeadRuntimeError(error)) {
         this.runtimeCache.evict(entry);

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -726,16 +726,16 @@ class RuntimeCache {
     if (this.entries.get(entry.hash) === entry) {
       this.entries.delete(entry.hash);
     }
-    if (entry.activeJobs === 0) {
-      this.disposeEntry(entry);
-      return;
-    }
+    // Track before disposing: a runtime is still alive while dispose() runs, so
+    // it has to stay visible to the capacity accounting until disposeEntry()
+    // untracks it.
     let draining = this.drainingEntries.get(entry.hash);
     if (!draining) {
       draining = new Set();
       this.drainingEntries.set(entry.hash, draining);
     }
     draining.add(entry);
+    if (entry.activeJobs === 0) this.disposeEntry(entry);
   }
 
   async evictInactiveRuntime() {

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -195,6 +195,29 @@ function isSidecarFrameTimeout(error) {
   return formatError(error).includes("timed out waiting for sidecar protocol frame");
 }
 
+const DEAD_RUNTIME_ERROR_NAMES = new Set([
+  "SidecarEventBufferOverflow",
+  "SidecarProcessError",
+  "SidecarProcessExited",
+]);
+
+function isDeadRuntimeError(error) {
+  // The secure-exec facade does not re-export these core error classes, but
+  // their names are stable and distinguish dead runtimes from script failures.
+  if (error?.name && DEAD_RUNTIME_ERROR_NAMES.has(error.name)) {
+    return true;
+  }
+  const message = formatError(error).toLowerCase();
+  return (
+    message.includes("resident runner exited before completing request") ||
+    message.includes("resident runner is not running") ||
+    message.includes("sidecar protocol stream ended") ||
+    message.includes("sidecar exited with code") ||
+    message.includes("unknown sidecar vm") ||
+    message.includes("no such process")
+  );
+}
+
 // @secure-exec/core has a fire-and-forget proc.kill() path without a catch for
 // this sidecar timeout; letting it terminate the mock takes down every later
 // E2E test that depends on the rendering service.
@@ -659,9 +682,32 @@ class RuntimeCache {
       jobsHandled: 0,
       lastUsed: performance.now(),
       retiring: false,
+      evicted: false,
+      disposePromise: null,
     };
     this.entries.set(dependency.hash, entry);
     return entry;
+  }
+
+  evict(entry) {
+    if (this.entries.get(entry.hash) !== entry) return;
+    // Remove it before disposal so the next acquire can create a replacement;
+    // release must not recycle an entry already known to be unusable.
+    this.entries.delete(entry.hash);
+    entry.evicted = true;
+    entry.retiring = true;
+    this.disposeEntry(entry);
+  }
+
+  disposeEntry(entry) {
+    if (entry.disposePromise) return;
+    entry.disposePromise = (async () => {
+      try {
+        await entry.runtime.dispose();
+      } catch (error) {
+        logInternalError("dispose evicted runtime", error);
+      }
+    })();
   }
 
   async evictInactiveRuntime() {
@@ -714,6 +760,7 @@ class RuntimeCache {
 
   release(entry) {
     entry.activeJobs--;
+    if (entry.evicted) return;
     entry.jobsHandled++;
     entry.lastUsed = performance.now();
     if (entry.jobsHandled >= MAX_JOBS_PER_RUNTIME) {
@@ -1142,6 +1189,7 @@ async function executeScript(runtime, job) {
     });
   } catch (error) {
     logInternalError("secure-exec execution", error);
+    if (isDeadRuntimeError(error)) throw error;
     return {
       statusCode: 500,
       payload: {
@@ -1286,6 +1334,11 @@ class JobQueue {
       if (job.timer) clearTimeout(job.timer);
       this.armExecutionTimeout(job);
       return await executeScript(entry.runtime, job);
+    } catch (error) {
+      if (entry && isDeadRuntimeError(error)) {
+        this.runtimeCache.evict(entry);
+      }
+      throw error;
     } finally {
       if (entry) this.runtimeCache.release(entry);
       dependency?.release();

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -195,13 +195,6 @@ function isSidecarFrameTimeout(error) {
   return formatError(error).includes("timed out waiting for sidecar protocol frame");
 }
 
-function isPreparationAbort(job) {
-  return (
-    job.controller.signal.aborted &&
-    formatError(job.controller.signal.reason) === "Dependency preparation timed out"
-  );
-}
-
 // @secure-exec/core has a fire-and-forget proc.kill() path without a catch for
 // this sidecar timeout; letting it terminate the mock takes down every later
 // E2E test that depends on the rendering service.
@@ -615,25 +608,20 @@ class RuntimeCache {
       }
       let creation = this.creationPromises.get(dependency.hash);
       if (!creation) {
-        const creationState = {
-          discarded: false,
-          promise: null,
-        };
-        creationState.promise = this.createEntry(dependency, creationState);
-        creation = creationState;
+        creation = this.createEntry(dependency);
         this.creationPromises.set(dependency.hash, creation);
         const clearCreation = () => {
           if (this.creationPromises.get(dependency.hash) === creation) {
             this.creationPromises.delete(dependency.hash);
           }
         };
-        creation.promise.then(clearCreation, clearCreation);
+        creation.then(clearCreation, clearCreation);
       }
-      await awaitAbort(creation.promise, signal);
+      await awaitAbort(creation, signal);
     }
   }
 
-  async createEntry(dependency, creationState) {
+  async createEntry(dependency) {
     const options = {
       nodeModules: dependency.nodeModulesPath,
       permissions: {
@@ -662,14 +650,6 @@ class RuntimeCache {
       };
     }
     const runtime = await NodeRuntime.create(options);
-    if (creationState?.discarded) {
-      try {
-        await runtime.dispose();
-      } catch (error) {
-        logInternalError("dispose discarded runtime", error);
-      }
-      throw new Error("Secure-exec runtime creation was discarded");
-    }
     const entry = {
       hash: dependency.hash,
       isDefault: dependency.isDefault,
@@ -679,36 +659,9 @@ class RuntimeCache {
       jobsHandled: 0,
       lastUsed: performance.now(),
       retiring: false,
-      discarded: false,
-      disposePromise: null,
     };
     this.entries.set(dependency.hash, entry);
     return entry;
-  }
-
-  discardCreation(dependency) {
-    const creation = this.creationPromises.get(dependency.hash);
-    if (!creation) return;
-    creation.discarded = true;
-    this.creationPromises.delete(dependency.hash);
-  }
-
-  discard(entry) {
-    entry.discarded = true;
-    entry.retiring = true;
-    if (this.entries.get(entry.hash) === entry) {
-      this.entries.delete(entry.hash);
-    }
-    if (entry.activeJobs === 0) this.disposeEntry(entry);
-  }
-
-  disposeEntry(entry) {
-    if (!entry.disposePromise) {
-      entry.disposePromise = entry.runtime
-        .dispose()
-        .catch((error) => logInternalError("dispose discarded runtime", error));
-    }
-    return entry.disposePromise;
   }
 
   async evictInactiveRuntime() {
@@ -763,10 +716,6 @@ class RuntimeCache {
     entry.activeJobs--;
     entry.jobsHandled++;
     entry.lastUsed = performance.now();
-    if (entry.discarded) {
-      if (entry.activeJobs === 0) this.disposeEntry(entry);
-      return;
-    }
     if (entry.jobsHandled >= MAX_JOBS_PER_RUNTIME) {
       entry.retiring = true;
     }
@@ -1193,9 +1142,6 @@ async function executeScript(runtime, job) {
     });
   } catch (error) {
     logInternalError("secure-exec execution", error);
-    if (isSidecarFrameTimeout(error) || isPreparationAbort(job)) {
-      throw error;
-    }
     return {
       statusCode: 500,
       payload: {
@@ -1322,20 +1268,16 @@ class JobQueue {
   async execute(job) {
     let entry;
     let dependency;
-    let acquiringRuntime = false;
-    let runningRuntime = false;
     try {
       dependency = await this.dependencyCache.get(
         job.config.nodeModules,
         job.controller.signal,
       );
       if (job.settled || job.controller.signal.aborted) return null;
-      acquiringRuntime = true;
       entry = await this.runtimeCache.acquire(
         dependency,
         job.controller.signal,
       );
-      acquiringRuntime = false;
       // Preparation can finish after the preparation watchdog already settled
       // the response; never hand a settled job to the guest or arm a timer for
       // it, or a late timer would retire a healthy runtime.
@@ -1343,19 +1285,7 @@ class JobQueue {
       job.entry = entry;
       if (job.timer) clearTimeout(job.timer);
       this.armExecutionTimeout(job);
-      runningRuntime = true;
       return await executeScript(entry.runtime, job);
-    } catch (error) {
-      const sidecarFailure =
-        isSidecarFrameTimeout(error) &&
-        (acquiringRuntime || runningRuntime || entry);
-      const preparationAbort =
-        isPreparationAbort(job) && (acquiringRuntime || runningRuntime);
-      if (sidecarFailure || preparationAbort) {
-        if (entry) this.runtimeCache.discard(entry);
-        else if (dependency) this.runtimeCache.discardCreation(dependency);
-      }
-      throw error;
     } finally {
       if (entry) this.runtimeCache.release(entry);
       dependency?.release();

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -698,7 +698,7 @@ class RuntimeCache {
     if (this.entries.get(entry.hash) === entry) {
       this.entries.delete(entry.hash);
     }
-    this.disposeEntry(entry);
+    if (entry.activeJobs === 0) this.disposeEntry(entry);
   }
 
   disposeEntry(entry) {
@@ -762,7 +762,10 @@ class RuntimeCache {
 
   release(entry) {
     entry.activeJobs--;
-    if (entry.evicted) return;
+    if (entry.evicted) {
+      if (entry.activeJobs === 0) this.disposeEntry(entry);
+      return;
+    }
     entry.jobsHandled++;
     entry.lastUsed = performance.now();
     if (entry.jobsHandled >= MAX_JOBS_PER_RUNTIME) {


### PR DESCRIPTION
E2E on `dev` fails with ~44 test files erroring on `connect ECONNREFUSED 127.0.0.1:8122` ("Freestyle rendering service unavailable"). The mock container dies mid-run and never comes back, so every later test that renders an email or executes JS fails.

From the compose logs of the failing run: repeated `[execute job] Error: Dependency preparation timed out`, then a fatal uncaught `Error: timed out waiting for sidecar protocol frame for kill_process` thrown from `@secure-exec/core/dist/correlation.js` with no `server.mjs` frames, then the process is gone. In `@secure-exec/core@0.3.3` the spawned process' `kill()` is fire-and-forget (`void entry.startPromise.then(async () => { await this.signalProcess(...) })`, no `.catch`), and `signalProcess` rethrows a correlation timeout — so when our job watchdogs abort a job and the sidecar doesn't answer the kill frame, Node 24 turns that into a fatal unhandled rejection.

Three layers, smallest first:

- `unhandledRejection` guard in the mock, deliberately narrow: only that sidecar protocol frame timeout is logged-and-tolerated, everything else stays fatal.
- Evict dead runtimes from `RuntimeCache` when a job fails with an error that means the runtime is gone (`SidecarProcessExited` & friends), so the next request builds a fresh runtime instead of reusing a corpse. The request that hit the dead runtime still returns its usual 500.
- `restart: unless-stopped` on the compose service, so if the mock ever does die again CI recovers in seconds instead of failing the rest of the suite.

Validation (containers on the mock image, `{"lodash":"4.17.21"}` dependency so a runtime gets cached):

| scenario | before | after |
| --- | --- | --- |
| sidecar SIGKILLed, 6 requests over ~60s | all 500, never recovers | first request 500, next requests 200 |
| sidecar SIGSTOPped, then SIGCONT | bounded 500, container alive | same, plus recovery to 200 |
| node killed inside the container | container stays down | container restarts, 8122 serving |

The unhandled-rejection crash itself is only reproducible under the CI timing (a paused sidecar produces a bounded execution timeout locally, not the kill-frame timeout), so that layer rests on the CI logs above rather than a local repro.


Link to Devin session: https://app.devin.ai/sessions/2a434b6124334d8e9e5072013849df47
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the dev/CI Freestyle mock and compose; no production auth, data, or app runtime paths.
> 
> **Overview**
> Fixes CI E2E failures where the **freestyle-mock** process exited mid-suite (`ECONNREFUSED` on the rendering port) after `@secure-exec/core` surfaced an uncaught rejection from a fire-and-forget sidecar `kill` timeout.
> 
> The mock now **swallows only** that specific sidecar protocol frame timeout via `unhandledRejection`; other rejections still fail fast. When execution hits errors that mean the cached **NodeRuntime** is gone (e.g. `SidecarProcessExited`, sidecar stream ended), it **evicts** that cache entry and disposes it asynchronously so the next request builds a fresh runtime instead of reusing a dead one—the failing request still returns 500 as before. **`restart: unless-stopped`** is added on the compose service so a rare fatal exit restarts the container instead of leaving the rest of the suite broken.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa38f57322891fd5d3ebffcad8362bbb0f113493. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the freestyle mock from stalling the E2E suite. Previously the mock exited on an unhandled `@secure-exec/core` kill-frame timeout and could reuse dead runtimes; now it tolerates that specific timeout, evicts dead runtimes, retires asynchronously, and lets Compose restart the container if it ever exits.

- Add a narrow `unhandledRejection` handler for “timed out waiting for sidecar protocol frame”; other rejections remain fatal.
- Detect and evict dead runtimes on execution or post-exec cleanup errors; detach entries immediately and dispose after their last job. The triggering request still returns 500; later requests rebuild and succeed.
- Retire hot runtimes without blocking new jobs; track detached/draining runtimes until disposal completes and include them in capacity accounting.
- Bound draining overlap: allow at most one draining generation per module set; count draining and in-flight creations toward the non-default runtime cap.
- Docker Compose: add `restart: unless-stopped`; raise `HEXCLAVE_FREESTYLE_MOCK_MAX_IN_FLIGHT` to 16; add `HEXCLAVE_FREESTYLE_MOCK_MAX_NON_DEFAULT_RUNTIMES` (default 3) and set to 6; increase `mem_limit` to 2g.

<sup>Written for commit 18584ee3ec2bc19334ba1cac9744ca7cf7f9ceee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of secure execution failures so isolated errors no longer terminate the service.
  * Automatically removes and cleans up failed execution environments, improving recovery for subsequent jobs.
  * Suppressed expected timeout errors that do not require service shutdown.

* **Chores**
  * Updated the mock service to restart automatically unless explicitly stopped, improving resilience in CI and other environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->