### PR TITLE
Fix growth e2e Eve wiring, tick driver, long-running transports, and stale MCP snapshot

### DIFF
--- a/apps/backend/.env.development
+++ b/apps/backend/.env.development
@@ -82,7 +82,8 @@ HEXCLAVE_BULLDOZER_SERVER_SECRET=mock_bulldozer_server_secret
 # Growth agent (Eve): shared machine secret for /internal/growth agent routes, and the base
 # URL the backend uses to dispatch work to the agent service.
 HEXCLAVE_GROWTH_AGENT_API_SECRET=mock_growth_agent_secret
-HEXCLAVE_GROWTH_EVE_URL=http://localhost:${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}49
+# Keep this URL in sync with apps/e2e/.env.development: the real agent and the e2e mock take turns owning this one explicit loopback port.
+HEXCLAVE_GROWTH_EVE_URL=http://127.0.0.1:${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}49
 HEXCLAVE_FREESTYLE_API_KEY=mock_stack_freestyle_key
 # Base URL workflow sandboxes use to call back into the API. The Freestyle
 # mock runs in Docker, so localhost would point at the container itself;

--- a/apps/backend/scripts/run-cron-jobs-config.ts
+++ b/apps/backend/scripts/run-cron-jobs-config.ts
@@ -2,6 +2,10 @@ import { WORKFLOW_INVOCATION_BACKSTOP_TIMEOUT_MS } from "../src/lib/workflows/pr
 
 export const CRON_WORKFLOW_ENGINE_MAX_DURATION_MS = 3 * 60 * 1000;
 const CRON_TRANSPORT_TIMEOUT_MARGIN_MS = 30_000;
+
+// These maintenance endpoints perform one short tick and do not request a
+// loop budget. Preserve the former global-fetch 300-second headers bound for
+// them rather than giving them the workflow endpoint's longer budget.
 const CRON_DEFAULT_TRANSPORT_TIMEOUT_MS = 5 * 60 * 1000;
 
 // The workflow endpoint receives this same max_duration_ms. Caller bound =
@@ -13,3 +17,22 @@ export function getCronTransportTimeoutMs(maxDurationMs: number): number {
 export function getCronRequestTimeoutMs(maxDurationMs: number | undefined): number {
   return maxDurationMs == null ? CRON_DEFAULT_TRANSPORT_TIMEOUT_MS : getCronTransportTimeoutMs(maxDurationMs);
 }
+
+export type CronEndpoint = {
+  path: string,
+  intervalMs: number,
+  maxDurationMs?: number,
+};
+
+export const CRON_WORKFLOW_ENGINE_ENDPOINT = {
+  path: "/api/latest/internal/workflow-engine-step",
+  intervalMs: 1000,
+  maxDurationMs: CRON_WORKFLOW_ENGINE_MAX_DURATION_MS,
+} satisfies CronEndpoint & { maxDurationMs: number };
+
+export const CRON_ENDPOINTS: CronEndpoint[] = [
+  { path: "/api/latest/internal/external-db-sync/sequencer", intervalMs: 1000 },
+  { path: "/api/latest/internal/external-db-sync/poller", intervalMs: 1000 },
+  CRON_WORKFLOW_ENGINE_ENDPOINT,
+  { path: "/api/latest/internal/growth-watchdog-step", intervalMs: 5 * 60_000 },
+];

--- a/apps/backend/scripts/run-cron-jobs-config.ts
+++ b/apps/backend/scripts/run-cron-jobs-config.ts
@@ -1,0 +1,15 @@
+import { WORKFLOW_INVOCATION_BACKSTOP_TIMEOUT_MS } from "../src/lib/workflows/protocol";
+
+export const CRON_WORKFLOW_ENGINE_MAX_DURATION_MS = 3 * 60 * 1000;
+const CRON_TRANSPORT_TIMEOUT_MARGIN_MS = 30_000;
+const CRON_DEFAULT_TRANSPORT_TIMEOUT_MS = 5 * 60 * 1000;
+
+// The workflow endpoint receives this same max_duration_ms. Caller bound =
+// its requested loop budget + the engine backstop + a small transport margin.
+export function getCronTransportTimeoutMs(maxDurationMs: number): number {
+  return maxDurationMs + WORKFLOW_INVOCATION_BACKSTOP_TIMEOUT_MS + CRON_TRANSPORT_TIMEOUT_MARGIN_MS;
+}
+
+export function getCronRequestTimeoutMs(maxDurationMs: number | undefined): number {
+  return maxDurationMs == null ? CRON_DEFAULT_TRANSPORT_TIMEOUT_MS : getCronTransportTimeoutMs(maxDurationMs);
+}

--- a/apps/backend/scripts/run-cron-jobs-transport.test.ts
+++ b/apps/backend/scripts/run-cron-jobs-transport.test.ts
@@ -1,18 +1,42 @@
 import { createServer } from "node:http";
+import type { Socket } from "node:net";
 import { afterEach, describe, expect, test } from "vitest";
-import { cronFetch, getCronTransportTimeoutMs } from "./run-cron-jobs-transport";
+import { nodeHttpTransport } from "../src/lib/node-http-transport";
+import { CRON_WORKFLOW_ENGINE_MAX_DURATION_MS, getCronTransportTimeoutMs } from "./run-cron-jobs-config";
 
-const servers: ReturnType<typeof createServer>[] = [];
+const servers: { server: ReturnType<typeof createServer>, sockets: Set<Socket> }[] = [];
 
-afterEach(() => {
-  for (const server of servers.splice(0)) {
-    server.close();
-  }
+function registerServer(server: ReturnType<typeof createServer>): ReturnType<typeof createServer> {
+  const sockets = new Set<Socket>();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  servers.push({ server, sockets });
+  return server;
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(async ({ server, sockets }) => {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    if (!server.listening) return;
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error != null) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }));
 });
 
 describe("cron transport", () => {
   test("outlasts the workflow invocation backstop", () => {
-    expect(getCronTransportTimeoutMs()).toBe(660_000);
+    expect(getCronTransportTimeoutMs(CRON_WORKFLOW_ENGINE_MAX_DURATION_MS)).toBe(840_000);
   });
 
   test("allows a slow progressing response within the injected bound", async () => {
@@ -20,14 +44,14 @@ describe("cron transport", () => {
       response.write("first");
       setTimeout(() => response.end("last"), 20);
     });
-    servers.push(server);
+    registerServer(server);
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
     const address = server.address();
     if (address == null || typeof address === "string") {
       throw new Error("Expected the test server to expose a TCP address.");
     }
 
-    const response = await cronFetch(`http://127.0.0.1:${address.port}`, undefined, 100);
+    const response = await nodeHttpTransport(`http://127.0.0.1:${address.port}`, undefined, 100);
 
     expect(response.status).toBe(200);
     await expect(response.text()).resolves.toBe("firstlast");
@@ -35,13 +59,13 @@ describe("cron transport", () => {
 
   test("fails a hung response at the injected absolute deadline", async () => {
     const server = createServer(() => {});
-    servers.push(server);
+    registerServer(server);
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
     const address = server.address();
     if (address == null || typeof address === "string") {
       throw new Error("Expected the test server to expose a TCP address.");
     }
 
-    await expect(cronFetch(`http://127.0.0.1:${address.port}`, undefined, 20)).rejects.toThrow("absolute deadline");
+    await expect(nodeHttpTransport(`http://127.0.0.1:${address.port}`, undefined, 20)).rejects.toThrow("absolute deadline");
   });
 });

--- a/apps/backend/scripts/run-cron-jobs-transport.test.ts
+++ b/apps/backend/scripts/run-cron-jobs-transport.test.ts
@@ -75,11 +75,40 @@ describe("cron transport", () => {
       start(controller) {
         controller.enqueue(new TextEncoder().encode("partial"));
       },
+      cancel() {
+        return new Promise<never>(() => {});
+      },
     });
 
+    const startedAt = performance.now();
     await expect(nodeHttpTransport("http://127.0.0.1:1", {
       method: "POST",
       body,
-    }, 20)).rejects.toThrow("request body exceeded its 20ms absolute deadline");
+    }, 20)).rejects.toThrow("absolute deadline");
+    expect(performance.now() - startedAt).toBeLessThan(200);
+  });
+
+  test("does not restart the full deadline after reading a request body", async () => {
+    const server = createServer((_request, response) => {
+      setTimeout(() => response.end("done"), 45);
+    });
+    registerServer(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (address == null || typeof address === "string") {
+      throw new Error("Expected the test server to expose a TCP address.");
+    }
+
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial"));
+        setTimeout(() => controller.close(), 45);
+      },
+    });
+
+    await expect(nodeHttpTransport(`http://127.0.0.1:${address.port}`, {
+      method: "POST",
+      body,
+    }, 80)).rejects.toThrow("absolute deadline");
   });
 });

--- a/apps/backend/scripts/run-cron-jobs-transport.test.ts
+++ b/apps/backend/scripts/run-cron-jobs-transport.test.ts
@@ -1,0 +1,47 @@
+import { createServer } from "node:http";
+import { afterEach, describe, expect, test } from "vitest";
+import { cronFetch, getCronTransportTimeoutMs } from "./run-cron-jobs-transport";
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(() => {
+  for (const server of servers.splice(0)) {
+    server.close();
+  }
+});
+
+describe("cron transport", () => {
+  test("outlasts the workflow invocation backstop", () => {
+    expect(getCronTransportTimeoutMs()).toBe(660_000);
+  });
+
+  test("allows a slow progressing response within the injected bound", async () => {
+    const server = createServer((_request, response) => {
+      response.write("first");
+      setTimeout(() => response.end("last"), 20);
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (address == null || typeof address === "string") {
+      throw new Error("Expected the test server to expose a TCP address.");
+    }
+
+    const response = await cronFetch(`http://127.0.0.1:${address.port}`, undefined, 100);
+
+    expect(response.status).toBe(200);
+    await expect(response.text()).resolves.toBe("firstlast");
+  });
+
+  test("fails a hung response at the injected absolute deadline", async () => {
+    const server = createServer(() => {});
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (address == null || typeof address === "string") {
+      throw new Error("Expected the test server to expose a TCP address.");
+    }
+
+    await expect(cronFetch(`http://127.0.0.1:${address.port}`, undefined, 20)).rejects.toThrow("absolute deadline");
+  });
+});

--- a/apps/backend/scripts/run-cron-jobs-transport.test.ts
+++ b/apps/backend/scripts/run-cron-jobs-transport.test.ts
@@ -2,7 +2,7 @@ import { createServer } from "node:http";
 import type { Socket } from "node:net";
 import { afterEach, describe, expect, test } from "vitest";
 import { nodeHttpTransport } from "../src/lib/node-http-transport";
-import { CRON_WORKFLOW_ENGINE_MAX_DURATION_MS, getCronTransportTimeoutMs } from "./run-cron-jobs-config";
+import { CRON_ENDPOINTS, CRON_WORKFLOW_ENGINE_ENDPOINT, getCronTransportTimeoutMs } from "./run-cron-jobs-config";
 
 const servers: { server: ReturnType<typeof createServer>, sockets: Set<Socket> }[] = [];
 
@@ -36,7 +36,8 @@ afterEach(async () => {
 
 describe("cron transport", () => {
   test("outlasts the workflow invocation backstop", () => {
-    expect(getCronTransportTimeoutMs(CRON_WORKFLOW_ENGINE_MAX_DURATION_MS)).toBe(840_000);
+    expect(CRON_ENDPOINTS).toContain(CRON_WORKFLOW_ENGINE_ENDPOINT);
+    expect(getCronTransportTimeoutMs(CRON_WORKFLOW_ENGINE_ENDPOINT.maxDurationMs)).toBe(840_000);
   });
 
   test("allows a slow progressing response within the injected bound", async () => {
@@ -67,5 +68,18 @@ describe("cron transport", () => {
     }
 
     await expect(nodeHttpTransport(`http://127.0.0.1:${address.port}`, undefined, 20)).rejects.toThrow("absolute deadline");
+  });
+
+  test("fails an unending request body at the injected absolute deadline", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("partial"));
+      },
+    });
+
+    await expect(nodeHttpTransport("http://127.0.0.1:1", {
+      method: "POST",
+      body,
+    }, 20)).rejects.toThrow("request body exceeded its 20ms absolute deadline");
   });
 });

--- a/apps/backend/scripts/run-cron-jobs-transport.ts
+++ b/apps/backend/scripts/run-cron-jobs-transport.ts
@@ -1,74 +1,10 @@
-import { request as httpRequest } from "node:http";
-import { request as httpsRequest } from "node:https";
-import { WORKFLOW_INVOCATION_BACKSTOP_TIMEOUT_MS } from "../src/lib/workflows/engine";
-
-const CRON_TRANSPORT_TIMEOUT_MARGIN_MS = 30_000;
-
-// Engine steps can legitimately occupy the full backstop; Undici's 300s
-// headers timeout would abort the cron caller while the backend keeps working,
-// allowing the next tick to pile another sandbox invocation on top.
-export function getCronTransportTimeoutMs(): number {
-  return WORKFLOW_INVOCATION_BACKSTOP_TIMEOUT_MS + CRON_TRANSPORT_TIMEOUT_MARGIN_MS;
-}
+import { nodeHttpTransport, type NodeHttpTransportInit } from "../src/lib/node-http-transport";
+import { getCronRequestTimeoutMs } from "./run-cron-jobs-config";
 
 export function cronFetch(
   input: string | URL,
-  init: { headers?: HeadersInit, signal?: AbortSignal } | undefined,
-  transportTimeoutMs = getCronTransportTimeoutMs(),
+  init: NodeHttpTransportInit | undefined,
+  maxDurationMs: number | undefined,
 ): Promise<Response> {
-  const requestUrl = new URL(input);
-  const requestHeaders = new Headers(init?.headers);
-  const headers: Record<string, string> = {};
-  for (const [name, value] of requestHeaders) {
-    headers[name] = value;
-  }
-  const requestFunction = requestUrl.protocol === "https:" ? httpsRequest : httpRequest;
-
-  return new Promise<Response>((resolve, reject) => {
-    let settled = false;
-    let deadlineTimer: ReturnType<typeof setTimeout>;
-    const clearDeadlineTimer = () => {
-      clearTimeout(deadlineTimer);
-    };
-    const rejectOnce = (error: unknown) => {
-      if (settled) return;
-      settled = true;
-      clearDeadlineTimer();
-      reject(error);
-    };
-    const requestHandle = requestFunction(requestUrl, {
-      method: "GET",
-      headers,
-      signal: init?.signal,
-    }, (response) => {
-      const chunks: Buffer[] = [];
-      response.on("data", (chunk: Buffer | string) => {
-        chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
-      });
-      response.once("error", rejectOnce);
-      response.once("end", () => {
-        if (settled) return;
-        settled = true;
-        clearDeadlineTimer();
-        const responseHeaders = new Headers();
-        for (const [name, value] of Object.entries(response.headers)) {
-          if (value == null) continue;
-          responseHeaders.set(name, Array.isArray(value) ? value.join(", ") : value);
-        }
-        resolve(new Response(Buffer.concat(chunks), {
-          status: response.statusCode ?? 0,
-          statusText: response.statusMessage,
-          headers: responseHeaders,
-        }));
-      });
-    });
-    requestHandle.once("error", rejectOnce);
-    requestHandle.setTimeout(transportTimeoutMs, () => {
-      requestHandle.destroy(new Error(`Cron request exceeded ${transportTimeoutMs}ms.`));
-    });
-    deadlineTimer = setTimeout(() => {
-      requestHandle.destroy(new Error(`Cron request exceeded its ${transportTimeoutMs}ms absolute deadline.`));
-    }, transportTimeoutMs);
-    requestHandle.end();
-  });
+  return nodeHttpTransport(input, init, getCronRequestTimeoutMs(maxDurationMs));
 }

--- a/apps/backend/scripts/run-cron-jobs-transport.ts
+++ b/apps/backend/scripts/run-cron-jobs-transport.ts
@@ -1,0 +1,74 @@
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { WORKFLOW_INVOCATION_BACKSTOP_TIMEOUT_MS } from "../src/lib/workflows/engine";
+
+const CRON_TRANSPORT_TIMEOUT_MARGIN_MS = 30_000;
+
+// Engine steps can legitimately occupy the full backstop; Undici's 300s
+// headers timeout would abort the cron caller while the backend keeps working,
+// allowing the next tick to pile another sandbox invocation on top.
+export function getCronTransportTimeoutMs(): number {
+  return WORKFLOW_INVOCATION_BACKSTOP_TIMEOUT_MS + CRON_TRANSPORT_TIMEOUT_MARGIN_MS;
+}
+
+export function cronFetch(
+  input: string | URL,
+  init: { headers?: HeadersInit, signal?: AbortSignal } | undefined,
+  transportTimeoutMs = getCronTransportTimeoutMs(),
+): Promise<Response> {
+  const requestUrl = new URL(input);
+  const requestHeaders = new Headers(init?.headers);
+  const headers: Record<string, string> = {};
+  for (const [name, value] of requestHeaders) {
+    headers[name] = value;
+  }
+  const requestFunction = requestUrl.protocol === "https:" ? httpsRequest : httpRequest;
+
+  return new Promise<Response>((resolve, reject) => {
+    let settled = false;
+    let deadlineTimer: ReturnType<typeof setTimeout>;
+    const clearDeadlineTimer = () => {
+      clearTimeout(deadlineTimer);
+    };
+    const rejectOnce = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      clearDeadlineTimer();
+      reject(error);
+    };
+    const requestHandle = requestFunction(requestUrl, {
+      method: "GET",
+      headers,
+      signal: init?.signal,
+    }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer | string) => {
+        chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+      });
+      response.once("error", rejectOnce);
+      response.once("end", () => {
+        if (settled) return;
+        settled = true;
+        clearDeadlineTimer();
+        const responseHeaders = new Headers();
+        for (const [name, value] of Object.entries(response.headers)) {
+          if (value == null) continue;
+          responseHeaders.set(name, Array.isArray(value) ? value.join(", ") : value);
+        }
+        resolve(new Response(Buffer.concat(chunks), {
+          status: response.statusCode ?? 0,
+          statusText: response.statusMessage,
+          headers: responseHeaders,
+        }));
+      });
+    });
+    requestHandle.once("error", rejectOnce);
+    requestHandle.setTimeout(transportTimeoutMs, () => {
+      requestHandle.destroy(new Error(`Cron request exceeded ${transportTimeoutMs}ms.`));
+    });
+    deadlineTimer = setTimeout(() => {
+      requestHandle.destroy(new Error(`Cron request exceeded its ${transportTimeoutMs}ms absolute deadline.`));
+    }, transportTimeoutMs);
+    requestHandle.end();
+  });
+}

--- a/apps/backend/scripts/run-cron-jobs.ts
+++ b/apps/backend/scripts/run-cron-jobs.ts
@@ -2,6 +2,7 @@ import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { captureError, HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronously, wait } from "@hexclave/shared/dist/utils/promises";
 import { Result } from "@hexclave/shared/dist/utils/results";
+import { CRON_WORKFLOW_ENGINE_MAX_DURATION_MS } from "./run-cron-jobs-config";
 import { cronFetch } from "./run-cron-jobs-transport";
 
 const endpoints: { path: string, intervalMs: number }[] = [
@@ -29,9 +30,16 @@ async function main() {
 
   const run = async (endpoint: string) => {
     console.log(`Running ${endpoint}...`);
-    const res = await cronFetch(`${baseUrl}${endpoint}`, {
+    const requestUrl = new URL(endpoint, baseUrl);
+    const maxDurationMs = endpoint === "/api/latest/internal/workflow-engine-step"
+      ? CRON_WORKFLOW_ENGINE_MAX_DURATION_MS
+      : undefined;
+    if (maxDurationMs != null) {
+      requestUrl.searchParams.set("max_duration_ms", String(maxDurationMs));
+    }
+    const res = await cronFetch(requestUrl, {
       headers: { 'Authorization': `Bearer ${cronSecret}` },
-    });
+    }, maxDurationMs);
     if (!res.ok) throw new HexclaveAssertionError(`Failed to call ${endpoint}: ${res.status} ${res.statusText}\n${await res.text()}`, { res });
     console.log(`${endpoint} completed.`);
   };

--- a/apps/backend/scripts/run-cron-jobs.ts
+++ b/apps/backend/scripts/run-cron-jobs.ts
@@ -2,6 +2,7 @@ import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { captureError, HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronously, wait } from "@hexclave/shared/dist/utils/promises";
 import { Result } from "@hexclave/shared/dist/utils/results";
+import { cronFetch } from "./run-cron-jobs-transport";
 
 const endpoints: { path: string, intervalMs: number }[] = [
   { path: "/api/latest/internal/external-db-sync/sequencer", intervalMs: 1000 },
@@ -28,7 +29,7 @@ async function main() {
 
   const run = async (endpoint: string) => {
     console.log(`Running ${endpoint}...`);
-    const res = await fetch(`${baseUrl}${endpoint}`, {
+    const res = await cronFetch(`${baseUrl}${endpoint}`, {
       headers: { 'Authorization': `Bearer ${cronSecret}` },
     });
     if (!res.ok) throw new HexclaveAssertionError(`Failed to call ${endpoint}: ${res.status} ${res.statusText}\n${await res.text()}`, { res });

--- a/apps/backend/scripts/run-cron-jobs.ts
+++ b/apps/backend/scripts/run-cron-jobs.ts
@@ -2,15 +2,8 @@ import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { captureError, HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronously, wait } from "@hexclave/shared/dist/utils/promises";
 import { Result } from "@hexclave/shared/dist/utils/results";
-import { CRON_WORKFLOW_ENGINE_MAX_DURATION_MS } from "./run-cron-jobs-config";
+import { CRON_ENDPOINTS, type CronEndpoint } from "./run-cron-jobs-config";
 import { cronFetch } from "./run-cron-jobs-transport";
-
-const endpoints: { path: string, intervalMs: number }[] = [
-  { path: "/api/latest/internal/external-db-sync/sequencer", intervalMs: 1000 },
-  { path: "/api/latest/internal/external-db-sync/poller", intervalMs: 1000 },
-  { path: "/api/latest/internal/workflow-engine-step", intervalMs: 1000 },
-  { path: "/api/latest/internal/growth-watchdog-step", intervalMs: 5 * 60_000 },
-];
 
 async function main() {
   if (getEnvVariable("NEXT_PUBLIC_STACK_IS_PREVIEW", "") === "true") {
@@ -28,31 +21,28 @@ async function main() {
   const backendPort = getEnvVariable("PORT", getEnvVariable("BACKEND_PORT", `${portPrefix}02`));
   const baseUrl = `http://localhost:${backendPort}`;
 
-  const run = async (endpoint: string) => {
-    console.log(`Running ${endpoint}...`);
-    const requestUrl = new URL(endpoint, baseUrl);
-    const maxDurationMs = endpoint === "/api/latest/internal/workflow-engine-step"
-      ? CRON_WORKFLOW_ENGINE_MAX_DURATION_MS
-      : undefined;
+  const run = async ({ path, maxDurationMs }: CronEndpoint) => {
+    console.log(`Running ${path}...`);
+    const requestUrl = new URL(path, baseUrl);
     if (maxDurationMs != null) {
       requestUrl.searchParams.set("max_duration_ms", String(maxDurationMs));
     }
     const res = await cronFetch(requestUrl, {
       headers: { 'Authorization': `Bearer ${cronSecret}` },
     }, maxDurationMs);
-    if (!res.ok) throw new HexclaveAssertionError(`Failed to call ${endpoint}: ${res.status} ${res.statusText}\n${await res.text()}`, { res });
-    console.log(`${endpoint} completed.`);
+    if (!res.ok) throw new HexclaveAssertionError(`Failed to call ${path}: ${res.status} ${res.statusText}\n${await res.text()}`, { res });
+    console.log(`${path} completed.`);
   };
 
-  for (const { path, intervalMs } of endpoints) {
+  for (const endpoint of CRON_ENDPOINTS) {
     runAsynchronously(async () => {
       await wait(30_000); // Wait 30 seconds to make sure the server is fully started
       while (true) {
-        const runResult = await Result.fromPromise(run(path));
+        const runResult = await Result.fromPromise(run(endpoint));
         if (runResult.status === "error") {
           captureError("run-cron-jobs", runResult.error);
         }
-        await wait(intervalMs);
+        await wait(endpoint.intervalMs);
       }
     });
   }

--- a/apps/backend/src/lib/js-execution.test.tsx
+++ b/apps/backend/src/lib/js-execution.test.tsx
@@ -1,13 +1,36 @@
 import { createServer } from "node:http";
+import type { Socket } from "node:net";
 import { afterEach, describe, expect, test } from "vitest";
 import { freestyleFetch, getFreestyleTransportTimeoutMs } from "./js-execution";
 
-const servers: ReturnType<typeof createServer>[] = [];
+const servers: { server: ReturnType<typeof createServer>, sockets: Set<Socket> }[] = [];
 
-afterEach(() => {
-  for (const server of servers.splice(0)) {
-    server.close();
-  }
+function registerServer(server: ReturnType<typeof createServer>): ReturnType<typeof createServer> {
+  const sockets = new Set<Socket>();
+  server.on("connection", (socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+  });
+  servers.push({ server, sockets });
+  return server;
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(async ({ server, sockets }) => {
+    for (const socket of sockets) {
+      socket.destroy();
+    }
+    if (!server.listening) return;
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error != null) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }));
 });
 
 describe("Freestyle transport", () => {
@@ -23,7 +46,7 @@ describe("Freestyle transport", () => {
         response.end(JSON.stringify({ result: { status: "ok", data: "done" } }));
       }, 20);
     });
-    servers.push(server);
+    registerServer(server);
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
     const address = server.address();
     if (address == null || typeof address === "string") {
@@ -55,7 +78,7 @@ describe("Freestyle transport", () => {
         }));
       });
     });
-    servers.push(server);
+    registerServer(server);
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
     const address = server.address();
     if (address == null || typeof address === "string") {
@@ -83,7 +106,7 @@ describe("Freestyle transport", () => {
       const interval = setInterval(() => response.write("chunk"), 5);
       response.on("close", () => clearInterval(interval));
     });
-    servers.push(server);
+    registerServer(server);
     await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
     const address = server.address();
     if (address == null || typeof address === "string") {

--- a/apps/backend/src/lib/js-execution.test.tsx
+++ b/apps/backend/src/lib/js-execution.test.tsx
@@ -39,4 +39,57 @@ describe("Freestyle transport", () => {
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ result: { status: "ok", data: "done" } });
   });
+
+  test("applies init headers and body when input is a Request", async () => {
+    const server = createServer((request, response) => {
+      const chunks: Buffer[] = [];
+      request.on("data", (chunk: Buffer | string) => {
+        chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+      });
+      request.once("end", () => {
+        response.setHeader("content-type", "application/json");
+        response.end(JSON.stringify({
+          inputHeader: request.headers["x-input"],
+          initHeader: request.headers["x-init"],
+          body: Buffer.concat(chunks).toString(),
+        }));
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (address == null || typeof address === "string") {
+      throw new Error("Expected the test server to expose a TCP address.");
+    }
+
+    const input = new Request(`http://127.0.0.1:${address.port}`, {
+      method: "POST",
+      headers: { "x-input": "from-input" },
+      body: "input-body",
+    });
+    const response = await freestyleFetch(input, {
+      headers: { "x-init": "from-init" },
+      body: "init-body",
+    }, 1, 100);
+
+    await expect(response.json()).resolves.toEqual({
+      initHeader: "from-init",
+      body: "init-body",
+    });
+  });
+
+  test("enforces an absolute deadline for a response that keeps streaming", async () => {
+    const server = createServer((_request, response) => {
+      const interval = setInterval(() => response.write("chunk"), 5);
+      response.on("close", () => clearInterval(interval));
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (address == null || typeof address === "string") {
+      throw new Error("Expected the test server to expose a TCP address.");
+    }
+
+    await expect(freestyleFetch(`http://127.0.0.1:${address.port}`, undefined, 1, 25)).rejects.toThrow("absolute deadline");
+  });
 });

--- a/apps/backend/src/lib/js-execution.test.tsx
+++ b/apps/backend/src/lib/js-execution.test.tsx
@@ -1,0 +1,42 @@
+import { createServer } from "node:http";
+import { afterEach, describe, expect, test } from "vitest";
+import { freestyleFetch, getFreestyleTransportTimeoutMs } from "./js-execution";
+
+const servers: ReturnType<typeof createServer>[] = [];
+
+afterEach(() => {
+  for (const server of servers.splice(0)) {
+    server.close();
+  }
+});
+
+describe("Freestyle transport", () => {
+  test("adds a margin to the workflow engine execution timeout", () => {
+    expect(getFreestyleTransportTimeoutMs(630_000)).toBe(660_000);
+    expect(getFreestyleTransportTimeoutMs(undefined)).toBe(60_000);
+  });
+
+  test("accepts a delayed JSON response without the global fetch headers timeout", async () => {
+    const server = createServer((_request, response) => {
+      setTimeout(() => {
+        response.setHeader("content-type", "application/json");
+        response.end(JSON.stringify({ result: { status: "ok", data: "done" } }));
+      }, 20);
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", () => resolve()));
+    const address = server.address();
+    if (address == null || typeof address === "string") {
+      throw new Error("Expected the test server to expose a TCP address.");
+    }
+
+    const response = await freestyleFetch(
+      `http://127.0.0.1:${address.port}`,
+      { method: "POST", body: JSON.stringify({ config: { timeout: 1 } }) },
+      1,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ result: { status: "ok", data: "done" } });
+  });
+});

--- a/apps/backend/src/lib/js-execution.tsx
+++ b/apps/backend/src/lib/js-execution.tsx
@@ -6,6 +6,8 @@ import { HexclaveAssertionError, captureError } from '@hexclave/shared/dist/util
 import { Result } from '@hexclave/shared/dist/utils/results';
 import { Sandbox } from '@vercel/sandbox';
 import { Freestyle as FreestyleClient } from 'freestyle';
+import { request as httpRequest } from 'node:http';
+import { request as httpsRequest } from 'node:https';
 
 export type ExecuteJavascriptOptions = {
   /** Cancels provider setup, command execution, and fallback attempts. */
@@ -41,6 +43,68 @@ type JsEngine = {
   execute: (code: string, options: ExecuteJavascriptOptions) => Promise<ExecuteResult>,
 };
 
+// Workflow execution can legitimately use the full 630s engine backstop; the
+// default fetch headers timeout is only 300s, so leave transport time to finish
+// the requested execution plus a small margin while still bounding hung calls.
+const FREESTYLE_TRANSPORT_TIMEOUT_MARGIN_MS = 30_000;
+
+export function getFreestyleTransportTimeoutMs(executionTimeoutMs: number | undefined): number {
+  return (executionTimeoutMs ?? 30_000) + FREESTYLE_TRANSPORT_TIMEOUT_MARGIN_MS;
+}
+
+export async function freestyleFetch(input: RequestInfo | URL, init: RequestInit | undefined, executionTimeoutMs: number | undefined): Promise<Response> {
+  const requestInit = init ?? {};
+  const requestUrl = input instanceof Request ? new URL(input.url) : new URL(input.toString());
+  const requestHeaders = new Headers(input instanceof Request ? input.headers : requestInit.headers);
+  const headers: Record<string, string> = {};
+  for (const [name, value] of requestHeaders) {
+    headers[name] = value;
+  }
+  const body = await new Response(input instanceof Request ? input.body : requestInit.body).arrayBuffer();
+  const requestBody = Buffer.from(body);
+  const requestFunction = requestUrl.protocol === "https:" ? httpsRequest : httpRequest;
+  const transportTimeoutMs = getFreestyleTransportTimeoutMs(executionTimeoutMs);
+
+  return await new Promise<Response>((resolve, reject) => {
+    let settled = false;
+    const rejectOnce = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+    const requestHandle = requestFunction(requestUrl, {
+      method: requestInit.method ?? (input instanceof Request ? input.method : "GET"),
+      headers,
+      signal: requestInit.signal ?? (input instanceof Request ? input.signal : undefined),
+    }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer | string) => {
+        chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+      });
+      response.once("error", rejectOnce);
+      response.once("end", () => {
+        if (settled) return;
+        settled = true;
+        const responseHeaders = new Headers();
+        for (const [name, value] of Object.entries(response.headers)) {
+          if (value == null) continue;
+          responseHeaders.set(name, Array.isArray(value) ? value.join(", ") : value);
+        }
+        resolve(new Response(Buffer.concat(chunks), {
+          status: response.statusCode ?? 0,
+          statusText: response.statusMessage,
+          headers: responseHeaders,
+        }));
+      });
+    });
+    requestHandle.once("error", rejectOnce);
+    requestHandle.setTimeout(transportTimeoutMs, () => {
+      requestHandle.destroy(new Error(`Freestyle request exceeded ${transportTimeoutMs}ms.`));
+    });
+    requestHandle.end(requestBody);
+  });
+}
+
 function createFreestyleEngine(): JsEngine {
   return {
     name: 'freestyle',
@@ -61,6 +125,7 @@ function createFreestyleEngine(): JsEngine {
       const freestyle = new FreestyleClient({
         apiKey,
         baseUrl,
+        fetch: (input, init) => freestyleFetch(input, init, options.executionTimeoutMs),
       });
 
       const response = await awaitWithAbortSignal(freestyle.serverless.runs.create({

--- a/apps/backend/src/lib/js-execution.tsx
+++ b/apps/backend/src/lib/js-execution.tsx
@@ -52,30 +52,42 @@ export function getFreestyleTransportTimeoutMs(executionTimeoutMs: number | unde
   return (executionTimeoutMs ?? 30_000) + FREESTYLE_TRANSPORT_TIMEOUT_MARGIN_MS;
 }
 
-export async function freestyleFetch(input: RequestInfo | URL, init: RequestInit | undefined, executionTimeoutMs: number | undefined): Promise<Response> {
+export async function freestyleFetch(
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+  executionTimeoutMs: number | undefined,
+  transportTimeoutMs = getFreestyleTransportTimeoutMs(executionTimeoutMs),
+): Promise<Response> {
+  const normalizedRequest = input instanceof Request ? new Request(input, init) : undefined;
   const requestInit = init ?? {};
-  const requestUrl = input instanceof Request ? new URL(input.url) : new URL(input.toString());
-  const requestHeaders = new Headers(input instanceof Request ? input.headers : requestInit.headers);
+  const requestUrl = new URL(normalizedRequest?.url ?? input.toString());
+  const requestHeaders = new Headers(normalizedRequest?.headers ?? requestInit.headers);
   const headers: Record<string, string> = {};
   for (const [name, value] of requestHeaders) {
     headers[name] = value;
   }
-  const body = await new Response(input instanceof Request ? input.body : requestInit.body).arrayBuffer();
+  const body = await (normalizedRequest?.arrayBuffer() ?? new Response(requestInit.body).arrayBuffer());
   const requestBody = Buffer.from(body);
   const requestFunction = requestUrl.protocol === "https:" ? httpsRequest : httpRequest;
-  const transportTimeoutMs = getFreestyleTransportTimeoutMs(executionTimeoutMs);
+  const requestMethod = normalizedRequest?.method ?? requestInit.method ?? "GET";
+  const requestSignal = normalizedRequest == null ? requestInit.signal ?? undefined : normalizedRequest.signal;
 
   return await new Promise<Response>((resolve, reject) => {
     let settled = false;
+    let deadlineTimer: ReturnType<typeof setTimeout>;
+    const clearDeadlineTimer = () => {
+      clearTimeout(deadlineTimer);
+    };
     const rejectOnce = (error: unknown) => {
       if (settled) return;
       settled = true;
+      clearDeadlineTimer();
       reject(error);
     };
     const requestHandle = requestFunction(requestUrl, {
-      method: requestInit.method ?? (input instanceof Request ? input.method : "GET"),
+      method: requestMethod,
       headers,
-      signal: requestInit.signal ?? (input instanceof Request ? input.signal : undefined),
+      signal: requestSignal,
     }, (response) => {
       const chunks: Buffer[] = [];
       response.on("data", (chunk: Buffer | string) => {
@@ -85,6 +97,7 @@ export async function freestyleFetch(input: RequestInfo | URL, init: RequestInit
       response.once("end", () => {
         if (settled) return;
         settled = true;
+        clearDeadlineTimer();
         const responseHeaders = new Headers();
         for (const [name, value] of Object.entries(response.headers)) {
           if (value == null) continue;
@@ -101,6 +114,9 @@ export async function freestyleFetch(input: RequestInfo | URL, init: RequestInit
     requestHandle.setTimeout(transportTimeoutMs, () => {
       requestHandle.destroy(new Error(`Freestyle request exceeded ${transportTimeoutMs}ms.`));
     });
+    deadlineTimer = setTimeout(() => {
+      requestHandle.destroy(new Error(`Freestyle request exceeded its ${transportTimeoutMs}ms absolute deadline.`));
+    }, transportTimeoutMs);
     requestHandle.end(requestBody);
   });
 }

--- a/apps/backend/src/lib/js-execution.tsx
+++ b/apps/backend/src/lib/js-execution.tsx
@@ -6,8 +6,7 @@ import { HexclaveAssertionError, captureError } from '@hexclave/shared/dist/util
 import { Result } from '@hexclave/shared/dist/utils/results';
 import { Sandbox } from '@vercel/sandbox';
 import { Freestyle as FreestyleClient } from 'freestyle';
-import { request as httpRequest } from 'node:http';
-import { request as httpsRequest } from 'node:https';
+import { nodeHttpTransport } from './node-http-transport';
 
 export type ExecuteJavascriptOptions = {
   /** Cancels provider setup, command execution, and fallback attempts. */
@@ -60,65 +59,15 @@ export async function freestyleFetch(
 ): Promise<Response> {
   const normalizedRequest = input instanceof Request ? new Request(input, init) : undefined;
   const requestInit = init ?? {};
-  const requestUrl = new URL(normalizedRequest?.url ?? input.toString());
-  const requestHeaders = new Headers(normalizedRequest?.headers ?? requestInit.headers);
-  const headers: Record<string, string> = {};
-  for (const [name, value] of requestHeaders) {
-    headers[name] = value;
-  }
-  const body = await (normalizedRequest?.arrayBuffer() ?? new Response(requestInit.body).arrayBuffer());
-  const requestBody = Buffer.from(body);
-  const requestFunction = requestUrl.protocol === "https:" ? httpsRequest : httpRequest;
-  const requestMethod = normalizedRequest?.method ?? requestInit.method ?? "GET";
-  const requestSignal = normalizedRequest == null ? requestInit.signal ?? undefined : normalizedRequest.signal;
-
-  return await new Promise<Response>((resolve, reject) => {
-    let settled = false;
-    let deadlineTimer: ReturnType<typeof setTimeout>;
-    const clearDeadlineTimer = () => {
-      clearTimeout(deadlineTimer);
-    };
-    const rejectOnce = (error: unknown) => {
-      if (settled) return;
-      settled = true;
-      clearDeadlineTimer();
-      reject(error);
-    };
-    const requestHandle = requestFunction(requestUrl, {
-      method: requestMethod,
-      headers,
-      signal: requestSignal,
-    }, (response) => {
-      const chunks: Buffer[] = [];
-      response.on("data", (chunk: Buffer | string) => {
-        chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
-      });
-      response.once("error", rejectOnce);
-      response.once("end", () => {
-        if (settled) return;
-        settled = true;
-        clearDeadlineTimer();
-        const responseHeaders = new Headers();
-        for (const [name, value] of Object.entries(response.headers)) {
-          if (value == null) continue;
-          responseHeaders.set(name, Array.isArray(value) ? value.join(", ") : value);
-        }
-        resolve(new Response(Buffer.concat(chunks), {
-          status: response.statusCode ?? 0,
-          statusText: response.statusMessage,
-          headers: responseHeaders,
-        }));
-      });
-    });
-    requestHandle.once("error", rejectOnce);
-    requestHandle.setTimeout(transportTimeoutMs, () => {
-      requestHandle.destroy(new Error(`Freestyle request exceeded ${transportTimeoutMs}ms.`));
-    });
-    deadlineTimer = setTimeout(() => {
-      requestHandle.destroy(new Error(`Freestyle request exceeded its ${transportTimeoutMs}ms absolute deadline.`));
+  if (normalizedRequest != null) {
+    return await nodeHttpTransport(normalizedRequest.url, {
+      method: normalizedRequest.method,
+      headers: normalizedRequest.headers,
+      body: await normalizedRequest.arrayBuffer(),
+      signal: normalizedRequest.signal,
     }, transportTimeoutMs);
-    requestHandle.end(requestBody);
-  });
+  }
+  return await nodeHttpTransport(input.toString(), requestInit, transportTimeoutMs);
 }
 
 function createFreestyleEngine(): JsEngine {

--- a/apps/backend/src/lib/node-http-transport.ts
+++ b/apps/backend/src/lib/node-http-transport.ts
@@ -1,5 +1,6 @@
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
+import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 
 export type NodeHttpTransportInit = {
   method?: RequestInit["method"],
@@ -18,6 +19,9 @@ export async function nodeHttpTransport(
   init: NodeHttpTransportInit | undefined,
   timeoutMs: number,
 ): Promise<Response> {
+  const deadlineAt = performance.now() + timeoutMs;
+  const getRemainingTimeoutMs = () => Math.max(0, deadlineAt - performance.now());
+  const deadlineError = () => new Error(`HTTP request exceeded its ${timeoutMs}ms absolute deadline.`);
   const requestUrl = new URL(input);
   const requestHeaders = new Headers(init?.headers);
   const headers: Record<string, string> = {};
@@ -45,8 +49,8 @@ export async function nodeHttpTransport(
     };
     const deadlinePromise = new Promise<never>((_resolve, reject) => {
       deadlineTimer = setTimeout(() => {
-        reject(new Error(`HTTP request body exceeded its ${timeoutMs}ms absolute deadline.`));
-      }, timeoutMs);
+        reject(deadlineError());
+      }, getRemainingTimeoutMs());
     });
     try {
       if (requestSignal?.aborted) {
@@ -63,8 +67,12 @@ export async function nodeHttpTransport(
     } finally {
       if (deadlineTimer != null) clearTimeout(deadlineTimer);
       requestSignal?.removeEventListener("abort", abort);
-      await reader.cancel();
+      runAsynchronously(reader.cancel());
     }
+  }
+  const requestTimeoutMs = getRemainingTimeoutMs();
+  if (requestTimeoutMs <= 0) {
+    throw deadlineError();
   }
   const requestFunction = requestUrl.protocol === "https:" ? httpsRequest : httpRequest;
 
@@ -107,12 +115,12 @@ export async function nodeHttpTransport(
       });
     });
     requestHandle.once("error", rejectOnce);
-    requestHandle.setTimeout(timeoutMs, () => {
-      requestHandle.destroy(new Error(`HTTP request exceeded ${timeoutMs}ms.`));
+    requestHandle.setTimeout(requestTimeoutMs, () => {
+      requestHandle.destroy(new Error(`HTTP request exceeded ${requestTimeoutMs}ms of inactivity.`));
     });
     deadlineTimer = setTimeout(() => {
-      requestHandle.destroy(new Error(`HTTP request exceeded its ${timeoutMs}ms absolute deadline.`));
-    }, timeoutMs);
+      requestHandle.destroy(deadlineError());
+    }, requestTimeoutMs);
     requestHandle.end(requestBody);
   });
 }

--- a/apps/backend/src/lib/node-http-transport.ts
+++ b/apps/backend/src/lib/node-http-transport.ts
@@ -1,0 +1,73 @@
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+
+export type NodeHttpTransportInit = {
+  method?: RequestInit["method"],
+  headers?: RequestInit["headers"],
+  body?: RequestInit["body"] | ArrayBuffer,
+  signal?: RequestInit["signal"],
+};
+
+export async function nodeHttpTransport(
+  input: string | URL,
+  init: NodeHttpTransportInit | undefined,
+  timeoutMs: number,
+): Promise<Response> {
+  const requestUrl = new URL(input);
+  const requestHeaders = new Headers(init?.headers);
+  const headers: Record<string, string> = {};
+  for (const [name, value] of requestHeaders) {
+    headers[name] = value;
+  }
+  const body = await new Response(init?.body ?? null).arrayBuffer();
+  const requestBody = Buffer.from(body);
+  const requestFunction = requestUrl.protocol === "https:" ? httpsRequest : httpRequest;
+
+  return await new Promise<Response>((resolve, reject) => {
+    let settled = false;
+    let deadlineTimer: ReturnType<typeof setTimeout>;
+    const clearDeadlineTimer = () => {
+      clearTimeout(deadlineTimer);
+    };
+    const rejectOnce = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      clearDeadlineTimer();
+      reject(error);
+    };
+    const requestHandle = requestFunction(requestUrl, {
+      method: init?.method ?? "GET",
+      headers,
+      signal: init?.signal ?? undefined,
+    }, (response) => {
+      const chunks: Buffer[] = [];
+      response.on("data", (chunk: Buffer | string) => {
+        chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk);
+      });
+      response.once("error", rejectOnce);
+      response.once("end", () => {
+        if (settled) return;
+        settled = true;
+        clearDeadlineTimer();
+        const responseHeaders = new Headers();
+        for (const [name, value] of Object.entries(response.headers)) {
+          if (value == null) continue;
+          responseHeaders.set(name, Array.isArray(value) ? value.join(", ") : value);
+        }
+        resolve(new Response(Buffer.concat(chunks), {
+          status: response.statusCode ?? 0,
+          statusText: response.statusMessage,
+          headers: responseHeaders,
+        }));
+      });
+    });
+    requestHandle.once("error", rejectOnce);
+    requestHandle.setTimeout(timeoutMs, () => {
+      requestHandle.destroy(new Error(`HTTP request exceeded ${timeoutMs}ms.`));
+    });
+    deadlineTimer = setTimeout(() => {
+      requestHandle.destroy(new Error(`HTTP request exceeded its ${timeoutMs}ms absolute deadline.`));
+    }, timeoutMs);
+    requestHandle.end(requestBody);
+  });
+}

--- a/apps/backend/src/lib/node-http-transport.ts
+++ b/apps/backend/src/lib/node-http-transport.ts
@@ -8,6 +8,11 @@ export type NodeHttpTransportInit = {
   signal?: RequestInit["signal"],
 };
 
+// Global fetch uses Undici's 300-second headers timeout, but a workflow
+// invocation can legitimately occupy the full 630-second engine backstop.
+// Aborting the caller while the backend keeps working lets the next cron tick
+// pile another sandbox invocation on top, so these callers need an explicit
+// long-lived transport with an independent absolute deadline.
 export async function nodeHttpTransport(
   input: string | URL,
   init: NodeHttpTransportInit | undefined,
@@ -19,8 +24,48 @@ export async function nodeHttpTransport(
   for (const [name, value] of requestHeaders) {
     headers[name] = value;
   }
-  const body = await new Response(init?.body ?? null).arrayBuffer();
-  const requestBody = Buffer.from(body);
+  const requestSignal = init?.signal ?? undefined;
+  const body = init?.body ?? null;
+  let requestBody: Buffer;
+  if (!(body instanceof ReadableStream)) {
+    if (requestSignal?.aborted) {
+      throw requestSignal.reason ?? new DOMException("The operation was aborted.", "AbortError");
+    }
+    requestBody = Buffer.from(await new Response(body).arrayBuffer());
+  } else {
+    const reader = body.getReader();
+    const chunks: Buffer[] = [];
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    let rejectAbort: (reason?: unknown) => void = () => {};
+    const abortPromise = new Promise<never>((_resolve, reject) => {
+      rejectAbort = reject;
+    });
+    const abort = () => {
+      rejectAbort(requestSignal?.reason ?? new DOMException("The operation was aborted.", "AbortError"));
+    };
+    const deadlinePromise = new Promise<never>((_resolve, reject) => {
+      deadlineTimer = setTimeout(() => {
+        reject(new Error(`HTTP request body exceeded its ${timeoutMs}ms absolute deadline.`));
+      }, timeoutMs);
+    });
+    try {
+      if (requestSignal?.aborted) {
+        abort();
+      } else {
+        requestSignal?.addEventListener("abort", abort, { once: true });
+      }
+      while (true) {
+        const result = await Promise.race([reader.read(), abortPromise, deadlinePromise]);
+        if (result.done) break;
+        chunks.push(Buffer.from(result.value));
+      }
+      requestBody = Buffer.concat(chunks);
+    } finally {
+      if (deadlineTimer != null) clearTimeout(deadlineTimer);
+      requestSignal?.removeEventListener("abort", abort);
+      await reader.cancel();
+    }
+  }
   const requestFunction = requestUrl.protocol === "https:" ? httpsRequest : httpRequest;
 
   return await new Promise<Response>((resolve, reject) => {
@@ -38,7 +83,7 @@ export async function nodeHttpTransport(
     const requestHandle = requestFunction(requestUrl, {
       method: init?.method ?? "GET",
       headers,
-      signal: init?.signal ?? undefined,
+      signal: requestSignal,
     }, (response) => {
       const chunks: Buffer[] = [];
       response.on("data", (chunk: Buffer | string) => {

--- a/apps/backend/src/lib/workflows/engine.tsx
+++ b/apps/backend/src/lib/workflows/engine.tsx
@@ -17,6 +17,7 @@ import { invokeWorkflowSandbox } from "./invoke";
 import { listCronOccurrences, MAX_CATCHUP_WINDOW_MS, parseCronExpression } from "./cron";
 import {
   WORKFLOWS_DEFAULT_LIMITS,
+  WORKFLOW_INVOCATION_BACKSTOP_TIMEOUT_MS,
   WORKFLOWS_PROTOCOL_VERSION,
   type WorkflowSandboxCredentials,
   type WorkflowSandboxEvent,
@@ -26,6 +27,8 @@ import {
 } from "./protocol";
 import { getWorkflowsRuntimeEnv } from "./runtime-env";
 import { createWorkflowRunToken } from "./run-token";
+
+export { WORKFLOW_INVOCATION_BACKSTOP_TIMEOUT_MS };
 
 // The workflow engine: tick-driven like the email queue. A cron route calls
 // runWorkflowEngineStep() in a loop; each step (1) materializes due schedule
@@ -55,7 +58,6 @@ const PER_WORKFLOW_CONCURRENCY = 10;
 const RUN_LEASE_MS = 12 * 60 * 1000;
 // See the credential-minting comment in executeClaimedRun.
 const WORKFLOW_RUN_TOKEN_TTL_MS = 35 * 60 * 1000;
-export const WORKFLOW_INVOCATION_BACKSTOP_TIMEOUT_MS = WORKFLOWS_DEFAULT_LIMITS.maxStepTimeoutMs + 30 * 1000;
 // How many steps a single claim may chain before handing the run back to
 // the queue, so a hot run cannot starve others for a whole tick.
 const MAX_CHAINED_STEPS_PER_CLAIM = 50;

--- a/apps/backend/src/lib/workflows/protocol.tsx
+++ b/apps/backend/src/lib/workflows/protocol.tsx
@@ -166,3 +166,5 @@ export const WORKFLOWS_DEFAULT_LIMITS: WorkflowSandboxLimits = {
   inlineSleepMaxMs: 60 * 1000,
   inlineSleepBudgetMs: 90 * 1000,
 };
+
+export const WORKFLOW_INVOCATION_BACKSTOP_TIMEOUT_MS = WORKFLOWS_DEFAULT_LIMITS.maxStepTimeoutMs + 30 * 1000;

--- a/apps/e2e/.env.development
+++ b/apps/e2e/.env.development
@@ -16,4 +16,5 @@ HEXCLAVE_EMAIL_MONITOR_SECRET_TOKEN=this-secret-token-is-for-local-development-o
 CRON_SECRET=mock_cron_secret
 HEXCLAVE_BULLDOZER_SERVER_SECRET=mock_bulldozer_server_secret
 HEXCLAVE_GROWTH_AGENT_API_SECRET=mock_growth_agent_secret
-HEXCLAVE_GROWTH_EVE_URL=http://127.0.0.1:32872
+# Keep this URL in sync with apps/backend/.env.development: the e2e mock and opt-in real agent take turns owning this one explicit loopback port.
+HEXCLAVE_GROWTH_EVE_URL=http://127.0.0.1:${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}49

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
@@ -420,7 +420,7 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
   });
 
   it("retries exhausted phases with fresh token anchors and attempt budgets", { timeout: 300_000 }, async ({ expect }) => {
-    await withGrowthMockEve(expect, async (mock) => {
+    await withMockEve(async (mock) => {
       const { projectId, branchId } = await setUpOnboardedProject();
       const scope: AgentScope = { project_id: projectId, branch_id: branchId };
 
@@ -484,7 +484,7 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
 
       const redispatchTick = await bridgeCall("analysis/tick", { run_id: runId });
       expect(redispatchTick.status).toBe(200);
-      const freshDispatch = await mock.waitForDispatch((candidate) => isAnalysisPhaseDispatchFor(candidate, projectId, runId, "website-research", 1));
+      const freshDispatch = await mock.waitForDispatch((candidate) => isAnalysisPhaseDispatchFor(candidate, projectId, runId, "website-research", 1) && candidate.respondedWithStatus === 200);
       expect(freshDispatch.respondedWithStatus).toBe(200);
       expect(freshDispatch.body.agent_token).toMatch(/^grt_/);
       expect(freshDispatch.body.agent_token).not.toBe(oldToken);

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
@@ -19,10 +19,11 @@ const SERVER_BASE = "/api/v1/internal/growth-server";
 // routes (analysis/tick + analysis/wait) — and those bridge ticks dispatch analysis phases to Eve
 // (played by the in-process mock Eve server) exactly like the deleted v1 cron engine did.
 //
-// IMPORTANT: every test that needs the mock Eve lives in THIS file. The mock's port is fixed by
-// HEXCLAVE_GROWTH_EVE_URL in apps/e2e/.env.development (the backend reads it per-dispatch), and
-// vitest runs test files in separate workers, so a second file binding the same port would flake
-// with EADDRINUSE. Within this file, withMockEve serializes entries via a module-level mutex.
+// IMPORTANT: every test that needs the mock Eve lives in THIS file. The mock derives its port from
+// HEXCLAVE_GROWTH_EVE_URL in apps/e2e/.env.development (the backend reads the same value per
+// dispatch), and vitest runs test files in separate workers, so a second file binding the same port
+// would flake with EADDRINUSE. Within this file, withMockEve serializes entries via a module-level
+// mutex.
 //
 // Time-dependent orchestration paths — the stuck-phase reaper (15min timeout), the milestone
 // hourly claim, the watchdog's 5-minute resurrection grace, and the stale-brief sweep (3h) — keep
@@ -672,7 +673,7 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
 
 // The interview streaming turn needs a mock Eve that RESPONDS with a body (unlike the
 // fire-and-forget run routes, the backend consumes /interview's response), so it lives in this file
-// — the only one allowed to bind the fixed mock-Eve port. Non-streaming interview behavior
+// — the only one allowed to bind the shared mock-Eve port. Non-streaming interview behavior
 // (GET/skip/answer-persistence negatives) lives in interview.test.ts without the mock.
 describe("growth interview streaming (mock Eve)", () => {
   it("persists the answer before proxying, passes the assistant turn through as a UI chunk stream, and persists the transcript", { timeout: 420_000 }, async ({ expect }) => {

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
@@ -343,7 +343,15 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
         return run.status === "completed" ? run : null;
       }, { timeoutMs: 180_000 });
       expect(typeof completedRun.completed_at_millis).toBe("number");
-      expect(completedRun.phases.every((phase) => phase.status === "completed" && phase.attempt === 1)).toBe(true);
+      // The orchestration DAG never dispatches integrations; the tick auto-skips it once
+      // compute-metrics settles. See apps/backend/src/lib/growth/orchestration.ts.
+      expect(completedRun.phases.every((phase) => phase.phase_key === "integrations"
+        ? phase.status === "skipped" && phase.attempt === 0
+        : phase.status === "completed" && phase.attempt === 1)).toBe(true);
+      expect(completedRun.phases.find((phase) => phase.phase_key === "integrations")).toMatchObject({
+        status: "skipped",
+        attempt: 0,
+      });
       await pollWithTicks(expect, async () => {
         const leg = await findAnalysisLegRun(runId, INTERVIEW_FINISHED_EVENT_TYPE);
         return leg != null && leg.state === "completed" ? leg : null;

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
@@ -1,7 +1,7 @@
 import { describe, type ExpectStatic } from "vitest";
 import { it } from "../../../../../../helpers";
 import { niceBackendFetch } from "../../../../../backend-helpers";
-import { listRuns, pollWithTicks, sendCustomEvent } from "../workflows-helpers";
+import { listRuns, pollWithTicks as pollWithEngineTicks, sendCustomEvent, withBackgroundWorkflowEngineTicks } from "../workflows-helpers";
 import { GROWTH_AGENT_AUTH, createGrowthProject, releaseGrowthInterviewAsStaff, requireRunId, unlockGrowthWorkspaceAsStaff } from "./growth-helpers";
 import { MockEve, MockEveDispatch, withMockEve } from "./mock-eve";
 
@@ -54,9 +54,17 @@ const IMMEDIATE_PHASE_KEYS = [
   "analysis:icp-visitor-outreach",
 ] as const;
 
-/** Waits for a dispatch matching `predicate`, ticking the WORKFLOW engine while waiting. */
+async function pollWithTicks<T>(expect: ExpectStatic, check: () => Promise<T | null>, options: { timeoutMs?: number } = {}): Promise<T> {
+  return await pollWithEngineTicks(expect, check, { ...options, driveTicks: false });
+}
+
+/** Waits for a dispatch matching `predicate` while the background engine driver advances workflows. */
 async function waitForDispatchWithTicks(expect: ExpectStatic, mock: MockEve, predicate: (dispatch: MockEveDispatch) => boolean, options: { timeoutMs?: number } = {}): Promise<MockEveDispatch> {
   return await pollWithTicks(expect, async () => mock.dispatches.find(predicate) ?? null, options);
+}
+
+async function withGrowthMockEve<T>(expect: ExpectStatic, fn: (mock: MockEve) => Promise<T>): Promise<T> {
+  return await withMockEve(async (mock) => await withBackgroundWorkflowEngineTicks(expect, () => fn(mock)));
 }
 
 async function setUpOnboardedProject() {
@@ -138,7 +146,7 @@ async function bridgeCall(path: string, body: unknown) {
 
 describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, () => {
   it("drives a full analysis lifecycle through the workflow engine: seeding, legs, dispatches, interview gate, report, completion", { timeout: 420_000 }, async ({ expect }) => {
-    await withMockEve(async (mock) => {
+    await withGrowthMockEve(expect, async (mock) => {
       const { projectId, branchId } = await setUpOnboardedProject();
       const scope: AgentScope = { project_id: projectId, branch_id: branchId };
       const runId = await completeOnboarding();
@@ -361,7 +369,7 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
   });
 
   it("resets failed dispatches to pending and re-dispatches with a bumped attempt", { timeout: 300_000 }, async ({ expect }) => {
-    await withMockEve(async (mock) => {
+    await withGrowthMockEve(expect, async (mock) => {
       const { projectId, branchId } = await setUpOnboardedProject();
       const scope: AgentScope = { project_id: projectId, branch_id: branchId };
 
@@ -412,7 +420,7 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
   });
 
   it("retries exhausted phases with fresh token anchors and attempt budgets", { timeout: 300_000 }, async ({ expect }) => {
-    await withMockEve(async (mock) => {
+    await withGrowthMockEve(expect, async (mock) => {
       const { projectId, branchId } = await setUpOnboardedProject();
       const scope: AgentScope = { project_id: projectId, branch_id: branchId };
 
@@ -485,7 +493,7 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
   });
 
   it("fences zombie agents echoing a stale attempt after a re-dispatch, without changing state", { timeout: 300_000 }, async ({ expect }) => {
-    await withMockEve(async (mock) => {
+    await withGrowthMockEve(expect, async (mock) => {
       const { projectId, branchId } = await setUpOnboardedProject();
       const scope: AgentScope = { project_id: projectId, branch_id: branchId };
 
@@ -525,7 +533,7 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
   });
 
   it("runs the daily-brief workflow end to end: rollup, Eve dispatch, agent content, deliveries, milestone evaluation", { timeout: 300_000 }, async ({ expect }) => {
-    await withMockEve(async (mock) => {
+    await withGrowthMockEve(expect, async (mock) => {
       const { projectId, branchId } = await setUpOnboardedProject();
       const scope: AgentScope = { project_id: projectId, branch_id: branchId };
       await completeOnboarding();
@@ -677,7 +685,7 @@ describe("growth workflow orchestration e2e (mock Eve)", { timeout: 90_000 }, ()
 // (GET/skip/answer-persistence negatives) lives in interview.test.ts without the mock.
 describe("growth interview streaming (mock Eve)", () => {
   it("persists the answer before proxying, passes the assistant turn through as a UI chunk stream, and persists the transcript", { timeout: 420_000 }, async ({ expect }) => {
-    await withMockEve(async (mock) => {
+    await withGrowthMockEve(expect, async (mock) => {
       const { projectId, branchId } = await setUpOnboardedProject();
       const scope: AgentScope = { project_id: projectId, branch_id: branchId };
       const runId = await completeOnboarding();

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/mock-eve.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/mock-eve.ts
@@ -1,15 +1,19 @@
 import http from "node:http";
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 
 // Mock Eve server for the growth engine e2e suite.
 //
 // The backend dispatches growth agent invocations as HTTP POSTs to
-// getEnvVariable("HEXCLAVE_GROWTH_EVE_URL"), which apps/e2e/.env.development pins to
-// http://127.0.0.1:32872. Because that URL (and therefore the port) is FIXED, only one server can
-// play Eve at a time — so:
+// getEnvVariable("HEXCLAVE_GROWTH_EVE_URL"), which apps/e2e/.env.development keeps in sync with the
+// backend's development URL. Because that URL is the single Eve endpoint, only one server can play
+// Eve at a time — so:
 //   - withMockEve serializes concurrent entries within this process via a module-level
 //     promise-chain mutex, and
 //   - only ONE e2e file may use this helper (growth-workflows.test.ts) — vitest runs test FILES in
 //     separate workers, and a second file binding the same port would flake with EADDRINUSE.
+//
+// The real agent can own this same port when started explicitly with
+// `pnpm -C apps/growth-agent dev:agent`; stop it before running this suite.
 //
 // The server answers every POST with 200 {"accepted":true} (the real Eve app's ack contract) and
 // records it. Note that while the mock is listening, engine ticks triggered by OTHER concurrently
@@ -57,10 +61,31 @@ export type MockEve = {
 };
 
 export const MOCK_EVE_HOST = "127.0.0.1";
-export const MOCK_EVE_PORT = 32872;
+
+function getMockEvePort(): number {
+  const configuredUrl = getEnvVariable("HEXCLAVE_GROWTH_EVE_URL");
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(configuredUrl);
+  } catch (error) {
+    throw new Error(`HEXCLAVE_GROWTH_EVE_URL must be a valid URL for the e2e Eve mock: ${JSON.stringify(configuredUrl)}`, { cause: error });
+  }
+  if (parsedUrl.protocol !== "http:" || parsedUrl.hostname !== MOCK_EVE_HOST || parsedUrl.port === "" || parsedUrl.pathname !== "/" || parsedUrl.search !== "" || parsedUrl.hash !== "") {
+    throw new Error(
+      `HEXCLAVE_GROWTH_EVE_URL must be an http URL on ${MOCK_EVE_HOST} with an explicit port and no path or query for the e2e Eve mock: ${JSON.stringify(configuredUrl)}`,
+    );
+  }
+  const port = Number(parsedUrl.port);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`HEXCLAVE_GROWTH_EVE_URL has an invalid port for the e2e Eve mock: ${JSON.stringify(configuredUrl)}`);
+  }
+  return port;
+}
+
+export const MOCK_EVE_PORT = getMockEvePort();
 
 // Module-level mutex: chains every withMockEve entry so two tests in the same worker never race
-// for the fixed port. (Across workers there is no such protection — hence the one-file rule above.)
+// for the shared port. (Across workers there is no such protection — hence the one-file rule above.)
 let mockEveMutex: Promise<void> = Promise.resolve();
 
 export async function withMockEve<T>(fn: (mock: MockEve) => Promise<T>): Promise<T> {
@@ -133,10 +158,9 @@ export async function withMockEve<T>(fn: (mock: MockEve) => Promise<T>): Promise
       server.on("error", (error: NodeJS.ErrnoException) => {
         if (error.code === "EADDRINUSE") {
           reject(new Error(
-            `mock Eve could not bind ${MOCK_EVE_HOST}:${MOCK_EVE_PORT} — the port is already taken. `
-            + `The port is fixed by HEXCLAVE_GROWTH_EVE_URL in apps/e2e/.env.development, so only ONE e2e file `
-            + `(growth-workflows.test.ts) may use withMockEve; if another file started using it, or a stray process `
-            + `holds the port, free it before running this suite.`,
+            `mock Eve could not bind ${MOCK_EVE_HOST}:${MOCK_EVE_PORT} — the single configured Eve port is already taken. `
+            + `Stop the real agent started by \`pnpm -C apps/growth-agent dev:agent\` (or any other Eve process) `
+            + `before running growth-workflows.test.ts; only one Eve owner can use HEXCLAVE_GROWTH_EVE_URL at a time.`,
           ));
         } else {
           reject(error);

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/mcp.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/mcp.test.ts
@@ -56,7 +56,7 @@ it("internal MCP endpoint should expose the Hexclave docs assistant tool", async
                   "type": "string",
                 },
                 "project": {
-                  "description": "The project the user is working on: its name and, when known, details such as its language, framework, purpose, and project type. Omit when unknown.",
+                  "description": "A plaintext description of the project the user is working on, including its name and, when known, details such as its language, framework, purpose, and project type. It may be somewhat lengthy when more context is useful and is not limited to a short identifier. This helps Hexclave return the correct documentation and answers. Omit when unknown.",
                   "minLength": 1,
                   "type": "string",
                 },
@@ -70,7 +70,7 @@ it("internal MCP endpoint should expose the Hexclave docs assistant tool", async
                   "type": "string",
                 },
                 "user": {
-                  "description": "Who is asking the question, such as the user's name and any other non-sensitive information that could help the Hexclave team identify and assist them. Omit when unknown.",
+                  "description": "A plaintext description of who is asking the question, such as the user's name, company, and any other information that could help the Hexclave team identify and assist them. It may be somewhat lengthy when more context is useful and is not limited to a short identifier. Omit when unknown.",
                   "minLength": 1,
                   "type": "string",
                 },

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/workflows-helpers.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/workflows-helpers.ts
@@ -95,7 +95,7 @@ export function startBackgroundWorkflowEngineTicks(expect: ExpectStatic): { stop
 
 export async function withBackgroundWorkflowEngineTicks<T>(expect: ExpectStatic, fn: () => Promise<T>): Promise<T> {
   const driver = startBackgroundWorkflowEngineTicks(expect);
-  const [callbackResult] = await Promise.allSettled([fn()]);
+  const [callbackResult] = await Promise.allSettled([Promise.resolve().then(fn)]);
   const [teardownResult] = await Promise.allSettled([driver.stop()]);
   if (callbackResult.status === "rejected") throw callbackResult.reason;
   if (teardownResult.status === "rejected") throw teardownResult.reason;

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/workflows-helpers.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/workflows-helpers.ts
@@ -13,15 +13,21 @@ export const CRON_AUTH = { "authorization": "Bearer mock_cron_secret" };
 const TICK_REQUEST_TIMEOUT_MS = 660_000;
 const TICK_DELAY_MS = 1_000;
 
+function isAbortError(error: unknown): boolean {
+  if (error instanceof Error && error.name === "AbortError") return true;
+  return error != null && typeof error === "object" && "code" in error && error.code === "ABORT_ERR";
+}
+
 export function randomSlug(prefix: string): string {
   return `${prefix}-${generateSecureRandomString(8).toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 8) || "x"}`;
 }
 
-export async function tickWorkflowEngine(expect: ExpectStatic): Promise<void> {
+export async function tickWorkflowEngine(expect: ExpectStatic, signal?: AbortSignal): Promise<void> {
   const url = new URL("/api/v1/internal/workflow-engine-step?only_one_step=true", STACK_BACKEND_BASE_URL);
   const status = await new Promise<number>((resolve, reject) => {
     const requestHandle = request(url, {
       method: "GET",
+      signal,
       headers: {
         ...CRON_AUTH,
         "x-stack-disable-artificial-development-delay": "yes",
@@ -44,11 +50,15 @@ export async function tickWorkflowEngine(expect: ExpectStatic): Promise<void> {
 export function startBackgroundWorkflowEngineTicks(expect: ExpectStatic): { stop: () => Promise<void> } {
   let stopped = false;
   let tickError: unknown = null;
+  const abortController = new AbortController();
   const loop = (async () => {
     while (!stopped) {
       try {
-        await tickWorkflowEngine(expect);
+        await tickWorkflowEngine(expect, abortController.signal);
       } catch (error) {
+        if (abortController.signal.aborted && isAbortError(error)) {
+          break;
+        }
         tickError = error;
         stopped = true;
         break;
@@ -60,6 +70,7 @@ export function startBackgroundWorkflowEngineTicks(expect: ExpectStatic): { stop
   return {
     async stop() {
       stopped = true;
+      abortController.abort();
       await loop;
       if (tickError != null) throw tickError;
     },
@@ -68,10 +79,22 @@ export function startBackgroundWorkflowEngineTicks(expect: ExpectStatic): { stop
 
 export async function withBackgroundWorkflowEngineTicks<T>(expect: ExpectStatic, fn: () => Promise<T>): Promise<T> {
   const driver = startBackgroundWorkflowEngineTicks(expect);
+  let fnFailed = false;
   try {
     return await fn();
+  } catch (error) {
+    fnFailed = true;
+    throw error;
   } finally {
-    await driver.stop();
+    if (fnFailed) {
+      try {
+        await driver.stop();
+      } catch {
+        // Preserve the test failure that caused teardown.
+      }
+    } else {
+      await driver.stop();
+    }
   }
 }
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/workflows-helpers.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/workflows-helpers.ts
@@ -1,5 +1,7 @@
 import { generateSecureRandomString } from "@hexclave/shared/dist/utils/crypto";
+import { request } from "node:http";
 import type { ExpectStatic } from "vitest";
+import { STACK_BACKEND_BASE_URL } from "../../../../../helpers";
 import { niceBackendFetch } from "../../../../backend-helpers";
 
 // Shared drivers for e2e suites that exercise the workflow engine. Extracted from
@@ -8,28 +10,79 @@ import { niceBackendFetch } from "../../../../backend-helpers";
 // to the originals; workflows.test.ts remains the canonical consumer.
 
 export const CRON_AUTH = { "authorization": "Bearer mock_cron_secret" };
+const TICK_REQUEST_TIMEOUT_MS = 660_000;
+const TICK_DELAY_MS = 1_000;
 
 export function randomSlug(prefix: string): string {
   return `${prefix}-${generateSecureRandomString(8).toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 8) || "x"}`;
 }
 
-export async function tickWorkflowEngine(expect: ExpectStatic) {
-  const response = await niceBackendFetch("/api/v1/internal/workflow-engine-step", {
-    method: "GET",
-    headers: CRON_AUTH,
-    query: { only_one_step: "true" },
+export async function tickWorkflowEngine(expect: ExpectStatic): Promise<void> {
+  const url = new URL("/api/v1/internal/workflow-engine-step?only_one_step=true", STACK_BACKEND_BASE_URL);
+  const status = await new Promise<number>((resolve, reject) => {
+    const requestHandle = request(url, {
+      method: "GET",
+      headers: {
+        ...CRON_AUTH,
+        "x-stack-disable-artificial-development-delay": "yes",
+        "x-stack-development-disable-extended-logging": "yes",
+      },
+    }, (response) => {
+      response.resume();
+      response.once("end", () => resolve(response.statusCode ?? 0));
+      response.once("error", reject);
+    });
+    requestHandle.once("error", reject);
+    requestHandle.setTimeout(TICK_REQUEST_TIMEOUT_MS, () => {
+      requestHandle.destroy(new Error(`Workflow engine tick exceeded ${TICK_REQUEST_TIMEOUT_MS}ms.`));
+    });
+    requestHandle.end();
   });
-  expect(response.status).toBe(200);
+  expect(status).toBe(200);
 }
 
-export async function pollWithTicks<T>(expect: ExpectStatic, check: () => Promise<T | null>, options: { timeoutMs?: number } = {}): Promise<T> {
+export function startBackgroundWorkflowEngineTicks(expect: ExpectStatic): { stop: () => Promise<void> } {
+  let stopped = false;
+  let tickError: unknown = null;
+  const loop = (async () => {
+    while (!stopped) {
+      try {
+        await tickWorkflowEngine(expect);
+      } catch (error) {
+        tickError = error;
+        stopped = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, TICK_DELAY_MS));
+    }
+  })();
+
+  return {
+    async stop() {
+      stopped = true;
+      await loop;
+      if (tickError != null) throw tickError;
+    },
+  };
+}
+
+export async function withBackgroundWorkflowEngineTicks<T>(expect: ExpectStatic, fn: () => Promise<T>): Promise<T> {
+  const driver = startBackgroundWorkflowEngineTicks(expect);
+  try {
+    return await fn();
+  } finally {
+    await driver.stop();
+  }
+}
+
+export async function pollWithTicks<T>(expect: ExpectStatic, check: () => Promise<T | null>, options: { timeoutMs?: number, driveTicks?: boolean } = {}): Promise<T> {
   const timeoutMs = options.timeoutMs ?? 90_000;
-  const deadline = Date.now() + timeoutMs;
+  const startedAt = performance.now();
   while (true) {
-    await tickWorkflowEngine(expect);
     const result = await check();
     if (result != null) return result;
-    if (Date.now() > deadline) throw new Error(`pollWithTicks: condition not met within ${timeoutMs}ms`);
+    if (performance.now() - startedAt > timeoutMs) throw new Error(`pollWithTicks: condition not met within ${timeoutMs}ms`);
+    if (options.driveTicks !== false) await tickWorkflowEngine(expect);
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 }

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/workflows-helpers.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/workflows-helpers.ts
@@ -18,6 +18,22 @@ function isAbortError(error: unknown): boolean {
   return error != null && typeof error === "object" && "code" in error && error.code === "ABORT_ERR";
 }
 
+async function waitBetweenWorkflowTicks(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return;
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, TICK_DELAY_MS);
+    const onAbort = () => {
+      clearTimeout(timeout);
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 export function randomSlug(prefix: string): string {
   return `${prefix}-${generateSecureRandomString(8).toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, 8) || "x"}`;
 }
@@ -63,7 +79,7 @@ export function startBackgroundWorkflowEngineTicks(expect: ExpectStatic): { stop
         stopped = true;
         break;
       }
-      await new Promise((resolve) => setTimeout(resolve, TICK_DELAY_MS));
+      await waitBetweenWorkflowTicks(abortController.signal);
     }
   })();
 
@@ -79,23 +95,11 @@ export function startBackgroundWorkflowEngineTicks(expect: ExpectStatic): { stop
 
 export async function withBackgroundWorkflowEngineTicks<T>(expect: ExpectStatic, fn: () => Promise<T>): Promise<T> {
   const driver = startBackgroundWorkflowEngineTicks(expect);
-  let fnFailed = false;
-  try {
-    return await fn();
-  } catch (error) {
-    fnFailed = true;
-    throw error;
-  } finally {
-    if (fnFailed) {
-      try {
-        await driver.stop();
-      } catch {
-        // Preserve the test failure that caused teardown.
-      }
-    } else {
-      await driver.stop();
-    }
-  }
+  const [callbackResult] = await Promise.allSettled([fn()]);
+  const [teardownResult] = await Promise.allSettled([driver.stop()]);
+  if (callbackResult.status === "rejected") throw callbackResult.reason;
+  if (teardownResult.status === "rejected") throw teardownResult.reason;
+  return callbackResult.value;
 }
 
 export async function pollWithTicks<T>(expect: ExpectStatic, check: () => Promise<T | null>, options: { timeoutMs?: number, driveTicks?: boolean } = {}): Promise<T> {

--- a/apps/growth-agent/README.md
+++ b/apps/growth-agent/README.md
@@ -25,8 +25,13 @@ The development script uses `dotenv-cli` like the other monorepo apps: it loads 
 ## Development
 
 ```sh
-pnpm dev  # eve dev on port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}49 (default 8149)
+pnpm dev:agent  # opt-in: eve dev on port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}49 (default 8149)
 ```
+
+The development stack does not start Eve automatically. There is one Eve endpoint in local
+development and e2e: the port configured by `HEXCLAVE_GROWTH_EVE_URL` (default `8149`). The
+growth agent owns that port when you run `pnpm dev:agent`; the growth e2e mock owns the same port
+while its suite is running, so stop the other process before switching owners.
 
 ## HTTP surface
 

--- a/apps/growth-agent/package.json
+++ b/apps/growth-agent/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "with-env": "dotenv -c --",
     "with-env:dev": "dotenv -c development --",
-    "dev": "dotenv -c development -- eve dev --no-ui --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}49",
+    "dev:agent": "dotenv -c development -- eve dev --no-ui --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}49",
     "build": "eve build",
     "start": "eve start",
     "test": "vitest",


### PR DESCRIPTION
Three fixes for `dev`'s red E2E/setup jobs.

**1. One Eve endpoint (`HEXCLAVE_GROWTH_EVE_URL`)**

The e2e mock Eve bound a hardcoded `127.0.0.1:32872`, while the backend under test is started by `pnpm dev` and dispatches to `apps/backend/.env.development`'s URL (port prefix+49) — so no growth dispatch ever reached the mock, and every mock-Eve assertion failed. Now both env files carry the same explicit-loopback URL, the mock derives its port from it (failing loudly if it's missing/unparseable), and the real agent no longer takes that port automatically: `apps/growth-agent`'s `dev` script became `dev:agent`, so whoever plays Eve owns the port explicitly.

**2. Engine ticks off the test's critical path**

`growth-analysis`'s `advance-<round>` step long-polls `analysis/wait` for up to 2×240s, and that poll only returns early when the run changes — which in this suite is the *test* posting agent phase results. The driver awaited each tick before doing that, so the suite blocked inside its own tick, blew its deadlines, and node's default ~300s header timeout then aborted steps mid-flight (piling up sandbox work). The growth suite now drives ticks from a background loop, `pollWithTicks` checks its predicate before spending a tick, and the tick request tolerates the engine's own 630s ceiling. No workflow timeout and no assertion changed.

**3. Stale inline snapshot**

`mcp.test.ts` still snapshotted the pre-2a6beb93a `ask_hexclave` `user`/`project` descriptions.


Link to Devin session: https://app.devin.ai/sessions/2a434b6124334d8e9e5072013849df47
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the growth Eve endpoint across dev and e2e, runs workflow ticks in the background, and moves Freestyle and cron calls to long‑lived Node HTTP(S) transports with a single absolute deadline. This makes growth e2e deterministic, enforces loop budgets, prevents overlapping ticks and 300s header timeouts, and updates a stale MCP snapshot.

- One Eve endpoint: both envs set HEXCLAVE_GROWTH_EVE_URL to http://127.0.0.1:${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}49; the mock derives/validates it. Start the real agent via `pnpm -C apps/growth-agent dev:agent` and stop it before growth e2e.
- Background engine ticks: tests use withBackgroundWorkflowEngineTicks; pollWithTicks checks its predicate before spending a tick and supports driveTicks: false. Tick requests use Node HTTP with a 660s timeout and disable dev delay/logging headers.
- Long‑lived transports with one deadline: add a Node HTTP transport that applies a single absolute deadline across request body read, request, and response phases. Freestyle uses a timeout of execution_timeout + 30s; cron ties per‑endpoint budgets to request timeouts (workflow engine: max_duration_ms=3m; transport = budget + engine backstop + 30s; others default to 5m). Adds tests for timeout calculation, body/headers handling, and slow/streaming/hung responses.
- Growth lifecycle and redispatch: auto‑skips the integrations phase (attempt 0); redispatch requires a 200 Eve ack and fences stale‑attempt echoes.
- MCP: updates the `ask_hexclave` snapshot for revised `user` and `project` descriptions.

<sup>Written for commit 1f1523eadd0c46c21727c538056160307a483f33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Local development supports a configurable loopback endpoint for the growth workflow service.
  - Growth Agent startup is opt-in via the dedicated `dev:agent` command.
  - End-to-end workflows can run with background engine processing.

- **Improvements**
  - Added clearer setup guidance for coordinating local services and ports.
  - Expanded MCP contextual description support.
  - Improved workflow shutdown handling, polling, retries, and error reporting.
  - Workflow integrations are automatically skipped when unavailable.
  - Improved Freestyle request handling with execution-aware timeouts and abort support.

- **Bug Fixes**
  - Improved validation and error messages for invalid local workflow endpoint configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->