### PR TITLE
Data Sources: sync a customer's Postgres into their warehouse

### DIFF
--- a/apps/backend/prisma/migrations/20260821000000_add_data_sources/migration.sql
+++ b/apps/backend/prisma/migrations/20260821000000_add_data_sources/migration.sql
@@ -1,0 +1,72 @@
+-- CreateEnum
+CREATE TYPE "DataSourceType" AS ENUM ('POSTGRES');
+
+-- CreateEnum
+CREATE TYPE "DataSourceStatus" AS ENUM ('PENDING', 'ACTIVE', 'PAUSED', 'FAILED');
+
+-- CreateEnum
+CREATE TYPE "DataSourceStreamMode" AS ENUM ('FULL_REFRESH', 'CURSOR', 'CDC');
+
+-- CreateEnum
+CREATE TYPE "DataSourceStreamStatus" AS ENUM ('PENDING', 'SNAPSHOTTING', 'ACTIVE', 'FAILED');
+
+-- CreateTable
+CREATE TABLE "DataSource" (
+    "id" UUID NOT NULL,
+    "tenancyId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "type" "DataSourceType" NOT NULL DEFAULT 'POSTGRES',
+    "host" TEXT NOT NULL,
+    "port" INTEGER NOT NULL,
+    "database" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "sslMode" TEXT NOT NULL DEFAULT 'require',
+    "encryptedPassword" JSONB NOT NULL,
+    "status" "DataSourceStatus" NOT NULL DEFAULT 'PENDING',
+    "error" TEXT,
+    "syncIntervalSeconds" INTEGER NOT NULL DEFAULT 300,
+    "capabilities" JSONB,
+    "replicationSlotName" TEXT,
+    "publicationName" TEXT,
+    "lastSyncStartedAt" TIMESTAMP(3),
+    "lastSyncFinishedAt" TIMESTAMP(3),
+
+    CONSTRAINT "DataSource_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DataSourceStream" (
+    "id" UUID NOT NULL,
+    "dataSourceId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "schemaName" TEXT NOT NULL,
+    "tableName" TEXT NOT NULL,
+    "mode" "DataSourceStreamMode" NOT NULL,
+    "cursorColumn" TEXT,
+    "primaryKeyColumns" TEXT[],
+    "destinationTable" TEXT NOT NULL,
+    "status" "DataSourceStreamStatus" NOT NULL DEFAULT 'PENDING',
+    "error" TEXT,
+    "syncCursor" JSONB,
+    "rowsSynced" BIGINT NOT NULL DEFAULT 0,
+    "lastSyncedAt" TIMESTAMP(3),
+
+    CONSTRAINT "DataSourceStream_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "DataSource_tenancyId_idx" ON "DataSource"("tenancyId");
+
+-- CreateIndex
+CREATE INDEX "DataSourceStream_dataSourceId_idx" ON "DataSourceStream"("dataSourceId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DataSourceStream_dataSourceId_schemaName_tableName_key" ON "DataSourceStream"("dataSourceId", "schemaName", "tableName");
+
+-- AddForeignKey
+ALTER TABLE "DataSource" ADD CONSTRAINT "DataSource_tenancyId_fkey" FOREIGN KEY ("tenancyId") REFERENCES "Tenancy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DataSourceStream" ADD CONSTRAINT "DataSourceStream_dataSourceId_fkey" FOREIGN KEY ("dataSourceId") REFERENCES "DataSource"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/migrations/20260821000000_add_data_sources/migration.sql
+++ b/apps/backend/prisma/migrations/20260821000000_add_data_sources/migration.sql
@@ -60,7 +60,7 @@ CREATE TABLE "DataSourceStream" (
 CREATE INDEX "DataSource_tenancyId_idx" ON "DataSource"("tenancyId");
 
 -- CreateIndex
-CREATE INDEX "DataSourceStream_dataSourceId_idx" ON "DataSourceStream"("dataSourceId");
+CREATE INDEX "DataSource_status_lastSyncFinishedAt_idx" ON "DataSource"("status", "lastSyncFinishedAt");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "DataSourceStream_dataSourceId_schemaName_tableName_key" ON "DataSourceStream"("dataSourceId", "schemaName", "tableName");

--- a/apps/backend/prisma/migrations/20260821000000_add_data_sources/migration.sql
+++ b/apps/backend/prisma/migrations/20260821000000_add_data_sources/migration.sql
@@ -5,7 +5,7 @@ CREATE TYPE "DataSourceType" AS ENUM ('POSTGRES');
 CREATE TYPE "DataSourceStatus" AS ENUM ('PENDING', 'ACTIVE', 'PAUSED', 'FAILED');
 
 -- CreateEnum
-CREATE TYPE "DataSourceStreamMode" AS ENUM ('FULL_REFRESH', 'CURSOR', 'CDC');
+CREATE TYPE "DataSourceStreamMode" AS ENUM ('CURSOR', 'CDC');
 
 -- CreateEnum
 CREATE TYPE "DataSourceStreamStatus" AS ENUM ('PENDING', 'SNAPSHOTTING', 'ACTIVE', 'FAILED');

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -857,6 +857,7 @@ model Tenancy {
   workflowEvents WorkflowEvent[]
   workflowScheduleCursors WorkflowScheduleCursor[]
   dataWarehouse       DataWarehouse?
+  dataSources         DataSource[]
 
   // Email capacity boost - when set and in the future, email capacity is multiplied by 4
   emailCapacityBoostExpiresAt DateTime?
@@ -2740,6 +2741,131 @@ model DataWarehouse {
   // { edkBase64, ciphertextBase64 } from encryptWithKms(), as in DataVaultEntry.
   encryptedPassword Json?
   passwordUpdatedAt DateTime?
+}
+
+// ─── Data Sources ───────────────────────────────────────────────────────────
+//
+// A customer-owned database we pull FROM, into the project's own warehouse
+// (see DataWarehouse above). The opposite direction from ExternalDbSync, which
+// pushes Hexclave's own tables out to a sink the customer owns.
+//
+// Postgres is the only source type today. The row is shaped so that adding one
+// later is a new `type` plus a new set of `config` keys, not a new table: the
+// per-stream cursor is deliberately an opaque JSON blob so that a REST source's
+// page token fits the same column as a Postgres LSN.
+
+enum DataSourceType {
+  POSTGRES
+}
+
+enum DataSourceStatus {
+  // Credentials verified and the catalog read, but no streams configured yet.
+  PENDING
+  ACTIVE
+  PAUSED
+  // Set when a sync fails in a way that is about the source as a whole
+  // (unreachable, credentials rejected) rather than one stream.
+  FAILED
+}
+
+model DataSource {
+  id String @id @default(uuid()) @db.Uuid
+
+  tenancyId String  @db.Uuid
+  tenancy   Tenancy @relation(fields: [tenancyId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  type DataSourceType @default(POSTGRES)
+
+  // Connection, split into fields rather than a single string: the dashboard
+  // collects them separately, and we never want to render a URL that contains
+  // the password back to the client.
+  host     String
+  port     Int
+  database String
+  username String
+  sslMode  String @default("require")
+
+  // { edkBase64, ciphertextBase64 } from encryptWithKms(), as for DataWarehouse.
+  encryptedPassword Json
+
+  status DataSourceStatus @default(PENDING)
+  error  String?
+
+  syncIntervalSeconds Int @default(300)
+
+  // Snapshot of the last capability probe (wal_level, replication grant, slot
+  // budget, server version). Re-read on every probe: a customer who enables
+  // logical replication later should be offered CDC without re-adding the source.
+  capabilities Json?
+
+  // Named after the source id, so two sources on the same server never collide.
+  replicationSlotName String?
+  publicationName     String?
+
+  lastSyncStartedAt  DateTime?
+  lastSyncFinishedAt DateTime?
+
+  streams DataSourceStream[]
+
+  @@index([tenancyId])
+}
+
+enum DataSourceStreamMode {
+  FULL_REFRESH
+  CURSOR
+  CDC
+}
+
+enum DataSourceStreamStatus {
+  // Configured, waiting for its first snapshot.
+  PENDING
+  SNAPSHOTTING
+  ACTIVE
+  FAILED
+}
+
+model DataSourceStream {
+  id String @id @default(uuid()) @db.Uuid
+
+  dataSourceId String     @db.Uuid
+  dataSource   DataSource @relation(fields: [dataSourceId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  schemaName String
+  tableName  String
+
+  mode DataSourceStreamMode
+
+  // Only set when mode is CURSOR. Chosen by the customer from the candidates the
+  // probe found, because only they know which column their writes actually bump.
+  cursorColumn String?
+
+  // From the source's primary key. Empty means the destination table cannot
+  // deduplicate, so it is written append-only.
+  primaryKeyColumns String[]
+
+  // The destination table in the project's warehouse database.
+  destinationTable String
+
+  status DataSourceStreamStatus @default(PENDING)
+  error  String?
+
+  // Opaque per-mode resume point: { mode: "cursor", value } for CURSOR,
+  // { mode: "lsn", value } for CDC, null for FULL_REFRESH. The engine never
+  // inspects the shape of another mode's cursor, which is what lets a future
+  // source type store a page token here unchanged.
+  syncCursor Json?
+
+  rowsSynced   BigInt    @default(0)
+  lastSyncedAt DateTime?
+
+  @@unique([dataSourceId, schemaName, tableName])
+  @@index([dataSourceId])
 }
 
 // ─── Workflows ──────────────────────────────────────────────────────────────

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2816,7 +2816,6 @@ model DataSource {
 }
 
 enum DataSourceStreamMode {
-  FULL_REFRESH
   CURSOR
   CDC
 }

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2811,6 +2811,8 @@ model DataSource {
   streams DataSourceStream[]
 
   @@index([tenancyId])
+  // The scheduler scans on exactly this predicate every minute.
+  @@index([status, lastSyncFinishedAt])
 }
 
 enum DataSourceStreamMode {
@@ -2865,7 +2867,6 @@ model DataSourceStream {
   lastSyncedAt DateTime?
 
   @@unique([dataSourceId, schemaName, tableName])
-  @@index([dataSourceId])
 }
 
 // ─── Workflows ──────────────────────────────────────────────────────────────

--- a/apps/backend/src/app/api/latest/data-sources/[data_source_id]/catalog/route.tsx
+++ b/apps/backend/src/app/api/latest/data-sources/[data_source_id]/catalog/route.tsx
@@ -1,0 +1,27 @@
+import { refreshDataSourceProbe } from "@/lib/data-sources";
+import { serializeCatalog } from "@/lib/data-sources/serialize";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { adaptSchema, adminAuthTypeSchema, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
+
+export const GET = createSmartRouteHandler({
+  metadata: {
+    summary: "Read a data source's catalog",
+    description: "Re-reads the source's tables and capabilities. Run on every visit to the table picker, so a customer who enables logical replication later is offered change data capture without reconnecting.",
+    tags: ["Data Warehouse"],
+    hidden: true,
+  },
+  request: yupObject({
+    auth: yupObject({ type: adminAuthTypeSchema, tenancy: adaptSchema.defined() }).defined(),
+    params: yupObject({ data_source_id: yupString().defined() }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({ catalog: yupMixed().defined() }).defined(),
+  }),
+  handler: async ({ auth, params }) => ({
+    statusCode: 200,
+    bodyType: "json",
+    body: { catalog: serializeCatalog(await refreshDataSourceProbe(auth.tenancy, params.data_source_id)) },
+  }),
+});

--- a/apps/backend/src/app/api/latest/data-sources/[data_source_id]/catalog/route.tsx
+++ b/apps/backend/src/app/api/latest/data-sources/[data_source_id]/catalog/route.tsx
@@ -3,6 +3,10 @@ import { serializeCatalog } from "@/lib/data-sources/serialize";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { adaptSchema, adminAuthTypeSchema, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
 
+// Connects out to the customer's database under a 120s statement timeout per
+// stream, so it needs more than the platform default.
+export const maxDuration = 300;
+
 export const GET = createSmartRouteHandler({
   metadata: {
     summary: "Read a data source's catalog",

--- a/apps/backend/src/app/api/latest/data-sources/[data_source_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/data-sources/[data_source_id]/route.tsx
@@ -1,0 +1,48 @@
+import { deleteDataSource, getDataSourceOrThrow } from "@/lib/data-sources";
+import { serializeDataSource } from "@/lib/data-sources/serialize";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { adaptSchema, adminAuthTypeSchema, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
+
+const paramsSchema = yupObject({
+  data_source_id: yupString().defined(),
+}).defined();
+
+export const GET = createSmartRouteHandler({
+  metadata: { summary: "Get data source", tags: ["Data Warehouse"], hidden: true },
+  request: yupObject({
+    auth: yupObject({ type: adminAuthTypeSchema, tenancy: adaptSchema.defined() }).defined(),
+    params: paramsSchema,
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({ data_source: yupMixed().defined() }).defined(),
+  }),
+  handler: async ({ auth, params }) => ({
+    statusCode: 200,
+    bodyType: "json",
+    body: { data_source: serializeDataSource(await getDataSourceOrThrow(auth.tenancy, params.data_source_id)) },
+  }),
+});
+
+export const DELETE = createSmartRouteHandler({
+  metadata: {
+    summary: "Disconnect a data source",
+    description: "Drops the replication slot on the source if one was created, and forgets the connection. Tables already synced into the warehouse are left in place.",
+    tags: ["Data Warehouse"],
+    hidden: true,
+  },
+  request: yupObject({
+    auth: yupObject({ type: adminAuthTypeSchema, tenancy: adaptSchema.defined() }).defined(),
+    method: yupString().oneOf(["DELETE"]).defined(),
+    params: paramsSchema,
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["success"]).defined(),
+  }),
+  handler: async ({ auth, params }) => {
+    await deleteDataSource(auth.tenancy, params.data_source_id);
+    return { statusCode: 200, bodyType: "success" };
+  },
+});

--- a/apps/backend/src/app/api/latest/data-sources/[data_source_id]/streams/route.tsx
+++ b/apps/backend/src/app/api/latest/data-sources/[data_source_id]/streams/route.tsx
@@ -1,0 +1,45 @@
+import { setDataSourceStreams } from "@/lib/data-sources";
+import { serializeDataSource } from "@/lib/data-sources/serialize";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { DATA_SOURCE_SYNC_MODES } from "@hexclave/shared/dist/data-sources/modes";
+import { adaptSchema, adminAuthTypeSchema, yupArray, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
+
+export const PUT = createSmartRouteHandler({
+  metadata: {
+    summary: "Configure which tables a data source syncs",
+    description: "Replaces the stream list wholesale. Modes are re-validated against a fresh probe, so a mode the picker offered but the source can no longer support is rejected rather than silently downgraded.",
+    tags: ["Data Warehouse"],
+    hidden: true,
+  },
+  request: yupObject({
+    auth: yupObject({ type: adminAuthTypeSchema, tenancy: adaptSchema.defined() }).defined(),
+    method: yupString().oneOf(["PUT"]).defined(),
+    params: yupObject({ data_source_id: yupString().defined() }).defined(),
+    body: yupObject({
+      streams: yupArray(yupObject({
+        schema_name: yupString().defined(),
+        table_name: yupString().defined(),
+        mode: yupString().oneOf([...DATA_SOURCE_SYNC_MODES]).defined(),
+        cursor_column: yupString().nullable().default(null),
+      }).defined()).defined(),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({ data_source: yupMixed().defined() }).defined(),
+  }),
+  handler: async ({ auth, params, body }) => {
+    const source = await setDataSourceStreams(
+      auth.tenancy,
+      params.data_source_id,
+      body.streams.map(stream => ({
+        schemaName: stream.schema_name,
+        tableName: stream.table_name,
+        mode: stream.mode,
+        cursorColumn: stream.cursor_column ?? null,
+      })),
+    );
+    return { statusCode: 200, bodyType: "json", body: { data_source: serializeDataSource(source) } };
+  },
+});

--- a/apps/backend/src/app/api/latest/data-sources/[data_source_id]/streams/route.tsx
+++ b/apps/backend/src/app/api/latest/data-sources/[data_source_id]/streams/route.tsx
@@ -4,6 +4,10 @@ import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { DATA_SOURCE_SYNC_MODES } from "@hexclave/shared/dist/data-sources/modes";
 import { adaptSchema, adminAuthTypeSchema, yupArray, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
 
+// Connects out to the customer's database under a 120s statement timeout per
+// stream, so it needs more than the platform default.
+export const maxDuration = 300;
+
 export const PUT = createSmartRouteHandler({
   metadata: {
     summary: "Configure which tables a data source syncs",

--- a/apps/backend/src/app/api/latest/data-sources/[data_source_id]/sync/route.tsx
+++ b/apps/backend/src/app/api/latest/data-sources/[data_source_id]/sync/route.tsx
@@ -3,6 +3,10 @@ import { serializeDataSource } from "@/lib/data-sources/serialize";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { adaptSchema, adminAuthTypeSchema, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
 
+// Connects out to the customer's database under a 120s statement timeout per
+// stream, so it needs more than the platform default.
+export const maxDuration = 300;
+
 export const POST = createSmartRouteHandler({
   metadata: {
     summary: "Sync a data source now",

--- a/apps/backend/src/app/api/latest/data-sources/[data_source_id]/sync/route.tsx
+++ b/apps/backend/src/app/api/latest/data-sources/[data_source_id]/sync/route.tsx
@@ -1,0 +1,28 @@
+import { syncDataSource } from "@/lib/data-sources";
+import { serializeDataSource } from "@/lib/data-sources/serialize";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { adaptSchema, adminAuthTypeSchema, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
+
+export const POST = createSmartRouteHandler({
+  metadata: {
+    summary: "Sync a data source now",
+    description: "Runs every configured stream once. One stream failing does not stop the others; each carries its own error.",
+    tags: ["Data Warehouse"],
+    hidden: true,
+  },
+  request: yupObject({
+    auth: yupObject({ type: adminAuthTypeSchema, tenancy: adaptSchema.defined() }).defined(),
+    method: yupString().oneOf(["POST"]).defined(),
+    params: yupObject({ data_source_id: yupString().defined() }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({ data_source: yupMixed().defined() }).defined(),
+  }),
+  handler: async ({ auth, params }) => ({
+    statusCode: 200,
+    bodyType: "json",
+    body: { data_source: serializeDataSource(await syncDataSource(auth.tenancy, params.data_source_id)) },
+  }),
+});

--- a/apps/backend/src/app/api/latest/data-sources/route.tsx
+++ b/apps/backend/src/app/api/latest/data-sources/route.tsx
@@ -4,6 +4,10 @@ import { DATA_SOURCE_SSL_MODES } from "@/lib/data-sources/postgres";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { adaptSchema, adminAuthTypeSchema, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
 
+// Connects out to the customer's database under a 120s statement timeout per
+// stream, so it needs more than the platform default.
+export const maxDuration = 300;
+
 export const GET = createSmartRouteHandler({
   metadata: {
     summary: "List data sources",

--- a/apps/backend/src/app/api/latest/data-sources/route.tsx
+++ b/apps/backend/src/app/api/latest/data-sources/route.tsx
@@ -1,0 +1,77 @@
+import { createDataSource, listDataSources } from "@/lib/data-sources";
+import { serializeCatalog, serializeDataSource } from "@/lib/data-sources/serialize";
+import { DATA_SOURCE_SSL_MODES } from "@/lib/data-sources/postgres";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { adaptSchema, adminAuthTypeSchema, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
+
+export const GET = createSmartRouteHandler({
+  metadata: {
+    summary: "List data sources",
+    description: "Returns every source configured for this project, with the streams each one syncs.",
+    tags: ["Data Warehouse"],
+    hidden: true,
+  },
+  request: yupObject({
+    auth: yupObject({
+      type: adminAuthTypeSchema,
+      tenancy: adaptSchema.defined(),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({ data_sources: yupMixed().defined() }).defined(),
+  }),
+  handler: async ({ auth }) => ({
+    statusCode: 200,
+    bodyType: "json",
+    body: { data_sources: (await listDataSources(auth.tenancy)).map(serializeDataSource) },
+  }),
+});
+
+export const POST = createSmartRouteHandler({
+  metadata: {
+    summary: "Connect a data source",
+    description: "Verifies the credentials, reads the source's catalog, and stores the connection. The password is encrypted before it is written and is never returned.",
+    tags: ["Data Warehouse"],
+    hidden: true,
+  },
+  request: yupObject({
+    auth: yupObject({
+      type: adminAuthTypeSchema,
+      tenancy: adaptSchema.defined(),
+    }).defined(),
+    method: yupString().oneOf(["POST"]).defined(),
+    body: yupObject({
+      host: yupString().defined(),
+      port: yupNumber().min(1).max(65535).defined(),
+      database: yupString().defined(),
+      username: yupString().defined(),
+      password: yupString().defined(),
+      ssl_mode: yupString().oneOf([...DATA_SOURCE_SSL_MODES]).default("require"),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({
+      data_source: yupMixed().defined(),
+      catalog: yupMixed().defined(),
+    }).defined(),
+  }),
+  handler: async ({ auth, body }) => {
+    const { source, probe } = await createDataSource(auth.tenancy, {
+      host: body.host,
+      port: body.port,
+      database: body.database,
+      username: body.username,
+      password: body.password,
+      sslMode: body.ssl_mode,
+    });
+    return {
+      statusCode: 200,
+      bodyType: "json",
+      body: { data_source: serializeDataSource(source), catalog: serializeCatalog(probe) },
+    };
+  },
+});

--- a/apps/backend/src/app/api/latest/internal/data-source-sync-step/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/data-source-sync-step/route.tsx
@@ -1,0 +1,55 @@
+import { runDueDataSourceSyncs } from "@/lib/data-sources";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { yupBoolean, yupNumber, yupObject, yupString, yupTuple } from "@hexclave/shared/dist/schema-fields";
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
+import { StatusError } from "@hexclave/shared/dist/utils/errors";
+
+export const dynamic = "force-dynamic";
+export const fetchCache = "force-no-store";
+// Snapshots of large tables are the slow case here, so this takes the full
+// function budget rather than the default.
+export const maxDuration = 300;
+
+const FUNCTION_BUDGET_MS = maxDuration * 1000;
+const FUNCTION_SHUTDOWN_SLACK_MS = 20 * 1000;
+const HARD_DEADLINE_MS = FUNCTION_BUDGET_MS - FUNCTION_SHUTDOWN_SLACK_MS;
+
+export const GET = createSmartRouteHandler({
+  metadata: {
+    summary: "Sync due data sources",
+    description: "Internal endpoint invoked by Vercel Cron. Syncs every data source whose interval has elapsed, until the queue drains or the function's time budget runs out.",
+    tags: ["Data Warehouse"],
+    hidden: true,
+  },
+  request: yupObject({
+    auth: yupObject({}).nullable().optional(),
+    method: yupString().oneOf(["GET"]).defined(),
+    headers: yupObject({
+      "authorization": yupTuple([yupString()]).defined(),
+    }).defined(),
+    query: yupObject({
+      max_duration_ms: yupString().optional(),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({ ok: yupBoolean().defined() }).defined(),
+  }),
+  handler: async ({ headers, query }) => {
+    if (headers.authorization[0] !== `Bearer ${getEnvVariable("CRON_SECRET")}`) {
+      throw new StatusError(401, "Unauthorized");
+    }
+    const requested = query.max_duration_ms != null ? Number(query.max_duration_ms) : HARD_DEADLINE_MS;
+    if (!Number.isFinite(requested) || requested < 0) {
+      throw new StatusError(400, "Invalid max_duration_ms");
+    }
+    const deadlineMs = Date.now() + Math.min(requested, HARD_DEADLINE_MS);
+
+    while (Date.now() < deadlineMs) {
+      const { didWork } = await runDueDataSourceSyncs({ deadlineMs });
+      if (!didWork) break;
+    }
+    return { statusCode: 200, bodyType: "json", body: { ok: true } };
+  },
+});

--- a/apps/backend/src/lib/data-sources.tsx
+++ b/apps/backend/src/lib/data-sources.tsx
@@ -1,9 +1,9 @@
-import { getClickhouseAdminClient } from "@/lib/clickhouse";
-import { ensureDataWarehouseEntitlement, getDataWarehouse, getDataWarehouseNames } from "@/lib/data-warehouse";
+import { createClickhouseWarehouseClient } from "@/lib/clickhouse";
+import { ensureDataWarehouseEntitlement, getDataWarehouse, getDataWarehouseNames, getDataWarehouseQueryAuth } from "@/lib/data-warehouse";
 import { getDestinationTableName } from "@/lib/data-sources/clickhouse-destination";
-import { DATA_SOURCE_SSL_MODES, type DataSourceCredentials } from "@/lib/data-sources/postgres";
+import { DATA_SOURCE_SSL_MODES, quotePgIdentifier, withDataSourceClient, type DataSourceCredentials } from "@/lib/data-sources/postgres";
 import { probeDataSource, type DataSourceProbeResult, type ProbedTable } from "@/lib/data-sources/probe";
-import { runStreamSyncs, type StreamSyncPlan } from "@/lib/data-sources/sync";
+import { runStreamSyncs, type StreamSyncPlan, type SyncCursorState } from "@/lib/data-sources/sync";
 import { getTenancy, type Tenancy } from "@/lib/tenancies";
 import { getPrismaClientForTenancy, globalPrismaClient, retryTransaction } from "@/prisma-client";
 import { Prisma, type DataSource, type DataSourceStream } from "@/generated/prisma/client";
@@ -20,6 +20,9 @@ const encryptedPasswordSchema = yupObject({
   edkBase64: yupString().defined(),
   ciphertextBase64: yupString().defined(),
 }).defined();
+
+/** How long a claimed sync may run before the scheduler assumes it died. */
+const SYNC_CLAIM_LEASE_SECONDS = 900;
 
 const MODE_TO_PRISMA = {
   full_refresh: "FULL_REFRESH",
@@ -137,23 +140,27 @@ export async function deleteDataSource(tenancy: Tenancy, dataSourceId: string): 
   const source = await getDataSourceOrThrow(tenancy, dataSourceId);
   const prisma = await getPrismaClientForTenancy(tenancy);
 
-  // Drop the replication slot before forgetting it exists. A slot nobody reads
+  // Drop the replication slot before forgetting it exists: a slot nobody reads
   // retains write-ahead log on the customer's server until their disk fills.
-  if (source.replicationSlotName != null) {
-    try {
-      const { withDataSourceClient } = await import("@/lib/data-sources/postgres");
-      const credentials = await getCredentials(source);
-      await withDataSourceClient(credentials, async client => {
-        await client.query(`SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)`, [source.replicationSlotName]);
-        if (source.publicationName != null) {
-          await client.query(`DROP PUBLICATION IF EXISTS ${JSON.stringify(source.publicationName).replace(/"/g, '"')}`).catch(() => {});
-        }
-      }, { allowWrites: true });
-    } catch (error) {
-      // The source may be unreachable, which must not make it undeletable. The
-      // slot is then the customer's to drop, and the error says so.
-      captureError("data-source-slot-cleanup", error);
-    }
+  //
+  // Attempted unconditionally rather than only when replicationSlotName is set,
+  // because that column is written after a sync completes — a sync that created
+  // the slot and then timed out leaves one behind with no record of it. The name
+  // is derived from the source id, so it is always recoverable.
+  const slotName = getReplicationSlotName(source.id);
+  try {
+    const credentials = await getCredentials(source);
+    await withDataSourceClient(credentials, async client => {
+      await client.query(
+        `SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)`,
+        [slotName],
+      );
+      await client.query(`DROP PUBLICATION IF EXISTS ${quotePgIdentifier(slotName)}`);
+    }, { allowWrites: true });
+  } catch (error) {
+    // The source may be unreachable, which must not make it undeletable. The slot
+    // is then the customer's to drop, and this records why we could not.
+    captureError("data-source-slot-cleanup", error);
   }
 
   // Destination tables are deliberately left in place: they are the customer's
@@ -162,8 +169,17 @@ export async function deleteDataSource(tenancy: Tenancy, dataSourceId: string): 
   await prisma.dataSource.delete({ where: { id: source.id } });
 }
 
+/** Deterministic so cleanup never depends on having recorded the name. */
+export function getReplicationSlotName(dataSourceId: string): string {
+  return `hexclave_${dataSourceId.replace(/-/g, "")}`;
+}
+
 /** Re-reads capabilities and catalog, and persists the capability snapshot. */
 export async function refreshDataSourceProbe(tenancy: Tenancy, dataSourceId: string): Promise<DataSourceProbeResult> {
+  // Gated like the other outbound paths: this opens a connection to the
+  // customer's database, so a project that has lost the entitlement must not
+  // keep being able to trigger it.
+  await ensureDataWarehouseEntitlement(tenancy);
   const source = await getDataSourceOrThrow(tenancy, dataSourceId);
   const credentials = await getCredentials(source);
   const probe = await probeDataSource(credentials);
@@ -201,6 +217,23 @@ export async function setDataSourceStreams(
 
   const tablesByName = new Map(probe.tables.map(t => [`${t.schemaName}.${t.tableName}`, t]));
   const existingByName = new Map(source.streams.map(s => [`${s.schemaName}.${s.tableName}`, s]));
+
+  // Two sources in one project can easily both have `public.users`, and both would
+  // otherwise map to the same destination table — where a full refresh's
+  // EXCHANGE TABLES would atomically replace the other source's data. Names stay
+  // clean for the first source to claim one and are suffixed after that.
+  const claimedByOtherSources = new Set(
+    (await prisma.dataSourceStream.findMany({
+      where: { dataSource: { tenancyId: tenancy.id }, NOT: { dataSourceId: source.id } },
+      select: { destinationTable: true },
+    })).map(row => row.destinationTable),
+  );
+  const resolveDestinationTable = (schemaName: string, tableName: string, existing: string | undefined) => {
+    if (existing != null) return existing;
+    const preferred = getDestinationTableName(schemaName, tableName);
+    if (!claimedByOtherSources.has(preferred)) return preferred;
+    return `${preferred}_${source.id.replace(/-/g, "").slice(0, 8)}`;
+  };
 
   for (const config of configs) {
     const key = `${config.schemaName}.${config.tableName}`;
@@ -243,7 +276,7 @@ export async function setDataSourceStreams(
         mode: MODE_TO_PRISMA[config.mode],
         cursorColumn,
         primaryKeyColumns: table.primaryKeyColumns,
-        destinationTable: getDestinationTableName(config.schemaName, config.tableName),
+        destinationTable: resolveDestinationTable(config.schemaName, config.tableName, existing?.destinationTable),
         ...(modeChanged || existing == null
           // Prisma distinguishes "set the column to JSON null" from "SQL NULL";
           // clearing a resume point means the latter.
@@ -268,6 +301,9 @@ export async function setDataSourceStreams(
 }
 
 export async function syncDataSource(tenancy: Tenancy, dataSourceId: string): Promise<DataSourceWithStreams> {
+  // Also covers the scheduler: a project that drops off the plan stops syncing
+  // rather than keeping an outbound connection on a one-minute cron forever.
+  await ensureDataWarehouseEntitlement(tenancy);
   const source = await getDataSourceOrThrow(tenancy, dataSourceId);
   if (source.streams.length === 0) return source;
 
@@ -276,17 +312,34 @@ export async function syncDataSource(tenancy: Tenancy, dataSourceId: string): Pr
   const credentials = await getCredentials(source);
   const startedAt = new Date();
 
-  await prisma.dataSource.update({ where: { id: source.id }, data: { lastSyncStartedAt: startedAt, error: null } });
+  // The same lease the scheduler takes, so a manual "Sync now" during a cron
+  // sweep is refused rather than running a second sync against the same source —
+  // which would have two runs sharing one staging table and one replication slot.
+  const claimed = await prisma.$executeRaw`
+    UPDATE "DataSource"
+    SET "lastSyncStartedAt" = ${startedAt}, "error" = NULL
+    WHERE "id" = ${source.id}::uuid
+      AND (
+        "lastSyncStartedAt" IS NULL
+        OR "lastSyncStartedAt" <= "lastSyncFinishedAt"
+        OR "lastSyncStartedAt" < NOW() - make_interval(secs => ${SYNC_CLAIM_LEASE_SECONDS})
+      )
+  `;
+  if (claimed === 0) {
+    throw new StatusError(StatusError.Conflict, "A sync is already running for this source.");
+  }
 
   let probe: DataSourceProbeResult;
   try {
     probe = await probeDataSource(credentials);
   } catch (error) {
     // A failure to connect is about the source, not any one stream.
+    // Recorded, but the source stays ACTIVE: the scheduler only picks up ACTIVE
+    // rows, so parking it on FAILED would make one DNS blip stop syncing forever.
     const message = error instanceof Error ? error.message : String(error);
     await prisma.dataSource.update({
       where: { id: source.id },
-      data: { status: "FAILED", error: message, lastSyncFinishedAt: new Date() },
+      data: { error: message, lastSyncFinishedAt: new Date() },
     });
     return await getDataSourceOrThrow(tenancy, dataSourceId);
   }
@@ -300,11 +353,19 @@ export async function syncDataSource(tenancy: Tenancy, dataSourceId: string): Pr
     cursorColumn: stream.cursorColumn,
     primaryKeyColumns: stream.primaryKeyColumns,
     destinationTable: stream.destinationTable,
-    syncCursor: stream.syncCursor as { mode: string, value: string } | null,
+    syncCursor: stream.syncCursor as SyncCursorState | null,
+    isPending: stream.status === "PENDING",
   }));
 
-  const slotName = `hexclave_${source.id.replace(/-/g, "")}`;
-  const clickhouse = getClickhouseAdminClient();
+  const slotName = getReplicationSlotName(source.id);
+  // Connects as the project's own warehouse user rather than the ClickHouse
+  // admin, so the tenancy boundary is enforced by ClickHouse privileges and the
+  // per-project quota — not by the correctness of an interpolated database name.
+  const warehouseAuth = await getDataWarehouseQueryAuth(tenancy);
+  if (warehouseAuth == null) {
+    throw new StatusError(StatusError.BadRequest, "This project's data warehouse is not ready.");
+  }
+  const clickhouse = createClickhouseWarehouseClient(warehouseAuth, databaseName);
   let results;
   try {
     results = await runStreamSyncs({
@@ -323,22 +384,29 @@ export async function syncDataSource(tenancy: Tenancy, dataSourceId: string): Pr
   const usesCdc = plans.some(plan => plan.mode === "cdc");
   await retryTransaction(prisma, async tx => {
     for (const result of results) {
+      // A truncated source table cannot be represented incrementally, so the
+      // stream goes back to PENDING and the next sync rebuilds it from scratch.
+      const resnapshot = result.needsResnapshot === true;
       await tx.dataSourceStream.update({
         where: { id: result.streamId },
         data: {
-          status: result.error == null ? "ACTIVE" : "FAILED",
+          status: result.error != null ? "FAILED" : resnapshot ? "PENDING" : "ACTIVE",
           error: result.error,
-          syncCursor: result.syncCursor ?? undefined,
+          syncCursor: resnapshot ? Prisma.DbNull : result.syncCursor ?? undefined,
           rowsSynced: { increment: BigInt(result.rowsSynced) },
           lastSyncedAt: result.error == null ? new Date() : undefined,
         },
       });
     }
+    const failed = results.filter(result => result.error != null);
     await tx.dataSource.update({
       where: { id: source.id },
       data: {
         lastSyncFinishedAt: new Date(),
         status: "ACTIVE",
+        // Surfaced at the source level only when nothing succeeded; a single bad
+        // table is already reported on its own stream.
+        error: failed.length === results.length ? failed[0]?.error ?? null : null,
         ...(usesCdc ? { replicationSlotName: slotName, publicationName: slotName } : {}),
       },
     });
@@ -356,37 +424,59 @@ export async function syncDataSource(tenancy: Tenancy, dataSourceId: string): Pr
  * starve the others by being picked repeatedly.
  */
 export async function runDueDataSourceSyncs(options: { deadlineMs: number }): Promise<{ didWork: boolean }> {
+  // Claims in the same statement that selects. The cron fires every minute while
+  // a sweep may run for minutes, so without a claim every overlapping invocation
+  // would pick the same rows and sync one source several times at once —
+  // concurrent slot reads, duplicate inserts, and a full refresh whose staging
+  // table is dropped underneath it.
   const due = await globalPrismaClient.$queryRaw<{ id: string, tenancyId: string }[]>`
-    SELECT "id", "tenancyId"
-    FROM "DataSource"
-    WHERE "status" = 'ACTIVE'
-      AND EXISTS (SELECT 1 FROM "DataSourceStream" s WHERE s."dataSourceId" = "DataSource"."id")
-      AND (
-        "lastSyncFinishedAt" IS NULL
-        OR "lastSyncFinishedAt" < NOW() - make_interval(secs => "syncIntervalSeconds")
-      )
-    ORDER BY "lastSyncFinishedAt" ASC NULLS FIRST
-    LIMIT 20
+    UPDATE "DataSource"
+    SET "lastSyncStartedAt" = NOW()
+    WHERE "id" IN (
+      SELECT "id" FROM "DataSource"
+      WHERE "status" = 'ACTIVE'
+        AND EXISTS (SELECT 1 FROM "DataSourceStream" s WHERE s."dataSourceId" = "DataSource"."id")
+        AND (
+          "lastSyncFinishedAt" IS NULL
+          OR "lastSyncFinishedAt" < NOW() - make_interval(secs => "syncIntervalSeconds")
+        )
+        -- The lease: a claim older than this belonged to an invocation that died,
+        -- so the row becomes eligible again rather than being stuck forever.
+        AND (
+          "lastSyncStartedAt" IS NULL
+          OR "lastSyncStartedAt" <= "lastSyncFinishedAt"
+          OR "lastSyncStartedAt" < NOW() - make_interval(secs => ${SYNC_CLAIM_LEASE_SECONDS})
+        )
+      ORDER BY "lastSyncFinishedAt" ASC NULLS FIRST
+      LIMIT 20
+      FOR UPDATE SKIP LOCKED
+    )
+    RETURNING "id", "tenancyId"
   `;
   if (due.length === 0) return { didWork: false };
 
+  let didWork = false;
   for (const row of due) {
     if (Date.now() >= options.deadlineMs) break;
     try {
       const tenancy = await getTenancy(row.tenancyId);
       if (tenancy == null) continue;
       await syncDataSource(tenancy, row.id);
+      didWork = true;
     } catch (error) {
       // A source that cannot sync must not stop the sweep, and the failure is
       // already recorded on the row for the dashboard to show.
       captureError("data-source-scheduled-sync", error);
+      // lastSyncFinishedAt is set so the interval applies to the retry too; the
+      // status stays ACTIVE so a transient failure does not park the source.
       await globalPrismaClient.dataSource.update({
         where: { id: row.id },
-        data: { lastSyncFinishedAt: new Date(), status: "FAILED", error: error instanceof Error ? error.message : String(error) },
+        data: { lastSyncFinishedAt: new Date(), error: error instanceof Error ? error.message : String(error) },
       }).catch(() => {
         // The row may have been deleted mid-sweep.
       });
+      didWork = true;
     }
   }
-  return { didWork: true };
+  return { didWork };
 }

--- a/apps/backend/src/lib/data-sources.tsx
+++ b/apps/backend/src/lib/data-sources.tsx
@@ -1,0 +1,392 @@
+import { getClickhouseAdminClient } from "@/lib/clickhouse";
+import { ensureDataWarehouseEntitlement, getDataWarehouse, getDataWarehouseNames } from "@/lib/data-warehouse";
+import { getDestinationTableName } from "@/lib/data-sources/clickhouse-destination";
+import { DATA_SOURCE_SSL_MODES, type DataSourceCredentials } from "@/lib/data-sources/postgres";
+import { probeDataSource, type DataSourceProbeResult, type ProbedTable } from "@/lib/data-sources/probe";
+import { runStreamSyncs, type StreamSyncPlan } from "@/lib/data-sources/sync";
+import { getTenancy, type Tenancy } from "@/lib/tenancies";
+import { getPrismaClientForTenancy, globalPrismaClient, retryTransaction } from "@/prisma-client";
+import { Prisma, type DataSource, type DataSourceStream } from "@/generated/prisma/client";
+import {
+  getDefaultCursorColumn,
+  getModeAvailability,
+  type DataSourceSyncMode,
+} from "@hexclave/shared/dist/data-sources/modes";
+import { decryptWithKms, encryptWithKms } from "@hexclave/shared/dist/helpers/vault/server-side";
+import { yupObject, yupString, yupValidate } from "@hexclave/shared/dist/schema-fields";
+import { StatusError, captureError } from "@hexclave/shared/dist/utils/errors";
+
+const encryptedPasswordSchema = yupObject({
+  edkBase64: yupString().defined(),
+  ciphertextBase64: yupString().defined(),
+}).defined();
+
+const MODE_TO_PRISMA = {
+  full_refresh: "FULL_REFRESH",
+  cursor: "CURSOR",
+  cdc: "CDC",
+} as const;
+const MODE_FROM_PRISMA = {
+  FULL_REFRESH: "full_refresh",
+  CURSOR: "cursor",
+  CDC: "cdc",
+} as const;
+
+export type DataSourceWithStreams = DataSource & { streams: DataSourceStream[] };
+
+async function decryptPassword(encrypted: DataSource["encryptedPassword"]): Promise<string> {
+  const envelope = await yupValidate(encryptedPasswordSchema, encrypted);
+  return await decryptWithKms(envelope);
+}
+
+export async function getCredentials(source: DataSource): Promise<DataSourceCredentials> {
+  return {
+    host: source.host,
+    port: source.port,
+    database: source.database,
+    username: source.username,
+    password: await decryptPassword(source.encryptedPassword),
+    sslMode: source.sslMode,
+  };
+}
+
+/**
+ * Sources write into the project's own warehouse database, so there has to be
+ * one. Failing here rather than at sync time keeps the customer from configuring
+ * streams that could never have run.
+ */
+async function getWarehouseDatabaseName(tenancy: Tenancy): Promise<string> {
+  const warehouse = await getDataWarehouse(tenancy);
+  if (warehouse == null || warehouse.status !== "READY") {
+    throw new StatusError(
+      StatusError.BadRequest,
+      "This project does not have a data warehouse yet. Provision one before connecting a source.",
+    );
+  }
+  return warehouse.databaseName || getDataWarehouseNames(tenancy.project.id).databaseName;
+}
+
+export async function listDataSources(tenancy: Tenancy): Promise<DataSourceWithStreams[]> {
+  const prisma = await getPrismaClientForTenancy(tenancy);
+  return await prisma.dataSource.findMany({
+    where: { tenancyId: tenancy.id },
+    include: { streams: { orderBy: [{ schemaName: "asc" }, { tableName: "asc" }] } },
+    orderBy: { createdAt: "asc" },
+  });
+}
+
+export async function getDataSourceOrThrow(tenancy: Tenancy, dataSourceId: string): Promise<DataSourceWithStreams> {
+  const prisma = await getPrismaClientForTenancy(tenancy);
+  const source = await prisma.dataSource.findFirst({
+    where: { id: dataSourceId, tenancyId: tenancy.id },
+    include: { streams: { orderBy: [{ schemaName: "asc" }, { tableName: "asc" }] } },
+  });
+  if (source == null) throw new StatusError(StatusError.NotFound, "No such data source.");
+  return source;
+}
+
+export type CreateDataSourceInput = {
+  host: string,
+  port: number,
+  database: string,
+  username: string,
+  password: string,
+  sslMode: string,
+};
+
+function assertValidSslMode(sslMode: string): void {
+  if (!(DATA_SOURCE_SSL_MODES as readonly string[]).includes(sslMode)) {
+    throw new StatusError(StatusError.BadRequest, `Unsupported SSL mode: ${sslMode}`);
+  }
+}
+
+/**
+ * Probes first, and only stores the source if the probe succeeded. A source row
+ * that has never once connected is worse than no row: it shows up in the list
+ * looking configured.
+ */
+export async function createDataSource(
+  tenancy: Tenancy,
+  input: CreateDataSourceInput,
+): Promise<{ source: DataSourceWithStreams, probe: DataSourceProbeResult }> {
+  await ensureDataWarehouseEntitlement(tenancy);
+  await getWarehouseDatabaseName(tenancy);
+  assertValidSslMode(input.sslMode);
+
+  const probe = await probeDataSource({ ...input, sslMode: input.sslMode });
+  const encryptedPassword = await encryptWithKms(input.password);
+  const prisma = await getPrismaClientForTenancy(tenancy);
+  const source = await prisma.dataSource.create({
+    data: {
+      tenancyId: tenancy.id,
+      host: input.host,
+      port: input.port,
+      database: input.database,
+      username: input.username,
+      sslMode: input.sslMode,
+      encryptedPassword,
+      capabilities: probe.capabilities,
+      status: "PENDING",
+    },
+    include: { streams: true },
+  });
+  return { source, probe };
+}
+
+export async function deleteDataSource(tenancy: Tenancy, dataSourceId: string): Promise<void> {
+  const source = await getDataSourceOrThrow(tenancy, dataSourceId);
+  const prisma = await getPrismaClientForTenancy(tenancy);
+
+  // Drop the replication slot before forgetting it exists. A slot nobody reads
+  // retains write-ahead log on the customer's server until their disk fills.
+  if (source.replicationSlotName != null) {
+    try {
+      const { withDataSourceClient } = await import("@/lib/data-sources/postgres");
+      const credentials = await getCredentials(source);
+      await withDataSourceClient(credentials, async client => {
+        await client.query(`SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)`, [source.replicationSlotName]);
+        if (source.publicationName != null) {
+          await client.query(`DROP PUBLICATION IF EXISTS ${JSON.stringify(source.publicationName).replace(/"/g, '"')}`).catch(() => {});
+        }
+      }, { allowWrites: true });
+    } catch (error) {
+      // The source may be unreachable, which must not make it undeletable. The
+      // slot is then the customer's to drop, and the error says so.
+      captureError("data-source-slot-cleanup", error);
+    }
+  }
+
+  // Destination tables are deliberately left in place: they are the customer's
+  // data, in the customer's warehouse, and dropping them on a disconnect would
+  // be a surprising amount of destruction for one click.
+  await prisma.dataSource.delete({ where: { id: source.id } });
+}
+
+/** Re-reads capabilities and catalog, and persists the capability snapshot. */
+export async function refreshDataSourceProbe(tenancy: Tenancy, dataSourceId: string): Promise<DataSourceProbeResult> {
+  const source = await getDataSourceOrThrow(tenancy, dataSourceId);
+  const credentials = await getCredentials(source);
+  const probe = await probeDataSource(credentials);
+  const prisma = await getPrismaClientForTenancy(tenancy);
+  await prisma.dataSource.update({
+    where: { id: source.id },
+    data: { capabilities: probe.capabilities },
+  });
+  return probe;
+}
+
+export type StreamConfigInput = {
+  schemaName: string,
+  tableName: string,
+  mode: DataSourceSyncMode,
+  cursorColumn: string | null,
+};
+
+/**
+ * Replaces the stream configuration wholesale. Modes are re-validated against a
+ * fresh probe rather than trusted from the client: the dashboard's view of what
+ * is available can be minutes old, and CDC on a table that lost its primary key
+ * would silently produce an append-only mess.
+ */
+export async function setDataSourceStreams(
+  tenancy: Tenancy,
+  dataSourceId: string,
+  configs: StreamConfigInput[],
+): Promise<DataSourceWithStreams> {
+  await ensureDataWarehouseEntitlement(tenancy);
+  const source = await getDataSourceOrThrow(tenancy, dataSourceId);
+  const credentials = await getCredentials(source);
+  const probe = await probeDataSource(credentials);
+  const prisma = await getPrismaClientForTenancy(tenancy);
+
+  const tablesByName = new Map(probe.tables.map(t => [`${t.schemaName}.${t.tableName}`, t]));
+  const existingByName = new Map(source.streams.map(s => [`${s.schemaName}.${s.tableName}`, s]));
+
+  for (const config of configs) {
+    const key = `${config.schemaName}.${config.tableName}`;
+    const table = tablesByName.get(key);
+    if (table == null) {
+      throw new StatusError(StatusError.BadRequest, `The source has no readable table ${key}.`);
+    }
+    const availability = getModeAvailability(table, probe.capabilities)[config.mode];
+    if (!availability.available) {
+      throw new StatusError(StatusError.BadRequest, `${config.mode} is not available for ${key}: ${availability.reason}.`);
+    }
+    if (config.mode === "cursor") {
+      const cursorColumn = config.cursorColumn ?? getDefaultCursorColumn(table);
+      if (cursorColumn == null || !table.cursorCandidates.some(c => c.column === cursorColumn)) {
+        throw new StatusError(StatusError.BadRequest, `${cursorColumn ?? "No column"} cannot be used as a cursor for ${key}.`);
+      }
+    }
+  }
+
+  const keep = new Set(configs.map(c => `${c.schemaName}.${c.tableName}`));
+  await retryTransaction(prisma, async tx => {
+    for (const stream of source.streams) {
+      if (!keep.has(`${stream.schemaName}.${stream.tableName}`)) {
+        await tx.dataSourceStream.delete({ where: { id: stream.id } });
+      }
+    }
+    for (const config of configs) {
+      const key = `${config.schemaName}.${config.tableName}`;
+      const table = tablesByName.get(key)!;
+      const existing = existingByName.get(key);
+      const cursorColumn = config.mode === "cursor"
+        ? (config.cursorColumn ?? getDefaultCursorColumn(table))
+        : null;
+      // Any change of mode or cursor invalidates the resume point: the new mode
+      // cannot interpret the old one's cursor, and reusing it would skip rows.
+      const modeChanged = existing != null && (
+        MODE_FROM_PRISMA[existing.mode] !== config.mode || existing.cursorColumn !== cursorColumn
+      );
+      const data = {
+        mode: MODE_TO_PRISMA[config.mode],
+        cursorColumn,
+        primaryKeyColumns: table.primaryKeyColumns,
+        destinationTable: getDestinationTableName(config.schemaName, config.tableName),
+        ...(modeChanged || existing == null
+          // Prisma distinguishes "set the column to JSON null" from "SQL NULL";
+          // clearing a resume point means the latter.
+          ? { syncCursor: Prisma.DbNull, status: "PENDING" as const, error: null, rowsSynced: 0n }
+          : {}),
+      };
+      if (existing == null) {
+        await tx.dataSourceStream.create({
+          data: { dataSourceId: source.id, schemaName: config.schemaName, tableName: config.tableName, ...data },
+        });
+      } else {
+        await tx.dataSourceStream.update({ where: { id: existing.id }, data });
+      }
+    }
+    await tx.dataSource.update({
+      where: { id: source.id },
+      data: { status: configs.length > 0 ? "ACTIVE" : "PENDING", capabilities: probe.capabilities },
+    });
+  });
+
+  return await getDataSourceOrThrow(tenancy, dataSourceId);
+}
+
+export async function syncDataSource(tenancy: Tenancy, dataSourceId: string): Promise<DataSourceWithStreams> {
+  const source = await getDataSourceOrThrow(tenancy, dataSourceId);
+  if (source.streams.length === 0) return source;
+
+  const prisma = await getPrismaClientForTenancy(tenancy);
+  const databaseName = await getWarehouseDatabaseName(tenancy);
+  const credentials = await getCredentials(source);
+  const startedAt = new Date();
+
+  await prisma.dataSource.update({ where: { id: source.id }, data: { lastSyncStartedAt: startedAt, error: null } });
+
+  let probe: DataSourceProbeResult;
+  try {
+    probe = await probeDataSource(credentials);
+  } catch (error) {
+    // A failure to connect is about the source, not any one stream.
+    const message = error instanceof Error ? error.message : String(error);
+    await prisma.dataSource.update({
+      where: { id: source.id },
+      data: { status: "FAILED", error: message, lastSyncFinishedAt: new Date() },
+    });
+    return await getDataSourceOrThrow(tenancy, dataSourceId);
+  }
+
+  const tablesByName = new Map<string, ProbedTable>(probe.tables.map(t => [`${t.schemaName}.${t.tableName}`, t]));
+  const plans: StreamSyncPlan[] = source.streams.map(stream => ({
+    streamId: stream.id,
+    schemaName: stream.schemaName,
+    tableName: stream.tableName,
+    mode: MODE_FROM_PRISMA[stream.mode],
+    cursorColumn: stream.cursorColumn,
+    primaryKeyColumns: stream.primaryKeyColumns,
+    destinationTable: stream.destinationTable,
+    syncCursor: stream.syncCursor as { mode: string, value: string } | null,
+  }));
+
+  const slotName = `hexclave_${source.id.replace(/-/g, "")}`;
+  const clickhouse = getClickhouseAdminClient();
+  let results;
+  try {
+    results = await runStreamSyncs({
+      credentials,
+      clickhouse,
+      databaseName,
+      tablesByName,
+      slotName,
+      publicationName: slotName,
+      startedAt,
+    }, plans);
+  } finally {
+    await clickhouse.close();
+  }
+
+  const usesCdc = plans.some(plan => plan.mode === "cdc");
+  await retryTransaction(prisma, async tx => {
+    for (const result of results) {
+      await tx.dataSourceStream.update({
+        where: { id: result.streamId },
+        data: {
+          status: result.error == null ? "ACTIVE" : "FAILED",
+          error: result.error,
+          syncCursor: result.syncCursor ?? undefined,
+          rowsSynced: { increment: BigInt(result.rowsSynced) },
+          lastSyncedAt: result.error == null ? new Date() : undefined,
+        },
+      });
+    }
+    await tx.dataSource.update({
+      where: { id: source.id },
+      data: {
+        lastSyncFinishedAt: new Date(),
+        status: "ACTIVE",
+        ...(usesCdc ? { replicationSlotName: slotName, publicationName: slotName } : {}),
+      },
+    });
+  });
+
+  return await getDataSourceOrThrow(tenancy, dataSourceId);
+}
+
+/**
+ * One pass of the scheduler: syncs every source whose interval has elapsed.
+ * Returns whether it did anything, so the cron route can keep going until the
+ * queue is empty or its time budget runs out.
+ *
+ * Sources are taken oldest-sync-first so that one source erroring quickly cannot
+ * starve the others by being picked repeatedly.
+ */
+export async function runDueDataSourceSyncs(options: { deadlineMs: number }): Promise<{ didWork: boolean }> {
+  const due = await globalPrismaClient.$queryRaw<{ id: string, tenancyId: string }[]>`
+    SELECT "id", "tenancyId"
+    FROM "DataSource"
+    WHERE "status" = 'ACTIVE'
+      AND EXISTS (SELECT 1 FROM "DataSourceStream" s WHERE s."dataSourceId" = "DataSource"."id")
+      AND (
+        "lastSyncFinishedAt" IS NULL
+        OR "lastSyncFinishedAt" < NOW() - make_interval(secs => "syncIntervalSeconds")
+      )
+    ORDER BY "lastSyncFinishedAt" ASC NULLS FIRST
+    LIMIT 20
+  `;
+  if (due.length === 0) return { didWork: false };
+
+  for (const row of due) {
+    if (Date.now() >= options.deadlineMs) break;
+    try {
+      const tenancy = await getTenancy(row.tenancyId);
+      if (tenancy == null) continue;
+      await syncDataSource(tenancy, row.id);
+    } catch (error) {
+      // A source that cannot sync must not stop the sweep, and the failure is
+      // already recorded on the row for the dashboard to show.
+      captureError("data-source-scheduled-sync", error);
+      await globalPrismaClient.dataSource.update({
+        where: { id: row.id },
+        data: { lastSyncFinishedAt: new Date(), status: "FAILED", error: error instanceof Error ? error.message : String(error) },
+      }).catch(() => {
+        // The row may have been deleted mid-sweep.
+      });
+    }
+  }
+  return { didWork: true };
+}

--- a/apps/backend/src/lib/data-sources.tsx
+++ b/apps/backend/src/lib/data-sources.tsx
@@ -25,12 +25,10 @@ const encryptedPasswordSchema = yupObject({
 const SYNC_CLAIM_LEASE_SECONDS = 900;
 
 const MODE_TO_PRISMA = {
-  full_refresh: "FULL_REFRESH",
   cursor: "CURSOR",
   cdc: "CDC",
 } as const;
 const MODE_FROM_PRISMA = {
-  FULL_REFRESH: "full_refresh",
   CURSOR: "cursor",
   CDC: "cdc",
 } as const;

--- a/apps/backend/src/lib/data-sources.tsx
+++ b/apps/backend/src/lib/data-sources.tsx
@@ -245,25 +245,24 @@ export async function setDataSourceStreams(
     }
   }
 
-  // Removing the final CDC stream destroys infrastructure used by an in-flight
-  // sync, so take the same lease as a sync before touching either side. Teardown
-  // happens before the local transaction: if that transaction fails, the still-
-  // configured CDC stream will detect the missing slot and resnapshot next time.
-  const configurationClaimStartedAt = removesLastCdcStream ? new Date() : null;
-  if (configurationClaimStartedAt != null) {
-    const claimed = await prisma.$executeRaw`
-      UPDATE "DataSource"
-      SET "lastSyncStartedAt" = ${configurationClaimStartedAt}
-      WHERE "id" = ${source.id}::uuid
-        AND (
-          "lastSyncStartedAt" IS NULL
-          OR "lastSyncStartedAt" <= "lastSyncFinishedAt"
-          OR "lastSyncStartedAt" < NOW() - make_interval(secs => ${SYNC_CLAIM_LEASE_SECONDS})
-        )
-    `;
-    if (claimed === 0) {
-      throw new StatusError(StatusError.Conflict, "Wait for the running sync to finish before removing the last CDC stream.");
-    }
+  // Every stream change takes the sync lease. Otherwise a worker using the old
+  // configuration can finish after this transaction and overwrite its PENDING
+  // rebuild marker, old cursor, or even a newly selected mode. If the worker's
+  // lease has expired, this claim also changes its fence token so its completion
+  // transaction rolls back instead of publishing stale stream state.
+  const configurationClaimStartedAt = new Date();
+  const claimed = await prisma.$executeRaw`
+    UPDATE "DataSource"
+    SET "lastSyncStartedAt" = ${configurationClaimStartedAt}
+    WHERE "id" = ${source.id}::uuid
+      AND (
+        "lastSyncStartedAt" IS NULL
+        OR "lastSyncStartedAt" <= "lastSyncFinishedAt"
+        OR "lastSyncStartedAt" < NOW() - make_interval(secs => ${SYNC_CLAIM_LEASE_SECONDS})
+      )
+  `;
+  if (claimed === 0) {
+    throw new StatusError(StatusError.Conflict, "Wait for the running sync to finish before changing the stream configuration.");
   }
 
   try {
@@ -322,14 +321,16 @@ export async function setDataSourceStreams(
       });
     });
   } finally {
-    if (configurationClaimStartedAt != null) {
-      // Never restore the previous start token: a worker whose old lease expired
-      // could otherwise finish later and regain permission to overwrite state.
-      await prisma.dataSource.updateMany({
-        where: { id: source.id, lastSyncStartedAt: configurationClaimStartedAt },
-        data: { lastSyncStartedAt: source.lastSyncFinishedAt },
-      });
-    }
+    // Never restore the previous start token: a worker whose old lease expired
+    // could otherwise finish later and regain permission to overwrite state.
+    // Referencing the current finish column also avoids regressing this marker if
+    // a sync completed while the fresh capability probe above was still running.
+    await prisma.$executeRaw`
+      UPDATE "DataSource"
+      SET "lastSyncStartedAt" = "lastSyncFinishedAt"
+      WHERE "id" = ${source.id}::uuid
+        AND "lastSyncStartedAt" = ${configurationClaimStartedAt}
+    `;
   }
 
   return await getDataSourceOrThrow(tenancy, dataSourceId);

--- a/apps/backend/src/lib/data-sources.tsx
+++ b/apps/backend/src/lib/data-sources.tsx
@@ -134,6 +134,23 @@ export async function createDataSource(
   return { source, probe };
 }
 
+/**
+ * A logical slot that nobody consumes retains WAL on the source database. Keep
+ * teardown in one idempotent path so configuration changes and source deletion
+ * cannot accidentally disagree about which objects Hexclave owns.
+ */
+async function dropCdcInfrastructure(source: DataSource): Promise<void> {
+  const credentials = await getCredentials(source);
+  const slotName = getReplicationSlotName(source.id);
+  await withDataSourceClient(credentials, async client => {
+    await client.query(
+      `SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)`,
+      [slotName],
+    );
+    await client.query(`DROP PUBLICATION IF EXISTS ${quotePgIdentifier(slotName)}`);
+  }, { allowWrites: true });
+}
+
 export async function deleteDataSource(tenancy: Tenancy, dataSourceId: string): Promise<void> {
   const source = await getDataSourceOrThrow(tenancy, dataSourceId);
   const prisma = await getPrismaClientForTenancy(tenancy);
@@ -145,16 +162,8 @@ export async function deleteDataSource(tenancy: Tenancy, dataSourceId: string): 
   // because that column is written after a sync completes — a sync that created
   // the slot and then timed out leaves one behind with no record of it. The name
   // is derived from the source id, so it is always recoverable.
-  const slotName = getReplicationSlotName(source.id);
   try {
-    const credentials = await getCredentials(source);
-    await withDataSourceClient(credentials, async client => {
-      await client.query(
-        `SELECT pg_drop_replication_slot($1) WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1)`,
-        [slotName],
-      );
-      await client.query(`DROP PUBLICATION IF EXISTS ${quotePgIdentifier(slotName)}`);
-    }, { allowWrites: true });
+    await dropCdcInfrastructure(source);
   } catch (error) {
     // The source may be unreachable, which must not make it undeletable. The slot
     // is then the customer's to drop, and this records why we could not.
@@ -215,23 +224,8 @@ export async function setDataSourceStreams(
 
   const tablesByName = new Map(probe.tables.map(t => [`${t.schemaName}.${t.tableName}`, t]));
   const existingByName = new Map(source.streams.map(s => [`${s.schemaName}.${s.tableName}`, s]));
-
-  // Two sources in one project can easily both have `public.users`, and both would
-  // otherwise map to the same destination table — where a full refresh's
-  // EXCHANGE TABLES would atomically replace the other source's data. Names stay
-  // clean for the first source to claim one and are suffixed after that.
-  const claimedByOtherSources = new Set(
-    (await prisma.dataSourceStream.findMany({
-      where: { dataSource: { tenancyId: tenancy.id }, NOT: { dataSourceId: source.id } },
-      select: { destinationTable: true },
-    })).map(row => row.destinationTable),
-  );
-  const resolveDestinationTable = (schemaName: string, tableName: string, existing: string | undefined) => {
-    if (existing != null) return existing;
-    const preferred = getDestinationTableName(schemaName, tableName);
-    if (!claimedByOtherSources.has(preferred)) return preferred;
-    return `${preferred}_${source.id.replace(/-/g, "").slice(0, 8)}`;
-  };
+  const removesLastCdcStream = source.streams.some(stream => stream.mode === "CDC")
+    && !configs.some(config => config.mode === "cdc");
 
   for (const config of configs) {
     const key = `${config.schemaName}.${config.tableName}`;
@@ -251,81 +245,112 @@ export async function setDataSourceStreams(
     }
   }
 
-  const keep = new Set(configs.map(c => `${c.schemaName}.${c.tableName}`));
-  await retryTransaction(prisma, async tx => {
-    for (const stream of source.streams) {
-      if (!keep.has(`${stream.schemaName}.${stream.tableName}`)) {
-        await tx.dataSourceStream.delete({ where: { id: stream.id } });
-      }
+  // Removing the final CDC stream destroys infrastructure used by an in-flight
+  // sync, so take the same lease as a sync before touching either side. Teardown
+  // happens before the local transaction: if that transaction fails, the still-
+  // configured CDC stream will detect the missing slot and resnapshot next time.
+  const configurationClaimStartedAt = removesLastCdcStream ? new Date() : null;
+  if (configurationClaimStartedAt != null) {
+    const claimed = await prisma.$executeRaw`
+      UPDATE "DataSource"
+      SET "lastSyncStartedAt" = ${configurationClaimStartedAt}
+      WHERE "id" = ${source.id}::uuid
+        AND (
+          "lastSyncStartedAt" IS NULL
+          OR "lastSyncStartedAt" <= "lastSyncFinishedAt"
+          OR "lastSyncStartedAt" < NOW() - make_interval(secs => ${SYNC_CLAIM_LEASE_SECONDS})
+        )
+    `;
+    if (claimed === 0) {
+      throw new StatusError(StatusError.Conflict, "Wait for the running sync to finish before removing the last CDC stream.");
     }
-    for (const config of configs) {
-      const key = `${config.schemaName}.${config.tableName}`;
-      const table = tablesByName.get(key)!;
-      const existing = existingByName.get(key);
-      const cursorColumn = config.mode === "cursor"
-        ? (config.cursorColumn ?? getDefaultCursorColumn(table))
-        : null;
-      // Any change of mode or cursor invalidates the resume point: the new mode
-      // cannot interpret the old one's cursor, and reusing it would skip rows.
-      const modeChanged = existing != null && (
-        MODE_FROM_PRISMA[existing.mode] !== config.mode || existing.cursorColumn !== cursorColumn
-      );
-      const data = {
-        mode: MODE_TO_PRISMA[config.mode],
-        cursorColumn,
-        primaryKeyColumns: table.primaryKeyColumns,
-        destinationTable: resolveDestinationTable(config.schemaName, config.tableName, existing?.destinationTable),
-        ...(modeChanged || existing == null
-          // Prisma distinguishes "set the column to JSON null" from "SQL NULL";
-          // clearing a resume point means the latter.
-          ? { syncCursor: Prisma.DbNull, status: "PENDING" as const, error: null, rowsSynced: 0n }
-          : {}),
-      };
-      if (existing == null) {
-        await tx.dataSourceStream.create({
-          data: { dataSourceId: source.id, schemaName: config.schemaName, tableName: config.tableName, ...data },
-        });
-      } else {
-        await tx.dataSourceStream.update({ where: { id: existing.id }, data });
-      }
+  }
+
+  try {
+    if (removesLastCdcStream) {
+      // Unlike source deletion, a configuration update must fail loudly here.
+      // Otherwise it can succeed while leaving an unconsumed, WAL-retaining slot.
+      await dropCdcInfrastructure(source);
     }
-    await tx.dataSource.update({
-      where: { id: source.id },
-      data: { status: configs.length > 0 ? "ACTIVE" : "PENDING", capabilities: probe.capabilities },
+
+    const keep = new Set(configs.map(c => `${c.schemaName}.${c.tableName}`));
+    await retryTransaction(prisma, async tx => {
+      for (const stream of source.streams) {
+        if (!keep.has(`${stream.schemaName}.${stream.tableName}`)) {
+          await tx.dataSourceStream.delete({ where: { id: stream.id } });
+        }
+      }
+      for (const config of configs) {
+        const key = `${config.schemaName}.${config.tableName}`;
+        const table = tablesByName.get(key)!;
+        const existing = existingByName.get(key);
+        const cursorColumn = config.mode === "cursor"
+          ? (config.cursorColumn ?? getDefaultCursorColumn(table))
+          : null;
+        // Any change of mode or cursor invalidates the resume point: the new mode
+        // cannot interpret the old one's cursor, and reusing it would skip rows.
+        const modeChanged = existing != null && (
+          MODE_FROM_PRISMA[existing.mode] !== config.mode || existing.cursorColumn !== cursorColumn
+        );
+        const data = {
+          mode: MODE_TO_PRISMA[config.mode],
+          cursorColumn,
+          primaryKeyColumns: table.primaryKeyColumns,
+          destinationTable: existing?.destinationTable
+            ?? getDestinationTableName(source.id, config.schemaName, config.tableName),
+          ...(modeChanged || existing == null
+            // Prisma distinguishes "set the column to JSON null" from "SQL NULL";
+            // clearing a resume point means the latter.
+            ? { syncCursor: Prisma.DbNull, status: "PENDING" as const, error: null, rowsSynced: 0n }
+            : {}),
+        };
+        if (existing == null) {
+          await tx.dataSourceStream.create({
+            data: { dataSourceId: source.id, schemaName: config.schemaName, tableName: config.tableName, ...data },
+          });
+        } else {
+          await tx.dataSourceStream.update({ where: { id: existing.id }, data });
+        }
+      }
+      await tx.dataSource.update({
+        where: { id: source.id },
+        data: {
+          status: configs.length > 0 ? "ACTIVE" : "PENDING",
+          capabilities: probe.capabilities,
+          ...(removesLastCdcStream ? { replicationSlotName: null, publicationName: null } : {}),
+        },
+      });
     });
-  });
+  } finally {
+    if (configurationClaimStartedAt != null) {
+      // Never restore the previous start token: a worker whose old lease expired
+      // could otherwise finish later and regain permission to overwrite state.
+      await prisma.dataSource.updateMany({
+        where: { id: source.id, lastSyncStartedAt: configurationClaimStartedAt },
+        data: { lastSyncStartedAt: source.lastSyncFinishedAt },
+      });
+    }
+  }
 
   return await getDataSourceOrThrow(tenancy, dataSourceId);
 }
 
-export async function syncDataSource(tenancy: Tenancy, dataSourceId: string): Promise<DataSourceWithStreams> {
-  // Also covers the scheduler: a project that drops off the plan stops syncing
-  // rather than keeping an outbound connection on a one-minute cron forever.
-  await ensureDataWarehouseEntitlement(tenancy);
-  const source = await getDataSourceOrThrow(tenancy, dataSourceId);
-  if (source.streams.length === 0) return source;
-
+async function syncClaimedDataSource(
+  tenancy: Tenancy,
+  source: DataSourceWithStreams,
+  startedAt: Date,
+): Promise<DataSourceWithStreams> {
   const prisma = await getPrismaClientForTenancy(tenancy);
+  if (source.streams.length === 0) {
+    await prisma.dataSource.updateMany({
+      where: { id: source.id, lastSyncStartedAt: startedAt },
+      data: { lastSyncFinishedAt: new Date() },
+    });
+    return await getDataSourceOrThrow(tenancy, source.id);
+  }
+
   const databaseName = await getWarehouseDatabaseName(tenancy);
   const credentials = await getCredentials(source);
-  const startedAt = new Date();
-
-  // The same lease the scheduler takes, so a manual "Sync now" during a cron
-  // sweep is refused rather than running a second sync against the same source —
-  // which would have two runs sharing one staging table and one replication slot.
-  const claimed = await prisma.$executeRaw`
-    UPDATE "DataSource"
-    SET "lastSyncStartedAt" = ${startedAt}, "error" = NULL
-    WHERE "id" = ${source.id}::uuid
-      AND (
-        "lastSyncStartedAt" IS NULL
-        OR "lastSyncStartedAt" <= "lastSyncFinishedAt"
-        OR "lastSyncStartedAt" < NOW() - make_interval(secs => ${SYNC_CLAIM_LEASE_SECONDS})
-      )
-  `;
-  if (claimed === 0) {
-    throw new StatusError(StatusError.Conflict, "A sync is already running for this source.");
-  }
 
   let probe: DataSourceProbeResult;
   try {
@@ -335,11 +360,11 @@ export async function syncDataSource(tenancy: Tenancy, dataSourceId: string): Pr
     // Recorded, but the source stays ACTIVE: the scheduler only picks up ACTIVE
     // rows, so parking it on FAILED would make one DNS blip stop syncing forever.
     const message = error instanceof Error ? error.message : String(error);
-    await prisma.dataSource.update({
-      where: { id: source.id },
+    await prisma.dataSource.updateMany({
+      where: { id: source.id, lastSyncStartedAt: startedAt },
       data: { error: message, lastSyncFinishedAt: new Date() },
     });
-    return await getDataSourceOrThrow(tenancy, dataSourceId);
+    return await getDataSourceOrThrow(tenancy, source.id);
   }
 
   const tablesByName = new Map<string, ProbedTable>(probe.tables.map(t => [`${t.schemaName}.${t.tableName}`, t]));
@@ -397,8 +422,8 @@ export async function syncDataSource(tenancy: Tenancy, dataSourceId: string): Pr
       });
     }
     const failed = results.filter(result => result.error != null);
-    await tx.dataSource.update({
-      where: { id: source.id },
+    const completed = await tx.dataSource.updateMany({
+      where: { id: source.id, lastSyncStartedAt: startedAt },
       data: {
         lastSyncFinishedAt: new Date(),
         status: "ACTIVE",
@@ -408,29 +433,71 @@ export async function syncDataSource(tenancy: Tenancy, dataSourceId: string): Pr
         ...(usesCdc ? { replicationSlotName: slotName, publicationName: slotName } : {}),
       },
     });
+    if (completed.count === 0) {
+      // All stream updates above roll back with this transaction. A newer lease is
+      // now authoritative, so this worker must not publish any of its stale state.
+      throw new StatusError(StatusError.Conflict, "This sync's lease expired before it could finish.");
+    }
   });
 
-  return await getDataSourceOrThrow(tenancy, dataSourceId);
+  return await getDataSourceOrThrow(tenancy, source.id);
+}
+
+export async function syncDataSource(tenancy: Tenancy, dataSourceId: string): Promise<DataSourceWithStreams> {
+  await ensureDataWarehouseEntitlement(tenancy);
+  const source = await getDataSourceOrThrow(tenancy, dataSourceId);
+  if (source.streams.length === 0) return source;
+
+  const prisma = await getPrismaClientForTenancy(tenancy);
+  const startedAt = new Date();
+  const claimed = await prisma.$executeRaw`
+    UPDATE "DataSource"
+    SET "lastSyncStartedAt" = ${startedAt}, "error" = NULL
+    WHERE "id" = ${source.id}::uuid
+      AND (
+        "lastSyncStartedAt" IS NULL
+        OR "lastSyncStartedAt" <= "lastSyncFinishedAt"
+        OR "lastSyncStartedAt" < NOW() - make_interval(secs => ${SYNC_CLAIM_LEASE_SECONDS})
+      )
+  `;
+  if (claimed === 0) {
+    throw new StatusError(StatusError.Conflict, "A sync is already running for this source.");
+  }
+
+  try {
+    // Configuration may have changed between the initial read and our claim.
+    // Once the lease is ours, re-read so execution cannot resurrect a removed CDC
+    // stream (and its replication slot) from a stale plan.
+    const claimedSource = await getDataSourceOrThrow(tenancy, dataSourceId);
+    return await syncClaimedDataSource(tenancy, claimedSource, startedAt);
+  } catch (error) {
+    await prisma.dataSource.updateMany({
+      where: { id: source.id, lastSyncStartedAt: startedAt },
+      data: { lastSyncFinishedAt: new Date(), error: error instanceof Error ? error.message : String(error) },
+    });
+    throw error;
+  }
 }
 
 /**
- * One pass of the scheduler: syncs every source whose interval has elapsed.
- * Returns whether it did anything, so the cron route can keep going until the
- * queue is empty or its time budget runs out.
+ * One step of the scheduler: claims and syncs the oldest source whose interval
+ * has elapsed. Returns whether it did anything, so the cron route can keep going
+ * until the queue is empty or its time budget runs out.
  *
  * Sources are taken oldest-sync-first so that one source erroring quickly cannot
  * starve the others by being picked repeatedly.
  */
 export async function runDueDataSourceSyncs(options: { deadlineMs: number }): Promise<{ didWork: boolean }> {
+  if (Date.now() >= options.deadlineMs) return { didWork: false };
+
   // Claims in the same statement that selects. The cron fires every minute while
   // a sweep may run for minutes, so without a claim every overlapping invocation
   // would pick the same rows and sync one source several times at once —
-  // concurrent slot reads, duplicate inserts, and a full refresh whose staging
-  // table is dropped underneath it.
-  const due = await globalPrismaClient.$queryRaw<{ id: string, tenancyId: string }[]>`
+  // causing concurrent slot reads and duplicate inserts.
+  const due = await globalPrismaClient.$queryRaw<{ id: string, tenancyId: string, lastSyncStartedAt: Date }[]>`
     UPDATE "DataSource"
-    SET "lastSyncStartedAt" = NOW()
-    WHERE "id" IN (
+    SET "lastSyncStartedAt" = NOW(), "error" = NULL
+    WHERE "id" = (
       SELECT "id" FROM "DataSource"
       WHERE "status" = 'ACTIVE'
         AND EXISTS (SELECT 1 FROM "DataSourceStream" s WHERE s."dataSourceId" = "DataSource"."id")
@@ -446,35 +513,31 @@ export async function runDueDataSourceSyncs(options: { deadlineMs: number }): Pr
           OR "lastSyncStartedAt" < NOW() - make_interval(secs => ${SYNC_CLAIM_LEASE_SECONDS})
         )
       ORDER BY "lastSyncFinishedAt" ASC NULLS FIRST
-      LIMIT 20
+      LIMIT 1
       FOR UPDATE SKIP LOCKED
     )
-    RETURNING "id", "tenancyId"
+    RETURNING "id", "tenancyId", "lastSyncStartedAt"
   `;
   if (due.length === 0) return { didWork: false };
 
-  let didWork = false;
   for (const row of due) {
-    if (Date.now() >= options.deadlineMs) break;
     try {
       const tenancy = await getTenancy(row.tenancyId);
-      if (tenancy == null) continue;
-      await syncDataSource(tenancy, row.id);
-      didWork = true;
+      if (tenancy == null) throw new Error(`No tenancy exists for data source ${row.id}.`);
+      await ensureDataWarehouseEntitlement(tenancy);
+      const source = await getDataSourceOrThrow(tenancy, row.id);
+      await syncClaimedDataSource(tenancy, source, row.lastSyncStartedAt);
     } catch (error) {
       // A source that cannot sync must not stop the sweep, and the failure is
       // already recorded on the row for the dashboard to show.
       captureError("data-source-scheduled-sync", error);
       // lastSyncFinishedAt is set so the interval applies to the retry too; the
       // status stays ACTIVE so a transient failure does not park the source.
-      await globalPrismaClient.dataSource.update({
-        where: { id: row.id },
+      await globalPrismaClient.dataSource.updateMany({
+        where: { id: row.id, lastSyncStartedAt: row.lastSyncStartedAt },
         data: { lastSyncFinishedAt: new Date(), error: error instanceof Error ? error.message : String(error) },
-      }).catch(() => {
-        // The row may have been deleted mid-sweep.
       });
-      didWork = true;
     }
   }
-  return { didWork };
+  return { didWork: true };
 }

--- a/apps/backend/src/lib/data-sources/clickhouse-destination.test.ts
+++ b/apps/backend/src/lib/data-sources/clickhouse-destination.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getDestinationTableName } from "./clickhouse-destination";
+
+describe("data-source destination table names", () => {
+  it("is stable for one source table", () => {
+    expect(getDestinationTableName("source-1", "public", "users"))
+      .toBe(getDestinationTableName("source-1", "public", "users"));
+  });
+
+  it("distinguishes names that collide when schema and table are flattened", () => {
+    expect(getDestinationTableName("source-1", "a_b", "c"))
+      .not.toBe(getDestinationTableName("source-1", "a", "b_c"));
+  });
+
+  it("distinguishes quoted names that sanitize to the same prefix", () => {
+    expect(getDestinationTableName("source-1", "public", "audit-log"))
+      .not.toBe(getDestinationTableName("source-1", "public", "audit_log"));
+  });
+
+  it("distinguishes the same table connected through different sources", () => {
+    expect(getDestinationTableName("source-1", "public", "users"))
+      .not.toBe(getDestinationTableName("source-2", "public", "users"));
+  });
+});

--- a/apps/backend/src/lib/data-sources/clickhouse-destination.ts
+++ b/apps/backend/src/lib/data-sources/clickhouse-destination.ts
@@ -1,0 +1,142 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+import type { DataSourceColumn } from "./probe";
+
+/** Metadata every destination table carries, whatever the source. */
+export const EXTRACTED_AT_COLUMN = "_hexclave_extracted_at";
+export const VERSION_COLUMN = "_hexclave_version";
+export const DELETED_COLUMN = "_hexclave_deleted";
+
+export function quoteClickhouseIdentifier(identifier: string): string {
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier)) {
+    // Identifiers reaching here are derived from the source catalog, so a name we
+    // cannot represent is a bug in sanitization rather than something to escape.
+    throw new HexclaveAssertionError(`Unsafe ClickHouse identifier: ${JSON.stringify(identifier)}`);
+  }
+  return `\`${identifier}\``;
+}
+
+/**
+ * Destination name for a source table. Schema-qualified and flattened, because
+ * ClickHouse has one level of namespacing and the project's warehouse database
+ * is already spent on tenancy.
+ */
+export function getDestinationTableName(schemaName: string, tableName: string): string {
+  const sanitize = (value: string) => value.replace(/[^A-Za-z0-9_]/g, "_");
+  return `${sanitize(schemaName)}_${sanitize(tableName)}`;
+}
+
+const NUMERIC_WITH_PRECISION = /^numeric\((\d+),\s*(\d+)\)$/i;
+
+/**
+ * Postgres type -> ClickHouse type. Anything we do not recognise lands as
+ * String: an unqueryable column is recoverable, a wrong one silently corrupts.
+ */
+export function mapPostgresTypeToClickhouse(dataType: string): string {
+  const type = dataType.trim().toLowerCase();
+  if (type.endsWith("[]")) return "String"; // JSON-encoded; ClickHouse arrays would need per-element mapping
+  const numeric = NUMERIC_WITH_PRECISION.exec(type);
+  if (numeric) {
+    const precision = Number.parseInt(numeric[1], 10);
+    const scale = Number.parseInt(numeric[2], 10);
+    // Decimal is only safe when the source declared bounds we can honour.
+    if (precision <= 76 && scale <= precision) return `Decimal(${precision}, ${scale})`;
+    return "String";
+  }
+  if (/^character varying|^varchar|^character|^char|^text|^citext|^name$/.test(type)) return "String";
+  if (/^smallint$|^int2$/.test(type)) return "Int16";
+  if (/^integer$|^int4$|^serial$/.test(type)) return "Int32";
+  if (/^bigint$|^int8$|^bigserial$/.test(type)) return "Int64";
+  if (/^real$|^float4$/.test(type)) return "Float32";
+  if (/^double precision$|^float8$/.test(type)) return "Float64";
+  if (/^boolean$|^bool$/.test(type)) return "Bool";
+  if (/^uuid$/.test(type)) return "UUID";
+  if (/^date$/.test(type)) return "Date32";
+  if (/^timestamp/.test(type)) return "DateTime64(6)";
+  // Bare `numeric`, json, jsonb, bytea, time, interval, enums, geometry, ...
+  return "String";
+}
+
+function columnDefinition(column: DataSourceColumn, isPrimaryKey: boolean): string {
+  const baseType = mapPostgresTypeToClickhouse(column.dataType);
+  // ORDER BY columns must not be Nullable, and a primary key column is NOT NULL
+  // at the source by definition.
+  const type = column.nullable && !isPrimaryKey ? `Nullable(${baseType})` : baseType;
+  return `${quoteClickhouseIdentifier(column.name)} ${type}`;
+}
+
+export function buildCreateTableSql(options: {
+  databaseName: string,
+  tableName: string,
+  columns: DataSourceColumn[],
+  primaryKeyColumns: string[],
+}): string {
+  const { databaseName, tableName, columns, primaryKeyColumns } = options;
+  const definitions = columns.map(c => columnDefinition(c, primaryKeyColumns.includes(c.name)));
+  definitions.push(
+    `${quoteClickhouseIdentifier(EXTRACTED_AT_COLUMN)} DateTime64(3)`,
+    `${quoteClickhouseIdentifier(VERSION_COLUMN)} UInt64`,
+    `${quoteClickhouseIdentifier(DELETED_COLUMN)} UInt8 DEFAULT 0`,
+  );
+
+  // With a key we can deduplicate: the highest version of a row wins, and a
+  // tombstone removes it. Without one there is nothing to match on, so the table
+  // is append-only and the customer picks the row they want at query time.
+  const engine = primaryKeyColumns.length > 0
+    ? `ReplacingMergeTree(${quoteClickhouseIdentifier(VERSION_COLUMN)}, ${quoteClickhouseIdentifier(DELETED_COLUMN)})`
+    : "MergeTree";
+  const orderBy = primaryKeyColumns.length > 0
+    ? primaryKeyColumns.map(quoteClickhouseIdentifier).join(", ")
+    : quoteClickhouseIdentifier(EXTRACTED_AT_COLUMN);
+
+  return `CREATE TABLE IF NOT EXISTS ${quoteClickhouseIdentifier(databaseName)}.${quoteClickhouseIdentifier(tableName)} (
+  ${definitions.join(",\n  ")}
+) ENGINE = ${engine}
+ORDER BY (${orderBy})`;
+}
+
+export async function ensureDestinationTable(
+  client: ClickHouseClient,
+  options: { databaseName: string, tableName: string, columns: DataSourceColumn[], primaryKeyColumns: string[] },
+): Promise<void> {
+  await client.command({ query: buildCreateTableSql(options) });
+
+  // Additive schema drift: a column the source grew since the table was created
+  // is added rather than quarantined, which covers the overwhelmingly common case.
+  const existing = await client.query({
+    query: `SELECT name FROM system.columns WHERE database = {db:String} AND table = {tbl:String}`,
+    query_params: { db: options.databaseName, tbl: options.tableName },
+    format: "JSONEachRow",
+  });
+  const existingNames = new Set((await existing.json<{ name: string }>()).map(r => r.name));
+  for (const column of options.columns) {
+    if (existingNames.has(column.name)) continue;
+    await client.command({
+      query: `ALTER TABLE ${quoteClickhouseIdentifier(options.databaseName)}.${quoteClickhouseIdentifier(options.tableName)}
+              ADD COLUMN IF NOT EXISTS ${columnDefinition(column, false)}`,
+    });
+  }
+}
+
+/** Converts a `pg` value into something ClickHouse's JSONEachRow reader accepts. */
+export function normalizeValueForClickhouse(value: unknown): unknown {
+  if (value === null || value === undefined) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (Buffer.isBuffer(value)) return value.toString("base64");
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "object") return JSON.stringify(value);
+  return value;
+}
+
+export async function insertRows(
+  client: ClickHouseClient,
+  options: { databaseName: string, tableName: string, rows: Record<string, unknown>[] },
+): Promise<void> {
+  if (options.rows.length === 0) return;
+  await client.insert({
+    table: `${quoteClickhouseIdentifier(options.databaseName)}.${quoteClickhouseIdentifier(options.tableName)}`,
+    values: options.rows,
+    format: "JSONEachRow",
+    clickhouse_settings: { date_time_input_format: "best_effort" },
+  });
+}

--- a/apps/backend/src/lib/data-sources/clickhouse-destination.ts
+++ b/apps/backend/src/lib/data-sources/clickhouse-destination.ts
@@ -7,13 +7,21 @@ export const EXTRACTED_AT_COLUMN = "_hexclave_extracted_at";
 export const VERSION_COLUMN = "_hexclave_version";
 export const DELETED_COLUMN = "_hexclave_deleted";
 
+/**
+ * Identifiers cannot be parameterized, so every name is interpolated into DDL and
+ * this quoting is what makes that safe. Backslashes and backticks are escaped the
+ * way ClickHouse expects; control characters are refused outright, since nothing
+ * legitimate contains them and they have no escape we can rely on.
+ *
+ * Deliberately permissive about the rest: warehouse databases are named by project
+ * UUID (so hyphens must survive), and column names come from the customer's own
+ * schema, where a quoted "odd name" is perfectly legal.
+ */
 export function quoteClickhouseIdentifier(identifier: string): string {
-  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(identifier)) {
-    // Identifiers reaching here are derived from the source catalog, so a name we
-    // cannot represent is a bug in sanitization rather than something to escape.
+  if (identifier.length === 0 || /[\u0000-\u001f\u007f]/.test(identifier)) {
     throw new HexclaveAssertionError(`Unsafe ClickHouse identifier: ${JSON.stringify(identifier)}`);
   }
-  return `\`${identifier}\``;
+  return `\`${identifier.replace(/\\/g, "\\\\").replace(/`/g, "\\`")}\``;
 }
 
 /**
@@ -59,9 +67,12 @@ export function mapPostgresTypeToClickhouse(dataType: string): string {
 
 function columnDefinition(column: DataSourceColumn, isPrimaryKey: boolean): string {
   const baseType = mapPostgresTypeToClickhouse(column.dataType);
-  // ORDER BY columns must not be Nullable, and a primary key column is NOT NULL
-  // at the source by definition.
-  const type = column.nullable && !isPrimaryKey ? `Nullable(${baseType})` : baseType;
+  // Every non-key column is Nullable regardless of the source's NOT NULL, because
+  // a delete tombstone carries only the replica identity: Postgres sends the other
+  // columns as SQL NULL. A non-Nullable column would coerce those to '' or 0 and,
+  // depending on server settings, could reject the whole WAL batch.
+  // ORDER BY columns must not be Nullable, and a key column is NOT NULL anyway.
+  const type = isPrimaryKey ? baseType : `Nullable(${baseType})`;
   return `${quoteClickhouseIdentifier(column.name)} ${type}`;
 }
 

--- a/apps/backend/src/lib/data-sources/clickhouse-destination.ts
+++ b/apps/backend/src/lib/data-sources/clickhouse-destination.ts
@@ -1,5 +1,6 @@
 import type { ClickHouseClient } from "@clickhouse/client";
 import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+import { createHash } from "node:crypto";
 import type { DataSourceColumn } from "./probe";
 
 /** Metadata every destination table carries, whatever the source. */
@@ -25,13 +26,26 @@ export function quoteClickhouseIdentifier(identifier: string): string {
 }
 
 /**
- * Destination name for a source table. Schema-qualified and flattened, because
- * ClickHouse has one level of namespacing and the project's warehouse database
- * is already spent on tenancy.
+ * Destination name for a source table. The readable prefix helps customers
+ * recognise it, while the full source/table identity hash makes the name stable
+ * and collision-resistant across sources and quoted Postgres identifiers.
+ *
+ * The identity must be part of every name, not only a collision fallback. Stream
+ * metadata can be deleted while its destination table is deliberately retained;
+ * allocating pretty names from only the currently configured streams could later
+ * reuse that retained table and drop or mix the customer's existing data.
  */
-export function getDestinationTableName(schemaName: string, tableName: string): string {
+export function getDestinationTableName(dataSourceId: string, schemaName: string, tableName: string): string {
   const sanitize = (value: string) => value.replace(/[^A-Za-z0-9_]/g, "_");
-  return `${sanitize(schemaName)}_${sanitize(tableName)}`;
+  const readablePrefix = `${sanitize(schemaName)}_${sanitize(tableName)}`.slice(0, 96);
+  const identity = createHash("sha256")
+    .update(dataSourceId)
+    .update("\0")
+    .update(schemaName)
+    .update("\0")
+    .update(tableName)
+    .digest("hex");
+  return `${readablePrefix}_${identity}`;
 }
 
 const NUMERIC_WITH_PRECISION = /^numeric\((\d+),\s*(\d+)\)$/i;

--- a/apps/backend/src/lib/data-sources/pgoutput.test.ts
+++ b/apps/backend/src/lib/data-sources/pgoutput.test.ts
@@ -175,3 +175,23 @@ describe("LSN formatting", () => {
     expect(() => parseLsn("not-an-lsn")).toThrow("Malformed LSN");
   });
 });
+
+describe("cursor candidate types", () => {
+  it("accepts the type names format_type() actually emits, typmods and all", async () => {
+    const { isCursorCandidateType } = await import("./probe");
+    // Prisma renders DateTime as timestamp(3); Hibernate as timestamp(6) with tz.
+    // Matching only the bare spellings left those sources with no cursor at all.
+    for (const type of [
+      "timestamp(3) without time zone",
+      "timestamp(6) with time zone",
+      "timestamp with time zone",
+      "timestamp without time zone",
+      "date", "bigint", "integer", "smallint",
+    ]) {
+      expect(isCursorCandidateType(type), type).toBe(true);
+    }
+    for (const type of ["text", "uuid", "jsonb", "numeric(10,2)", "boolean", "bytea"]) {
+      expect(isCursorCandidateType(type), type).toBe(false);
+    }
+  });
+});

--- a/apps/backend/src/lib/data-sources/pgoutput.test.ts
+++ b/apps/backend/src/lib/data-sources/pgoutput.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+import { decodePgoutputMessage, formatLsn, parseLsn, type PgoutputRelation } from "./pgoutput";
+
+/** Builders that produce the exact byte layout Postgres emits, so the tests exercise real parsing. */
+function cstring(value: string): Buffer {
+  return Buffer.concat([Buffer.from(value, "utf8"), Buffer.from([0])]);
+}
+function int32(value: number): Buffer {
+  const buffer = Buffer.alloc(4);
+  buffer.writeInt32BE(value);
+  return buffer;
+}
+function int16(value: number): Buffer {
+  const buffer = Buffer.alloc(2);
+  buffer.writeInt16BE(value);
+  return buffer;
+}
+function uint64(value: bigint): Buffer {
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigUInt64BE(value);
+  return buffer;
+}
+function relationMessage(relationId: number, columns: { name: string, isKey: boolean }[]): Buffer {
+  return Buffer.concat([
+    Buffer.from("R"),
+    int32(relationId),
+    cstring("public"),
+    cstring("users"),
+    Buffer.from("d"),
+    int16(columns.length),
+    ...columns.flatMap(column => [Buffer.from([column.isKey ? 1 : 0]), cstring(column.name), int32(23), int32(-1)]),
+  ]);
+}
+/** `values`: string = a text value, null = SQL NULL, undefined = unchanged TOAST. */
+function tupleData(values: (string | null | undefined)[]): Buffer {
+  return Buffer.concat([
+    int16(values.length),
+    ...values.map(value => {
+      if (value === null) return Buffer.from("n");
+      if (value === undefined) return Buffer.from("u");
+      const bytes = Buffer.from(value, "utf8");
+      return Buffer.concat([Buffer.from("t"), int32(bytes.length), bytes]);
+    }),
+  ]);
+}
+
+function newRelations(): Map<number, PgoutputRelation> {
+  return new Map<number, PgoutputRelation>();
+}
+
+describe("pgoutput decoding", () => {
+  it("registers a relation and decodes an insert against it", () => {
+    const relations = newRelations();
+    decodePgoutputMessage(relationMessage(16385, [{ name: "id", isKey: true }, { name: "email", isKey: false }]), relations);
+    expect(relations.get(16385)?.columns.map(c => c.name)).toEqual(["id", "email"]);
+
+    const message = decodePgoutputMessage(
+      Buffer.concat([Buffer.from("I"), int32(16385), Buffer.from("N"), tupleData(["7", "a@example.com"])]),
+      relations,
+    );
+    expect(message).toEqual({ type: "insert", relationId: 16385, row: { id: "7", email: "a@example.com" } });
+  });
+
+  it("distinguishes a SQL NULL from an unchanged TOAST value", () => {
+    // These must not collapse together: null means "erase this", undefined means
+    // "the server did not send it", and writing null for the latter loses data.
+    const relations = newRelations();
+    decodePgoutputMessage(relationMessage(1, [{ name: "id", isKey: true }, { name: "body", isKey: false }, { name: "note", isKey: false }]), relations);
+    const message = decodePgoutputMessage(
+      Buffer.concat([Buffer.from("I"), int32(1), Buffer.from("N"), tupleData(["1", undefined, null])]),
+      relations,
+    );
+    if (message.type !== "insert") throw new Error("expected an insert");
+    expect(message.row.body).toBeUndefined();
+    expect("body" in message.row).toBe(true);
+    expect(message.row.note).toBeNull();
+  });
+
+  it("decodes an update that carries an old key tuple", () => {
+    const relations = newRelations();
+    decodePgoutputMessage(relationMessage(2, [{ name: "id", isKey: true }, { name: "email", isKey: false }]), relations);
+    const message = decodePgoutputMessage(
+      Buffer.concat([
+        Buffer.from("U"), int32(2),
+        Buffer.from("K"), tupleData(["7", null]),
+        Buffer.from("N"), tupleData(["8", "new@example.com"]),
+      ]),
+      relations,
+    );
+    expect(message).toEqual({
+      type: "update",
+      relationId: 2,
+      keyRow: { id: "7", email: null },
+      row: { id: "8", email: "new@example.com" },
+    });
+  });
+
+  it("decodes an update with no old tuple", () => {
+    const relations = newRelations();
+    decodePgoutputMessage(relationMessage(3, [{ name: "id", isKey: true }]), relations);
+    const message = decodePgoutputMessage(
+      Buffer.concat([Buffer.from("U"), int32(3), Buffer.from("N"), tupleData(["9"])]),
+      relations,
+    );
+    if (message.type !== "update") throw new Error("expected an update");
+    expect(message.keyRow).toBeNull();
+    expect(message.row).toEqual({ id: "9" });
+  });
+
+  it("decodes a delete's key tuple", () => {
+    const relations = newRelations();
+    decodePgoutputMessage(relationMessage(4, [{ name: "id", isKey: true }, { name: "email", isKey: false }]), relations);
+    const message = decodePgoutputMessage(
+      Buffer.concat([Buffer.from("D"), int32(4), Buffer.from("K"), tupleData(["7", null])]),
+      relations,
+    );
+    expect(message).toEqual({ type: "delete", relationId: 4, keyRow: { id: "7", email: null } });
+  });
+
+  it("reads begin and commit LSNs", () => {
+    const relations = newRelations();
+    const begin = decodePgoutputMessage(
+      Buffer.concat([Buffer.from("B"), uint64(0x1a3f0000d8n), uint64(0n), int32(4242)]),
+      relations,
+    );
+    expect(begin).toEqual({ type: "begin", finalLsn: 0x1a3f0000d8n, xid: 4242 });
+
+    const commit = decodePgoutputMessage(
+      Buffer.concat([Buffer.from("C"), Buffer.from([0]), uint64(0x1a3f0000d8n), uint64(0x1a3f000120n), uint64(0n)]),
+      relations,
+    );
+    expect(commit).toEqual({ type: "commit", commitLsn: 0x1a3f0000d8n, endLsn: 0x1a3f000120n });
+  });
+
+  it("decodes truncate", () => {
+    const relations = newRelations();
+    const message = decodePgoutputMessage(
+      Buffer.concat([Buffer.from("T"), int32(2), Buffer.from([0]), int32(11), int32(12)]),
+      relations,
+    );
+    expect(message).toEqual({ type: "truncate", relationIds: [11, 12] });
+  });
+
+  it("ignores message types it has no use for rather than failing the batch", () => {
+    // A new server emitting proto v2 stream messages must not break syncing.
+    const message = decodePgoutputMessage(Buffer.concat([Buffer.from("Y"), int32(1)]), newRelations());
+    expect(message).toEqual({ type: "unsupported", tag: "Y" });
+  });
+
+  it("refuses a change for a relation it never saw", () => {
+    expect(() => decodePgoutputMessage(
+      Buffer.concat([Buffer.from("I"), int32(999), Buffer.from("N"), tupleData(["1"])]),
+      newRelations(),
+    )).toThrow("unknown relation");
+  });
+
+  it("refuses a truncated message rather than reading past the end", () => {
+    const relations = newRelations();
+    decodePgoutputMessage(relationMessage(5, [{ name: "id", isKey: true }]), relations);
+    expect(() => decodePgoutputMessage(
+      Buffer.concat([Buffer.from("I"), int32(5), Buffer.from("N"), int16(1), Buffer.from("t"), int32(50)]),
+      relations,
+    )).toThrow("Truncated");
+  });
+});
+
+describe("LSN formatting", () => {
+  it("round-trips Postgres' two-half hex form", () => {
+    expect(formatLsn(0x1a3f0000d8n)).toBe("1A/3F0000D8");
+    expect(parseLsn("1A/3F0000D8")).toBe(0x1a3f0000d8n);
+    expect(parseLsn(formatLsn(0n))).toBe(0n);
+  });
+
+  it("rejects a malformed LSN", () => {
+    expect(() => parseLsn("not-an-lsn")).toThrow("Malformed LSN");
+  });
+});

--- a/apps/backend/src/lib/data-sources/pgoutput.ts
+++ b/apps/backend/src/lib/data-sources/pgoutput.ts
@@ -1,0 +1,237 @@
+import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+
+/**
+ * Decoder for Postgres' built-in `pgoutput` logical replication format.
+ *
+ * We read the WAL in batches over an ordinary SQL connection
+ * (`pg_logical_slot_peek_binary_changes`) rather than holding a streaming
+ * replication connection open, so this only has to understand the message
+ * payloads — no protocol state machine, no keepalives. `pgoutput` is used in
+ * preference to wal2json because it is built into every Postgres 10+ server,
+ * including managed ones that will not install an extension for us.
+ *
+ * Protocol version 1, which sends every value as text.
+ */
+
+export type PgoutputColumn = {
+  name: string,
+  /** Part of the replica identity, so usable for matching rows on update/delete. */
+  isKey: boolean,
+  dataTypeId: number,
+};
+
+export type PgoutputRelation = {
+  relationId: number,
+  schemaName: string,
+  tableName: string,
+  replicaIdentity: string,
+  columns: PgoutputColumn[],
+};
+
+/** `null` for a SQL NULL; `undefined` for an unchanged TOAST value, which is not the same thing. */
+export type PgoutputTuple = Record<string, string | null | undefined>;
+
+export type PgoutputMessage =
+  | { type: "begin", finalLsn: bigint, xid: number }
+  | { type: "commit", commitLsn: bigint, endLsn: bigint }
+  | { type: "relation", relation: PgoutputRelation }
+  | { type: "insert", relationId: number, row: PgoutputTuple }
+  | { type: "update", relationId: number, row: PgoutputTuple, keyRow: PgoutputTuple | null }
+  | { type: "delete", relationId: number, keyRow: PgoutputTuple }
+  | { type: "truncate", relationIds: number[] }
+  | { type: "unsupported", tag: string };
+
+class Reader {
+  private offset = 0;
+  constructor(private readonly buffer: Buffer) {}
+
+  hasMore(): boolean {
+    return this.offset < this.buffer.length;
+  }
+  uint8(): number {
+    this.require(1);
+    return this.buffer.readUInt8(this.offset++);
+  }
+  int16(): number {
+    this.require(2);
+    const value = this.buffer.readInt16BE(this.offset);
+    this.offset += 2;
+    return value;
+  }
+  int32(): number {
+    this.require(4);
+    const value = this.buffer.readInt32BE(this.offset);
+    this.offset += 4;
+    return value;
+  }
+  uint64(): bigint {
+    this.require(8);
+    const value = this.buffer.readBigUInt64BE(this.offset);
+    this.offset += 8;
+    return value;
+  }
+  /** Null-terminated string. */
+  string(): string {
+    const end = this.buffer.indexOf(0, this.offset);
+    if (end === -1) throw new HexclaveAssertionError("Unterminated string in pgoutput message");
+    const value = this.buffer.toString("utf8", this.offset, end);
+    this.offset = end + 1;
+    return value;
+  }
+  bytes(length: number): Buffer {
+    this.require(length);
+    const value = this.buffer.subarray(this.offset, this.offset + length);
+    this.offset += length;
+    return value;
+  }
+  skip(length: number): void {
+    this.require(length);
+    this.offset += length;
+  }
+  private require(length: number): void {
+    if (this.offset + length > this.buffer.length) {
+      throw new HexclaveAssertionError("Truncated pgoutput message");
+    }
+  }
+}
+
+function readTuple(reader: Reader, relation: PgoutputRelation): PgoutputTuple {
+  const columnCount = reader.int16();
+  const tuple: PgoutputTuple = {};
+  for (let i = 0; i < columnCount; i++) {
+    const kind = String.fromCharCode(reader.uint8());
+    // A column beyond the relation's known shape means our cached relation is
+    // stale; the value still has to be consumed to keep the reader aligned.
+    // Indexing past the end is possible when our cached relation is stale, so the
+    // column may genuinely be absent even though the type says otherwise.
+    const column = relation.columns[i] as PgoutputColumn | undefined;
+    if (kind === "n") {
+      if (column) tuple[column.name] = null;
+    } else if (kind === "u") {
+      // Unchanged TOAST: the server did not send it, and writing null here would
+      // erase a value the customer never touched.
+      if (column) tuple[column.name] = undefined;
+    } else if (kind === "t" || kind === "b") {
+      const length = reader.int32();
+      const value = reader.bytes(length).toString("utf8");
+      if (column) tuple[column.name] = value;
+    } else {
+      throw new HexclaveAssertionError(`Unknown pgoutput tuple column kind: ${JSON.stringify(kind)}`);
+    }
+  }
+  return tuple;
+}
+
+/**
+ * Decodes one message. `relations` is both an input and an output: Relation
+ * messages register the shape that later Insert/Update/Delete messages refer to
+ * by id, so the same map must be carried across every message in a batch.
+ */
+export function decodePgoutputMessage(
+  buffer: Buffer,
+  relations: Map<number, PgoutputRelation>,
+): PgoutputMessage {
+  const reader = new Reader(buffer);
+  const tag = String.fromCharCode(reader.uint8());
+
+  switch (tag) {
+    case "B": {
+      const finalLsn = reader.uint64();
+      reader.skip(8); // commit timestamp
+      const xid = reader.int32();
+      return { type: "begin", finalLsn, xid };
+    }
+    case "C": {
+      reader.skip(1); // flags
+      const commitLsn = reader.uint64();
+      const endLsn = reader.uint64();
+      reader.skip(8); // commit timestamp
+      return { type: "commit", commitLsn, endLsn };
+    }
+    case "R": {
+      const relationId = reader.int32();
+      const schemaName = reader.string();
+      const tableName = reader.string();
+      const replicaIdentity = String.fromCharCode(reader.uint8());
+      const columnCount = reader.int16();
+      const columns: PgoutputColumn[] = [];
+      for (let i = 0; i < columnCount; i++) {
+        const flags = reader.uint8();
+        const name = reader.string();
+        const dataTypeId = reader.int32();
+        reader.skip(4); // type modifier
+        columns.push({ name, isKey: (flags & 1) === 1, dataTypeId });
+      }
+      const relation = { relationId, schemaName, tableName, replicaIdentity, columns };
+      relations.set(relationId, relation);
+      return { type: "relation", relation };
+    }
+    case "I": {
+      const relationId = reader.int32();
+      const relation = requireRelation(relations, relationId);
+      reader.uint8(); // always 'N'
+      return { type: "insert", relationId, row: readTuple(reader, relation) };
+    }
+    case "U": {
+      const relationId = reader.int32();
+      const relation = requireRelation(relations, relationId);
+      let keyRow: PgoutputTuple | null = null;
+      let marker = String.fromCharCode(reader.uint8());
+      // 'K' = key only, 'O' = full old tuple (REPLICA IDENTITY FULL). Either is
+      // optional; when absent the new tuple carries the key already.
+      if (marker === "K" || marker === "O") {
+        keyRow = readTuple(reader, relation);
+        marker = String.fromCharCode(reader.uint8());
+      }
+      if (marker !== "N") {
+        throw new HexclaveAssertionError(`Expected a new tuple in a pgoutput update, got ${JSON.stringify(marker)}`);
+      }
+      return { type: "update", relationId, row: readTuple(reader, relation), keyRow };
+    }
+    case "D": {
+      const relationId = reader.int32();
+      const relation = requireRelation(relations, relationId);
+      const marker = String.fromCharCode(reader.uint8());
+      if (marker !== "K" && marker !== "O") {
+        throw new HexclaveAssertionError(`Expected a key tuple in a pgoutput delete, got ${JSON.stringify(marker)}`);
+      }
+      return { type: "delete", relationId, keyRow: readTuple(reader, relation) };
+    }
+    case "T": {
+      const count = reader.int32();
+      reader.skip(1); // flags (cascade / restart identity)
+      const relationIds: number[] = [];
+      for (let i = 0; i < count; i++) relationIds.push(reader.int32());
+      return { type: "truncate", relationIds };
+    }
+    default: {
+      // Type ('Y'), Origin ('O'), and the streaming messages of proto v2+ carry
+      // nothing we act on. Skipping them keeps a new server version from
+      // breaking the sync.
+      return { type: "unsupported", tag };
+    }
+  }
+}
+
+function requireRelation(relations: Map<number, PgoutputRelation>, relationId: number): PgoutputRelation {
+  const relation = relations.get(relationId);
+  if (!relation) {
+    // Postgres always emits a Relation before the first change referencing it in
+    // a given decoding session, so this means we lost the start of the batch.
+    throw new HexclaveAssertionError(`pgoutput referenced unknown relation ${relationId}`);
+  }
+  return relation;
+}
+
+/** Postgres renders LSNs as two hex halves, e.g. `1A/3F0000D8`. */
+export function formatLsn(lsn: bigint): string {
+  const high = (lsn >> 32n) & 0xffffffffn;
+  const low = lsn & 0xffffffffn;
+  return `${high.toString(16).toUpperCase()}/${low.toString(16).toUpperCase()}`;
+}
+
+export function parseLsn(text: string): bigint {
+  const match = /^([0-9A-Fa-f]+)\/([0-9A-Fa-f]+)$/.exec(text.trim());
+  if (!match) throw new HexclaveAssertionError(`Malformed LSN: ${JSON.stringify(text)}`);
+  return (BigInt(`0x${match[1]}`) << 32n) | BigInt(`0x${match[2]}`);
+}

--- a/apps/backend/src/lib/data-sources/postgres-integration.test.ts
+++ b/apps/backend/src/lib/data-sources/postgres-integration.test.ts
@@ -144,11 +144,11 @@ it("runs full refresh and cursor modes end to end on the Postgres side", async (
   const results = await runStreamSyncs(context, [
     {
       streamId: "s-plans", schemaName: "public", tableName: "plans", mode: "full_refresh" as const,
-      cursorColumn: null, primaryKeyColumns: ["id"], destinationTable: "public_plans", syncCursor: null,
+      cursorColumn: null, primaryKeyColumns: ["id"], destinationTable: "public_plans", isPending: false, syncCursor: null,
     },
     {
       streamId: "s-users", schemaName: "public", tableName: "users", mode: "cursor" as const,
-      cursorColumn: "id", primaryKeyColumns: ["id"], destinationTable: "public_users", syncCursor: null,
+      cursorColumn: "id", primaryKeyColumns: ["id"], destinationTable: "public_users", isPending: false, syncCursor: null,
     },
   ]);
 
@@ -163,7 +163,10 @@ it("runs full refresh and cursor modes end to end on the Postgres side", async (
   expect(plans.rowsSynced).toBe(2);
   expect(users.error).toBeNull();
   expect(users.rowsSynced).toBe(500);
-  expect(users.syncCursor).toEqual({ mode: "cursor", value: "500" });
+  expect(users.syncCursor).toMatchObject({ mode: "cursor", value: "500" });
+  // The primary key of the last row read rides along, so a group of rows sharing
+  // one cursor value can be resumed through instead of re-read forever.
+  expect(JSON.parse(users.syncCursor!.key!)).toEqual(["500"]); // bigserial arrives as a string from pg
   // The swap is what makes a full refresh atomic for readers.
   expect(recorder.commands.some(c => c.startsWith("EXCHANGE TABLES"))).toBe(true);
 }, 60000);
@@ -182,10 +185,12 @@ it("resumes a cursor stream from its watermark", async () => {
   }, [{
     streamId: "s-users", schemaName: "public", tableName: "users", mode: "cursor" as const,
     cursorColumn: "id", primaryKeyColumns: ["id"], destinationTable: "public_users",
+    isPending: false,
     syncCursor: { mode: "cursor", value: "495" },
   }]);
   console.log("RESUMED", JSON.stringify(results));
-  // >= the watermark, so the boundary row is re-read rather than skipped.
+  // Without a stored key the watermark is inclusive, so the boundary row is
+  // re-read rather than skipped.
   expect(results[0].rowsSynced).toBe(6);
 }, 60000);
 
@@ -210,7 +215,7 @@ it("holds a timestamp cursor back from now(), so a late commit is not skipped", 
     slotName: "x", publicationName: "x", startedAt: new Date(),
   }, [{
     streamId: "s-users", schemaName: "public", tableName: "users", mode: "cursor" as const,
-    cursorColumn: "updated_at", primaryKeyColumns: ["id"], destinationTable: "public_users", syncCursor: null,
+    cursorColumn: "updated_at", primaryKeyColumns: ["id"], destinationTable: "public_users", isPending: false, syncCursor: null,
   }]);
 
   const emails = recorder.inserts.flatMap(i => i.rows).map(r => r.email);

--- a/apps/backend/src/lib/data-sources/postgres-integration.test.ts
+++ b/apps/backend/src/lib/data-sources/postgres-integration.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Exercises the SQL this module actually sends against a real Postgres. The
+ * catalog queries, the server-side cursor, and the whole CDC path are the parts
+ * most likely to be wrong in a way types cannot catch, and mocking them would
+ * only test the mock.
+ *
+ * Skipped unless a server is pointed at explicitly, since it needs one with
+ * logical replication enabled:
+ *
+ *   docker run -d --name hexclave-ds-test -e POSTGRES_PASSWORD=testpass \
+ *     -e POSTGRES_DB=appdb -p 55432:5432 postgres:16 \
+ *     -c wal_level=logical -c max_replication_slots=10 -c max_wal_senders=10
+ *   HEXCLAVE_DATA_SOURCE_TEST_POSTGRES=postgres:testpass@localhost:55432/appdb \
+ *     pnpm test run apps/backend/src/lib/data-sources/postgres-integration.test.ts
+ */
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
+import { beforeAll, describe, expect, it } from "vitest";
+import { probeDataSource } from "./probe";
+import { withDataSourceClient } from "./postgres";
+import { decodePgoutputMessage, formatLsn, type PgoutputRelation } from "./pgoutput";
+
+const TEST_SERVER = getEnvVariable("HEXCLAVE_DATA_SOURCE_TEST_POSTGRES", "") || undefined;
+
+function parseTestServer(value: string) {
+  const url = new URL(`postgresql://${value}`);
+  return {
+    host: url.hostname,
+    port: Number.parseInt(url.port || "5432", 10),
+    database: url.pathname.replace(/^\//, ""),
+    username: decodeURIComponent(url.username),
+    password: decodeURIComponent(url.password),
+    sslMode: "disable",
+  };
+}
+
+const credentials = parseTestServer(TEST_SERVER ?? "postgres:postgres@localhost:5432/postgres");
+
+describe.skipIf(!TEST_SERVER)("Postgres data source", () => {
+
+beforeAll(async () => {
+  await withDataSourceClient(credentials, async client => {
+    await client.query(`DROP TABLE IF EXISTS users, plans, events_noindex, keyless CASCADE`);
+    await client.query(`CREATE TABLE users (id bigserial PRIMARY KEY, email text NOT NULL, updated_at timestamptz NOT NULL DEFAULT now())`);
+    await client.query(`CREATE INDEX users_updated_at_idx ON users (updated_at)`);
+    await client.query(`CREATE TABLE plans (id int PRIMARY KEY, name text NOT NULL)`);
+    await client.query(`CREATE TABLE events_noindex (id bigserial PRIMARY KEY, payload jsonb, modified_at timestamp NOT NULL DEFAULT now())`);
+    await client.query(`CREATE TABLE keyless (a int NOT NULL, b text)`);
+    // Backdated so they sit outside the cursor safety lag; the lag test adds a
+    // fresh row of its own to check the near edge.
+    await client.query(`INSERT INTO users (email, updated_at) SELECT 'u' || g || '@example.com', now() - interval '1 hour' FROM generate_series(1, 500) g`);
+    await client.query(`INSERT INTO plans VALUES (1, 'free'), (2, 'pro')`);
+    await client.query(`ANALYZE`);
+  }, { allowWrites: true });
+}, 60000);
+
+it("probes a real server", async () => {
+  const result = await probeDataSource(credentials);
+  console.log("CAPABILITIES", JSON.stringify(result.capabilities));
+  for (const table of result.tables) {
+    console.log(`TABLE ${table.schemaName}.${table.tableName} rows=${table.approxRows} pk=[${table.primaryKeyColumns}] cursors=[${table.cursorCandidates.map(c => `${c.column}${c.indexed ? "*" : ""}`).join(",")}] cols=${table.columns.map(c => c.name + ":" + c.dataType).join(",")}`);
+  }
+  expect(result.capabilities.walLevel).toBe("logical");
+  expect(result.tables.map(t => t.tableName).sort()).toEqual(["events_noindex", "keyless", "plans", "users"]);
+}, 30000);
+
+it("creates a slot, decodes real WAL, and advances", async () => {
+  await withDataSourceClient(credentials, async client => {
+    await client.query(`DROP PUBLICATION IF EXISTS hexclave_check`);
+    await client.query(`SELECT pg_drop_replication_slot('hexclave_check') WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name='hexclave_check')`);
+    await client.query(`CREATE PUBLICATION hexclave_check FOR TABLE users, plans`);
+    await client.query(`SELECT pg_create_logical_replication_slot('hexclave_check', 'pgoutput')`);
+
+    await client.query(`INSERT INTO users (email) VALUES ('cdc-insert@example.com')`);
+    await client.query(`UPDATE users SET email = 'cdc-updated@example.com' WHERE email = 'cdc-insert@example.com'`);
+    await client.query(`DELETE FROM users WHERE email = 'cdc-updated@example.com'`);
+
+    const changes = await client.query<{ lsn: string, data: Buffer }>(
+      `SELECT lsn::text AS lsn, data FROM pg_logical_slot_peek_binary_changes($1, NULL, $2, 'proto_version', '1', 'publication_names', $3)`,
+      ["hexclave_check", 1000, "hexclave_check"],
+    );
+    const relations = new Map<number, PgoutputRelation>();
+    const decoded = changes.rows.map(row => decodePgoutputMessage(row.data, relations));
+    const kinds = decoded.map(m => m.type);
+    console.log("WAL MESSAGES", kinds.join(","));
+    console.log("DECODED", JSON.stringify(decoded.filter(m => ["insert", "update", "delete"].includes(m.type))));
+
+    expect(kinds).toContain("insert");
+    expect(kinds).toContain("update");
+    expect(kinds).toContain("delete");
+    expect(relations.size).toBeGreaterThan(0);
+
+    const lastCommit = [...decoded].reverse().find(m => m.type === "commit");
+    if (lastCommit?.type !== "commit") throw new Error("no commit decoded");
+    const lsnText = formatLsn(lastCommit.endLsn);
+    await client.query(`SELECT pg_replication_slot_advance($1, $2::pg_lsn)`, ["hexclave_check", lsnText]);
+
+    const after = await client.query(
+      `SELECT count(*)::int AS n FROM pg_logical_slot_peek_binary_changes($1, NULL, NULL, 'proto_version', '1', 'publication_names', $2)`,
+      ["hexclave_check", "hexclave_check"],
+    );
+    console.log("REMAINING AFTER ADVANCE", after.rows[0].n);
+    expect(after.rows[0].n).toBe(0);
+
+    await client.query(`SELECT pg_drop_replication_slot('hexclave_check')`);
+    await client.query(`DROP PUBLICATION hexclave_check`);
+  }, { allowWrites: true });
+}, 30000);
+
+/** Records what the engine would write, so the Postgres side can be exercised without ClickHouse. */
+function recordingClickhouse() {
+  const inserts: { table: string, rows: Record<string, unknown>[] }[] = [];
+  const commands: string[] = [];
+  return {
+    client: {
+      command: async ({ query }: { query: string }) => { commands.push(query.trim().split("\n")[0]); },
+      query: async () => ({ json: async () => [] }),
+      insert: async ({ table, values }: { table: string, values: Record<string, unknown>[] }) => {
+        inserts.push({ table, rows: values });
+      },
+      close: async () => {},
+    },
+    inserts,
+    commands,
+  };
+}
+
+it("runs full refresh and cursor modes end to end on the Postgres side", async () => {
+  const { probeDataSource } = await import("./probe");
+  const { runStreamSyncs } = await import("./sync");
+  const probe = await probeDataSource(credentials);
+  const tablesByName = new Map(probe.tables.map(t => [`${t.schemaName}.${t.tableName}`, t]));
+  const recorder = recordingClickhouse();
+
+  const context = {
+    credentials,
+    clickhouse: recorder.client as never,
+    databaseName: "wh_test",
+    tablesByName,
+    slotName: "hexclave_check2",
+    publicationName: "hexclave_check2",
+    startedAt: new Date("2026-08-21T00:00:00Z"),
+  };
+
+  const results = await runStreamSyncs(context, [
+    {
+      streamId: "s-plans", schemaName: "public", tableName: "plans", mode: "full_refresh" as const,
+      cursorColumn: null, primaryKeyColumns: ["id"], destinationTable: "public_plans", syncCursor: null,
+    },
+    {
+      streamId: "s-users", schemaName: "public", tableName: "users", mode: "cursor" as const,
+      cursorColumn: "id", primaryKeyColumns: ["id"], destinationTable: "public_users", syncCursor: null,
+    },
+  ]);
+
+  console.log("RESULTS", JSON.stringify(results, null, 2));
+  console.log("COMMANDS", JSON.stringify(recorder.commands, null, 2));
+  console.log("SAMPLE ROW", JSON.stringify(recorder.inserts.find(i => i.table.includes("plans"))?.rows[0]));
+  console.log("USER ROW", JSON.stringify(recorder.inserts.find(i => i.table.includes("users"))?.rows[0]));
+
+  const plans = results.find(r => r.streamId === "s-plans")!;
+  const users = results.find(r => r.streamId === "s-users")!;
+  expect(plans.error).toBeNull();
+  expect(plans.rowsSynced).toBe(2);
+  expect(users.error).toBeNull();
+  expect(users.rowsSynced).toBe(500);
+  expect(users.syncCursor).toEqual({ mode: "cursor", value: "500" });
+  // The swap is what makes a full refresh atomic for readers.
+  expect(recorder.commands.some(c => c.startsWith("EXCHANGE TABLES"))).toBe(true);
+}, 60000);
+
+it("resumes a cursor stream from its watermark", async () => {
+  const { probeDataSource } = await import("./probe");
+  const { runStreamSyncs } = await import("./sync");
+  const probe = await probeDataSource(credentials);
+  const recorder = recordingClickhouse();
+  const results = await runStreamSyncs({
+    credentials,
+    clickhouse: recorder.client as never,
+    databaseName: "wh_test",
+    tablesByName: new Map(probe.tables.map(t => [`${t.schemaName}.${t.tableName}`, t])),
+    slotName: "x", publicationName: "x", startedAt: new Date(),
+  }, [{
+    streamId: "s-users", schemaName: "public", tableName: "users", mode: "cursor" as const,
+    cursorColumn: "id", primaryKeyColumns: ["id"], destinationTable: "public_users",
+    syncCursor: { mode: "cursor", value: "495" },
+  }]);
+  console.log("RESUMED", JSON.stringify(results));
+  // >= the watermark, so the boundary row is re-read rather than skipped.
+  expect(results[0].rowsSynced).toBe(6);
+}, 60000);
+
+it("holds a timestamp cursor back from now(), so a late commit is not skipped", async () => {
+  const { probeDataSource } = await import("./probe");
+  const { runStreamSyncs } = await import("./sync");
+
+  // Rows written just now sit inside the safety lag and must not be read yet:
+  // reading up to now() would move the watermark past a transaction that has not
+  // committed, and that row would never be read again.
+  await withDataSourceClient(credentials, async client => {
+    await client.query(`INSERT INTO users (email, updated_at) VALUES ('fresh@example.com', now())`);
+  }, { allowWrites: true });
+
+  const probe = await probeDataSource(credentials);
+  const recorder = recordingClickhouse();
+  const results = await runStreamSyncs({
+    credentials,
+    clickhouse: recorder.client as never,
+    databaseName: "wh_test",
+    tablesByName: new Map(probe.tables.map(t => [`${t.schemaName}.${t.tableName}`, t])),
+    slotName: "x", publicationName: "x", startedAt: new Date(),
+  }, [{
+    streamId: "s-users", schemaName: "public", tableName: "users", mode: "cursor" as const,
+    cursorColumn: "updated_at", primaryKeyColumns: ["id"], destinationTable: "public_users", syncCursor: null,
+  }]);
+
+  const emails = recorder.inserts.flatMap(i => i.rows).map(r => r.email);
+  expect(emails).not.toContain("fresh@example.com");
+  expect(results[0].error).toBeNull();
+  expect(results[0].rowsSynced).toBeGreaterThan(0);
+}, 60000);
+
+});

--- a/apps/backend/src/lib/data-sources/postgres-integration.test.ts
+++ b/apps/backend/src/lib/data-sources/postgres-integration.test.ts
@@ -124,7 +124,7 @@ function recordingClickhouse() {
   };
 }
 
-it("runs full refresh and cursor modes end to end on the Postgres side", async () => {
+it("runs cursor mode end to end on the Postgres side", async () => {
   const { probeDataSource } = await import("./probe");
   const { runStreamSyncs } = await import("./sync");
   const probe = await probeDataSource(credentials);
@@ -143,8 +143,8 @@ it("runs full refresh and cursor modes end to end on the Postgres side", async (
 
   const results = await runStreamSyncs(context, [
     {
-      streamId: "s-plans", schemaName: "public", tableName: "plans", mode: "full_refresh" as const,
-      cursorColumn: null, primaryKeyColumns: ["id"], destinationTable: "public_plans", isPending: false, syncCursor: null,
+      streamId: "s-plans", schemaName: "public", tableName: "plans", mode: "cursor" as const,
+      cursorColumn: "id", primaryKeyColumns: ["id"], destinationTable: "public_plans", isPending: false, syncCursor: null,
     },
     {
       streamId: "s-users", schemaName: "public", tableName: "users", mode: "cursor" as const,
@@ -167,8 +167,6 @@ it("runs full refresh and cursor modes end to end on the Postgres side", async (
   // The primary key of the last row read rides along, so a group of rows sharing
   // one cursor value can be resumed through instead of re-read forever.
   expect(JSON.parse(users.syncCursor!.key!)).toEqual(["500"]); // bigserial arrives as a string from pg
-  // The swap is what makes a full refresh atomic for readers.
-  expect(recorder.commands.some(c => c.startsWith("EXCHANGE TABLES"))).toBe(true);
 }, 60000);
 
 it("resumes a cursor stream from its watermark", async () => {

--- a/apps/backend/src/lib/data-sources/postgres.ts
+++ b/apps/backend/src/lib/data-sources/postgres.ts
@@ -1,0 +1,87 @@
+import { getSafeExternalPostgresClientOptions } from "@/lib/ssrf-protection/external-db-sync";
+import { StatusError } from "@hexclave/shared/dist/utils/errors";
+import { Client } from "pg";
+
+/** What the customer typed into the connect form, plus the decrypted password. */
+export type DataSourceCredentials = {
+  host: string,
+  port: number,
+  database: string,
+  username: string,
+  password: string,
+  sslMode: string,
+};
+
+export const DATA_SOURCE_SSL_MODES = ["require", "verify-full", "no-verify", "disable"] as const;
+
+/**
+ * Queries run against a customer's production database, so they are bounded and
+ * identifiable: a DBA looking at pg_stat_activity should be able to tell at a
+ * glance that the query is ours and that it cannot run away.
+ */
+const STATEMENT_TIMEOUT_MS = 120_000;
+const APPLICATION_NAME = "hexclave_data_source_sync";
+
+function buildConnectionString(credentials: DataSourceCredentials): string {
+  const url = new URL("postgresql://placeholder");
+  url.hostname = credentials.host;
+  url.port = String(credentials.port);
+  url.pathname = `/${encodeURIComponent(credentials.database)}`;
+  url.username = encodeURIComponent(credentials.username);
+  url.password = encodeURIComponent(credentials.password);
+  url.searchParams.set("sslmode", credentials.sslMode);
+  return url.toString();
+}
+
+/**
+ * Connects to the customer's database with SSRF protection and our own guard
+ * rails applied, runs `fn`, and always closes the connection. Read-only: the
+ * transaction default is set so a bug in a query builder cannot write to their
+ * database, whatever privileges they happened to grant us.
+ */
+export async function withDataSourceClient<T>(
+  credentials: DataSourceCredentials,
+  fn: (client: Client) => Promise<T>,
+  options?: {
+    /**
+     * Replication slot management (creating a slot, advancing it) is not a table
+     * write but still refuses to run in a read-only transaction, so the CDC path
+     * opts out. Everything that reads customer data keeps the default.
+     */
+    allowWrites?: boolean,
+  },
+): Promise<T> {
+  const clientOptions = await getSafeExternalPostgresClientOptions(buildConnectionString(credentials));
+  const client = new Client({
+    ...clientOptions,
+    application_name: APPLICATION_NAME,
+    statement_timeout: STATEMENT_TIMEOUT_MS,
+  });
+  try {
+    await client.connect();
+  } catch (error) {
+    throw new StatusError(
+      StatusError.BadRequest,
+      `Could not connect to the source database: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  try {
+    if (!options?.allowWrites) {
+      await client.query("SET default_transaction_read_only = on");
+    }
+    return await fn(client);
+  } finally {
+    await client.end().catch(() => {
+      // The work is already done; a failure to close cleanly must not mask its result.
+    });
+  }
+}
+
+/** Quotes an identifier for interpolation into SQL we send to the source. */
+export function quotePgIdentifier(identifier: string): string {
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
+export function quotePgQualifiedName(schemaName: string, tableName: string): string {
+  return `${quotePgIdentifier(schemaName)}.${quotePgIdentifier(tableName)}`;
+}

--- a/apps/backend/src/lib/data-sources/probe.ts
+++ b/apps/backend/src/lib/data-sources/probe.ts
@@ -66,18 +66,19 @@ async function readCapabilities(client: Client): Promise<DataSourceCapabilities>
   // the budget must not fail the whole probe, so fall back to "none used" and let
   // slot creation surface the real error if it ever comes to that.
   let slotsUsed = 0;
-  // Unknown must not read as "full": `slotsUsed >= slotsMax` would report
-  // "no replication slots free" and hide CDC on a server that supports it.
-  let slotsMax = Number.POSITIVE_INFINITY;
+  // Keep unknown explicit. Non-finite sentinels cannot survive either Prisma's
+  // JSON column protocol or an API response without silently becoming null.
+  let slotsMax: number | null = null;
   try {
     const slots = await client.query<{ used: string, max: string }>(`
       SELECT (SELECT count(*) FROM pg_replication_slots) AS used,
              current_setting('max_replication_slots') AS max
     `);
     slotsUsed = Number.parseInt(slots.rows[0].used, 10);
-    slotsMax = Number.parseInt(slots.rows[0].max, 10);
+    const parsedSlotsMax = Number.parseInt(slots.rows[0].max, 10);
+    slotsMax = Number.isFinite(parsedSlotsMax) ? parsedSlotsMax : null;
   } catch {
-    slotsMax = Number.POSITIVE_INFINITY;
+    // Some managed providers intentionally hide pg_replication_slots.
   }
 
   return {

--- a/apps/backend/src/lib/data-sources/probe.ts
+++ b/apps/backend/src/lib/data-sources/probe.ts
@@ -24,11 +24,16 @@ const EXCLUDED_SCHEMAS = ["pg_catalog", "information_schema", "pg_toast"];
  * Types a cursor column may have. A cursor must be monotonic under the
  * customer's own writes, which in practice means a timestamp or an ascending
  * integer key.
+ *
+ * Matched against `format_type()` output, which spells types out and carries the
+ * type modifier: a Prisma `DateTime` column reads as
+ * `timestamp(3) without time zone`, not `timestamptz`. Stripping the modifier
+ * first is what makes those tables usable at all.
  */
-const CURSOR_TYPE_PATTERN = /^(timestamp|timestamptz|timestamp with time zone|timestamp without time zone|date|smallint|integer|bigint|int2|int4|int8)$/i;
+const CURSOR_TYPE_PATTERN = /^(timestamp( with(out)? time zone)?|date|smallint|integer|bigint)$/i;
 
 export function isCursorCandidateType(dataType: string): boolean {
-  return CURSOR_TYPE_PATTERN.test(dataType.trim());
+  return CURSOR_TYPE_PATTERN.test(dataType.trim().replace(/\(\d+(,\s*\d+)?\)/, ""));
 }
 
 async function readCapabilities(client: Client): Promise<DataSourceCapabilities> {
@@ -41,7 +46,19 @@ async function readCapabilities(client: Client): Promise<DataSourceCapabilities>
     SELECT current_setting('server_version') AS version,
            current_setting('wal_level') AS wal_level,
            pg_is_in_recovery() AS in_recovery,
-           COALESCE((SELECT rolreplication OR rolsuper FROM pg_roles WHERE rolname = current_user), false) AS has_replication
+           COALESCE(
+             (SELECT rolreplication OR rolsuper FROM pg_roles WHERE rolname = current_user)
+             -- RDS and Cloud SQL grant slot creation through role membership while
+             -- leaving rolreplication false, so the direct attribute is not enough.
+             -- Looked up through pg_roles because pg_has_role() errors outright on
+             -- a role name that does not exist, which is every self-hosted server.
+             OR EXISTS (
+               SELECT 1 FROM pg_roles r
+               WHERE r.rolname IN ('rds_replication', 'cloudsqlsuperuser')
+                 AND pg_has_role(current_user, r.oid, 'MEMBER')
+             ),
+             false
+           ) AS has_replication
   `);
   const row = rows[0];
 
@@ -49,7 +66,9 @@ async function readCapabilities(client: Client): Promise<DataSourceCapabilities>
   // the budget must not fail the whole probe, so fall back to "none used" and let
   // slot creation surface the real error if it ever comes to that.
   let slotsUsed = 0;
-  let slotsMax = 0;
+  // Unknown must not read as "full": `slotsUsed >= slotsMax` would report
+  // "no replication slots free" and hide CDC on a server that supports it.
+  let slotsMax = Number.POSITIVE_INFINITY;
   try {
     const slots = await client.query<{ used: string, max: string }>(`
       SELECT (SELECT count(*) FROM pg_replication_slots) AS used,
@@ -58,7 +77,7 @@ async function readCapabilities(client: Client): Promise<DataSourceCapabilities>
     slotsUsed = Number.parseInt(slots.rows[0].used, 10);
     slotsMax = Number.parseInt(slots.rows[0].max, 10);
   } catch {
-    slotsMax = 0;
+    slotsMax = Number.POSITIVE_INFINITY;
   }
 
   return {
@@ -67,7 +86,7 @@ async function readCapabilities(client: Client): Promise<DataSourceCapabilities>
     inRecovery: row.in_recovery,
     hasReplication: row.has_replication,
     slotsUsed: Number.isFinite(slotsUsed) ? slotsUsed : 0,
-    slotsMax: Number.isFinite(slotsMax) ? slotsMax : 0,
+    slotsMax,
     probedAtMillis: Date.now(),
   };
 }
@@ -79,15 +98,27 @@ async function readCatalog(client: Client): Promise<ProbedTable[]> {
     schema_name: string,
     table_name: string,
     approx_rows: string,
+    replica_identity: string,
+    is_logged: boolean,
+    is_partitioned: boolean,
   }>(`
     SELECT n.nspname AS schema_name,
            c.relname AS table_name,
-           GREATEST(c.reltuples, 0)::bigint::text AS approx_rows
+           -- -1 means "never analyzed", which is not the same as empty. Kept
+           -- distinct so the size-based mode gates can refuse to guess.
+           c.reltuples::bigint::text AS approx_rows,
+           c.relreplident AS replica_identity,
+           (c.relpersistence = 'p') AS is_logged,
+           (c.relkind = 'p') AS is_partitioned
     FROM pg_class c
     JOIN pg_namespace n ON n.oid = c.relnamespace
     WHERE c.relkind IN ('r', 'p')
+      -- Individual partitions are reachable through their parent, and listing
+      -- both would sync the same rows into two destination tables.
+      AND NOT c.relispartition
       AND n.nspname <> ALL($1::text[])
       AND n.nspname NOT LIKE 'pg\\_temp%'
+      AND has_schema_privilege(n.oid, 'USAGE')
       AND has_table_privilege(c.oid, 'SELECT')
     ORDER BY n.nspname, c.relname
   `, [EXCLUDED_SCHEMAS]);
@@ -105,9 +136,15 @@ async function readCatalog(client: Client): Promise<ProbedTable[]> {
            a.attname AS column_name,
            format_type(a.atttypid, a.atttypmod) AS data_type,
            a.attnotnull AS not_null,
+           -- Only a LEADING index column makes a range scan cheap; a trailing
+           -- one still reads the whole table, so calling it "indexed" would
+           -- steer getDefaultCursorColumn straight at a sequential scan.
            EXISTS (
              SELECT 1 FROM pg_index ix
-             WHERE ix.indrelid = c.oid AND a.attnum = ANY(ix.indkey)
+             WHERE ix.indrelid = c.oid
+               AND ix.indisvalid
+               AND ix.indpred IS NULL
+               AND ix.indkey[0] = a.attnum
            ) AS indexed
     FROM pg_attribute a
     JOIN pg_class c ON c.oid = a.attrelid
@@ -116,6 +153,7 @@ async function readCatalog(client: Client): Promise<ProbedTable[]> {
       AND NOT a.attisdropped
       AND c.relkind IN ('r', 'p')
       AND n.nspname <> ALL($1::text[])
+      AND has_schema_privilege(n.oid, 'USAGE')
       AND has_table_privilege(c.oid, 'SELECT')
     ORDER BY n.nspname, c.relname, a.attnum
   `, [EXCLUDED_SCHEMAS]);
@@ -134,7 +172,11 @@ async function readCatalog(client: Client): Promise<ProbedTable[]> {
     JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) ON true
     JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = k.attnum
     WHERE i.indisprimary
+      -- indkey spans INCLUDE columns too; those are not part of the key and
+      -- must not end up in ClickHouse's dedup ORDER BY.
+      AND k.ord <= i.indnkeyatts
       AND n.nspname <> ALL($1::text[])
+      AND has_schema_privilege(n.oid, 'USAGE')
       AND has_table_privilege(c.oid, 'SELECT')
     ORDER BY n.nspname, c.relname, k.ord
   `, [EXCLUDED_SCHEMAS]);
@@ -161,13 +203,19 @@ async function readCatalog(client: Client): Promise<ProbedTable[]> {
 
   return tables.rows.map(row => {
     const k = key(row.schema_name, row.table_name);
+    const rawRows = Number.parseInt(row.approx_rows, 10);
     return {
       schemaName: row.schema_name,
       tableName: row.table_name,
-      approxRows: Number.parseInt(row.approx_rows, 10) || 0,
+      // -1 is Postgres for "never analyzed". Reporting it as 0 would sneak an
+      // arbitrarily large table past every size-based gate.
+      approxRows: Number.isFinite(rawRows) && rawRows >= 0 ? rawRows : null,
       primaryKeyColumns: pkByTable.get(k) ?? [],
       cursorCandidates: cursorsByTable.get(k) ?? [],
       columns: columnsByTable.get(k) ?? [],
+      replicaIdentity: row.replica_identity,
+      isLogged: row.is_logged,
+      isPartitioned: row.is_partitioned,
     };
   });
 }

--- a/apps/backend/src/lib/data-sources/probe.ts
+++ b/apps/backend/src/lib/data-sources/probe.ts
@@ -1,0 +1,186 @@
+import type { DataSourceCapabilities, DataSourceCursorCandidate, DataSourceTableInfo } from "@hexclave/shared/dist/data-sources/modes";
+import type { Client } from "pg";
+import { withDataSourceClient, type DataSourceCredentials } from "./postgres";
+
+export type DataSourceColumn = {
+  name: string,
+  dataType: string,
+  nullable: boolean,
+};
+
+export type ProbedTable = DataSourceTableInfo & {
+  columns: DataSourceColumn[],
+};
+
+export type DataSourceProbeResult = {
+  capabilities: DataSourceCapabilities,
+  tables: ProbedTable[],
+};
+
+/** Schemas that are Postgres' own bookkeeping and never interesting to sync. */
+const EXCLUDED_SCHEMAS = ["pg_catalog", "information_schema", "pg_toast"];
+
+/**
+ * Types a cursor column may have. A cursor must be monotonic under the
+ * customer's own writes, which in practice means a timestamp or an ascending
+ * integer key.
+ */
+const CURSOR_TYPE_PATTERN = /^(timestamp|timestamptz|timestamp with time zone|timestamp without time zone|date|smallint|integer|bigint|int2|int4|int8)$/i;
+
+export function isCursorCandidateType(dataType: string): boolean {
+  return CURSOR_TYPE_PATTERN.test(dataType.trim());
+}
+
+async function readCapabilities(client: Client): Promise<DataSourceCapabilities> {
+  const { rows } = await client.query<{
+    version: string,
+    wal_level: string,
+    in_recovery: boolean,
+    has_replication: boolean,
+  }>(`
+    SELECT current_setting('server_version') AS version,
+           current_setting('wal_level') AS wal_level,
+           pg_is_in_recovery() AS in_recovery,
+           COALESCE((SELECT rolreplication OR rolsuper FROM pg_roles WHERE rolname = current_user), false) AS has_replication
+  `);
+  const row = rows[0];
+
+  // Slot accounting needs privileges some managed providers withhold. Not knowing
+  // the budget must not fail the whole probe, so fall back to "none used" and let
+  // slot creation surface the real error if it ever comes to that.
+  let slotsUsed = 0;
+  let slotsMax = 0;
+  try {
+    const slots = await client.query<{ used: string, max: string }>(`
+      SELECT (SELECT count(*) FROM pg_replication_slots) AS used,
+             current_setting('max_replication_slots') AS max
+    `);
+    slotsUsed = Number.parseInt(slots.rows[0].used, 10);
+    slotsMax = Number.parseInt(slots.rows[0].max, 10);
+  } catch {
+    slotsMax = 0;
+  }
+
+  return {
+    version: row.version,
+    walLevel: row.wal_level,
+    inRecovery: row.in_recovery,
+    hasReplication: row.has_replication,
+    slotsUsed: Number.isFinite(slotsUsed) ? slotsUsed : 0,
+    slotsMax: Number.isFinite(slotsMax) ? slotsMax : 0,
+    probedAtMillis: Date.now(),
+  };
+}
+
+async function readCatalog(client: Client): Promise<ProbedTable[]> {
+  // Only tables the role can actually read: offering a table we would be denied
+  // at sync time turns a permissions problem into a mysterious failure later.
+  const tables = await client.query<{
+    schema_name: string,
+    table_name: string,
+    approx_rows: string,
+  }>(`
+    SELECT n.nspname AS schema_name,
+           c.relname AS table_name,
+           GREATEST(c.reltuples, 0)::bigint::text AS approx_rows
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind IN ('r', 'p')
+      AND n.nspname <> ALL($1::text[])
+      AND n.nspname NOT LIKE 'pg\\_temp%'
+      AND has_table_privilege(c.oid, 'SELECT')
+    ORDER BY n.nspname, c.relname
+  `, [EXCLUDED_SCHEMAS]);
+
+  const columns = await client.query<{
+    schema_name: string,
+    table_name: string,
+    column_name: string,
+    data_type: string,
+    not_null: boolean,
+    indexed: boolean,
+  }>(`
+    SELECT n.nspname AS schema_name,
+           c.relname AS table_name,
+           a.attname AS column_name,
+           format_type(a.atttypid, a.atttypmod) AS data_type,
+           a.attnotnull AS not_null,
+           EXISTS (
+             SELECT 1 FROM pg_index ix
+             WHERE ix.indrelid = c.oid AND a.attnum = ANY(ix.indkey)
+           ) AS indexed
+    FROM pg_attribute a
+    JOIN pg_class c ON c.oid = a.attrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE a.attnum > 0
+      AND NOT a.attisdropped
+      AND c.relkind IN ('r', 'p')
+      AND n.nspname <> ALL($1::text[])
+      AND has_table_privilege(c.oid, 'SELECT')
+    ORDER BY n.nspname, c.relname, a.attnum
+  `, [EXCLUDED_SCHEMAS]);
+
+  const primaryKeys = await client.query<{
+    schema_name: string,
+    table_name: string,
+    column_name: string,
+  }>(`
+    SELECT n.nspname AS schema_name,
+           c.relname AS table_name,
+           a.attname AS column_name
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indrelid
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN LATERAL unnest(i.indkey) WITH ORDINALITY AS k(attnum, ord) ON true
+    JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum = k.attnum
+    WHERE i.indisprimary
+      AND n.nspname <> ALL($1::text[])
+      AND has_table_privilege(c.oid, 'SELECT')
+    ORDER BY n.nspname, c.relname, k.ord
+  `, [EXCLUDED_SCHEMAS]);
+
+  const key = (schemaName: string, tableName: string) => `${schemaName}.${tableName}`;
+  const columnsByTable = new Map<string, DataSourceColumn[]>();
+  const cursorsByTable = new Map<string, DataSourceCursorCandidate[]>();
+  for (const row of columns.rows) {
+    const k = key(row.schema_name, row.table_name);
+    if (!columnsByTable.has(k)) columnsByTable.set(k, []);
+    columnsByTable.get(k)!.push({ name: row.column_name, dataType: row.data_type, nullable: !row.not_null });
+    // A nullable cursor column would let rows sit permanently below any watermark.
+    if (row.not_null && isCursorCandidateType(row.data_type)) {
+      if (!cursorsByTable.has(k)) cursorsByTable.set(k, []);
+      cursorsByTable.get(k)!.push({ column: row.column_name, dataType: row.data_type, indexed: row.indexed });
+    }
+  }
+  const pkByTable = new Map<string, string[]>();
+  for (const row of primaryKeys.rows) {
+    const k = key(row.schema_name, row.table_name);
+    if (!pkByTable.has(k)) pkByTable.set(k, []);
+    pkByTable.get(k)!.push(row.column_name);
+  }
+
+  return tables.rows.map(row => {
+    const k = key(row.schema_name, row.table_name);
+    return {
+      schemaName: row.schema_name,
+      tableName: row.table_name,
+      approxRows: Number.parseInt(row.approx_rows, 10) || 0,
+      primaryKeyColumns: pkByTable.get(k) ?? [],
+      cursorCandidates: cursorsByTable.get(k) ?? [],
+      columns: columnsByTable.get(k) ?? [],
+    };
+  });
+}
+
+/**
+ * Connects to the customer's database and reads everything the "choose tables"
+ * screen needs: what the server can do, and what is in it. Runs on every sync as
+ * well as on connect, so a customer who enables logical replication later is
+ * offered CDC without re-adding the source.
+ */
+export async function probeDataSource(credentials: DataSourceCredentials): Promise<DataSourceProbeResult> {
+  return await withDataSourceClient(credentials, async client => ({
+    capabilities: await readCapabilities(client),
+    tables: await readCatalog(client),
+  }));
+}

--- a/apps/backend/src/lib/data-sources/rows.test.ts
+++ b/apps/backend/src/lib/data-sources/rows.test.ts
@@ -1,5 +1,37 @@
 import { describe, expect, it } from "vitest";
-import { versionFromCursorValue } from "./rows";
+import { buildDestinationRow, buildSourceRow, versionFromCursorValue } from "./rows";
+
+describe("source row conversion", () => {
+  it("preserves prototype-sensitive PostgreSQL column names as own fields", () => {
+    const source = buildSourceRow(["__proto__", "constructor", "toString"], ["proto", "ctor", "string"]);
+
+    expect(Object.hasOwn(source, "__proto__")).toBe(true);
+    expect(source["__proto__"]).toBe("proto");
+    expect(source["constructor"]).toBe("ctor");
+    expect(source["toString"]).toBe("string");
+
+    const destination = buildDestinationRow({
+      values: source,
+      columns: [
+        { name: "__proto__", dataType: "text", nullable: false },
+        { name: "constructor", dataType: "text", nullable: false },
+        { name: "toString", dataType: "text", nullable: false },
+      ],
+      version: 1n,
+      deleted: false,
+      extractedAt: new Date("2026-08-22T00:00:00Z"),
+    });
+
+    expect(Object.hasOwn(destination, "__proto__")).toBe(true);
+    expect(destination["__proto__"]).toBe("proto");
+    expect(destination["constructor"]).toBe("ctor");
+    expect(destination["toString"]).toBe("string");
+  });
+
+  it("rejects array rows whose field metadata does not match", () => {
+    expect(() => buildSourceRow(["one"], [])).toThrow("1 columns");
+  });
+});
 
 describe("sync versions", () => {
   it("keeps pre-1970 timestamps positive for a UInt64 column", () => {

--- a/apps/backend/src/lib/data-sources/rows.test.ts
+++ b/apps/backend/src/lib/data-sources/rows.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { versionFromCursorValue } from "./rows";
+
+describe("sync versions", () => {
+  it("keeps pre-1970 timestamps positive for a UInt64 column", () => {
+    // ClickHouse rejects a leading '-' outright, and ORDER BY cursor ASC puts the
+    // oldest rows in the very first batch — so this used to fail every sync.
+    const old = versionFromCursorValue(new Date("1900-01-01T00:00:00Z"));
+    expect(old > 0n).toBe(true);
+    expect(old < versionFromCursorValue(new Date("2026-01-01T00:00:00Z"))).toBe(true);
+  });
+
+  it("orders timestamps regardless of representation", () => {
+    expect(versionFromCursorValue(new Date("2026-01-01T00:00:00Z")))
+      .toBe(versionFromCursorValue("2026-01-01T00:00:00.000Z"));
+  });
+
+  it("clamps negative integer cursors instead of failing the batch", () => {
+    expect(versionFromCursorValue(-5)).toBe(0n);
+    expect(versionFromCursorValue("42")).toBe(42n);
+  });
+
+  it("refuses a value it cannot order", () => {
+    expect(() => versionFromCursorValue({})).toThrow("Cannot derive a sync version");
+  });
+});

--- a/apps/backend/src/lib/data-sources/rows.ts
+++ b/apps/backend/src/lib/data-sources/rows.ts
@@ -1,0 +1,75 @@
+import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+import {
+  DELETED_COLUMN,
+  EXTRACTED_AT_COLUMN,
+  VERSION_COLUMN,
+  mapPostgresTypeToClickhouse,
+  normalizeValueForClickhouse,
+} from "./clickhouse-destination";
+import type { DataSourceColumn } from "./probe";
+
+/**
+ * Rows reach us two ways — as native `pg` values from a SELECT, and as text from
+ * the WAL — and both have to land in the same typed ClickHouse columns. These
+ * helpers are the single place that reconciles them.
+ */
+
+/** Converts a WAL text value to the JS type its destination column expects. */
+export function coerceTextValue(text: string | null, postgresType: string): unknown {
+  if (text === null) return null;
+  const clickhouseType = mapPostgresTypeToClickhouse(postgresType);
+  if (/^Int|^Float|^Decimal/.test(clickhouseType)) {
+    const value = Number(text);
+    // Int64 beyond 2^53 loses precision as a JS number; ClickHouse accepts the
+    // decimal string for those, so keep it as text rather than round it.
+    if (!Number.isSafeInteger(value) && /^Int64|^Decimal/.test(clickhouseType)) return text;
+    if (!Number.isFinite(value)) return null;
+    return value;
+  }
+  if (clickhouseType === "Bool") return text === "t" || text === "true" || text === "1";
+  return text;
+}
+
+export function buildDestinationRow(options: {
+  values: Record<string, unknown>,
+  columns: DataSourceColumn[],
+  version: bigint,
+  deleted: boolean,
+  extractedAt: Date,
+}): Record<string, unknown> {
+  const row: Record<string, unknown> = {};
+  for (const column of options.columns) {
+    // `undefined` means the WAL withheld an unchanged TOAST value. Writing null
+    // would erase it, so those columns are simply omitted and ClickHouse's
+    // default applies — the previous version of the row stays queryable.
+    if (!(column.name in options.values)) continue;
+    const value = options.values[column.name];
+    if (value === undefined) continue;
+    row[column.name] = normalizeValueForClickhouse(value);
+  }
+  row[EXTRACTED_AT_COLUMN] = options.extractedAt.toISOString();
+  row[VERSION_COLUMN] = options.version.toString();
+  row[DELETED_COLUMN] = options.deleted ? 1 : 0;
+  return row;
+}
+
+/**
+ * A monotonic UInt64 for ReplacingMergeTree to resolve duplicates with. Whatever
+ * the mode, a later version of a row must produce a larger number than an
+ * earlier one, or the wrong row wins.
+ */
+export function versionFromCursorValue(value: unknown): bigint {
+  if (value instanceof Date) return BigInt(value.getTime()) * 1000n;
+  if (typeof value === "bigint") return value;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new HexclaveAssertionError("Cursor value is not finite");
+    return BigInt(Math.trunc(value));
+  }
+  if (typeof value === "string") {
+    const asNumber = Number(value);
+    if (Number.isFinite(asNumber) && /^-?\d+$/.test(value.trim())) return BigInt(value.trim());
+    const asDate = new Date(value);
+    if (!Number.isNaN(asDate.getTime())) return BigInt(asDate.getTime()) * 1000n;
+  }
+  throw new HexclaveAssertionError(`Cannot derive a sync version from cursor value ${JSON.stringify(value)}`);
+}

--- a/apps/backend/src/lib/data-sources/rows.ts
+++ b/apps/backend/src/lib/data-sources/rows.ts
@@ -54,22 +54,49 @@ export function buildDestinationRow(options: {
 }
 
 /**
+ * Shifts timestamps so that dates before 1970 stay positive. The destination
+ * version column is UInt64 — ClickHouse rejects a leading '-' outright, which
+ * would fail the whole insert batch — and ORDER BY cursor ASC puts exactly those
+ * oldest rows in the first batch, so an unshifted stream would never sync a
+ * single row. Large enough for year 1 (~-6.2e16 µs) and far below UInt64's range.
+ */
+const TEMPORAL_VERSION_OFFSET = 100_000_000_000_000_000n;
+
+/**
  * A monotonic UInt64 for ReplacingMergeTree to resolve duplicates with. Whatever
  * the mode, a later version of a row must produce a larger number than an
  * earlier one, or the wrong row wins.
  */
 export function versionFromCursorValue(value: unknown): bigint {
-  if (value instanceof Date) return BigInt(value.getTime()) * 1000n;
-  if (typeof value === "bigint") return value;
+  if (value instanceof Date) return temporalVersion(BigInt(value.getTime()) * 1000n);
+  if (typeof value === "bigint") return integerVersion(value);
   if (typeof value === "number") {
     if (!Number.isFinite(value)) throw new HexclaveAssertionError("Cursor value is not finite");
-    return BigInt(Math.trunc(value));
+    return integerVersion(BigInt(Math.trunc(value)));
   }
   if (typeof value === "string") {
-    const asNumber = Number(value);
-    if (Number.isFinite(asNumber) && /^-?\d+$/.test(value.trim())) return BigInt(value.trim());
-    const asDate = new Date(value);
-    if (!Number.isNaN(asDate.getTime())) return BigInt(asDate.getTime()) * 1000n;
+    const trimmed = value.trim();
+    if (/^-?\d+$/.test(trimmed)) return integerVersion(BigInt(trimmed));
+    const asDate = new Date(trimmed);
+    if (!Number.isNaN(asDate.getTime())) return temporalVersion(BigInt(asDate.getTime()) * 1000n);
   }
   throw new HexclaveAssertionError(`Cannot derive a sync version from cursor value ${JSON.stringify(value)}`);
+}
+
+function temporalVersion(micros: bigint): bigint {
+  const shifted = micros + TEMPORAL_VERSION_OFFSET;
+  if (shifted < 0n) {
+    throw new HexclaveAssertionError(`Cursor timestamp is too far in the past to version: ${micros}`);
+  }
+  return shifted;
+}
+
+/**
+ * Negative integer cursors are legal in Postgres but cannot be represented. They
+ * collapse to 0 rather than failing the stream: ordering only matters between two
+ * versions of the same row, and a row appearing twice at two different negative
+ * cursor values is far less likely than a table that simply contains some.
+ */
+function integerVersion(value: bigint): bigint {
+  return value < 0n ? 0n : value;
 }

--- a/apps/backend/src/lib/data-sources/rows.ts
+++ b/apps/backend/src/lib/data-sources/rows.ts
@@ -30,6 +30,20 @@ export function coerceTextValue(text: string | null, postgresType: string): unkn
   return text;
 }
 
+/**
+ * Rebuilds a pg array-mode result as a prototype-safe object. pg's default row
+ * parser assigns by property name on `{}`, so a legitimate PostgreSQL column
+ * named `__proto__` mutates the object's prototype instead of becoming an own
+ * field. Array mode preserves every value; Object.fromEntries defines even
+ * prototype-sensitive names as ordinary data properties.
+ */
+export function buildSourceRow(columnNames: readonly string[], values: readonly unknown[]): Record<string, unknown> {
+  if (columnNames.length !== values.length) {
+    throw new HexclaveAssertionError(`Source row has ${values.length} values for ${columnNames.length} columns`);
+  }
+  return Object.fromEntries(columnNames.map((name, index) => [name, values[index]]));
+}
+
 export function buildDestinationRow(options: {
   values: Record<string, unknown>,
   columns: DataSourceColumn[],
@@ -37,20 +51,20 @@ export function buildDestinationRow(options: {
   deleted: boolean,
   extractedAt: Date,
 }): Record<string, unknown> {
-  const row: Record<string, unknown> = {};
+  const row = new Map<string, unknown>();
   for (const column of options.columns) {
     // `undefined` means the WAL withheld an unchanged TOAST value. Writing null
     // would erase it, so those columns are simply omitted and ClickHouse's
     // default applies — the previous version of the row stays queryable.
-    if (!(column.name in options.values)) continue;
+    if (!Object.hasOwn(options.values, column.name)) continue;
     const value = options.values[column.name];
     if (value === undefined) continue;
-    row[column.name] = normalizeValueForClickhouse(value);
+    row.set(column.name, normalizeValueForClickhouse(value));
   }
-  row[EXTRACTED_AT_COLUMN] = options.extractedAt.toISOString();
-  row[VERSION_COLUMN] = options.version.toString();
-  row[DELETED_COLUMN] = options.deleted ? 1 : 0;
-  return row;
+  row.set(EXTRACTED_AT_COLUMN, options.extractedAt.toISOString());
+  row.set(VERSION_COLUMN, options.version.toString());
+  row.set(DELETED_COLUMN, options.deleted ? 1 : 0);
+  return Object.fromEntries(row);
 }
 
 /**

--- a/apps/backend/src/lib/data-sources/serialize.test.ts
+++ b/apps/backend/src/lib/data-sources/serialize.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import type { DataSourceProbeResult } from "./probe";
+import { serializeCatalog } from "./serialize";
+
+describe("data source serialization", () => {
+  it("preserves an unknown replication slot maximum as null across JSON", () => {
+    const probe: DataSourceProbeResult = {
+      capabilities: {
+        version: "16.4",
+        walLevel: "logical",
+        hasReplication: true,
+        inRecovery: false,
+        slotsUsed: 0,
+        slotsMax: null,
+        probedAtMillis: 0,
+      },
+      tables: [],
+    };
+
+    const serialized = serializeCatalog(probe);
+
+    expect(serialized.capabilities.slots_max).toBeNull();
+    expect(JSON.stringify(serialized)).toContain('"slots_max":null');
+  });
+});

--- a/apps/backend/src/lib/data-sources/serialize.ts
+++ b/apps/backend/src/lib/data-sources/serialize.ts
@@ -9,7 +9,6 @@ import {
 import type { DataSourceProbeResult } from "./probe";
 
 const MODE_FROM_PRISMA = {
-  FULL_REFRESH: "full_refresh",
   CURSOR: "cursor",
   CDC: "cdc",
 } as const;

--- a/apps/backend/src/lib/data-sources/serialize.ts
+++ b/apps/backend/src/lib/data-sources/serialize.ts
@@ -96,6 +96,8 @@ export function serializeCatalog(probe: DataSourceProbeResult) {
         schema_name: table.schemaName,
         table_name: table.tableName,
         approx_rows: table.approxRows,
+        replica_identity: table.replicaIdentity,
+        is_partitioned: table.isPartitioned,
         primary_key_columns: table.primaryKeyColumns,
         cursor_candidates: table.cursorCandidates.map(candidate => ({
           column: candidate.column,

--- a/apps/backend/src/lib/data-sources/serialize.ts
+++ b/apps/backend/src/lib/data-sources/serialize.ts
@@ -1,0 +1,115 @@
+import type { DataSource, DataSourceStream } from "@/generated/prisma/client";
+import {
+  DATA_SOURCE_SYNC_MODES,
+  getDefaultCursorColumn,
+  getModeAvailability,
+  getRecommendedMode,
+  type DataSourceCapabilities,
+} from "@hexclave/shared/dist/data-sources/modes";
+import type { DataSourceProbeResult } from "./probe";
+
+const MODE_FROM_PRISMA = {
+  FULL_REFRESH: "full_refresh",
+  CURSOR: "cursor",
+  CDC: "cdc",
+} as const;
+
+const STATUS_FROM_PRISMA = {
+  PENDING: "pending",
+  ACTIVE: "active",
+  PAUSED: "paused",
+  FAILED: "failed",
+} as const;
+
+const STREAM_STATUS_FROM_PRISMA = {
+  PENDING: "pending",
+  SNAPSHOTTING: "snapshotting",
+  ACTIVE: "active",
+  FAILED: "failed",
+} as const;
+
+export function serializeStream(stream: DataSourceStream) {
+  return {
+    id: stream.id,
+    schema_name: stream.schemaName,
+    table_name: stream.tableName,
+    mode: MODE_FROM_PRISMA[stream.mode],
+    cursor_column: stream.cursorColumn,
+    primary_key_columns: stream.primaryKeyColumns,
+    destination_table: stream.destinationTable,
+    status: STREAM_STATUS_FROM_PRISMA[stream.status],
+    error: stream.error,
+    // BigInt does not survive JSON, and a row count is never precise enough for
+    // the extra digits to matter.
+    rows_synced: Number(stream.rowsSynced),
+    last_synced_at_millis: stream.lastSyncedAt?.getTime() ?? null,
+  };
+}
+
+export function serializeDataSource(source: DataSource & { streams: DataSourceStream[] }) {
+  const capabilities = (source.capabilities ?? null) as DataSourceCapabilities | null;
+  return {
+    id: source.id,
+    type: "postgres" as const,
+    host: source.host,
+    port: source.port,
+    database: source.database,
+    username: source.username,
+    ssl_mode: source.sslMode,
+    status: STATUS_FROM_PRISMA[source.status],
+    error: source.error,
+    sync_interval_seconds: source.syncIntervalSeconds,
+    capabilities: capabilities == null ? null : {
+      version: capabilities.version,
+      wal_level: capabilities.walLevel,
+      has_replication: capabilities.hasReplication,
+      in_recovery: capabilities.inRecovery,
+      slots_used: capabilities.slotsUsed,
+      slots_max: capabilities.slotsMax,
+      probed_at_millis: capabilities.probedAtMillis,
+    },
+    last_sync_started_at_millis: source.lastSyncStartedAt?.getTime() ?? null,
+    last_sync_finished_at_millis: source.lastSyncFinishedAt?.getTime() ?? null,
+    streams: source.streams.map(serializeStream),
+  };
+}
+
+/**
+ * The catalog the "choose tables" screen renders. Mode availability is resolved
+ * here rather than in the dashboard so that what is offered and what the backend
+ * will accept can never drift apart.
+ */
+export function serializeCatalog(probe: DataSourceProbeResult) {
+  return {
+    capabilities: {
+      version: probe.capabilities.version,
+      wal_level: probe.capabilities.walLevel,
+      has_replication: probe.capabilities.hasReplication,
+      in_recovery: probe.capabilities.inRecovery,
+      slots_used: probe.capabilities.slotsUsed,
+      slots_max: probe.capabilities.slotsMax,
+      probed_at_millis: probe.capabilities.probedAtMillis,
+    },
+    tables: probe.tables.map(table => {
+      const availability = getModeAvailability(table, probe.capabilities);
+      return {
+        schema_name: table.schemaName,
+        table_name: table.tableName,
+        approx_rows: table.approxRows,
+        primary_key_columns: table.primaryKeyColumns,
+        cursor_candidates: table.cursorCandidates.map(candidate => ({
+          column: candidate.column,
+          data_type: candidate.dataType,
+          indexed: candidate.indexed,
+        })),
+        available_modes: DATA_SOURCE_SYNC_MODES.map(mode => ({
+          mode,
+          available: availability[mode].available,
+          reason: availability[mode].reason,
+        })),
+        recommended_mode: getRecommendedMode(table, probe.capabilities),
+        default_cursor_column: getDefaultCursorColumn(table),
+      };
+    }),
+  };
+}

--- a/apps/backend/src/lib/data-sources/sync.test.ts
+++ b/apps/backend/src/lib/data-sources/sync.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { getCursorSyncBatchLimit } from "./sync";
+
+describe("cursor sync batch limits", () => {
+  it("reads a keyless cursor stream to exhaustion so a large tie cannot strand later values", () => {
+    expect(getCursorSyncBatchLimit([])).toBeNull();
+  });
+
+  it("keeps the fairness cap when a primary key provides a strict resume point", () => {
+    expect(getCursorSyncBatchLimit(["id"])).toBe(50);
+  });
+});

--- a/apps/backend/src/lib/data-sources/sync.ts
+++ b/apps/backend/src/lib/data-sources/sync.ts
@@ -9,7 +9,7 @@ import {
 import { decodePgoutputMessage, formatLsn, parseLsn, type PgoutputRelation, type PgoutputTuple } from "./pgoutput";
 import { quotePgIdentifier, quotePgQualifiedName, withDataSourceClient, type DataSourceCredentials } from "./postgres";
 import type { DataSourceColumn, ProbedTable } from "./probe";
-import { buildDestinationRow, coerceTextValue, versionFromCursorValue } from "./rows";
+import { buildDestinationRow, buildSourceRow, coerceTextValue, versionFromCursorValue } from "./rows";
 
 /** Rows per round trip. Large enough to amortise latency, small enough to bound memory. */
 const READ_BATCH_SIZE = 10_000;
@@ -120,9 +120,15 @@ async function forEachBatch(
   try {
     await client.query(`DECLARE ${quotePgIdentifier(cursorName)} NO SCROLL CURSOR FOR ${query}`, params);
     for (let batch = 0; options.maxBatches == null || batch < options.maxBatches; batch++) {
-      const result = await client.query(`FETCH ${READ_BATCH_SIZE} FROM ${quotePgIdentifier(cursorName)}`);
+      // Array mode is required for prototype-sensitive PostgreSQL column names.
+      // pg's default object parser cannot represent `__proto__` as an own field.
+      const result = await client.query<unknown[]>({
+        text: `FETCH ${READ_BATCH_SIZE} FROM ${quotePgIdentifier(cursorName)}`,
+        rowMode: "array",
+      });
       if (result.rows.length === 0) break;
-      await onBatch(result.rows as Record<string, unknown>[]);
+      const columnNames = result.fields.map(field => field.name);
+      await onBatch(result.rows.map(values => buildSourceRow(columnNames, values)));
       total += result.rows.length;
       if (result.rows.length < READ_BATCH_SIZE) break;
     }

--- a/apps/backend/src/lib/data-sources/sync.ts
+++ b/apps/backend/src/lib/data-sources/sync.ts
@@ -38,7 +38,7 @@ export type StreamSyncPlan = {
   streamId: string,
   schemaName: string,
   tableName: string,
-  mode: "full_refresh" | "cursor" | "cdc",
+  mode: "cursor" | "cdc",
   cursorColumn: string | null,
   primaryKeyColumns: string[],
   destinationTable: string,
@@ -125,59 +125,6 @@ async function forEachBatch(
     });
   }
   return total;
-}
-
-/**
- * Reload the table wholesale into a staging table, then swap it in atomically.
- * Readers see the old table until the exchange, and never a half-loaded one.
- */
-async function syncFullRefresh(
-  context: SyncContext,
-  plan: StreamSyncPlan,
-  table: ProbedTable,
-  client: Client,
-): Promise<StreamSyncResult> {
-  const stagingTable = `${plan.destinationTable}__staging`;
-  const version = BigInt(context.startedAt.getTime()) * 1000n;
-
-  await prepareDestination(context, plan, table);
-  await context.clickhouse.command({
-    query: `DROP TABLE IF EXISTS ${quoteClickhouseIdentifier(context.databaseName)}.${quoteClickhouseIdentifier(stagingTable)}`,
-  });
-  await ensureDestinationTable(context.clickhouse, {
-    databaseName: context.databaseName,
-    tableName: stagingTable,
-    columns: table.columns,
-    primaryKeyColumns: plan.primaryKeyColumns,
-  });
-
-  const rowsSynced = await forEachBatch(
-    client,
-    `SELECT * FROM ${quotePgQualifiedName(plan.schemaName, plan.tableName)}`,
-    [],
-    async rows => {
-      await insertRows(context.clickhouse, {
-        databaseName: context.databaseName,
-        tableName: stagingTable,
-        rows: rows.map(values => buildDestinationRow({
-          values, columns: table.columns, version, deleted: false, extractedAt: context.startedAt,
-        })),
-      });
-    },
-    // Unbounded: the mode is already restricted to tables under
-    // FULL_REFRESH_MAX_ROWS, and a partial load would be swapped in as if complete.
-    { maxBatches: Number.POSITIVE_INFINITY },
-  );
-
-  await context.clickhouse.command({
-    query: `EXCHANGE TABLES ${quoteClickhouseIdentifier(context.databaseName)}.${quoteClickhouseIdentifier(stagingTable)}
-            AND ${quoteClickhouseIdentifier(context.databaseName)}.${quoteClickhouseIdentifier(plan.destinationTable)}`,
-  });
-  await context.clickhouse.command({
-    query: `DROP TABLE IF EXISTS ${quoteClickhouseIdentifier(context.databaseName)}.${quoteClickhouseIdentifier(stagingTable)}`,
-  });
-
-  return { streamId: plan.streamId, rowsSynced, syncCursor: null, error: null };
 }
 
 /** Reads rows whose cursor column advanced past the last watermark. */
@@ -615,9 +562,7 @@ export async function runStreamSyncs(context: SyncContext, plans: StreamSyncPlan
           continue;
         }
         try {
-          results.push(plan.mode === "full_refresh"
-            ? await syncFullRefresh(context, plan, table, client)
-            : await syncCursor(context, plan, table, client));
+          results.push(await syncCursor(context, plan, table, client));
         } catch (error) {
           results.push({
             streamId: plan.streamId,

--- a/apps/backend/src/lib/data-sources/sync.ts
+++ b/apps/backend/src/lib/data-sources/sync.ts
@@ -13,12 +13,7 @@ import { buildDestinationRow, coerceTextValue, versionFromCursorValue } from "./
 
 /** Rows per round trip. Large enough to amortise latency, small enough to bound memory. */
 const READ_BATCH_SIZE = 10_000;
-/**
- * Stops one enormous table from monopolising a sync run. Only safe for cursor
- * mode, which resumes from its watermark next run — a full refresh or a CDC
- * snapshot that stopped early would publish a partial table, so those read to
- * exhaustion instead.
- */
+/** Stops one enormous, keyset-paginated table from monopolising a sync run. */
 const MAX_BATCHES_PER_CURSOR_SYNC = 50;
 /** WAL changes decoded per peek. Postgres always completes the transaction it is in, so this is a floor. */
 const MAX_WAL_CHANGES_PER_SYNC = 20_000;
@@ -84,6 +79,18 @@ function tableKey(schemaName: string, tableName: string): string {
   return `${schemaName}.${tableName}`;
 }
 
+/**
+ * Keyset pagination can stop at the fairness cap and resume strictly after the
+ * last `(cursor, primary key)` pair. A keyless stream has to resume inclusively
+ * so it does not skip late rows at the watermark. Capping that query could leave
+ * it forever behind a tie larger than the cap, so correctness requires reading
+ * it to exhaustion. The server-side cursor still bounds memory, but such a sync
+ * can run substantially longer than a keyed one.
+ */
+export function getCursorSyncBatchLimit(primaryKeyColumns: readonly string[]): number | null {
+  return primaryKeyColumns.length > 0 ? MAX_BATCHES_PER_CURSOR_SYNC : null;
+}
+
 async function prepareDestination(context: SyncContext, plan: StreamSyncPlan, table: ProbedTable): Promise<void> {
   if (plan.isPending) {
     // Rebuilt from scratch rather than merged into: see StreamSyncPlan.isPending.
@@ -105,14 +112,14 @@ async function forEachBatch(
   query: string,
   params: unknown[],
   onBatch: (rows: Record<string, unknown>[]) => Promise<void>,
-  options: { maxBatches: number },
+  options: { maxBatches: number | null },
 ): Promise<number> {
   const cursorName = `hexclave_sync_${Math.random().toString(36).slice(2, 10)}`;
   let total = 0;
   await client.query("BEGIN");
   try {
     await client.query(`DECLARE ${quotePgIdentifier(cursorName)} NO SCROLL CURSOR FOR ${query}`, params);
-    for (let batch = 0; batch < options.maxBatches; batch++) {
+    for (let batch = 0; options.maxBatches == null || batch < options.maxBatches; batch++) {
       const result = await client.query(`FETCH ${READ_BATCH_SIZE} FROM ${quotePgIdentifier(cursorName)}`);
       if (result.rows.length === 0) break;
       await onBatch(result.rows as Record<string, unknown>[]);
@@ -217,7 +224,7 @@ async function syncCursor(
         rows: destinationRows,
       });
     },
-    { maxBatches: MAX_BATCHES_PER_CURSOR_SYNC },
+    { maxBatches: getCursorSyncBatchLimit(plan.primaryKeyColumns) },
   );
 
   const nextValue = maxCursor;

--- a/apps/backend/src/lib/data-sources/sync.ts
+++ b/apps/backend/src/lib/data-sources/sync.ts
@@ -1,0 +1,468 @@
+import type { ClickHouseClient } from "@clickhouse/client";
+import type { Client } from "pg";
+import {
+  DELETED_COLUMN,
+  ensureDestinationTable,
+  insertRows,
+  quoteClickhouseIdentifier,
+} from "./clickhouse-destination";
+import { decodePgoutputMessage, formatLsn, parseLsn, type PgoutputRelation, type PgoutputTuple } from "./pgoutput";
+import { quotePgIdentifier, quotePgQualifiedName, withDataSourceClient, type DataSourceCredentials } from "./postgres";
+import type { DataSourceColumn, ProbedTable } from "./probe";
+import { buildDestinationRow, coerceTextValue, versionFromCursorValue } from "./rows";
+
+/** Rows per round trip. Large enough to amortise latency, small enough to bound memory. */
+const READ_BATCH_SIZE = 10_000;
+/** Stops one enormous table from monopolising a sync run; the next run resumes where this left off. */
+const MAX_BATCHES_PER_STREAM = 50;
+/** WAL changes decoded per peek. Postgres always completes the transaction it is in, so this is a floor. */
+const MAX_WAL_CHANGES_PER_SYNC = 20_000;
+
+/**
+ * Reading up to `now()` would race the commit of a transaction that set its
+ * timestamp earlier: its rows would become visible after we had already moved
+ * the watermark past them, and would never be read again. Staying behind by this
+ * much shrinks that window to transactions that run longer than it.
+ */
+const CURSOR_SAFETY_LAG_SECONDS = 10;
+
+export type StreamSyncPlan = {
+  streamId: string,
+  schemaName: string,
+  tableName: string,
+  mode: "full_refresh" | "cursor" | "cdc",
+  cursorColumn: string | null,
+  primaryKeyColumns: string[],
+  destinationTable: string,
+  syncCursor: { mode: string, value: string } | null,
+};
+
+export type StreamSyncResult = {
+  streamId: string,
+  rowsSynced: number,
+  syncCursor: { mode: string, value: string } | null,
+  error: string | null,
+};
+
+export type SyncContext = {
+  credentials: DataSourceCredentials,
+  clickhouse: ClickHouseClient,
+  databaseName: string,
+  /** Fresh catalog, keyed `schema.table`, so column lists match what we are about to read. */
+  tablesByName: Map<string, ProbedTable>,
+  slotName: string,
+  publicationName: string,
+  startedAt: Date,
+};
+
+function tableKey(schemaName: string, tableName: string): string {
+  return `${schemaName}.${tableName}`;
+}
+
+async function prepareDestination(context: SyncContext, plan: StreamSyncPlan, table: ProbedTable): Promise<void> {
+  await ensureDestinationTable(context.clickhouse, {
+    databaseName: context.databaseName,
+    tableName: plan.destinationTable,
+    columns: table.columns,
+    primaryKeyColumns: plan.primaryKeyColumns,
+  });
+}
+
+/** Streams a SELECT through a server-side cursor so memory stays bounded whatever the table size. */
+async function forEachBatch(
+  client: Client,
+  query: string,
+  params: unknown[],
+  onBatch: (rows: Record<string, unknown>[]) => Promise<void>,
+): Promise<number> {
+  const cursorName = `hexclave_sync_${Math.random().toString(36).slice(2, 10)}`;
+  let total = 0;
+  await client.query("BEGIN");
+  try {
+    await client.query(`DECLARE ${quotePgIdentifier(cursorName)} NO SCROLL CURSOR FOR ${query}`, params);
+    for (let batch = 0; batch < MAX_BATCHES_PER_STREAM; batch++) {
+      const result = await client.query(`FETCH ${READ_BATCH_SIZE} FROM ${quotePgIdentifier(cursorName)}`);
+      if (result.rows.length === 0) break;
+      await onBatch(result.rows as Record<string, unknown>[]);
+      total += result.rows.length;
+      if (result.rows.length < READ_BATCH_SIZE) break;
+    }
+  } finally {
+    await client.query("COMMIT").catch(() => {
+      // A cursor left open is closed by the connection ending moments later.
+    });
+  }
+  return total;
+}
+
+/**
+ * Reload the table wholesale into a staging table, then swap it in atomically.
+ * Readers see the old table until the exchange, and never a half-loaded one.
+ */
+async function syncFullRefresh(
+  context: SyncContext,
+  plan: StreamSyncPlan,
+  table: ProbedTable,
+  client: Client,
+): Promise<StreamSyncResult> {
+  const stagingTable = `${plan.destinationTable}__staging`;
+  const version = BigInt(context.startedAt.getTime()) * 1000n;
+
+  await prepareDestination(context, plan, table);
+  await context.clickhouse.command({
+    query: `DROP TABLE IF EXISTS ${quoteClickhouseIdentifier(context.databaseName)}.${quoteClickhouseIdentifier(stagingTable)}`,
+  });
+  await ensureDestinationTable(context.clickhouse, {
+    databaseName: context.databaseName,
+    tableName: stagingTable,
+    columns: table.columns,
+    primaryKeyColumns: plan.primaryKeyColumns,
+  });
+
+  const rowsSynced = await forEachBatch(
+    client,
+    `SELECT * FROM ${quotePgQualifiedName(plan.schemaName, plan.tableName)}`,
+    [],
+    async rows => {
+      await insertRows(context.clickhouse, {
+        databaseName: context.databaseName,
+        tableName: stagingTable,
+        rows: rows.map(values => buildDestinationRow({
+          values, columns: table.columns, version, deleted: false, extractedAt: context.startedAt,
+        })),
+      });
+    },
+  );
+
+  await context.clickhouse.command({
+    query: `EXCHANGE TABLES ${quoteClickhouseIdentifier(context.databaseName)}.${quoteClickhouseIdentifier(stagingTable)}
+            AND ${quoteClickhouseIdentifier(context.databaseName)}.${quoteClickhouseIdentifier(plan.destinationTable)}`,
+  });
+  await context.clickhouse.command({
+    query: `DROP TABLE IF EXISTS ${quoteClickhouseIdentifier(context.databaseName)}.${quoteClickhouseIdentifier(stagingTable)}`,
+  });
+
+  return { streamId: plan.streamId, rowsSynced, syncCursor: null, error: null };
+}
+
+/** Reads rows whose cursor column advanced past the last watermark. */
+async function syncCursor(
+  context: SyncContext,
+  plan: StreamSyncPlan,
+  table: ProbedTable,
+  client: Client,
+): Promise<StreamSyncResult> {
+  const cursorColumn = plan.cursorColumn;
+  if (cursorColumn == null) {
+    return { streamId: plan.streamId, rowsSynced: 0, syncCursor: plan.syncCursor, error: "No cursor column is configured for this table." };
+  }
+  const candidate = table.cursorCandidates.find(c => c.column === cursorColumn);
+  if (!candidate) {
+    return { streamId: plan.streamId, rowsSynced: 0, syncCursor: plan.syncCursor, error: `Column ${cursorColumn} is no longer usable as a cursor.` };
+  }
+
+  await prepareDestination(context, plan, table);
+
+  const quotedCursor = quotePgIdentifier(cursorColumn);
+  const isTemporal = /^(timestamp|date)/i.test(candidate.dataType);
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  const previous = plan.syncCursor?.mode === "cursor" ? plan.syncCursor.value : null;
+  if (previous != null) {
+    // `>=` rather than `>` so rows sharing the watermark's exact value are not
+    // skipped; the destination deduplicates the overlap by primary key.
+    conditions.push(`${quotedCursor} >= $${params.length + 1}`);
+    params.push(previous);
+  }
+  if (isTemporal) {
+    conditions.push(`${quotedCursor} <= now() - interval '${CURSOR_SAFETY_LAG_SECONDS} seconds'`);
+  }
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+
+  let maxCursor: unknown = previous;
+  const rowsSynced = await forEachBatch(
+    client,
+    `SELECT * FROM ${quotePgQualifiedName(plan.schemaName, plan.tableName)} ${where} ORDER BY ${quotedCursor} ASC`,
+    params,
+    async rows => {
+      const destinationRows = rows.map(values => buildDestinationRow({
+        values,
+        columns: table.columns,
+        version: versionFromCursorValue(values[cursorColumn]),
+        deleted: false,
+        extractedAt: context.startedAt,
+      }));
+      // The query is ORDER BY cursor ASC and batches arrive in order, so the last
+      // row of the last batch is the maximum. Comparing values ourselves would
+      // mean re-implementing Postgres' ordering per type — and comparing them as
+      // strings, which is the obvious shortcut, puts "99" above "500".
+      maxCursor = rows[rows.length - 1][cursorColumn];
+      await insertRows(context.clickhouse, {
+        databaseName: context.databaseName,
+        tableName: plan.destinationTable,
+        rows: destinationRows,
+      });
+    },
+  );
+
+  const nextValue = maxCursor instanceof Date ? maxCursor.toISOString() : maxCursor == null ? null : String(maxCursor);
+  return {
+    streamId: plan.streamId,
+    rowsSynced,
+    syncCursor: nextValue == null ? plan.syncCursor : { mode: "cursor", value: nextValue },
+    error: null,
+  };
+}
+
+/**
+ * Creates the publication and replication slot the CDC streams share. One slot
+ * per source: slots are per-database, and a slot per table would multiply the
+ * WAL-retention risk for no benefit.
+ */
+async function ensureCdcInfrastructure(
+  client: Client,
+  context: SyncContext,
+  plans: StreamSyncPlan[],
+): Promise<void> {
+  const tableList = plans
+    .map(plan => quotePgQualifiedName(plan.schemaName, plan.tableName))
+    .join(", ");
+
+  const existingPublication = await client.query<{ exists: boolean }>(
+    `SELECT EXISTS (SELECT 1 FROM pg_publication WHERE pubname = $1) AS exists`,
+    [context.publicationName],
+  );
+  try {
+    if (existingPublication.rows[0].exists) {
+      // SET rather than ADD: a table the customer removed from the sync must stop
+      // pinning WAL for changes nobody will read.
+      await client.query(`ALTER PUBLICATION ${quotePgIdentifier(context.publicationName)} SET TABLE ${tableList}`);
+    } else {
+      await client.query(`CREATE PUBLICATION ${quotePgIdentifier(context.publicationName)} FOR TABLE ${tableList}`);
+    }
+  } catch (error) {
+    // Publication DDL needs ownership of the tables. Rather than fail opaquely,
+    // hand back the exact statement a DBA can run.
+    throw new Error(
+      `Could not manage the publication for change data capture (${error instanceof Error ? error.message : String(error)}). ` +
+      `Run this on your database as a user that owns the tables, then sync again: ` +
+      `CREATE PUBLICATION ${quotePgIdentifier(context.publicationName)} FOR TABLE ${tableList};`,
+    );
+  }
+
+  const existingSlot = await client.query<{ exists: boolean }>(
+    `SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1) AS exists`,
+    [context.slotName],
+  );
+  if (!existingSlot.rows[0].exists) {
+    await client.query(`SELECT pg_create_logical_replication_slot($1, 'pgoutput')`, [context.slotName]);
+  }
+}
+
+/**
+ * Initial load for a CDC stream. Written at version 0 so that any WAL change for
+ * the same row — which necessarily has a non-zero LSN — wins during merges. That
+ * is what makes it safe to create the slot first and snapshot afterwards: the
+ * overlap produces duplicates, which deduplicate, rather than a gap, which would
+ * be silent data loss.
+ */
+async function snapshotForCdc(
+  context: SyncContext,
+  plan: StreamSyncPlan,
+  table: ProbedTable,
+  client: Client,
+): Promise<number> {
+  await prepareDestination(context, plan, table);
+  return await forEachBatch(
+    client,
+    `SELECT * FROM ${quotePgQualifiedName(plan.schemaName, plan.tableName)}`,
+    [],
+    async rows => {
+      await insertRows(context.clickhouse, {
+        databaseName: context.databaseName,
+        tableName: plan.destinationTable,
+        rows: rows.map(values => buildDestinationRow({
+          values, columns: table.columns, version: 0n, deleted: false, extractedAt: context.startedAt,
+        })),
+      });
+    },
+  );
+}
+
+function tupleToValues(tuple: PgoutputTuple, relation: PgoutputRelation, table: ProbedTable): Record<string, unknown> {
+  const typesByColumn = new Map(table.columns.map(c => [c.name, c.dataType]));
+  const values: Record<string, unknown> = {};
+  for (const column of relation.columns) {
+    const raw = tuple[column.name];
+    // Absent means an unchanged TOAST value; leaving the key out preserves it.
+    if (raw === undefined) continue;
+    values[column.name] = coerceTextValue(raw, typesByColumn.get(column.name) ?? "text");
+  }
+  return values;
+}
+
+/**
+ * Reads the WAL accumulated since the last sync and applies it. Peek rather than
+ * get: `pg_logical_slot_get_changes` consumes as it returns, so a failure between
+ * reading and writing to ClickHouse would lose those changes permanently. We
+ * advance the slot only once the destination write has succeeded.
+ */
+async function consumeWal(
+  context: SyncContext,
+  plans: StreamSyncPlan[],
+  client: Client,
+): Promise<{ rowsByStream: Map<string, number>, lastCommitLsn: bigint | null }> {
+  const planByTable = new Map(plans.map(plan => [tableKey(plan.schemaName, plan.tableName), plan]));
+  const changes = await client.query<{ lsn: string, data: Buffer }>(
+    `SELECT lsn::text AS lsn, data
+     FROM pg_logical_slot_peek_binary_changes($1, NULL, $2, 'proto_version', '1', 'publication_names', $3)`,
+    [context.slotName, MAX_WAL_CHANGES_PER_SYNC, context.publicationName],
+  );
+
+  const relations = new Map<number, PgoutputRelation>();
+  const rowsByDestination = new Map<string, Record<string, unknown>[]>();
+  const rowsByStream = new Map<string, number>();
+  let lastCommitLsn: bigint | null = null;
+  let currentCommitLsn = 0n;
+
+  for (const change of changes.rows) {
+    const message = decodePgoutputMessage(change.data, relations);
+    if (message.type === "begin") {
+      // Every row in the transaction is versioned by where the transaction ends,
+      // which is the order the rows actually became visible.
+      currentCommitLsn = message.finalLsn;
+      continue;
+    }
+    if (message.type === "commit") {
+      lastCommitLsn = message.endLsn;
+      continue;
+    }
+    if (message.type !== "insert" && message.type !== "update" && message.type !== "delete") continue;
+
+    const relation = relations.get(message.relationId);
+    if (!relation) continue;
+    const plan = planByTable.get(tableKey(relation.schemaName, relation.tableName));
+    if (!plan) continue;
+    const table = context.tablesByName.get(tableKey(plan.schemaName, plan.tableName));
+    if (!table) continue;
+
+    const deleted = message.type === "delete";
+    const tuple = deleted ? message.keyRow : message.row;
+    const row = buildDestinationRow({
+      values: tupleToValues(tuple, relation, table),
+      columns: table.columns,
+      version: currentCommitLsn,
+      deleted,
+      extractedAt: context.startedAt,
+    });
+    if (!rowsByDestination.has(plan.destinationTable)) rowsByDestination.set(plan.destinationTable, []);
+    rowsByDestination.get(plan.destinationTable)!.push(row);
+    rowsByStream.set(plan.streamId, (rowsByStream.get(plan.streamId) ?? 0) + 1);
+  }
+
+  for (const [destinationTable, rows] of rowsByDestination) {
+    await insertRows(context.clickhouse, { databaseName: context.databaseName, tableName: destinationTable, rows });
+  }
+
+  return { rowsByStream, lastCommitLsn };
+}
+
+async function syncCdcStreams(
+  context: SyncContext,
+  plans: StreamSyncPlan[],
+  client: Client,
+): Promise<StreamSyncResult[]> {
+  await ensureCdcInfrastructure(client, context, plans);
+
+  const results = new Map<string, StreamSyncResult>();
+  for (const plan of plans) {
+    results.set(plan.streamId, { streamId: plan.streamId, rowsSynced: 0, syncCursor: plan.syncCursor, error: null });
+  }
+
+  // Snapshot anything that has never been loaded. Done after the slot exists, so
+  // changes made during the snapshot are captured by the WAL as well.
+  for (const plan of plans) {
+    if (plan.syncCursor?.mode === "lsn") continue;
+    const table = context.tablesByName.get(tableKey(plan.schemaName, plan.tableName));
+    if (!table) continue;
+    const rowsSynced = await snapshotForCdc(context, plan, table, client);
+    results.set(plan.streamId, {
+      streamId: plan.streamId,
+      rowsSynced,
+      syncCursor: { mode: "lsn", value: "0/0" },
+      error: null,
+    });
+  }
+
+  const { rowsByStream, lastCommitLsn } = await consumeWal(context, plans, client);
+  if (lastCommitLsn != null) {
+    const lsnText = formatLsn(lastCommitLsn);
+    await client.query(`SELECT pg_replication_slot_advance($1, $2::pg_lsn)`, [context.slotName, lsnText]);
+    for (const plan of plans) {
+      const existing = results.get(plan.streamId)!;
+      results.set(plan.streamId, {
+        ...existing,
+        rowsSynced: existing.rowsSynced + (rowsByStream.get(plan.streamId) ?? 0),
+        syncCursor: { mode: "lsn", value: lsnText },
+      });
+    }
+  }
+  return [...results.values()];
+}
+
+/**
+ * Runs every configured stream. One stream failing must not stop the others:
+ * a permissions change on one table is not a reason to stop syncing the rest.
+ */
+export async function runStreamSyncs(context: SyncContext, plans: StreamSyncPlan[]): Promise<StreamSyncResult[]> {
+  const results: StreamSyncResult[] = [];
+  const cdcPlans = plans.filter(plan => plan.mode === "cdc");
+  const pullPlans = plans.filter(plan => plan.mode !== "cdc");
+
+  if (pullPlans.length > 0) {
+    await withDataSourceClient(context.credentials, async client => {
+      for (const plan of pullPlans) {
+        const table = context.tablesByName.get(tableKey(plan.schemaName, plan.tableName));
+        if (!table) {
+          results.push({ streamId: plan.streamId, rowsSynced: 0, syncCursor: plan.syncCursor, error: "The table no longer exists, or our role can no longer read it." });
+          continue;
+        }
+        try {
+          results.push(plan.mode === "full_refresh"
+            ? await syncFullRefresh(context, plan, table, client)
+            : await syncCursor(context, plan, table, client));
+        } catch (error) {
+          results.push({
+            streamId: plan.streamId,
+            rowsSynced: 0,
+            syncCursor: plan.syncCursor,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    });
+  }
+
+  if (cdcPlans.length > 0) {
+    try {
+      // Slot management is refused inside a read-only transaction, so the CDC
+      // connection opts out of it. Everything it runs is still only reads plus
+      // the slot calls themselves.
+      const cdcResults = await withDataSourceClient(
+        context.credentials,
+        async client => await syncCdcStreams(context, cdcPlans, client),
+        { allowWrites: true },
+      );
+      results.push(...cdcResults);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      for (const plan of cdcPlans) {
+        results.push({ streamId: plan.streamId, rowsSynced: 0, syncCursor: plan.syncCursor, error: message });
+      }
+    }
+  }
+
+  return results;
+}
+
+export { DELETED_COLUMN };

--- a/apps/backend/src/lib/data-sources/sync.ts
+++ b/apps/backend/src/lib/data-sources/sync.ts
@@ -13,8 +13,13 @@ import { buildDestinationRow, coerceTextValue, versionFromCursorValue } from "./
 
 /** Rows per round trip. Large enough to amortise latency, small enough to bound memory. */
 const READ_BATCH_SIZE = 10_000;
-/** Stops one enormous table from monopolising a sync run; the next run resumes where this left off. */
-const MAX_BATCHES_PER_STREAM = 50;
+/**
+ * Stops one enormous table from monopolising a sync run. Only safe for cursor
+ * mode, which resumes from its watermark next run — a full refresh or a CDC
+ * snapshot that stopped early would publish a partial table, so those read to
+ * exhaustion instead.
+ */
+const MAX_BATCHES_PER_CURSOR_SYNC = 50;
 /** WAL changes decoded per peek. Postgres always completes the transaction it is in, so this is a floor. */
 const MAX_WAL_CHANGES_PER_SYNC = 20_000;
 
@@ -34,14 +39,31 @@ export type StreamSyncPlan = {
   cursorColumn: string | null,
   primaryKeyColumns: string[],
   destinationTable: string,
-  syncCursor: { mode: string, value: string } | null,
+  syncCursor: SyncCursorState | null,
+  /**
+   * True until the stream has synced once in its current configuration. A mode or
+   * cursor change resets it, because the destination's existing rows were versioned
+   * on a scale the new mode cannot beat — full-refresh versions are epoch
+   * microseconds, CDC versions are LSNs, and no real LSN ever reaches 1.7e15 — so
+   * carrying them over would freeze the table forever.
+   */
+  isPending: boolean,
+};
+
+export type SyncCursorState = {
+  mode: string,
+  value: string,
+  /** JSON-encoded primary key of the last row read, for total-order resumption. */
+  key?: string,
 };
 
 export type StreamSyncResult = {
   streamId: string,
   rowsSynced: number,
-  syncCursor: { mode: string, value: string } | null,
+  syncCursor: SyncCursorState | null,
   error: string | null,
+  /** The source truncated this table; only a fresh snapshot can represent that. */
+  needsResnapshot?: boolean,
 };
 
 export type SyncContext = {
@@ -60,6 +82,12 @@ function tableKey(schemaName: string, tableName: string): string {
 }
 
 async function prepareDestination(context: SyncContext, plan: StreamSyncPlan, table: ProbedTable): Promise<void> {
+  if (plan.isPending) {
+    // Rebuilt from scratch rather than merged into: see StreamSyncPlan.isPending.
+    await context.clickhouse.command({
+      query: `DROP TABLE IF EXISTS ${quoteClickhouseIdentifier(context.databaseName)}.${quoteClickhouseIdentifier(plan.destinationTable)}`,
+    });
+  }
   await ensureDestinationTable(context.clickhouse, {
     databaseName: context.databaseName,
     tableName: plan.destinationTable,
@@ -74,13 +102,14 @@ async function forEachBatch(
   query: string,
   params: unknown[],
   onBatch: (rows: Record<string, unknown>[]) => Promise<void>,
+  options: { maxBatches: number },
 ): Promise<number> {
   const cursorName = `hexclave_sync_${Math.random().toString(36).slice(2, 10)}`;
   let total = 0;
   await client.query("BEGIN");
   try {
     await client.query(`DECLARE ${quotePgIdentifier(cursorName)} NO SCROLL CURSOR FOR ${query}`, params);
-    for (let batch = 0; batch < MAX_BATCHES_PER_STREAM; batch++) {
+    for (let batch = 0; batch < options.maxBatches; batch++) {
       const result = await client.query(`FETCH ${READ_BATCH_SIZE} FROM ${quotePgIdentifier(cursorName)}`);
       if (result.rows.length === 0) break;
       await onBatch(result.rows as Record<string, unknown>[]);
@@ -132,6 +161,9 @@ async function syncFullRefresh(
         })),
       });
     },
+    // Unbounded: the mode is already restricted to tables under
+    // FULL_REFRESH_MAX_ROWS, and a partial load would be swapped in as if complete.
+    { maxBatches: Number.POSITIVE_INFINITY },
   );
 
   await context.clickhouse.command({
@@ -168,11 +200,32 @@ async function syncCursor(
   const conditions: string[] = [];
   const params: unknown[] = [];
   const previous = plan.syncCursor?.mode === "cursor" ? plan.syncCursor.value : null;
+  const previousKey = plan.syncCursor?.mode === "cursor" ? plan.syncCursor.key ?? null : null;
+
+  // With a primary key, (cursor, key) is a total order, so the read can resume
+  // strictly after the last row seen. That both removes the duplicate re-read of
+  // the boundary and — the reason it matters — stops a group of rows sharing one
+  // cursor value from livelocking: a bulk backfill that stamps 600k rows with the
+  // same updated_at would otherwise re-read the same first batch forever.
+  const useKeyset = plan.primaryKeyColumns.length > 0;
+  const orderColumns = useKeyset
+    ? [quotedCursor, ...plan.primaryKeyColumns.map(quotePgIdentifier)]
+    : [quotedCursor];
+
   if (previous != null) {
-    // `>=` rather than `>` so rows sharing the watermark's exact value are not
-    // skipped; the destination deduplicates the overlap by primary key.
-    conditions.push(`${quotedCursor} >= $${params.length + 1}`);
-    params.push(previous);
+    if (useKeyset && previousKey != null) {
+      const keyValues = JSON.parse(previousKey) as unknown[];
+      const placeholders = [previous, ...keyValues].map(value => {
+        params.push(value);
+        return `$${params.length}`;
+      });
+      conditions.push(`(${orderColumns.join(", ")}) > (${placeholders.join(", ")})`);
+    } else {
+      // No key to break ties with, so the watermark is re-read inclusively and the
+      // overlap is tolerated rather than risking a skip.
+      conditions.push(`${quotedCursor} >= $${params.length + 1}`);
+      params.push(previous);
+    }
   }
   if (isTemporal) {
     conditions.push(`${quotedCursor} <= now() - interval '${CURSOR_SAFETY_LAG_SECONDS} seconds'`);
@@ -180,9 +233,10 @@ async function syncCursor(
   const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
   let maxCursor: unknown = previous;
+  let maxKey: string | null = previousKey;
   const rowsSynced = await forEachBatch(
     client,
-    `SELECT * FROM ${quotePgQualifiedName(plan.schemaName, plan.tableName)} ${where} ORDER BY ${quotedCursor} ASC`,
+    `SELECT * FROM ${quotePgQualifiedName(plan.schemaName, plan.tableName)} ${where} ORDER BY ${orderColumns.map(c => `${c} ASC`).join(", ")}`,
     params,
     async rows => {
       const destinationRows = rows.map(values => buildDestinationRow({
@@ -196,20 +250,23 @@ async function syncCursor(
       // row of the last batch is the maximum. Comparing values ourselves would
       // mean re-implementing Postgres' ordering per type — and comparing them as
       // strings, which is the obvious shortcut, puts "99" above "500".
-      maxCursor = rows[rows.length - 1][cursorColumn];
+      const last = rows[rows.length - 1];
+      maxCursor = last[cursorColumn];
+      maxKey = useKeyset ? JSON.stringify(plan.primaryKeyColumns.map(column => last[column])) : null;
       await insertRows(context.clickhouse, {
         databaseName: context.databaseName,
         tableName: plan.destinationTable,
         rows: destinationRows,
       });
     },
+    { maxBatches: MAX_BATCHES_PER_CURSOR_SYNC },
   );
 
   const nextValue = maxCursor instanceof Date ? maxCursor.toISOString() : maxCursor == null ? null : String(maxCursor);
   return {
     streamId: plan.streamId,
     rowsSynced,
-    syncCursor: nextValue == null ? plan.syncCursor : { mode: "cursor", value: nextValue },
+    syncCursor: nextValue == null ? plan.syncCursor : { mode: "cursor", value: nextValue, key: maxKey ?? undefined },
     error: null,
   };
 }
@@ -223,7 +280,7 @@ async function ensureCdcInfrastructure(
   client: Client,
   context: SyncContext,
   plans: StreamSyncPlan[],
-): Promise<void> {
+): Promise<{ slotWasCreated: boolean }> {
   const tableList = plans
     .map(plan => quotePgQualifiedName(plan.schemaName, plan.tableName))
     .join(", ");
@@ -254,9 +311,11 @@ async function ensureCdcInfrastructure(
     `SELECT EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = $1) AS exists`,
     [context.slotName],
   );
-  if (!existingSlot.rows[0].exists) {
-    await client.query(`SELECT pg_create_logical_replication_slot($1, 'pgoutput')`, [context.slotName]);
+  if (existingSlot.rows[0].exists) {
+    return { slotWasCreated: false };
   }
+  await client.query(`SELECT pg_create_logical_replication_slot($1, 'pgoutput')`, [context.slotName]);
+  return { slotWasCreated: true };
 }
 
 /**
@@ -272,7 +331,6 @@ async function snapshotForCdc(
   table: ProbedTable,
   client: Client,
 ): Promise<number> {
-  await prepareDestination(context, plan, table);
   return await forEachBatch(
     client,
     `SELECT * FROM ${quotePgQualifiedName(plan.schemaName, plan.tableName)}`,
@@ -286,7 +344,50 @@ async function snapshotForCdc(
         })),
       });
     },
+    // Unbounded: the LSN cursor is written once the snapshot returns, so stopping
+    // early would mark rows as loaded that never were.
+    { maxBatches: Number.POSITIVE_INFINITY },
   );
+}
+
+/**
+ * Re-reads rows whose WAL entry withheld an unchanged TOAST value.
+ *
+ * Postgres omits large unchanged column values from the WAL, so an UPDATE that
+ * touched only `title` sends nothing for a multi-kilobyte `body`. There is no way
+ * to express "leave this column alone" in a MergeTree insert — an omitted field
+ * takes the column default and a NULL erases it — and the new row carries a higher
+ * version, so it wins the merge either way. The only correct fix is to fetch the
+ * current row and write it whole.
+ */
+async function refetchRowsByKey(
+  client: Client,
+  plan: StreamSyncPlan,
+  keys: Record<string, unknown>[],
+): Promise<Map<string, Record<string, unknown>>> {
+  const byKey = new Map<string, Record<string, unknown>>();
+  if (keys.length === 0 || plan.primaryKeyColumns.length === 0) return byKey;
+
+  const keyColumns = plan.primaryKeyColumns;
+  const quotedKeys = keyColumns.map(quotePgIdentifier).join(", ");
+  const params: unknown[] = [];
+  const tuples = keys.map(key => {
+    const placeholders = keyColumns.map(column => {
+      params.push(key[column]);
+      return `$${params.length}`;
+    });
+    return `(${placeholders.join(", ")})`;
+  });
+
+  const result = await client.query(
+    `SELECT * FROM ${quotePgQualifiedName(plan.schemaName, plan.tableName)}
+     WHERE (${quotedKeys}) IN (${tuples.join(", ")})`,
+    params,
+  );
+  for (const row of result.rows as Record<string, unknown>[]) {
+    byKey.set(keyColumns.map(column => String(row[column])).join("\u0000"), row);
+  }
+  return byKey;
 }
 
 function tupleToValues(tuple: PgoutputTuple, relation: PgoutputRelation, table: ProbedTable): Record<string, unknown> {
@@ -311,7 +412,7 @@ async function consumeWal(
   context: SyncContext,
   plans: StreamSyncPlan[],
   client: Client,
-): Promise<{ rowsByStream: Map<string, number>, lastCommitLsn: bigint | null }> {
+): Promise<{ rowsByStream: Map<string, number>, lastCommitLsn: bigint | null, truncatedStreams: Set<string> }> {
   const planByTable = new Map(plans.map(plan => [tableKey(plan.schemaName, plan.tableName), plan]));
   const changes = await client.query<{ lsn: string, data: Buffer }>(
     `SELECT lsn::text AS lsn, data
@@ -322,8 +423,11 @@ async function consumeWal(
   const relations = new Map<number, PgoutputRelation>();
   const rowsByDestination = new Map<string, Record<string, unknown>[]>();
   const rowsByStream = new Map<string, number>();
+  // Rows whose WAL entry withheld an unchanged TOAST value, to be re-read whole.
+  const toastedByStream = new Map<string, { plan: StreamSyncPlan, rows: Record<string, unknown>[] }>();
   let lastCommitLsn: bigint | null = null;
   let currentCommitLsn = 0n;
+  const truncatedStreams = new Set<string>();
 
   for (const change of changes.rows) {
     const message = decodePgoutputMessage(change.data, relations);
@@ -337,6 +441,18 @@ async function consumeWal(
       lastCommitLsn = message.endLsn;
       continue;
     }
+    if (message.type === "truncate") {
+      // There is no tombstone that expresses "every row is gone", and leaving them
+      // in place would silently diverge from the source. The stream is flagged for
+      // a rebuild instead.
+      for (const relationId of message.relationIds) {
+        const truncated = relations.get(relationId);
+        if (truncated == null) continue;
+        const truncatedPlan = planByTable.get(tableKey(truncated.schemaName, truncated.tableName));
+        if (truncatedPlan != null) truncatedStreams.add(truncatedPlan.streamId);
+      }
+      continue;
+    }
     if (message.type !== "insert" && message.type !== "update" && message.type !== "delete") continue;
 
     const relation = relations.get(message.relationId);
@@ -348,23 +464,68 @@ async function consumeWal(
 
     const deleted = message.type === "delete";
     const tuple = deleted ? message.keyRow : message.row;
+    if (!rowsByDestination.has(plan.destinationTable)) rowsByDestination.set(plan.destinationTable, []);
+    const destinationRows = rowsByDestination.get(plan.destinationTable)!;
+
+    // An UPDATE that moves the primary key sends the old key alongside the new
+    // row. Without a tombstone for it the pre-update row stays in the warehouse
+    // forever, under a key the source no longer has.
+    if (message.type === "update" && message.keyRow != null) {
+      const oldKey = tupleToValues(message.keyRow, relation, table);
+      const movedKey = plan.primaryKeyColumns.some(
+        column => oldKey[column] !== undefined && String(oldKey[column]) !== String(message.row[column]),
+      );
+      if (movedKey) {
+        destinationRows.push(buildDestinationRow({
+          values: oldKey, columns: table.columns, version: currentCommitLsn, deleted: true, extractedAt: context.startedAt,
+        }));
+      }
+    }
+
+    const values = tupleToValues(tuple, relation, table);
     const row = buildDestinationRow({
-      values: tupleToValues(tuple, relation, table),
+      values,
       columns: table.columns,
       version: currentCommitLsn,
       deleted,
       extractedAt: context.startedAt,
     });
-    if (!rowsByDestination.has(plan.destinationTable)) rowsByDestination.set(plan.destinationTable, []);
-    rowsByDestination.get(plan.destinationTable)!.push(row);
+    destinationRows.push(row);
     rowsByStream.set(plan.streamId, (rowsByStream.get(plan.streamId) ?? 0) + 1);
+
+    // 'u' in the tuple means an unchanged TOAST value the server did not send.
+    if (!deleted && relation.columns.some(column => tuple[column.name] === undefined)) {
+      if (!toastedByStream.has(plan.streamId)) toastedByStream.set(plan.streamId, { plan, rows: [] });
+      toastedByStream.get(plan.streamId)!.rows.push(values);
+    }
+  }
+
+  // Written after the WAL rows, at the same commit version, so the complete row
+  // is what a merge keeps: ReplacingMergeTree takes the last inserted row when
+  // versions tie.
+  for (const { plan, rows } of toastedByStream.values()) {
+    const table = context.tablesByName.get(tableKey(plan.schemaName, plan.tableName));
+    if (table == null) continue;
+    const complete = await refetchRowsByKey(client, plan, rows);
+    const destinationRows = rowsByDestination.get(plan.destinationTable) ?? [];
+    for (const partial of rows) {
+      const key = plan.primaryKeyColumns.map(column => String(partial[column])).join("\u0000");
+      const full = complete.get(key);
+      // Absent means the row was deleted again later in the same batch; the
+      // tombstone we already queued is the correct final state.
+      if (full == null) continue;
+      destinationRows.push(buildDestinationRow({
+        values: full, columns: table.columns, version: currentCommitLsn, deleted: false, extractedAt: context.startedAt,
+      }));
+    }
+    rowsByDestination.set(plan.destinationTable, destinationRows);
   }
 
   for (const [destinationTable, rows] of rowsByDestination) {
     await insertRows(context.clickhouse, { databaseName: context.databaseName, tableName: destinationTable, rows });
   }
 
-  return { rowsByStream, lastCommitLsn };
+  return { rowsByStream, lastCommitLsn, truncatedStreams };
 }
 
 async function syncCdcStreams(
@@ -372,7 +533,16 @@ async function syncCdcStreams(
   plans: StreamSyncPlan[],
   client: Client,
 ): Promise<StreamSyncResult[]> {
-  await ensureCdcInfrastructure(client, context, plans);
+  const { slotWasCreated } = await ensureCdcInfrastructure(client, context, plans);
+
+  // Every sync, not just the snapshot: the WAL carries no DDL, so a column the
+  // customer added since the stream started only reaches the destination table
+  // through this. Without it ClickHouse silently drops the unknown field and the
+  // new column stays empty forever.
+  for (const plan of plans) {
+    const table = context.tablesByName.get(tableKey(plan.schemaName, plan.tableName));
+    if (table != null) await prepareDestination(context, plan, table);
+  }
 
   const results = new Map<string, StreamSyncResult>();
   for (const plan of plans) {
@@ -382,7 +552,12 @@ async function syncCdcStreams(
   // Snapshot anything that has never been loaded. Done after the slot exists, so
   // changes made during the snapshot are captured by the WAL as well.
   for (const plan of plans) {
-    if (plan.syncCursor?.mode === "lsn") continue;
+    // A slot we had to create while a stream already held an LSN means the old
+    // slot is gone — dropped, failed over, or restored from a backup. A new slot
+    // starts at the current WAL position, so everything in between is missing and
+    // only a fresh snapshot can recover it.
+    const lostSlot = slotWasCreated && plan.syncCursor?.mode === "lsn";
+    if (plan.syncCursor?.mode === "lsn" && !lostSlot) continue;
     const table = context.tablesByName.get(tableKey(plan.schemaName, plan.tableName));
     if (!table) continue;
     const rowsSynced = await snapshotForCdc(context, plan, table, client);
@@ -394,7 +569,7 @@ async function syncCdcStreams(
     });
   }
 
-  const { rowsByStream, lastCommitLsn } = await consumeWal(context, plans, client);
+  const { rowsByStream, lastCommitLsn, truncatedStreams } = await consumeWal(context, plans, client);
   if (lastCommitLsn != null) {
     const lsnText = formatLsn(lastCommitLsn);
     await client.query(`SELECT pg_replication_slot_advance($1, $2::pg_lsn)`, [context.slotName, lsnText]);
@@ -404,6 +579,7 @@ async function syncCdcStreams(
         ...existing,
         rowsSynced: existing.rowsSynced + (rowsByStream.get(plan.streamId) ?? 0),
         syncCursor: { mode: "lsn", value: lsnText },
+        needsResnapshot: truncatedStreams.has(plan.streamId),
       });
     }
   }

--- a/apps/backend/src/lib/data-sources/sync.ts
+++ b/apps/backend/src/lib/data-sources/sync.ts
@@ -31,6 +31,9 @@ const MAX_WAL_CHANGES_PER_SYNC = 20_000;
  */
 const CURSOR_SAFETY_LAG_SECONDS = 10;
 
+/** Alias the cursor's exact text is read back under; never written to the destination. */
+const CURSOR_TEXT_COLUMN = "_hexclave_cursor_text";
+
 export type StreamSyncPlan = {
   streamId: string,
   schemaName: string,
@@ -232,11 +235,19 @@ async function syncCursor(
   }
   const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
 
-  let maxCursor: unknown = previous;
+  let maxCursor: string | null = previous;
   let maxKey: string | null = previousKey;
   const rowsSynced = await forEachBatch(
     client,
-    `SELECT * FROM ${quotePgQualifiedName(plan.schemaName, plan.tableName)} ${where} ORDER BY ${orderColumns.map(c => `${c} ASC`).join(", ")}`,
+    // The cursor also comes back as text. `pg` materialises a timestamp as a JS
+    // Date, which is millisecond-precision, so a watermark round-tripped through
+    // one lands *below* the microsecond value it came from — and every sync then
+    // re-reads the whole table. Text is exactly what Postgres stored, and it also
+    // sidesteps `timestamp without time zone` being reinterpreted in the
+    // process's local timezone on the way out and back.
+    `SELECT *, (${quotedCursor})::text AS ${quotePgIdentifier(CURSOR_TEXT_COLUMN)}
+     FROM ${quotePgQualifiedName(plan.schemaName, plan.tableName)} ${where}
+     ORDER BY ${orderColumns.map(c => `${c} ASC`).join(", ")}`,
     params,
     async rows => {
       const destinationRows = rows.map(values => buildDestinationRow({
@@ -251,7 +262,7 @@ async function syncCursor(
       // mean re-implementing Postgres' ordering per type — and comparing them as
       // strings, which is the obvious shortcut, puts "99" above "500".
       const last = rows[rows.length - 1];
-      maxCursor = last[cursorColumn];
+      maxCursor = last[CURSOR_TEXT_COLUMN] as string;
       maxKey = useKeyset ? JSON.stringify(plan.primaryKeyColumns.map(column => last[column])) : null;
       await insertRows(context.clickhouse, {
         databaseName: context.databaseName,
@@ -262,7 +273,7 @@ async function syncCursor(
     { maxBatches: MAX_BATCHES_PER_CURSOR_SYNC },
   );
 
-  const nextValue = maxCursor instanceof Date ? maxCursor.toISOString() : maxCursor == null ? null : String(maxCursor);
+  const nextValue = maxCursor;
   return {
     streamId: plan.streamId,
     rowsSynced,

--- a/apps/backend/vercel.json
+++ b/apps/backend/vercel.json
@@ -21,6 +21,10 @@
     {
       "path": "/api/latest/internal/growth-watchdog-step",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/latest/internal/data-source-sync-step",
+      "schedule": "* * * * *"
     }
   ],
   "github": {

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/[dataSourceId]/page-client.test.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/[dataSourceId]/page-client.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import type { ReactNode } from "react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import PageClient from "./page-client";
+
+const mocks = vi.hoisted(() => ({
+  deleteDataSource: vi.fn(),
+  routerPush: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ dataSourceId: "source-1" }),
+}));
+
+vi.mock("@/components/router", () => ({
+  useRouter: () => ({ push: mocks.routerPush }),
+}));
+
+vi.mock("../../../app-enabled-guard", () => ({
+  AppEnabledGuard: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("../../../page-layout", () => ({
+  PageLayout: ({ actions, children }: { actions?: ReactNode, children: ReactNode }) => (
+    <div>{actions}{children}</div>
+  ),
+}));
+
+vi.mock("../../../use-admin-app", () => ({
+  useAdminApp: () => ({
+    projectId: "project-1",
+    useDataSources: () => [{
+      id: "source-1",
+      host: "postgres.example.com",
+      error: null,
+      streams: [],
+    }],
+    deleteDataSource: mocks.deleteDataSource,
+    syncDataSource: vi.fn(),
+    getDataSourceCatalog: vi.fn(),
+    setDataSourceStreams: vi.fn(),
+  }),
+}));
+
+vi.mock("../stream-picker", () => ({
+  StreamPicker: () => null,
+  formatRowCount: (value: number) => String(value),
+}));
+
+vi.mock("@/components/design-components", () => ({
+  DesignAlert: ({ title, description }: { title: ReactNode, description: ReactNode }) => (
+    <div role="alert"><div>{title}</div><div>{description}</div></div>
+  ),
+  DesignButton: ({ children, onClick }: { children: ReactNode, onClick?: () => void | Promise<void> }) => (
+    <button onClick={() => runAsynchronously(onClick?.())}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/ui", () => ({
+  ActionDialog: ({
+    open,
+    onOpenChange,
+    title,
+    okButton,
+    children,
+  }: {
+    open: boolean,
+    onOpenChange: (open: boolean) => void,
+    title: ReactNode,
+    okButton: { label: string, onClick: () => Promise<"prevent-close" | void> },
+    children: ReactNode,
+  }) => open ? (
+    <div role="dialog">
+      <div>{title}</div>
+      {children}
+      <button onClick={() => runAsynchronously(async () => {
+        if (await okButton.onClick() !== "prevent-close") onOpenChange(false);
+      })}>{okButton.label}</button>
+    </div>
+  ) : null,
+  Card: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Typography: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+describe("data source details", () => {
+  beforeEach(() => {
+    mocks.deleteDataSource.mockReset();
+    mocks.routerPush.mockReset();
+    mocks.toast.mockReset();
+  });
+
+  afterEach(cleanup);
+
+  it("keeps the disconnect dialog open and shows a blocking inline error when deletion fails", async () => {
+    mocks.deleteDataSource.mockRejectedValueOnce(new Error("The replication slot could not be removed."));
+    render(<PageClient />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+    fireEvent.click(within(screen.getByRole("dialog")).getByRole("button", { name: "Disconnect" }));
+
+    expect(await screen.findByRole("alert")).toBeTruthy();
+    expect(screen.getByText("Could not disconnect")).toBeTruthy();
+    expect(screen.getByText("The replication slot could not be removed.")).toBeTruthy();
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(mocks.routerPush).not.toHaveBeenCalled();
+    expect(mocks.toast).not.toHaveBeenCalled();
+  });
+
+  it("clears a previous error and navigates only after a successful retry", async () => {
+    mocks.deleteDataSource
+      .mockRejectedValueOnce(new Error("First failure"))
+      .mockResolvedValueOnce(undefined);
+    render(<PageClient />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+    const confirm = within(screen.getByRole("dialog")).getByRole("button", { name: "Disconnect" });
+    fireEvent.click(confirm);
+    expect(await screen.findByText("First failure")).toBeTruthy();
+
+    fireEvent.click(confirm);
+    await waitFor(() => {
+      expect(mocks.routerPush).toHaveBeenCalledWith("/projects/project-1/data-warehouse/sources");
+      expect(screen.queryByText("First failure")).toBeNull();
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+});

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/[dataSourceId]/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/[dataSourceId]/page-client.tsx
@@ -11,7 +11,7 @@ import { PageLayout } from "../../../page-layout";
 import { useAdminApp } from "../../../use-admin-app";
 import { StreamPicker, formatRowCount } from "../stream-picker";
 
-const MODE_LABEL: Record<string, string> = { cdc: "CDC", cursor: "Cursor", full_refresh: "Full refresh" };
+const MODE_LABEL: Record<string, string> = { cdc: "CDC", cursor: "Cursor" };
 
 export default function PageClient() {
   return (

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/[dataSourceId]/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/[dataSourceId]/page-client.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { DesignButton } from "@/components/design-components";
+import { ActionDialog, Card, Typography, useToast } from "@/components/ui";
+import type { DataSourceCatalogJson, DataSourceJson, DataSourceStreamConfig, DataSourceStreamJson } from "@hexclave/shared/dist/interface/admin-interface";
+import { useRouter } from "@/components/router";
+import { useParams } from "next/navigation";
+import { useState } from "react";
+import { AppEnabledGuard } from "../../../app-enabled-guard";
+import { PageLayout } from "../../../page-layout";
+import { useAdminApp } from "../../../use-admin-app";
+import { StreamPicker, formatRowCount } from "../stream-picker";
+
+const MODE_LABEL: Record<string, string> = { cdc: "CDC", cursor: "Cursor", full_refresh: "Full refresh" };
+
+export default function PageClient() {
+  return (
+    <AppEnabledGuard appId="data-warehouse-alpha">
+      <DataSourcePage />
+    </AppEnabledGuard>
+  );
+}
+
+function DataSourcePage() {
+  const adminApp = useAdminApp();
+  const params = useParams<{ dataSourceId: string }>();
+  const router = useRouter();
+  const { toast } = useToast();
+  const dataSources = adminApp.useDataSources();
+  const dataSource = dataSources.find(source => source.id === params.dataSourceId);
+
+  const [syncing, setSyncing] = useState(false);
+  const [editing, setEditing] = useState<DataSourceCatalogJson | null>(null);
+  const [loadingCatalog, setLoadingCatalog] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+
+  const sourcesHref = `/projects/${encodeURIComponent(adminApp.projectId)}/data-warehouse/sources`;
+
+  if (dataSource == null) {
+    return (
+      <PageLayout title="Source not found">
+        <DesignButton variant="secondary" onClick={() => router.push(sourcesHref)}>Back to sources</DesignButton>
+      </PageLayout>
+    );
+  }
+
+  const syncNow = async () => {
+    setSyncing(true);
+    try {
+      await adminApp.syncDataSource(dataSource.id);
+    } catch (error) {
+      toast({ variant: "destructive", title: "Sync failed", description: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const startEditing = async () => {
+    setLoadingCatalog(true);
+    try {
+      // Re-probed rather than cached: capabilities drift, and a customer who has
+      // since enabled logical replication should see CDC offered here.
+      setEditing(await adminApp.getDataSourceCatalog(dataSource.id));
+    } catch (error) {
+      toast({ variant: "destructive", title: "Could not read the source", description: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setLoadingCatalog(false);
+    }
+  };
+
+  const saveStreams = async (streams: DataSourceStreamConfig[]) => {
+    try {
+      await adminApp.setDataSourceStreams(dataSource.id, streams);
+      setEditing(null);
+    } catch (error) {
+      toast({ variant: "destructive", title: "Could not save", description: error instanceof Error ? error.message : String(error) });
+    }
+  };
+
+  if (editing != null) {
+    return (
+      <PageLayout title="Edit tables" description={dataSource.host}>
+        <StreamPicker
+          catalog={editing}
+          existingStreams={dataSource.streams.map(stream => ({
+            schema_name: stream.schema_name,
+            table_name: stream.table_name,
+            mode: stream.mode,
+            cursor_column: stream.cursor_column,
+          }))}
+          submitLabel="Save"
+          onCancel={() => setEditing(null)}
+          onSubmit={saveStreams}
+        />
+      </PageLayout>
+    );
+  }
+
+  const failing = dataSource.streams.filter(stream => stream.status === "failed").length;
+
+  return (
+    <PageLayout
+      title={dataSource.host}
+      description={`PostgreSQL · ${dataSource.streams.length} ${dataSource.streams.length === 1 ? "table" : "tables"}${failing > 0 ? ` · ${failing} failing` : ""}`}
+      actions={
+        <div className="flex gap-2">
+          <DesignButton variant="secondary" onClick={startEditing} loading={loadingCatalog}>Edit tables</DesignButton>
+          <DesignButton variant="secondary" onClick={syncNow} loading={syncing}>Sync now</DesignButton>
+          <DesignButton variant="ghost" onClick={() => setConfirmingDelete(true)}>Disconnect</DesignButton>
+        </div>
+      }
+    >
+      <DesignButton variant="ghost" className="self-start" onClick={() => router.push(sourcesHref)}>← Sources</DesignButton>
+
+      {dataSource.error != null && (
+        <Card className="border-destructive/40 bg-destructive/5 p-4">
+          <Typography type="p" className="text-destructive">{dataSource.error}</Typography>
+        </Card>
+      )}
+
+      <Card>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="px-4 pb-2 pt-4 text-left font-medium">Table</th>
+              <th className="px-4 pb-2 pt-4 text-left font-medium">Mode</th>
+              <th className="px-4 pb-2 pt-4 text-left font-medium">Status</th>
+              <th className="px-4 pb-2 pt-4 text-left font-medium">Rows synced</th>
+              <th className="px-4 pb-2 pt-4 text-left font-medium">Last sync</th>
+            </tr>
+          </thead>
+          <tbody>
+            {dataSource.streams.map(stream => (
+              <tr key={stream.id} className="border-t border-border-in-card">
+                <td className="px-4 py-2.5 font-medium">
+                  <span className="font-normal text-muted-foreground">{stream.schema_name}.</span>{stream.table_name}
+                </td>
+                <td className="px-4 py-2.5 text-muted-foreground">
+                  {MODE_LABEL[stream.mode] ?? stream.mode}
+                  {stream.mode === "cursor" && stream.cursor_column != null ? ` · ${stream.cursor_column}` : ""}
+                </td>
+                <td className="px-4 py-2.5"><StreamStatus stream={stream} /></td>
+                <td className="px-4 py-2.5 tabular-nums text-muted-foreground">{formatRowCount(stream.rows_synced)}</td>
+                <td className="px-4 py-2.5 text-muted-foreground">{formatRelativeTime(stream.last_synced_at_millis)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </Card>
+
+      <ActionDialog
+        open={confirmingDelete}
+        onOpenChange={setConfirmingDelete}
+        title="Disconnect this source?"
+        danger
+        okButton={{
+          label: "Disconnect",
+          onClick: async () => {
+            await adminApp.deleteDataSource(dataSource.id);
+            router.push(sourcesHref);
+          },
+        }}
+        cancelButton
+      >
+        <Typography type="p" variant="secondary">
+          We stop syncing and drop the replication slot on your database. Tables already synced into
+          your warehouse are left where they are — delete them yourself if you no longer want them.
+        </Typography>
+      </ActionDialog>
+    </PageLayout>
+  );
+}
+
+function StreamStatus({ stream }: { stream: DataSourceStreamJson }) {
+  const colors: Record<string, string> = {
+    active: "bg-green-500",
+    snapshotting: "bg-blue-500",
+    pending: "bg-muted-foreground",
+    failed: "bg-destructive",
+  };
+  const labels: Record<string, string> = {
+    active: stream.mode === "cdc" ? "Live" : "Synced",
+    snapshotting: "Snapshotting",
+    pending: "Waiting for first sync",
+    failed: "Failing",
+  };
+  return (
+    <span className="flex items-center gap-2">
+      <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${colors[stream.status]}`} />
+      <span>{labels[stream.status]}</span>
+      {stream.error != null && <span className="text-xs text-muted-foreground">{stream.error}</span>}
+    </span>
+  );
+}
+
+function formatRelativeTime(millis: number | null): string {
+  if (millis == null) return "never";
+  const seconds = Math.max(0, Math.round((Date.now() - millis) / 1000));
+  if (seconds < 60) return `${seconds}s ago`;
+  if (seconds < 3600) return `${Math.round(seconds / 60)}m ago`;
+  if (seconds < 86400) return `${Math.round(seconds / 3600)}h ago`;
+  return `${Math.round(seconds / 86400)}d ago`;
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/[dataSourceId]/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/[dataSourceId]/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { DesignButton } from "@/components/design-components";
+import { DesignAlert, DesignButton } from "@/components/design-components";
 import { ActionDialog, Card, Typography, useToast } from "@/components/ui";
 import type { DataSourceCatalogJson, DataSourceJson, DataSourceStreamConfig, DataSourceStreamJson } from "@hexclave/shared/dist/interface/admin-interface";
 import { useRouter } from "@/components/router";
@@ -33,6 +33,7 @@ function DataSourcePage() {
   const [editing, setEditing] = useState<DataSourceCatalogJson | null>(null);
   const [loadingCatalog, setLoadingCatalog] = useState(false);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [disconnectError, setDisconnectError] = useState<string | null>(null);
 
   const sourcesHref = `/projects/${encodeURIComponent(adminApp.projectId)}/data-warehouse/sources`;
 
@@ -150,18 +151,30 @@ function DataSourcePage() {
 
       <ActionDialog
         open={confirmingDelete}
-        onOpenChange={setConfirmingDelete}
+        onOpenChange={(open) => {
+          setConfirmingDelete(open);
+          if (!open) setDisconnectError(null);
+        }}
         title="Disconnect this source?"
         danger
         okButton={{
           label: "Disconnect",
           onClick: async () => {
-            await adminApp.deleteDataSource(dataSource.id);
-            router.push(sourcesHref);
+            setDisconnectError(null);
+            try {
+              await adminApp.deleteDataSource(dataSource.id);
+              router.push(sourcesHref);
+            } catch (error) {
+              setDisconnectError(error instanceof Error ? error.message : "The source could not be disconnected. Please try again.");
+              return "prevent-close";
+            }
           },
         }}
         cancelButton
       >
+        {disconnectError != null && (
+          <DesignAlert variant="error" title="Could not disconnect" description={disconnectError} />
+        )}
         <Typography type="p" variant="secondary">
           We stop syncing and drop the replication slot on your database. Tables already synced into
           your warehouse are left where they are — delete them yourself if you no longer want them.

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/[dataSourceId]/page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/[dataSourceId]/page.tsx
@@ -1,0 +1,5 @@
+import PageClient from "./page-client";
+
+export default function Page() {
+  return <PageClient />;
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/page-client.tsx
@@ -1,0 +1,227 @@
+"use client";
+
+import { DesignButton, DesignCard, DesignListItemRow } from "@/components/design-components";
+import { Card, Input, Label, Typography, useToast } from "@/components/ui";
+import type { DataSourceCatalogJson, DataSourceJson, DataSourceStreamConfig } from "@hexclave/shared/dist/interface/admin-interface";
+import { DatabaseIcon, LockSimpleIcon, PlugsIcon } from "@phosphor-icons/react";
+import { useRouter } from "@/components/router";
+import { useState } from "react";
+import { AppEnabledGuard } from "../../app-enabled-guard";
+import { PageLayout } from "../../page-layout";
+import { useAdminApp } from "../../use-admin-app";
+import { StreamPicker } from "./stream-picker";
+
+export default function PageClient() {
+  return (
+    <AppEnabledGuard appId="data-warehouse-alpha">
+      <SourcesPage />
+    </AppEnabledGuard>
+  );
+}
+
+type View =
+  | { step: "list" }
+  | { step: "catalog" }
+  | { step: "credentials" }
+  | { step: "tables", dataSource: DataSourceJson, catalog: DataSourceCatalogJson };
+
+function SourcesPage() {
+  const adminApp = useAdminApp();
+  const dataSources = adminApp.useDataSources();
+  const [view, setView] = useState<View>({ step: "list" });
+
+  switch (view.step) {
+    case "catalog": {
+      return <SourceCatalog onBack={() => setView({ step: "list" })} onPick={() => setView({ step: "credentials" })} />;
+    }
+    case "credentials": {
+      return (
+        <ConnectPostgres
+          onBack={() => setView({ step: "catalog" })}
+          onConnected={(dataSource, catalog) => setView({ step: "tables", dataSource, catalog })}
+        />
+      );
+    }
+    case "tables": {
+      return <ChooseTables dataSource={view.dataSource} catalog={view.catalog} />;
+    }
+    default: {
+      return <SourceList dataSources={dataSources} onAdd={() => setView({ step: "catalog" })} />;
+    }
+  }
+}
+
+function SourceList({ dataSources, onAdd }: { dataSources: DataSourceJson[], onAdd: () => void }) {
+  const router = useRouter();
+  const adminApp = useAdminApp();
+
+  if (dataSources.length === 0) {
+    return (
+      <PageLayout title="Sources" description="Sync data from your own systems into the warehouse.">
+        <Card className="flex flex-col items-center px-6 py-14 text-center">
+          <div className="mb-4 grid h-11 w-11 place-items-center rounded-full bg-primary/10 text-primary">
+            <PlugsIcon className="h-5 w-5" />
+          </div>
+          <Typography type="h4">No sources yet</Typography>
+          <Typography type="p" variant="secondary" className="mb-5 mt-1">
+            Connect a database to start syncing.
+          </Typography>
+          <DesignButton onClick={onAdd}>Add source</DesignButton>
+        </Card>
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout
+      title="Sources"
+      description={`${dataSources.length} connected`}
+      actions={<DesignButton onClick={onAdd}>Add source</DesignButton>}
+    >
+      <Card className="divide-y divide-border-in-card">
+        {dataSources.map(source => {
+          const failing = source.streams.filter(stream => stream.status === "failed").length;
+          return (
+            <DesignListItemRow
+              key={source.id}
+              size="sm"
+              icon={DatabaseIcon}
+              title={source.host}
+              subtitle={`PostgreSQL · ${source.streams.length} ${source.streams.length === 1 ? "table" : "tables"}${failing > 0 ? ` · ${failing} failing` : ""}`}
+              onClick={() => router.push(`/projects/${encodeURIComponent(adminApp.projectId)}/data-warehouse/sources/${encodeURIComponent(source.id)}`)}
+            />
+          );
+        })}
+      </Card>
+    </PageLayout>
+  );
+}
+
+/**
+ * PostgreSQL is the only source today. The screen still exists because it is
+ * where every future source type appears, and because "pick what you are syncing
+ * from" is a different decision from "type your credentials".
+ */
+function SourceCatalog({ onBack, onPick }: { onBack: () => void, onPick: () => void }) {
+  return (
+    <PageLayout title="Add source" description="Pick what you want to sync from.">
+      <DesignButton variant="ghost" className="self-start" onClick={onBack}>← Sources</DesignButton>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <button
+          type="button"
+          onClick={onPick}
+          className="flex flex-col items-start gap-2 rounded-xl border border-border-in-card p-4 text-left transition-colors hover:border-foreground/40"
+        >
+          <DatabaseIcon className="h-5 w-5" />
+          <span className="font-medium">PostgreSQL</span>
+          <span className="text-xs text-muted-foreground">Database</span>
+        </button>
+      </div>
+    </PageLayout>
+  );
+}
+
+function ConnectPostgres(props: {
+  onBack: () => void,
+  onConnected: (dataSource: DataSourceJson, catalog: DataSourceCatalogJson) => void,
+}) {
+  const adminApp = useAdminApp();
+  const { toast } = useToast();
+  const [form, setForm] = useState({ host: "", port: "5432", database: "", username: "", password: "", sslMode: "require" });
+  const [connecting, setConnecting] = useState(false);
+
+  const connect = async () => {
+    setConnecting(true);
+    try {
+      const result = await adminApp.createDataSource({
+        host: form.host.trim(),
+        port: Number.parseInt(form.port, 10),
+        database: form.database.trim(),
+        username: form.username.trim(),
+        password: form.password,
+        sslMode: form.sslMode,
+      });
+      props.onConnected(result.dataSource, result.catalog);
+    } catch (error) {
+      toast({ variant: "destructive", title: "Could not connect", description: error instanceof Error ? error.message : String(error) });
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const field = (key: keyof typeof form, label: string, type: "text" | "password" = "text") => (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={`data-source-${key}`}>{label}</Label>
+      <Input
+        id={`data-source-${key}`}
+        type={type}
+        value={form[key]}
+        onChange={event => setForm(prev => ({ ...prev, [key]: event.target.value }))}
+      />
+    </div>
+  );
+
+  const complete = form.host.trim() !== "" && form.database.trim() !== "" && form.username.trim() !== "";
+
+  return (
+    <PageLayout title="Connect PostgreSQL" description="A read-only role is enough.">
+      <DesignButton variant="ghost" className="self-start" onClick={props.onBack}>← Add source</DesignButton>
+      <DesignCard>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {field("host", "Host")}
+          {field("port", "Port")}
+          {field("database", "Database")}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="data-source-ssl">SSL mode</Label>
+            <select
+              id="data-source-ssl"
+              className="h-9 rounded-md border border-input-in-card bg-transparent px-2 text-sm"
+              value={form.sslMode}
+              onChange={event => setForm(prev => ({ ...prev, sslMode: event.target.value }))}
+            >
+              <option value="require">require</option>
+              <option value="verify-full">verify-full</option>
+              <option value="no-verify">no-verify</option>
+              <option value="disable">disable</option>
+            </select>
+          </div>
+          {field("username", "Username")}
+          {field("password", "Password", "password")}
+        </div>
+        <div className="mt-5 flex gap-2.5 border-t border-border-in-card pt-4">
+          <LockSimpleIcon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+          <Typography type="p" variant="secondary" className="text-xs">
+            <span className="font-medium text-foreground">Your password is encrypted at rest.</span>{" "}
+            It is sealed with a key from our KMS before it is written, decrypted only in memory for the
+            seconds a sync runs, and never shown again once saved.
+          </Typography>
+        </div>
+        <div className="mt-5 flex items-center gap-3">
+          <DesignButton onClick={connect} loading={connecting} disabled={!complete}>Connect</DesignButton>
+          <Typography type="label" variant="secondary">We will read your table list — nothing syncs yet.</Typography>
+        </div>
+      </DesignCard>
+    </PageLayout>
+  );
+}
+
+function ChooseTables({ dataSource, catalog }: { dataSource: DataSourceJson, catalog: DataSourceCatalogJson }) {
+  const adminApp = useAdminApp();
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const save = async (streams: DataSourceStreamConfig[]) => {
+    try {
+      await adminApp.setDataSourceStreams(dataSource.id, streams);
+      router.push(`/projects/${encodeURIComponent(adminApp.projectId)}/data-warehouse/sources/${encodeURIComponent(dataSource.id)}`);
+    } catch (error) {
+      toast({ variant: "destructive", title: "Could not save", description: error instanceof Error ? error.message : String(error) });
+    }
+  };
+
+  return (
+    <PageLayout title="Choose tables" description="We picked a mode for each table. Change any of them.">
+      <StreamPicker catalog={catalog} submitLabel="Start syncing" onSubmit={save} />
+    </PageLayout>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/page.tsx
@@ -1,0 +1,5 @@
+import PageClient from "./page-client";
+
+export default function Page() {
+  return <PageClient />;
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/stream-picker.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/stream-picker.test.ts
@@ -1,0 +1,63 @@
+import type { DataSourceCatalogJson, DataSourceCatalogTableJson, DataSourceStreamConfig } from "@hexclave/shared/dist/interface/admin-interface";
+import { describe, expect, it } from "vitest";
+import { buildInitialSelection } from "./stream-picker";
+
+function table(tableName: string): DataSourceCatalogTableJson {
+  return {
+    schema_name: "public",
+    table_name: tableName,
+    approx_rows: 10,
+    replica_identity: "d",
+    is_partitioned: false,
+    primary_key_columns: ["id"],
+    cursor_candidates: [{ column: "id", data_type: "bigint", indexed: true }],
+    available_modes: [
+      { mode: "cdc", available: true, reason: null },
+      { mode: "cursor", available: true, reason: null },
+    ],
+    recommended_mode: "cdc",
+    default_cursor_column: "id",
+  };
+}
+
+const catalog: DataSourceCatalogJson = {
+  capabilities: {
+    version: "16.4",
+    wal_level: "logical",
+    has_replication: true,
+    in_recovery: false,
+    slots_used: 0,
+    slots_max: 10,
+    probed_at_millis: 0,
+  },
+  tables: ["users", "audit_log"].map(table),
+};
+
+describe("StreamPicker initial selection", () => {
+  it("selects recommended tables during initial setup", () => {
+    const selection = buildInitialSelection(catalog, undefined);
+
+    expect(selection["public.users"]?.on).toBe(true);
+    expect(selection["public.audit_log"]?.on).toBe(true);
+  });
+
+  it("selects only configured streams while editing", () => {
+    const existing: DataSourceStreamConfig[] = [{
+      schema_name: "public",
+      table_name: "users",
+      mode: "cursor",
+      cursor_column: "id",
+    }];
+
+    const selection = buildInitialSelection(catalog, existing);
+
+    expect(selection["public.users"]).toEqual({ on: true, mode: "cursor", cursorColumn: "id" });
+    expect(selection["public.audit_log"]?.on).toBe(false);
+  });
+
+  it("keeps every table off when editing a source with no configured streams", () => {
+    const selection = buildInitialSelection(catalog, []);
+
+    expect(Object.values(selection).every(value => value?.on === false)).toBe(true);
+  });
+});

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/stream-picker.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/stream-picker.tsx
@@ -29,6 +29,10 @@ const NON_TEMPORAL_CURSOR_WARNING =
   "This column only changes when a row is inserted, so edits to existing rows will never be synced. "
   + "Pick a timestamp your application updates on every write — usually updated_at — unless this table is append-only.";
 
+function replicationSlotsAreFull(slotsUsed: number, slotsMax: number | null): boolean {
+  return slotsMax != null && slotsUsed >= slotsMax;
+}
+
 /** Concrete remediation for the specific reason CDC is off, not generic advice. */
 function getCdcRemediation(capabilities: DataSourceCatalogJson["capabilities"]): string | null {
   if (capabilities.wal_level !== "logical") {
@@ -40,7 +44,7 @@ function getCdcRemediation(capabilities: DataSourceCatalogJson["capabilities"]):
   if (capabilities.in_recovery) {
     return "Replication slots cannot live on a read replica. Point Hexclave at the primary instead.";
   }
-  if (capabilities.slots_used >= capabilities.slots_max) {
+  if (replicationSlotsAreFull(capabilities.slots_used, capabilities.slots_max)) {
     return "Every replication slot on the server is in use. Free one, or raise max_replication_slots.";
   }
   return null;
@@ -48,19 +52,20 @@ function getCdcRemediation(capabilities: DataSourceCatalogJson["capabilities"]):
 
 type Selection = { on: boolean, mode: DataSourceSyncMode | null, cursorColumn: string | null };
 
-function buildInitialSelection(
+export function buildInitialSelection(
   catalog: DataSourceCatalogJson,
-  existing: DataSourceStreamConfig[],
+  existing: DataSourceStreamConfig[] | undefined,
 ): Record<string, Selection | undefined> {
-  const existingByKey = new Map(existing.map(s => [`${s.schema_name}.${s.table_name}`, s]));
+  const existingByKey = new Map((existing ?? []).map(s => [`${s.schema_name}.${s.table_name}`, s]));
   const selection: Record<string, Selection | undefined> = {};
   for (const table of catalog.tables) {
     const key = `${table.schema_name}.${table.table_name}`;
     const prior = existingByKey.get(key);
     selection[key] = prior != null
       ? { on: true, mode: prior.mode, cursorColumn: prior.cursor_column ?? table.default_cursor_column }
-      // Default to the recommendation, so the common case needs no decisions.
-      : { on: table.recommended_mode != null, mode: table.recommended_mode, cursorColumn: table.default_cursor_column };
+      // Recommendations are defaults only during initial setup. While editing,
+      // newly discovered tables must require an explicit opt-in.
+      : { on: existing == null && table.recommended_mode != null, mode: table.recommended_mode, cursorColumn: table.default_cursor_column };
   }
   return selection;
 }
@@ -93,7 +98,7 @@ export function StreamPicker(props: {
   onCancel?: () => void,
   onSubmit: (streams: DataSourceStreamConfig[]) => Promise<void>,
 }) {
-  const [selection, setSelection] = useState(() => buildInitialSelection(props.catalog, props.existingStreams ?? []));
+  const [selection, setSelection] = useState(() => buildInitialSelection(props.catalog, props.existingStreams));
   const [saving, setSaving] = useState(false);
 
   const cdcAvailability = useMemo(() => {

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/stream-picker.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/stream-picker.tsx
@@ -99,8 +99,14 @@ export function StreamPicker(props: {
   const hasKeylessSelection = selected.some(t => t.primary_key_columns.length === 0);
   const remediation = cdcAvailability.available ? null : getCdcRemediation(props.catalog.capabilities);
 
+  // Falls back to the same defaults the row renders with, so ticking a table that
+  // the catalog grew after mount submits its recommended mode rather than null.
+  const defaultSelectionFor = (key: string): Selection => {
+    const table = props.catalog.tables.find(t => `${t.schema_name}.${t.table_name}` === key);
+    return { on: false, mode: table?.recommended_mode ?? null, cursorColumn: table?.default_cursor_column ?? null };
+  };
   const update = (key: string, patch: Partial<Selection>) => {
-    setSelection(prev => ({ ...prev, [key]: { on: false, mode: null, cursorColumn: null, ...prev[key], ...patch } }));
+    setSelection(prev => ({ ...prev, [key]: { ...defaultSelectionFor(key), ...prev[key], ...patch } }));
   };
 
   const submit = async () => {
@@ -175,7 +181,7 @@ export function StreamPicker(props: {
               const key = `${table.schema_name}.${table.table_name}`;
               // A table the catalog grew since this component mounted has no
               // entry yet; it renders unselected rather than crashing the page.
-              const current = selection[key] ?? { on: false, mode: table.recommended_mode, cursorColumn: table.default_cursor_column };
+              const current = selection[key] ?? defaultSelectionFor(key);
               const syncable = table.recommended_mode != null;
               return (
                 <tr key={key} className={`border-t border-border-in-card ${current.on ? "" : "opacity-50"}`}>
@@ -240,7 +246,8 @@ export function StreamPicker(props: {
   );
 }
 
-export function formatRowCount(rows: number): string {
+export function formatRowCount(rows: number | null): string {
+  if (rows == null) return "unknown";
   if (rows >= 1e9) return `${(rows / 1e9).toFixed(1)}B`;
   if (rows >= 1e6) return `${(rows / 1e6).toFixed(rows >= 1e7 ? 0 : 1)}M`;
   if (rows >= 1e3) return `${Math.round(rows / 1e3)}k`;

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/stream-picker.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/stream-picker.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import { DesignButton, DesignSelectorDropdown } from "@/components/design-components";
-import { Card, Checkbox, Typography } from "@/components/ui";
+import { Card, Checkbox, SimpleTooltip, Typography } from "@/components/ui";
+import { WarningCircleIcon } from "@phosphor-icons/react";
 import type { DataSourceCatalogJson, DataSourceCatalogTableJson, DataSourceStreamConfig } from "@hexclave/shared/dist/interface/admin-interface";
-import type { DataSourceSyncMode } from "@hexclave/shared/dist/data-sources/modes";
+import { isTemporalCursorType, type DataSourceSyncMode } from "@hexclave/shared/dist/data-sources/modes";
 import { useMemo, useState } from "react";
 
 /**
@@ -20,13 +21,13 @@ const MODE_INFO: Record<DataSourceSyncMode, { label: string, description: string
     label: "Cursor",
     description: "Re-reads rows whose cursor column moved past the last sync. Cannot see deleted rows.",
   },
-  full_refresh: {
-    label: "Full refresh",
-    description: "Reloads the whole table each sync. Always correct, only viable while the table is small.",
-  },
 };
 
-const MODE_ORDER: DataSourceSyncMode[] = ["cdc", "cursor", "full_refresh"];
+const MODE_ORDER: DataSourceSyncMode[] = ["cdc", "cursor"];
+
+const NON_TEMPORAL_CURSOR_WARNING =
+  "This column only changes when a row is inserted, so edits to existing rows will never be synced. "
+  + "Pick a timestamp your application updates on every write — usually updated_at — unless this table is append-only.";
 
 /** Concrete remediation for the specific reason CDC is off, not generic advice. */
 function getCdcRemediation(capabilities: DataSourceCatalogJson["capabilities"]): string | null {
@@ -64,6 +65,13 @@ function buildInitialSelection(
   return selection;
 }
 
+/** True when the chosen cursor moves on insert but not on update. */
+function selectedCursorIsInsertOnly(table: DataSourceCatalogTableJson, column: string | null): boolean {
+  if (column == null) return false;
+  const candidate = table.cursor_candidates.find(c => c.column === column);
+  return candidate != null && !isTemporalCursorType(candidate.data_type);
+}
+
 function modeOptions(table: DataSourceCatalogTableJson) {
   return MODE_ORDER.map(mode => {
     const availability = table.available_modes.find(m => m.mode === mode);
@@ -97,6 +105,7 @@ export function StreamPicker(props: {
 
   const selected = props.catalog.tables.filter(t => selection[`${t.schema_name}.${t.table_name}`]?.on);
   const hasKeylessSelection = selected.some(t => t.primary_key_columns.length === 0);
+  const selectedUsesCursor = selected.some(t => selection[`${t.schema_name}.${t.table_name}`]?.mode === "cursor");
   const remediation = cdcAvailability.available ? null : getCdcRemediation(props.catalog.capabilities);
 
   // Falls back to the same defaults the row renders with, so ticking a table that
@@ -158,6 +167,14 @@ export function StreamPicker(props: {
             To enable CDC: {remediation}
           </p>
         )}
+        {selectedUsesCursor && (
+          <p className="mt-3 border-t border-border-in-card pt-3 text-xs text-muted-foreground">
+            <span className="font-medium text-foreground">Choosing a cursor column.</span>{" "}
+            Pick a timestamp your application sets on every write, such as <code>updated_at</code> — that way
+            edits are picked up as well as new rows. An id or a <code>created_at</code> only moves when a row is
+            inserted, so it suits an append-only table and nothing else.
+          </p>
+        )}
         {hasKeylessSelection && (
           <p className="mt-2 text-xs text-muted-foreground">
             Tables without a primary key are written append-only: every version of a row is kept, because there is no key to deduplicate on.
@@ -210,17 +227,24 @@ export function StreamPicker(props: {
                   </td>
                   <td className="px-4 py-2.5">
                     {current.mode === "cursor" && table.cursor_candidates.length > 0 ? (
-                      <DesignSelectorDropdown
-                        size="sm"
-                        value={current.cursorColumn ?? ""}
-                        options={table.cursor_candidates.map(candidate => ({
-                          value: candidate.column,
-                          // An unindexed cursor works but scans the table, which is
-                          // the kind of thing to know before picking it.
-                          label: candidate.indexed ? candidate.column : `${candidate.column} — no index`,
-                        }))}
-                        onValueChange={value => update(key, { cursorColumn: value })}
-                      />
+                      <div className="flex items-center gap-1.5">
+                        <DesignSelectorDropdown
+                          size="sm"
+                          value={current.cursorColumn ?? ""}
+                          options={table.cursor_candidates.map(candidate => ({
+                            value: candidate.column,
+                            // An unindexed cursor works but scans the table, which is
+                            // the kind of thing to know before picking it.
+                            label: candidate.indexed ? candidate.column : `${candidate.column} — no index`,
+                          }))}
+                          onValueChange={value => update(key, { cursorColumn: value })}
+                        />
+                        {selectedCursorIsInsertOnly(table, current.cursorColumn) && (
+                          <SimpleTooltip tooltip={NON_TEMPORAL_CURSOR_WARNING}>
+                            <WarningCircleIcon className="h-4 w-4 shrink-0 text-amber-500" weight="fill" />
+                          </SimpleTooltip>
+                        )}
+                      </div>
                     ) : (
                       <span className="text-xs text-muted-foreground">—</span>
                     )}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/stream-picker.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/data-warehouse/sources/stream-picker.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { DesignButton, DesignSelectorDropdown } from "@/components/design-components";
+import { Card, Checkbox, Typography } from "@/components/ui";
+import type { DataSourceCatalogJson, DataSourceCatalogTableJson, DataSourceStreamConfig } from "@hexclave/shared/dist/interface/admin-interface";
+import type { DataSourceSyncMode } from "@hexclave/shared/dist/data-sources/modes";
+import { useMemo, useState } from "react";
+
+/**
+ * Human-facing description of each mode. Kept next to the availability verdict
+ * rather than on each table row: the concept only needs explaining once, and the
+ * per-table exceptions live in the mode dropdown, where the choice is made.
+ */
+const MODE_INFO: Record<DataSourceSyncMode, { label: string, description: string }> = {
+  cdc: {
+    label: "CDC",
+    description: "Reads your write-ahead log. Near real-time, and the only mode that sees deleted rows.",
+  },
+  cursor: {
+    label: "Cursor",
+    description: "Re-reads rows whose cursor column moved past the last sync. Cannot see deleted rows.",
+  },
+  full_refresh: {
+    label: "Full refresh",
+    description: "Reloads the whole table each sync. Always correct, only viable while the table is small.",
+  },
+};
+
+const MODE_ORDER: DataSourceSyncMode[] = ["cdc", "cursor", "full_refresh"];
+
+/** Concrete remediation for the specific reason CDC is off, not generic advice. */
+function getCdcRemediation(capabilities: DataSourceCatalogJson["capabilities"]): string | null {
+  if (capabilities.wal_level !== "logical") {
+    return "Set wal_level to logical on your server (on RDS, set rds.logical_replication = 1 in the parameter group), then restart it.";
+  }
+  if (!capabilities.has_replication) {
+    return "Grant the REPLICATION attribute to the role you gave us: ALTER ROLE <user> REPLICATION.";
+  }
+  if (capabilities.in_recovery) {
+    return "Replication slots cannot live on a read replica. Point Hexclave at the primary instead.";
+  }
+  if (capabilities.slots_used >= capabilities.slots_max) {
+    return "Every replication slot on the server is in use. Free one, or raise max_replication_slots.";
+  }
+  return null;
+}
+
+type Selection = { on: boolean, mode: DataSourceSyncMode | null, cursorColumn: string | null };
+
+function buildInitialSelection(
+  catalog: DataSourceCatalogJson,
+  existing: DataSourceStreamConfig[],
+): Record<string, Selection | undefined> {
+  const existingByKey = new Map(existing.map(s => [`${s.schema_name}.${s.table_name}`, s]));
+  const selection: Record<string, Selection | undefined> = {};
+  for (const table of catalog.tables) {
+    const key = `${table.schema_name}.${table.table_name}`;
+    const prior = existingByKey.get(key);
+    selection[key] = prior != null
+      ? { on: true, mode: prior.mode, cursorColumn: prior.cursor_column ?? table.default_cursor_column }
+      // Default to the recommendation, so the common case needs no decisions.
+      : { on: table.recommended_mode != null, mode: table.recommended_mode, cursorColumn: table.default_cursor_column };
+  }
+  return selection;
+}
+
+function modeOptions(table: DataSourceCatalogTableJson) {
+  return MODE_ORDER.map(mode => {
+    const availability = table.available_modes.find(m => m.mode === mode);
+    const unavailable = availability == null || !availability.available;
+    return {
+      value: mode,
+      // The reason rides on the option itself, so an unavailable mode explains
+      // itself where the customer looks for it.
+      label: unavailable ? `${MODE_INFO[mode].label} — ${availability?.reason ?? "unavailable"}` : MODE_INFO[mode].label,
+      disabled: unavailable,
+    };
+  });
+}
+
+export function StreamPicker(props: {
+  catalog: DataSourceCatalogJson,
+  existingStreams?: DataSourceStreamConfig[],
+  submitLabel: string,
+  onCancel?: () => void,
+  onSubmit: (streams: DataSourceStreamConfig[]) => Promise<void>,
+}) {
+  const [selection, setSelection] = useState(() => buildInitialSelection(props.catalog, props.existingStreams ?? []));
+  const [saving, setSaving] = useState(false);
+
+  const cdcAvailability = useMemo(() => {
+    // The server-level verdict is whatever a table with a primary key gets; a
+    // per-table "needs a primary key" is not a reason to tell everyone CDC is off.
+    const withKey = props.catalog.tables.find(t => t.primary_key_columns.length > 0);
+    return withKey?.available_modes.find(m => m.mode === "cdc") ?? { mode: "cdc" as const, available: false, reason: null };
+  }, [props.catalog]);
+
+  const selected = props.catalog.tables.filter(t => selection[`${t.schema_name}.${t.table_name}`]?.on);
+  const hasKeylessSelection = selected.some(t => t.primary_key_columns.length === 0);
+  const remediation = cdcAvailability.available ? null : getCdcRemediation(props.catalog.capabilities);
+
+  const update = (key: string, patch: Partial<Selection>) => {
+    setSelection(prev => ({ ...prev, [key]: { on: false, mode: null, cursorColumn: null, ...prev[key], ...patch } }));
+  };
+
+  const submit = async () => {
+    setSaving(true);
+    try {
+      await props.onSubmit(selected.map(table => {
+        const current = selection[`${table.schema_name}.${table.table_name}`];
+        return {
+          schema_name: table.schema_name,
+          table_name: table.table_name,
+          mode: current!.mode!,
+          cursor_column: current!.mode === "cursor" ? current!.cursorColumn : null,
+        };
+      }));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Card className="p-5">
+        <Typography type="label" className="mb-3 block">Sync modes</Typography>
+        <div className="flex flex-col">
+          {MODE_ORDER.map((mode, index) => {
+            const availableOn = props.catalog.tables.filter(
+              t => t.available_modes.find(m => m.mode === mode)?.available,
+            ).length;
+            const isAvailable = mode === "cdc" ? cdcAvailability.available : availableOn > 0;
+            return (
+              <div
+                key={mode}
+                className={`flex items-start gap-3 py-3 ${index > 0 ? "border-t border-border-in-card" : "pt-0"}`}
+              >
+                <span className="w-28 shrink-0 font-medium">{MODE_INFO[mode].label}</span>
+                <span className="flex-1 text-muted-foreground">{MODE_INFO[mode].description}</span>
+                <span className="flex shrink-0 items-center gap-2 text-xs text-muted-foreground">
+                  <span className={`h-1.5 w-1.5 rounded-full ${isAvailable ? "bg-green-500" : "bg-amber-500"}`} />
+                  {mode === "cdc"
+                    ? (cdcAvailability.available ? "Available" : cdcAvailability.reason ?? "Unavailable")
+                    : `Available on ${availableOn} of ${props.catalog.tables.length} tables`}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+        {remediation != null && (
+          <p className="mt-3 border-t border-border-in-card pt-3 text-xs text-muted-foreground">
+            To enable CDC: {remediation}
+          </p>
+        )}
+        {hasKeylessSelection && (
+          <p className="mt-2 text-xs text-muted-foreground">
+            Tables without a primary key are written append-only: every version of a row is kept, because there is no key to deduplicate on.
+          </p>
+        )}
+      </Card>
+
+      <Card>
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-xs uppercase tracking-wide text-muted-foreground">
+              <th className="w-10 px-4 pb-2 pt-4" />
+              <th className="px-4 pb-2 pt-4 text-left font-medium">Table</th>
+              <th className="px-4 pb-2 pt-4 text-left font-medium">Rows</th>
+              <th className="px-4 pb-2 pt-4 text-left font-medium">Sync mode</th>
+              <th className="px-4 pb-2 pt-4 text-left font-medium">Cursor column</th>
+            </tr>
+          </thead>
+          <tbody>
+            {props.catalog.tables.map(table => {
+              const key = `${table.schema_name}.${table.table_name}`;
+              // A table the catalog grew since this component mounted has no
+              // entry yet; it renders unselected rather than crashing the page.
+              const current = selection[key] ?? { on: false, mode: table.recommended_mode, cursorColumn: table.default_cursor_column };
+              const syncable = table.recommended_mode != null;
+              return (
+                <tr key={key} className={`border-t border-border-in-card ${current.on ? "" : "opacity-50"}`}>
+                  <td className="px-4 py-2.5">
+                    <Checkbox
+                      checked={current.on}
+                      disabled={!syncable}
+                      onCheckedChange={checked => update(key, { on: checked === true })}
+                    />
+                  </td>
+                  <td className="px-4 py-2.5 font-medium">
+                    <span className="font-normal text-muted-foreground">{table.schema_name}.</span>{table.table_name}
+                  </td>
+                  <td className="px-4 py-2.5 tabular-nums text-muted-foreground">{formatRowCount(table.approx_rows)}</td>
+                  <td className="px-4 py-2.5">
+                    {syncable ? (
+                      <DesignSelectorDropdown
+                        size="sm"
+                        value={current.mode ?? ""}
+                        options={modeOptions(table)}
+                        onValueChange={value => update(key, { mode: value as DataSourceSyncMode })}
+                      />
+                    ) : (
+                      <span className="text-xs text-muted-foreground">No mode available</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5">
+                    {current.mode === "cursor" && table.cursor_candidates.length > 0 ? (
+                      <DesignSelectorDropdown
+                        size="sm"
+                        value={current.cursorColumn ?? ""}
+                        options={table.cursor_candidates.map(candidate => ({
+                          value: candidate.column,
+                          // An unindexed cursor works but scans the table, which is
+                          // the kind of thing to know before picking it.
+                          label: candidate.indexed ? candidate.column : `${candidate.column} — no index`,
+                        }))}
+                        onValueChange={value => update(key, { cursorColumn: value })}
+                      />
+                    ) : (
+                      <span className="text-xs text-muted-foreground">—</span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </Card>
+
+      <div className="flex items-center gap-3">
+        {props.onCancel && <DesignButton variant="ghost" onClick={props.onCancel}>Cancel</DesignButton>}
+        <div className="flex-1" />
+        <Typography type="label" variant="secondary">
+          {selected.length} of {props.catalog.tables.length} selected
+        </Typography>
+        <DesignButton onClick={submit} disabled={selected.length === 0} loading={saving}>
+          {props.submitLabel}
+        </DesignButton>
+      </div>
+    </div>
+  );
+}
+
+export function formatRowCount(rows: number): string {
+  if (rows >= 1e9) return `${(rows / 1e9).toFixed(1)}B`;
+  if (rows >= 1e6) return `${(rows / 1e6).toFixed(rows >= 1e7 ? 0 : 1)}M`;
+  if (rows >= 1e3) return `${Math.round(rows / 1e3)}k`;
+  return String(rows);
+}

--- a/apps/dashboard/src/lib/apps-frontend.tsx
+++ b/apps/dashboard/src/lib/apps-frontend.tsx
@@ -543,6 +543,7 @@ export const ALL_APPS_FRONTEND = {
     href: "data-warehouse",
     navigationItems: [
       { displayName: "Data Warehouse", href: "." },
+      { displayName: "Sources", href: "sources" },
     ],
     screenshots: [],
     storeDescription: (

--- a/apps/e2e/tests/backend/endpoints/api/v1/data-sources.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/data-sources.test.ts
@@ -1,0 +1,537 @@
+import { ITEM_IDS } from "@hexclave/shared/dist/plans";
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
+import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+import { Client } from "pg";
+import { it } from "../../../../helpers";
+import { Project, niceBackendFetch, withInternalProject } from "../../../backend-helpers";
+import { waitForItemQuantityToReach } from "../../../payment-quota-helpers";
+
+/**
+ * Each test gets its own throwaway database on the local Postgres and points a
+ * data source at it. A separate database rather than a schema because logical
+ * replication slots are per-database: a leaked slot on the app's own database
+ * would pin write-ahead log for everything else running here.
+ */
+
+function sourceServer() {
+  const connectionString = getEnvVariable(
+    "HEXCLAVE_DATABASE_CONNECTION_STRING",
+    getEnvVariable("STACK_DATABASE_CONNECTION_STRING", ""),
+  );
+  if (connectionString === "") {
+    throw new HexclaveAssertionError("Data Source tests need a database connection string to build a source from");
+  }
+  const url = new URL(connectionString);
+  return {
+    host: url.hostname,
+    port: Number.parseInt(url.port || "5432", 10),
+    username: decodeURIComponent(url.username),
+    password: decodeURIComponent(url.password),
+    adminDatabase: url.pathname.replace(/^\//, ""),
+  };
+}
+
+function connectionStringFor(database: string) {
+  const server = sourceServer();
+  return `postgres://${encodeURIComponent(server.username)}:${encodeURIComponent(server.password)}@${server.host}:${server.port}/${database}`;
+}
+
+async function onSource<T>(database: string, fn: (client: Client) => Promise<T>): Promise<T> {
+  const client = new Client({ connectionString: connectionStringFor(database), connectionTimeoutMillis: 10_000 });
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    await client.end();
+  }
+}
+
+/** Creates a source database seeded with `setup`, runs the test, and drops it. */
+async function withSourceDatabase<T>(
+  setup: string,
+  fn: (source: { database: string, query: (sql: string) => Promise<void> }) => Promise<T>,
+): Promise<T> {
+  const server = sourceServer();
+  const database = `ds_e2e_${Math.random().toString(36).slice(2, 12)}`;
+  await onSource(server.adminDatabase, async client => {
+    await client.query(`CREATE DATABASE ${JSON.stringify(database).replace(/"/g, '"')}`);
+  });
+  try {
+    await onSource(database, async client => {
+      await client.query(setup);
+    });
+    return await fn({
+      database,
+      query: async (sql: string) => {
+        await onSource(database, async client => {
+          await client.query(sql);
+        });
+      },
+    });
+  } finally {
+    await onSource(server.adminDatabase, async client => {
+      // Slots and the connections holding them must go before the database can be
+      // dropped; a test that failed mid-sync would otherwise block cleanup.
+      await client.query(
+        `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()`,
+        [database],
+      ).catch(() => {});
+      await client.query(`DROP DATABASE IF EXISTS ${JSON.stringify(database).replace(/"/g, '"')} WITH (FORCE)`).catch(() => {});
+    });
+  }
+}
+
+/** A project on the team plan with a warehouse, which is what a source writes into. */
+async function createProjectWithWarehouse() {
+  const { createProjectResponse, projectId } = await Project.createAndSwitch();
+  const ownerTeamId = createProjectResponse.body.owner_team_id;
+  await withInternalProject(async () => {
+    const grant = await niceBackendFetch(`/api/v1/payments/products/team/${ownerTeamId}`, {
+      method: "POST",
+      accessType: "server",
+      body: { product_id: "team" },
+    });
+    if (grant.status !== 200) {
+      throw new HexclaveAssertionError(`Failed to grant the team plan to '${ownerTeamId}'`, { response: grant });
+    }
+  });
+  await waitForItemQuantityToReach(ownerTeamId, ITEM_IDS.dataWarehouse, 1);
+  const provision = await niceBackendFetch("/api/v1/data-warehouse/provision", {
+    method: "POST",
+    accessType: "admin",
+    body: {},
+  });
+  if (provision.status !== 200) {
+    throw new HexclaveAssertionError("Failed to provision the warehouse a data source needs", { response: provision });
+  }
+  return { projectId, credentials: { username: provision.body.username, password: provision.body.password } };
+}
+
+async function connectSource(database: string, overrides: Record<string, unknown> = {}) {
+  const server = sourceServer();
+  return await niceBackendFetch("/api/v1/data-sources", {
+    method: "POST",
+    accessType: "admin",
+    body: {
+      host: server.host,
+      port: server.port,
+      database,
+      username: server.username,
+      password: server.password,
+      ssl_mode: "disable",
+      ...overrides,
+    },
+  });
+}
+
+const listSources = () => niceBackendFetch("/api/v1/data-sources", { accessType: "admin" });
+const getSource = (id: string) => niceBackendFetch(`/api/v1/data-sources/${id}`, { accessType: "admin" });
+const getCatalog = (id: string) => niceBackendFetch(`/api/v1/data-sources/${id}/catalog`, { accessType: "admin" });
+const setStreams = (id: string, streams: unknown[]) => niceBackendFetch(`/api/v1/data-sources/${id}/streams`, {
+  method: "PUT", accessType: "admin", body: { streams },
+});
+const syncSource = (id: string) => niceBackendFetch(`/api/v1/data-sources/${id}/sync`, {
+  method: "POST", accessType: "admin", body: {},
+});
+const deleteSource = (id: string) => niceBackendFetch(`/api/v1/data-sources/${id}`, {
+  method: "DELETE", accessType: "admin",
+});
+
+/** Reads the destination as the customer would, with the project's own warehouse user. */
+async function queryWarehouse(credentials: { username: string, password: string }, query: string) {
+  const url = new URL(getEnvVariable("HEXCLAVE_CLICKHOUSE_URL", ""));
+  url.searchParams.set("user", credentials.username);
+  url.searchParams.set("password", credentials.password);
+  const response = await fetch(url, { method: "POST", body: query });
+  return { status: response.status, text: (await response.text()).trim() };
+}
+
+const SIMPLE_SCHEMA = `
+  CREATE TABLE plans (id int PRIMARY KEY, name text NOT NULL);
+  CREATE TABLE events (id bigserial PRIMARY KEY, label text NOT NULL, created_at timestamptz NOT NULL DEFAULT now() - interval '1 hour');
+  CREATE INDEX events_created_at_idx ON events (created_at);
+  CREATE TABLE keyless (a int NOT NULL, b text);
+  INSERT INTO plans VALUES (1, 'free'), (2, 'pro');
+  INSERT INTO events (label) SELECT 'e' || g FROM generate_series(1, 25) g;
+  ANALYZE;
+`;
+
+// ─── auth and entitlement ───────────────────────────────────────────────────
+
+it("refuses anything below admin access", async ({ expect }) => {
+  await Project.createAndSwitch();
+  const client = await niceBackendFetch("/api/v1/data-sources", { accessType: "client" });
+  expect(client.status).toBe(401);
+  const server = await niceBackendFetch("/api/v1/data-sources", { accessType: "server" });
+  expect(server.status).toBe(401);
+});
+
+it("lists nothing for a project that has never connected one", async ({ expect }) => {
+  await Project.createAndSwitch();
+  const response = await listSources();
+  expect(response.status).toBe(200);
+  expect(response.body.data_sources).toEqual([]);
+});
+
+it("cannot connect a source on the free plan", async ({ expect }) => {
+  await Project.createAndSwitch();
+  const response = await connectSource("postgres");
+  expect(response.status).toBe(400);
+  expect(response.body).toMatchObject({
+    code: "ITEM_QUANTITY_INSUFFICIENT_AMOUNT",
+    details: { item_id: ITEM_IDS.dataWarehouse },
+  });
+});
+
+it("cannot connect a source before the warehouse it would write into exists", async ({ expect }) => {
+  const { createProjectResponse } = await Project.createAndSwitch();
+  const ownerTeamId = createProjectResponse.body.owner_team_id;
+  await withInternalProject(async () => {
+    await niceBackendFetch(`/api/v1/payments/products/team/${ownerTeamId}`, {
+      method: "POST", accessType: "server", body: { product_id: "team" },
+    });
+  });
+  await waitForItemQuantityToReach(ownerTeamId, ITEM_IDS.dataWarehouse, 1);
+
+  const response = await connectSource("postgres");
+  expect(response.status).toBe(400);
+  expect(String(response.body)).toContain("does not have a data warehouse");
+});
+
+// ─── connecting ─────────────────────────────────────────────────────────────
+
+it("rejects credentials it cannot connect with, and stores nothing", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  const response = await connectSource("postgres", { password: "not-the-password" });
+  expect(response.status).toBe(400);
+  // A source row that has never connected is worse than no row: it looks configured.
+  const list = await listSources();
+  expect(list.body.data_sources).toEqual([]);
+});
+
+it("rejects an unsupported SSL mode", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  const response = await connectSource("postgres", { ssl_mode: "banana" });
+  expect(response.status).toBe(400);
+});
+
+it("connects, and returns a catalog with a mode decision per table", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const response = await connectSource(source.database);
+    expect(response.status).toBe(200);
+    expect(response.body.data_source).toMatchObject({
+      type: "postgres",
+      database: source.database,
+      status: "pending",
+      streams: [],
+    });
+    expect(response.body.data_source).not.toHaveProperty("password");
+    expect(response.body.data_source.capabilities.wal_level).toBe("logical");
+
+    const tables = response.body.catalog.tables;
+    expect(tables.map((t: any) => t.table_name).sort()).toEqual(["events", "keyless", "plans"]);
+
+    const events = tables.find((t: any) => t.table_name === "events");
+    expect(events.primary_key_columns).toEqual(["id"]);
+    // Both the indexed timestamp and the monotonic key qualify; the timestamp is
+    // preferred because it moves when a row is updated in place.
+    expect(events.cursor_candidates.map((c: any) => c.column).sort()).toEqual(["created_at", "id"]);
+    expect(events.default_cursor_column).toBe("created_at");
+    expect(events.recommended_mode).toBe("full_refresh"); // small enough to reload wholesale
+
+    // Without a primary key there is no key to match an update or delete against.
+    const keyless = tables.find((t: any) => t.table_name === "keyless");
+    expect(keyless.primary_key_columns).toEqual([]);
+    expect(keyless.available_modes.find((m: any) => m.mode === "cdc")).toEqual({
+      mode: "cdc", available: false, reason: "needs a primary key",
+    });
+  });
+});
+
+it("re-reads the catalog on demand, so a table added later becomes syncable", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    await source.query(`CREATE TABLE added_later (id int PRIMARY KEY)`);
+
+    const catalog = await getCatalog(data_source.id);
+    expect(catalog.status).toBe(200);
+    expect(catalog.body.catalog.tables.map((t: any) => t.table_name)).toContain("added_later");
+  });
+});
+
+// ─── configuring streams ────────────────────────────────────────────────────
+
+it("refuses a mode the source cannot support, rather than downgrading it", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    const response = await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "keyless", mode: "cdc" },
+    ]);
+    expect(response.status).toBe(400);
+    expect(String(response.body)).toContain("needs a primary key");
+  });
+});
+
+it("refuses a table the source does not have", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    const response = await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "no_such_table", mode: "full_refresh" },
+    ]);
+    expect(response.status).toBe(400);
+    expect(String(response.body)).toContain("no readable table");
+  });
+});
+
+it("refuses a cursor column that is not a usable cursor", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    const response = await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "label" },
+    ]);
+    expect(response.status).toBe(400);
+    expect(String(response.body)).toContain("cannot be used as a cursor");
+  });
+});
+
+it("replaces the stream list wholesale and reports it back", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+
+    const first = await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "plans", mode: "full_refresh" },
+      { schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "created_at" },
+    ]);
+    expect(first.status).toBe(200);
+    expect(first.body.data_source.status).toBe("active");
+    expect(first.body.data_source.streams.map((s: any) => [s.table_name, s.mode, s.cursor_column])).toEqual([
+      ["events", "cursor", "created_at"],
+      ["plans", "full_refresh", null],
+    ]);
+    expect(first.body.data_source.streams[0].destination_table).toBe("public_events");
+
+    const second = await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "plans", mode: "full_refresh" },
+    ]);
+    expect(second.body.data_source.streams.map((s: any) => s.table_name)).toEqual(["plans"]);
+
+    const fetched = await getSource(data_source.id);
+    expect(fetched.status).toBe(200);
+    expect(fetched.body.data_source.streams.map((s: any) => s.table_name)).toEqual(["plans"]);
+  });
+});
+
+// ─── syncing ────────────────────────────────────────────────────────────────
+
+it("syncs full-refresh and cursor streams into the project's warehouse", async ({ expect }) => {
+  const { projectId, credentials } = await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "plans", mode: "full_refresh" },
+      { schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "created_at" },
+    ]);
+
+    const sync = await syncSource(data_source.id);
+    expect(sync.status).toBe(200);
+    expect(sync.body.data_source.streams.map((s: any) => [s.table_name, s.status, s.error])).toEqual([
+      ["events", "active", null],
+      ["plans", "active", null],
+    ]);
+    expect(sync.body.data_source.streams.find((s: any) => s.table_name === "events").rows_synced).toBe(25);
+
+    const plans = await queryWarehouse(credentials, `SELECT name FROM \`${projectId}\`.public_plans FINAL ORDER BY id`);
+    expect(plans.status).toBe(200);
+    expect(plans.text).toBe("free\npro");
+
+    const events = await queryWarehouse(credentials, `SELECT count() FROM \`${projectId}\`.public_events FINAL`);
+    expect(events.text).toBe("25");
+  });
+});
+
+it("resumes a cursor stream instead of re-reading the table", async ({ expect }) => {
+  const { projectId, credentials } = await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "created_at" },
+    ]);
+    const first = await syncSource(data_source.id);
+    expect(first.body.data_source.streams[0].rows_synced).toBe(25);
+
+    // Backdated past the safety lag, which exists so a transaction committing
+    // after its timestamp is not skipped — a row written at now() is not due yet.
+    await source.query(`INSERT INTO events (label, created_at) VALUES ('late', now() - interval '30 minutes')`);
+    const second = await syncSource(data_source.id);
+    // rows_synced is cumulative, so only the one new row was read: a watermark
+    // that loses precision would re-read all 25 every time.
+    expect(second.body.data_source.streams[0].rows_synced).toBe(26);
+
+    const rows = await queryWarehouse(credentials, `SELECT count() FROM \`${projectId}\`.public_events FINAL`);
+    expect(rows.text).toBe("26");
+  });
+});
+
+it("holds a cursor stream back from now(), so a late commit is not skipped", async ({ expect }) => {
+  const { projectId, credentials } = await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "created_at" },
+    ]);
+    await syncSource(data_source.id);
+    await source.query(`INSERT INTO events (label, created_at) VALUES ('too-fresh', now())`);
+    await syncSource(data_source.id);
+
+    const fresh = await queryWarehouse(
+      credentials,
+      `SELECT count() FROM \`${projectId}\`.public_events FINAL WHERE label = 'too-fresh'`,
+    );
+    expect(fresh.text).toBe("0");
+  });
+});
+
+it("syncs inserts, updates and deletes through change data capture", async ({ expect }) => {
+  const { projectId, credentials } = await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    const configured = await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "events", mode: "cdc" },
+    ]);
+    expect(configured.status).toBe(200);
+
+    // First sync creates the slot and snapshots.
+    const snapshot = await syncSource(data_source.id);
+    expect(snapshot.status).toBe(200);
+    expect(snapshot.body.data_source.streams[0].error).toBe(null);
+    expect(snapshot.body.data_source.streams[0].rows_synced).toBe(25);
+
+    await source.query(`INSERT INTO events (label) VALUES ('inserted')`);
+    await source.query(`UPDATE events SET label = 'renamed' WHERE label = 'e1'`);
+    await source.query(`DELETE FROM events WHERE label = 'e2'`);
+
+    const second = await syncSource(data_source.id);
+    expect(second.status).toBe(200);
+    expect(second.body.data_source.streams[0].error).toBe(null);
+
+    const live = await queryWarehouse(
+      credentials,
+      `SELECT count() FROM \`${projectId}\`.public_events FINAL WHERE _hexclave_deleted = 0`,
+    );
+    expect(live.text).toBe("25"); // 25 + 1 inserted - 1 deleted
+
+    const renamed = await queryWarehouse(
+      credentials,
+      `SELECT count() FROM \`${projectId}\`.public_events FINAL WHERE label = 'renamed' AND _hexclave_deleted = 0`,
+    );
+    expect(renamed.text).toBe("1");
+
+    // The only mode that can observe a delete at all.
+    const deleted = await queryWarehouse(
+      credentials,
+      `SELECT count() FROM \`${projectId}\`.public_events FINAL WHERE label = 'e2' AND _hexclave_deleted = 0`,
+    );
+    expect(deleted.text).toBe("0");
+
+    await deleteSource(data_source.id);
+  });
+});
+
+it("rebuilds the destination when a stream changes mode", async ({ expect }) => {
+  const { projectId, credentials } = await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    await setStreams(data_source.id, [{ schema_name: "public", table_name: "events", mode: "full_refresh" }]);
+    await syncSource(data_source.id);
+
+    // Full-refresh versions are epoch microseconds and CDC versions are LSNs,
+    // which are many orders of magnitude smaller — merging the two would leave
+    // the table frozen at its pre-switch contents forever.
+    await setStreams(data_source.id, [{ schema_name: "public", table_name: "events", mode: "cdc" }]);
+    await syncSource(data_source.id);
+    await source.query(`UPDATE events SET label = 'after-switch' WHERE label = 'e3'`);
+    const afterSwitch = await syncSource(data_source.id);
+    expect(afterSwitch.body.data_source.streams[0].error).toBe(null);
+
+    const updated = await queryWarehouse(
+      credentials,
+      `SELECT count() FROM \`${projectId}\`.public_events FINAL WHERE label = 'after-switch'`,
+    );
+    expect(updated.text).toBe("1");
+
+    await deleteSource(data_source.id);
+  });
+});
+
+it("keeps one stream's failure from stopping the others", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "plans", mode: "full_refresh" },
+      { schema_name: "public", table_name: "events", mode: "full_refresh" },
+    ]);
+    // Dropped behind the configuration's back, which is what a permissions change
+    // or a migration looks like from here.
+    await source.query(`DROP TABLE events`);
+
+    const sync = await syncSource(data_source.id);
+    expect(sync.status).toBe(200);
+    const byTable = Object.fromEntries(sync.body.data_source.streams.map((s: any) => [s.table_name, s]));
+    expect(byTable.plans.status).toBe("active");
+    expect(byTable.plans.error).toBe(null);
+    expect(byTable.events.status).toBe("failed");
+    expect(String(byTable.events.error)).toContain("no longer exists");
+  });
+});
+
+// ─── deleting and isolation ─────────────────────────────────────────────────
+
+it("disconnects a source and drops the replication slot it created", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    await setStreams(data_source.id, [{ schema_name: "public", table_name: "events", mode: "cdc" }]);
+    await syncSource(data_source.id);
+
+    const slotsBefore = await onSource(source.database, async client =>
+      (await client.query(`SELECT count(*)::int AS n FROM pg_replication_slots WHERE database = current_database()`)).rows[0].n);
+    expect(slotsBefore).toBe(1);
+
+    const deleted = await deleteSource(data_source.id);
+    expect(deleted.status).toBe(200);
+
+    // A slot nobody reads pins write-ahead log until the customer's disk fills.
+    const slotsAfter = await onSource(source.database, async client =>
+      (await client.query(`SELECT count(*)::int AS n FROM pg_replication_slots WHERE database = current_database()`)).rows[0].n);
+    expect(slotsAfter).toBe(0);
+
+    expect((await listSources()).body.data_sources).toEqual([]);
+    expect((await getSource(data_source.id)).status).toBe(404);
+  });
+});
+
+it("does not let one project touch another's source", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  const ownedId = await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    await setStreams(data_source.id, [{ schema_name: "public", table_name: "plans", mode: "full_refresh" }]);
+    return data_source.id;
+  });
+
+  // A second project, entitled and provisioned, so the only thing standing
+  // between it and the first project's source is the tenancy scoping itself.
+  await createProjectWithWarehouse();
+  expect((await listSources()).body.data_sources).toEqual([]);
+  expect((await getSource(ownedId)).status).toBe(404);
+  expect((await getCatalog(ownedId)).status).toBe(404);
+  expect((await syncSource(ownedId)).status).toBe(404);
+  expect((await setStreams(ownedId, [])).status).toBe(404);
+  expect((await deleteSource(ownedId)).status).toBe(404);
+});

--- a/apps/e2e/tests/backend/endpoints/api/v1/data-sources.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/data-sources.test.ts
@@ -136,6 +136,32 @@ const syncSource = (id: string) => niceBackendFetch(`/api/v1/data-sources/${id}/
 const deleteSource = (id: string) => niceBackendFetch(`/api/v1/data-sources/${id}`, {
   method: "DELETE", accessType: "admin",
 });
+const runScheduledSyncs = () => niceBackendFetch("/api/v1/internal/data-source-sync-step", {
+  method: "GET",
+  headers: { "Authorization": "Bearer mock_cron_secret" },
+  query: { max_duration_ms: "120000" },
+});
+
+async function getCdcInfrastructureCounts(database: string): Promise<{ slots: number, publications: number }> {
+  return await onSource(database, async client => {
+    const slots = await client.query<{ count: number }>(
+      `SELECT count(*)::int AS count FROM pg_replication_slots WHERE database = current_database() AND slot_name LIKE 'hexclave_%'`,
+    );
+    const publications = await client.query<{ count: number }>(
+      `SELECT count(*)::int AS count FROM pg_publication WHERE pubname LIKE 'hexclave_%'`,
+    );
+    return { slots: slots.rows[0].count, publications: publications.rows[0].count };
+  });
+}
+
+function getDestinationTable(
+  response: { body: { data_source: { streams: { table_name: string, destination_table: string }[] } } },
+  tableName: string,
+): string {
+  const stream = response.body.data_source.streams.find(candidate => candidate.table_name === tableName);
+  if (stream == null) throw new HexclaveAssertionError(`Response has no stream for table ${tableName}`);
+  return stream.destination_table;
+}
 
 /** Reads the destination as the customer would, with the project's own warehouse user. */
 async function queryWarehouse(credentials: { username: string, password: string }, query: string) {
@@ -316,12 +342,17 @@ it("replaces the stream list wholesale and reports it back", async ({ expect }) 
       ["events", "cursor", "created_at"],
       ["plans", "cursor", "id"],
     ]);
-    expect(first.body.data_source.streams[0].destination_table).toBe("public_events");
+    const eventsDestination = getDestinationTable(first, "events");
+    const plansDestination = getDestinationTable(first, "plans");
+    expect(eventsDestination).toMatch(/^public_events_[0-9a-f]{64}$/);
+    expect(plansDestination).toMatch(/^public_plans_[0-9a-f]{64}$/);
+    expect(eventsDestination).not.toBe(plansDestination);
 
     const second = await setStreams(data_source.id, [
       { schema_name: "public", table_name: "plans", mode: "cursor", cursor_column: "id" },
     ]);
     expect(second.body.data_source.streams.map((s: any) => s.table_name)).toEqual(["plans"]);
+    expect(getDestinationTable(second, "plans")).toBe(plansDestination);
 
     const fetched = await getSource(data_source.id);
     expect(fetched.status).toBe(200);
@@ -330,6 +361,26 @@ it("replaces the stream list wholesale and reports it back", async ({ expect }) 
 });
 
 // ─── syncing ────────────────────────────────────────────────────────────────
+
+it("executes a due source through the scheduler's existing claim", async ({ expect }) => {
+  const { projectId, credentials } = await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    const configured = await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "plans", mode: "cursor", cursor_column: "id" },
+    ]);
+
+    const scheduled = await runScheduledSyncs();
+    expect(scheduled.status).toBe(200);
+
+    const synced = await getSource(data_source.id);
+    expect(synced.body.data_source.error).toBe(null);
+    expect(synced.body.data_source.streams[0]).toMatchObject({ status: "active", rows_synced: 2 });
+    const destinationTable = getDestinationTable(configured, "plans");
+    const rows = await queryWarehouse(credentials, `SELECT name FROM \`${projectId}\`.\`${destinationTable}\` FINAL ORDER BY id`);
+    expect(rows.text).toBe("free\npro");
+  });
+});
 
 it("syncs cursor streams into the project's warehouse", async ({ expect }) => {
   const { projectId, credentials } = await createProjectWithWarehouse();
@@ -348,11 +399,13 @@ it("syncs cursor streams into the project's warehouse", async ({ expect }) => {
     ]);
     expect(sync.body.data_source.streams.find((s: any) => s.table_name === "events").rows_synced).toBe(25);
 
-    const plans = await queryWarehouse(credentials, `SELECT name FROM \`${projectId}\`.public_plans FINAL ORDER BY id`);
+    const plansDestination = getDestinationTable(sync, "plans");
+    const eventsDestination = getDestinationTable(sync, "events");
+    const plans = await queryWarehouse(credentials, `SELECT name FROM \`${projectId}\`.\`${plansDestination}\` FINAL ORDER BY id`);
     expect(plans.status).toBe(200);
     expect(plans.text).toBe("free\npro");
 
-    const events = await queryWarehouse(credentials, `SELECT count() FROM \`${projectId}\`.public_events FINAL`);
+    const events = await queryWarehouse(credentials, `SELECT count() FROM \`${projectId}\`.\`${eventsDestination}\` FINAL`);
     expect(events.text).toBe("25");
   });
 });
@@ -375,7 +428,8 @@ it("resumes a cursor stream instead of re-reading the table", async ({ expect })
     // that loses precision would re-read all 25 every time.
     expect(second.body.data_source.streams[0].rows_synced).toBe(26);
 
-    const rows = await queryWarehouse(credentials, `SELECT count() FROM \`${projectId}\`.public_events FINAL`);
+    const destinationTable = getDestinationTable(second, "events");
+    const rows = await queryWarehouse(credentials, `SELECT count() FROM \`${projectId}\`.\`${destinationTable}\` FINAL`);
     expect(rows.text).toBe("26");
   });
 });
@@ -387,13 +441,13 @@ it("holds a cursor stream back from now(), so a late commit is not skipped", asy
     await setStreams(data_source.id, [
       { schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "created_at" },
     ]);
-    await syncSource(data_source.id);
+    const first = await syncSource(data_source.id);
     await source.query(`INSERT INTO events (label, created_at) VALUES ('too-fresh', now())`);
     await syncSource(data_source.id);
 
     const fresh = await queryWarehouse(
       credentials,
-      `SELECT count() FROM \`${projectId}\`.public_events FINAL WHERE label = 'too-fresh'`,
+      `SELECT count() FROM \`${projectId}\`.\`${getDestinationTable(first, "events")}\` FINAL WHERE label = 'too-fresh'`,
     );
     expect(fresh.text).toBe("0");
   });
@@ -424,20 +478,20 @@ it("syncs inserts, updates and deletes through change data capture", async ({ ex
 
     const live = await queryWarehouse(
       credentials,
-      `SELECT count() FROM \`${projectId}\`.public_events FINAL WHERE _hexclave_deleted = 0`,
+      `SELECT count() FROM \`${projectId}\`.\`${getDestinationTable(second, "events")}\` FINAL WHERE _hexclave_deleted = 0`,
     );
     expect(live.text).toBe("25"); // 25 + 1 inserted - 1 deleted
 
     const renamed = await queryWarehouse(
       credentials,
-      `SELECT count() FROM \`${projectId}\`.public_events FINAL WHERE label = 'renamed' AND _hexclave_deleted = 0`,
+      `SELECT count() FROM \`${projectId}\`.\`${getDestinationTable(second, "events")}\` FINAL WHERE label = 'renamed' AND _hexclave_deleted = 0`,
     );
     expect(renamed.text).toBe("1");
 
     // The only mode that can observe a delete at all.
     const deleted = await queryWarehouse(
       credentials,
-      `SELECT count() FROM \`${projectId}\`.public_events FINAL WHERE label = 'e2' AND _hexclave_deleted = 0`,
+      `SELECT count() FROM \`${projectId}\`.\`${getDestinationTable(second, "events")}\` FINAL WHERE label = 'e2' AND _hexclave_deleted = 0`,
     );
     expect(deleted.text).toBe("0");
 
@@ -463,11 +517,37 @@ it("rebuilds the destination when a stream changes mode", async ({ expect }) => 
 
     const updated = await queryWarehouse(
       credentials,
-      `SELECT count() FROM \`${projectId}\`.public_events FINAL WHERE label = 'after-switch'`,
+      `SELECT count() FROM \`${projectId}\`.\`${getDestinationTable(afterSwitch, "events")}\` FINAL WHERE label = 'after-switch'`,
     );
     expect(updated.text).toBe("1");
 
     await deleteSource(data_source.id);
+  });
+});
+
+it("drops CDC infrastructure when switching or removing the final CDC stream", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    await setStreams(data_source.id, [{ schema_name: "public", table_name: "events", mode: "cdc" }]);
+    await syncSource(data_source.id);
+    expect(await getCdcInfrastructureCounts(source.database)).toEqual({ slots: 1, publications: 1 });
+
+    const switched = await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "created_at" },
+    ]);
+    expect(switched.status).toBe(200);
+    expect(await getCdcInfrastructureCounts(source.database)).toEqual({ slots: 0, publications: 0 });
+
+    // Recreate both objects, then cover removing the stream rather than merely
+    // switching its mode. Teardown is idempotent across both transitions.
+    await setStreams(data_source.id, [{ schema_name: "public", table_name: "events", mode: "cdc" }]);
+    await syncSource(data_source.id);
+    expect(await getCdcInfrastructureCounts(source.database)).toEqual({ slots: 1, publications: 1 });
+
+    const removed = await setStreams(data_source.id, []);
+    expect(removed.status).toBe(200);
+    expect(await getCdcInfrastructureCounts(source.database)).toEqual({ slots: 0, publications: 0 });
   });
 });
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/data-sources.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/data-sources.test.ts
@@ -238,7 +238,9 @@ it("connects, and returns a catalog with a mode decision per table", async ({ ex
     // preferred because it moves when a row is updated in place.
     expect(events.cursor_candidates.map((c: any) => c.column).sort()).toEqual(["created_at", "id"]);
     expect(events.default_cursor_column).toBe("created_at");
-    expect(events.recommended_mode).toBe("full_refresh"); // small enough to reload wholesale
+    // CDC wherever the server allows it: cheaper in steady state, and the only
+    // mode that sees deletes.
+    expect(events.recommended_mode).toBe("cdc");
 
     // Without a primary key there is no key to match an update or delete against.
     const keyless = tables.find((t: any) => t.table_name === "keyless");
@@ -280,7 +282,7 @@ it("refuses a table the source does not have", async ({ expect }) => {
   await withSourceDatabase(SIMPLE_SCHEMA, async source => {
     const { body: { data_source } } = await connectSource(source.database);
     const response = await setStreams(data_source.id, [
-      { schema_name: "public", table_name: "no_such_table", mode: "full_refresh" },
+      { schema_name: "public", table_name: "no_such_table", mode: "cursor", cursor_column: "id" },
     ]);
     expect(response.status).toBe(400);
     expect(String(response.body)).toContain("no readable table");
@@ -305,19 +307,19 @@ it("replaces the stream list wholesale and reports it back", async ({ expect }) 
     const { body: { data_source } } = await connectSource(source.database);
 
     const first = await setStreams(data_source.id, [
-      { schema_name: "public", table_name: "plans", mode: "full_refresh" },
+      { schema_name: "public", table_name: "plans", mode: "cursor", cursor_column: "id" },
       { schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "created_at" },
     ]);
     expect(first.status).toBe(200);
     expect(first.body.data_source.status).toBe("active");
     expect(first.body.data_source.streams.map((s: any) => [s.table_name, s.mode, s.cursor_column])).toEqual([
       ["events", "cursor", "created_at"],
-      ["plans", "full_refresh", null],
+      ["plans", "cursor", "id"],
     ]);
     expect(first.body.data_source.streams[0].destination_table).toBe("public_events");
 
     const second = await setStreams(data_source.id, [
-      { schema_name: "public", table_name: "plans", mode: "full_refresh" },
+      { schema_name: "public", table_name: "plans", mode: "cursor", cursor_column: "id" },
     ]);
     expect(second.body.data_source.streams.map((s: any) => s.table_name)).toEqual(["plans"]);
 
@@ -329,12 +331,12 @@ it("replaces the stream list wholesale and reports it back", async ({ expect }) 
 
 // ─── syncing ────────────────────────────────────────────────────────────────
 
-it("syncs full-refresh and cursor streams into the project's warehouse", async ({ expect }) => {
+it("syncs cursor streams into the project's warehouse", async ({ expect }) => {
   const { projectId, credentials } = await createProjectWithWarehouse();
   await withSourceDatabase(SIMPLE_SCHEMA, async source => {
     const { body: { data_source } } = await connectSource(source.database);
     await setStreams(data_source.id, [
-      { schema_name: "public", table_name: "plans", mode: "full_refresh" },
+      { schema_name: "public", table_name: "plans", mode: "cursor", cursor_column: "id" },
       { schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "created_at" },
     ]);
 
@@ -447,12 +449,12 @@ it("rebuilds the destination when a stream changes mode", async ({ expect }) => 
   const { projectId, credentials } = await createProjectWithWarehouse();
   await withSourceDatabase(SIMPLE_SCHEMA, async source => {
     const { body: { data_source } } = await connectSource(source.database);
-    await setStreams(data_source.id, [{ schema_name: "public", table_name: "events", mode: "full_refresh" }]);
+    await setStreams(data_source.id, [{ schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "created_at" }]);
     await syncSource(data_source.id);
 
-    // Full-refresh versions are epoch microseconds and CDC versions are LSNs,
-    // which are many orders of magnitude smaller — merging the two would leave
-    // the table frozen at its pre-switch contents forever.
+    // Cursor versions are epoch microseconds and CDC versions are LSNs, which are
+    // many orders of magnitude smaller — merging the two would leave the table
+    // frozen at its pre-switch contents forever.
     await setStreams(data_source.id, [{ schema_name: "public", table_name: "events", mode: "cdc" }]);
     await syncSource(data_source.id);
     await source.query(`UPDATE events SET label = 'after-switch' WHERE label = 'e3'`);
@@ -474,8 +476,8 @@ it("keeps one stream's failure from stopping the others", async ({ expect }) => 
   await withSourceDatabase(SIMPLE_SCHEMA, async source => {
     const { body: { data_source } } = await connectSource(source.database);
     await setStreams(data_source.id, [
-      { schema_name: "public", table_name: "plans", mode: "full_refresh" },
-      { schema_name: "public", table_name: "events", mode: "full_refresh" },
+      { schema_name: "public", table_name: "plans", mode: "cursor", cursor_column: "id" },
+      { schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "created_at" },
     ]);
     // Dropped behind the configuration's back, which is what a permissions change
     // or a migration looks like from here.
@@ -521,7 +523,7 @@ it("does not let one project touch another's source", async ({ expect }) => {
   await createProjectWithWarehouse();
   const ownedId = await withSourceDatabase(SIMPLE_SCHEMA, async source => {
     const { body: { data_source } } = await connectSource(source.database);
-    await setStreams(data_source.id, [{ schema_name: "public", table_name: "plans", mode: "full_refresh" }]);
+    await setStreams(data_source.id, [{ schema_name: "public", table_name: "plans", mode: "cursor", cursor_column: "id" }]);
     return data_source.id;
   });
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/data-sources.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/data-sources.test.ts
@@ -1,6 +1,7 @@
 import { ITEM_IDS } from "@hexclave/shared/dist/plans";
 import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+import { wait } from "@hexclave/shared/dist/utils/promises";
 import { Client } from "pg";
 import { it } from "../../../../helpers";
 import { Project, niceBackendFetch, withInternalProject } from "../../../backend-helpers";
@@ -152,6 +153,28 @@ async function getCdcInfrastructureCounts(database: string): Promise<{ slots: nu
     );
     return { slots: slots.rows[0].count, publications: publications.rows[0].count };
   });
+}
+
+async function waitForBlockedDataSourceSync(database: string): Promise<void> {
+  const deadline = performance.now() + 10_000;
+  while (performance.now() < deadline) {
+    const blocked = await onSource(database, async client => {
+      const result = await client.query<{ exists: boolean }>(`
+        SELECT EXISTS (
+          SELECT 1
+          FROM pg_stat_activity
+          WHERE datname = current_database()
+            AND application_name = 'hexclave_data_source_sync'
+            AND state = 'active'
+            AND wait_event_type = 'Lock'
+        ) AS exists
+      `);
+      return result.rows[0].exists;
+    });
+    if (blocked) return;
+    await wait(25);
+  }
+  throw new HexclaveAssertionError("Timed out waiting for the data source sync to block on the test table lock");
 }
 
 function getDestinationTable(
@@ -357,6 +380,36 @@ it("replaces the stream list wholesale and reports it back", async ({ expect }) 
     const fetched = await getSource(data_source.id);
     expect(fetched.status).toBe(200);
     expect(fetched.body.data_source.streams.map((s: any) => s.table_name)).toEqual(["plans"]);
+  });
+});
+
+it("refuses stream changes while a sync is using the previous configuration", async ({ expect }) => {
+  await createProjectWithWarehouse();
+  await withSourceDatabase(SIMPLE_SCHEMA, async source => {
+    const { body: { data_source } } = await connectSource(source.database);
+    await setStreams(data_source.id, [
+      { schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "created_at" },
+    ]);
+
+    await onSource(source.database, async lockClient => {
+      await lockClient.query("BEGIN");
+      await lockClient.query("LOCK TABLE events IN ACCESS EXCLUSIVE MODE");
+      const syncing = syncSource(data_source.id);
+      try {
+        await waitForBlockedDataSourceSync(source.database);
+        const reconfigured = await setStreams(data_source.id, [
+          { schema_name: "public", table_name: "events", mode: "cursor", cursor_column: "id" },
+        ]);
+        expect(reconfigured.status).toBe(409);
+        expect(String(reconfigured.body)).toContain("Wait for the running sync to finish");
+      } finally {
+        await lockClient.query("ROLLBACK");
+        expect((await syncing).status).toBe(200);
+      }
+    });
+
+    const fetched = await getSource(data_source.id);
+    expect(fetched.body.data_source.streams[0].cursor_column).toBe("created_at");
   });
 });
 

--- a/packages/shared/src/data-sources/modes.test.ts
+++ b/packages/shared/src/data-sources/modes.test.ts
@@ -61,6 +61,10 @@ describe("CDC availability", () => {
   it("does not report a keyless table's problem as a server-level one", () => {
     expect(getCdcAvailability(capable)).toEqual({ available: true, reason: null });
   });
+
+  it("does not treat an unknown replication slot budget as full", () => {
+    expect(getCdcAvailability({ ...capable, slotsMax: null }, table())).toEqual({ available: true, reason: null });
+  });
 });
 
 describe("mode availability", () => {

--- a/packages/shared/src/data-sources/modes.test.ts
+++ b/packages/shared/src/data-sources/modes.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+  FULL_REFRESH_MAX_ROWS,
+  getCdcAvailability,
+  getDefaultCursorColumn,
+  getModeAvailability,
+  getRecommendedMode,
+  type DataSourceCapabilities,
+  type DataSourceTableInfo,
+} from "./modes";
+
+const capable: DataSourceCapabilities = {
+  version: "16.4", walLevel: "logical", hasReplication: true,
+  inRecovery: false, slotsUsed: 0, slotsMax: 10, probedAtMillis: 0,
+};
+
+function table(overrides: Partial<DataSourceTableInfo> = {}): DataSourceTableInfo {
+  return {
+    schemaName: "public",
+    tableName: "users",
+    approxRows: 5_000_000,
+    primaryKeyColumns: ["id"],
+    cursorCandidates: [{ column: "updated_at", dataType: "timestamptz", indexed: true }],
+    ...overrides,
+  };
+}
+
+describe("CDC availability", () => {
+  it("is available when the server and table both permit it", () => {
+    expect(getCdcAvailability(capable, table())).toEqual({ available: true, reason: null });
+  });
+
+  it("reports the blocking condition, in the order a customer can act on", () => {
+    expect(getCdcAvailability({ ...capable, walLevel: "replica" }).reason).toBe("needs wal_level=logical");
+    expect(getCdcAvailability({ ...capable, hasReplication: false }).reason).toBe("needs REPLICATION grant");
+    expect(getCdcAvailability({ ...capable, inRecovery: true }).reason).toBe("not on a read replica");
+    expect(getCdcAvailability({ ...capable, slotsUsed: 10 }).reason).toBe("no replication slots free");
+  });
+
+  it("blocks a keyless table even on a fully capable server", () => {
+    // Without a key there is nothing to match an UPDATE or DELETE against.
+    expect(getCdcAvailability(capable, table({ primaryKeyColumns: [] })).reason).toBe("needs a primary key");
+  });
+
+  it("does not report a keyless table's problem as a server-level one", () => {
+    expect(getCdcAvailability(capable)).toEqual({ available: true, reason: null });
+  });
+});
+
+describe("mode availability", () => {
+  it("refuses cursor mode when no column qualifies", () => {
+    const availability = getModeAvailability(table({ cursorCandidates: [] }), capable);
+    expect(availability.cursor).toEqual({ available: false, reason: "no usable column" });
+  });
+
+  it("refuses full refresh above the row ceiling", () => {
+    expect(getModeAvailability(table({ approxRows: FULL_REFRESH_MAX_ROWS + 1 }), capable).full_refresh.available).toBe(false);
+    expect(getModeAvailability(table({ approxRows: FULL_REFRESH_MAX_ROWS }), capable).full_refresh.available).toBe(true);
+  });
+});
+
+describe("recommendation", () => {
+  it("reloads small tables wholesale even when CDC is available", () => {
+    expect(getRecommendedMode(table({ approxRows: 40 }), capable)).toBe("full_refresh");
+  });
+
+  it("prefers CDC for large mutable tables", () => {
+    expect(getRecommendedMode(table(), capable)).toBe("cdc");
+  });
+
+  it("falls back to a cursor when CDC is unavailable", () => {
+    expect(getRecommendedMode(table(), { ...capable, walLevel: "replica" })).toBe("cursor");
+  });
+
+  it("returns null when nothing applies, rather than a mode that would fail", () => {
+    const impossible = table({ approxRows: 12_600_000, cursorCandidates: [], primaryKeyColumns: [] });
+    expect(getRecommendedMode(impossible, { ...capable, walLevel: "replica" })).toBeNull();
+  });
+});
+
+describe("default cursor column", () => {
+  it("prefers an indexed candidate over a conventionally named unindexed one", () => {
+    // An unindexed cursor makes every sync a sequential scan, which costs more
+    // than picking a less obvious column name.
+    const chosen = getDefaultCursorColumn(table({
+      cursorCandidates: [
+        { column: "updated_at", dataType: "timestamptz", indexed: false },
+        { column: "row_version", dataType: "bigint", indexed: true },
+      ],
+    }));
+    expect(chosen).toBe("row_version");
+  });
+
+  it("prefers the conventional name among equally indexed candidates", () => {
+    const chosen = getDefaultCursorColumn(table({
+      cursorCandidates: [
+        { column: "created_at", dataType: "timestamptz", indexed: true },
+        { column: "updated_at", dataType: "timestamptz", indexed: true },
+      ],
+    }));
+    expect(chosen).toBe("updated_at");
+  });
+
+  it("is null when there is nothing to pick", () => {
+    expect(getDefaultCursorColumn(table({ cursorCandidates: [] }))).toBeNull();
+  });
+});

--- a/packages/shared/src/data-sources/modes.test.ts
+++ b/packages/shared/src/data-sources/modes.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
-  FULL_REFRESH_MAX_ROWS,
   getCdcAvailability,
   getDefaultCursorColumn,
   getModeAvailability,
   getRecommendedMode,
+  isTemporalCursorType,
   type DataSourceCapabilities,
   type DataSourceTableInfo,
 } from "./modes";
@@ -69,15 +69,14 @@ describe("mode availability", () => {
     expect(availability.cursor).toEqual({ available: false, reason: "no usable column" });
   });
 
-  it("refuses full refresh above the row ceiling", () => {
-    expect(getModeAvailability(table({ approxRows: FULL_REFRESH_MAX_ROWS + 1 }), capable).full_refresh.available).toBe(false);
-    expect(getModeAvailability(table({ approxRows: FULL_REFRESH_MAX_ROWS }), capable).full_refresh.available).toBe(true);
+  it("offers only the two modes we support", () => {
+    expect(Object.keys(getModeAvailability(table(), capable)).sort()).toEqual(["cdc", "cursor"]);
   });
 });
 
 describe("recommendation", () => {
-  it("reloads small tables wholesale even when CDC is available", () => {
-    expect(getRecommendedMode(table({ approxRows: 40 }), capable)).toBe("full_refresh");
+  it("prefers CDC wherever it is possible, whatever the table's size", () => {
+    expect(getRecommendedMode(table({ approxRows: 40 }), capable)).toBe("cdc");
   });
 
   it("prefers CDC for large mutable tables", () => {
@@ -89,17 +88,9 @@ describe("recommendation", () => {
   });
 
   it("returns null when nothing applies, rather than a mode that would fail", () => {
-    const impossible = table({ approxRows: 12_600_000, cursorCandidates: [], primaryKeyColumns: [] });
+    // No key for CDC to match on, and no column that could serve as a cursor.
+    const impossible = table({ cursorCandidates: [], primaryKeyColumns: [] });
     expect(getRecommendedMode(impossible, { ...capable, walLevel: "replica" })).toBeNull();
-  });
-
-  it("does not treat a never-analyzed table as small", () => {
-    // reltuples is -1 until ANALYZE runs; reading that as 0 would recommend
-    // reloading an arbitrarily large table in full on every sync.
-    expect(getRecommendedMode(table({ approxRows: null }), capable)).toBe("cdc");
-    expect(getRecommendedMode(table({ approxRows: null }), { ...capable, walLevel: "replica" })).toBe("cursor");
-    const noCursor = table({ approxRows: null, cursorCandidates: [] });
-    expect(getRecommendedMode(noCursor, { ...capable, walLevel: "replica" })).toBeNull();
   });
 });
 
@@ -128,5 +119,26 @@ describe("default cursor column", () => {
 
   it("is null when there is nothing to pick", () => {
     expect(getDefaultCursorColumn(table({ cursorCandidates: [] }))).toBeNull();
+  });
+});
+
+describe("temporal cursor columns", () => {
+  it("recognises the timestamp types format_type() emits, typmods and all", () => {
+    for (const type of [
+      "timestamp with time zone",
+      "timestamp(3) without time zone",
+      "timestamp(6) with time zone",
+      "date",
+    ]) {
+      expect(isTemporalCursorType(type), type).toBe(true);
+    }
+  });
+
+  it("treats keys and counters as non-temporal, since they only move on insert", () => {
+    // These are legal cursors — an append-only log is exactly what they suit —
+    // but an edit to an existing row never bumps them, so the picker warns.
+    for (const type of ["bigint", "integer", "smallint"]) {
+      expect(isTemporalCursorType(type), type).toBe(false);
+    }
   });
 });

--- a/packages/shared/src/data-sources/modes.test.ts
+++ b/packages/shared/src/data-sources/modes.test.ts
@@ -20,7 +20,11 @@ function table(overrides: Partial<DataSourceTableInfo> = {}): DataSourceTableInf
     tableName: "users",
     approxRows: 5_000_000,
     primaryKeyColumns: ["id"],
-    cursorCandidates: [{ column: "updated_at", dataType: "timestamptz", indexed: true }],
+    // As format_type() renders it — the shape the probe actually produces.
+    cursorCandidates: [{ column: "updated_at", dataType: "timestamp with time zone", indexed: true }],
+    replicaIdentity: "d",
+    isLogged: true,
+    isPartitioned: false,
     ...overrides,
   };
 }
@@ -35,6 +39,18 @@ describe("CDC availability", () => {
     expect(getCdcAvailability({ ...capable, hasReplication: false }).reason).toBe("needs REPLICATION grant");
     expect(getCdcAvailability({ ...capable, inRecovery: true }).reason).toBe("not on a read replica");
     expect(getCdcAvailability({ ...capable, slotsUsed: 10 }).reason).toBe("no replication slots free");
+  });
+
+  it("blocks a table whose replica identity would break the customer's writes", () => {
+    // Adding a REPLICA IDENTITY NOTHING table to a publication makes their own
+    // UPDATEs start failing, so this must never be offered.
+    expect(getCdcAvailability(capable, table({ replicaIdentity: "n" })).reason).toBe("needs a replica identity");
+  });
+
+  it("blocks unlogged and partitioned tables", () => {
+    expect(getCdcAvailability(capable, table({ isLogged: false })).reason).toBe("table is unlogged");
+    // Changes publish under the leaf partition, not the parent we subscribe to.
+    expect(getCdcAvailability(capable, table({ isPartitioned: true })).reason).toBe("table is partitioned");
   });
 
   it("blocks a keyless table even on a fully capable server", () => {
@@ -75,6 +91,15 @@ describe("recommendation", () => {
   it("returns null when nothing applies, rather than a mode that would fail", () => {
     const impossible = table({ approxRows: 12_600_000, cursorCandidates: [], primaryKeyColumns: [] });
     expect(getRecommendedMode(impossible, { ...capable, walLevel: "replica" })).toBeNull();
+  });
+
+  it("does not treat a never-analyzed table as small", () => {
+    // reltuples is -1 until ANALYZE runs; reading that as 0 would recommend
+    // reloading an arbitrarily large table in full on every sync.
+    expect(getRecommendedMode(table({ approxRows: null }), capable)).toBe("cdc");
+    expect(getRecommendedMode(table({ approxRows: null }), { ...capable, walLevel: "replica" })).toBe("cursor");
+    const noCursor = table({ approxRows: null, cursorCandidates: [] });
+    expect(getRecommendedMode(noCursor, { ...capable, walLevel: "replica" })).toBeNull();
   });
 });
 

--- a/packages/shared/src/data-sources/modes.ts
+++ b/packages/shared/src/data-sources/modes.ts
@@ -37,7 +37,8 @@ export type DataSourceCapabilities = {
   /** Slots cannot be created on a hot standby, whatever wal_level says. */
   inRecovery: boolean,
   slotsUsed: number,
-  slotsMax: number,
+  /** Null when the provider does not allow the slot budget to be inspected. */
+  slotsMax: number | null,
   probedAtMillis: number,
 };
 
@@ -81,7 +82,7 @@ export function getCdcAvailability(
   if (capabilities.inRecovery) {
     return { available: false, reason: "not on a read replica" };
   }
-  if (capabilities.slotsUsed >= capabilities.slotsMax) {
+  if (capabilities.slotsMax != null && capabilities.slotsUsed >= capabilities.slotsMax) {
     return { available: false, reason: "no replication slots free" };
   }
   if (table != null) {

--- a/packages/shared/src/data-sources/modes.ts
+++ b/packages/shared/src/data-sources/modes.ts
@@ -7,18 +7,25 @@
  * possible outcome of this screen.
  */
 
-export type DataSourceSyncMode = "full_refresh" | "cursor" | "cdc";
+export type DataSourceSyncMode = "cursor" | "cdc";
 
-export const DATA_SOURCE_SYNC_MODES = ["cdc", "cursor", "full_refresh"] as const satisfies readonly DataSourceSyncMode[];
+export const DATA_SOURCE_SYNC_MODES = ["cdc", "cursor"] as const satisfies readonly DataSourceSyncMode[];
 
 /**
- * Above this a full reload on every sync puts sustained load on the customer's
- * database, so we refuse the mode rather than let them find out in production.
+ * Cursor columns that carry a wall-clock time. These are the ones that behave the
+ * way people expect: an application that touches the row bumps the timestamp, so
+ * updates are picked up as well as inserts.
+ *
+ * A monotonic id is still a legal cursor and is often the right one for an
+ * append-only log, but it only ever moves when a row is inserted — so edits to
+ * existing rows are invisible. The picker warns about that rather than refusing
+ * it, because the customer knows their write patterns and we do not.
  */
-export const FULL_REFRESH_MAX_ROWS = 2_000_000;
+const TEMPORAL_CURSOR_TYPE = /^(timestamp( with(out)? time zone)?|date)$/i;
 
-/** Below this, reloading the whole table is cheaper than tracking changes, and it can never drift. */
-export const SMALL_TABLE_ROWS = 100_000;
+export function isTemporalCursorType(dataType: string): boolean {
+  return TEMPORAL_CURSOR_TYPE.test(dataType.trim().replace(/\(\d+(,\s*\d+)?\)/, ""));
+}
 
 /** What the capability probe learned about the source server. */
 export type DataSourceCapabilities = {
@@ -111,12 +118,6 @@ export function getModeAvailability(
     cursor: table.cursorCandidates.length > 0
       ? { available: true, reason: null }
       : { available: false, reason: "no usable column" },
-    // An unknown row count cannot prove the table is small, but refusing on that
-    // basis would block every freshly restored source. It is allowed, just never
-    // recommended — see getRecommendedMode.
-    full_refresh: table.approxRows != null && table.approxRows > FULL_REFRESH_MAX_ROWS
-      ? { available: false, reason: "table too large" }
-      : { available: true, reason: null },
   };
 }
 
@@ -129,16 +130,10 @@ export function getRecommendedMode(
   capabilities: DataSourceCapabilities,
 ): DataSourceSyncMode | null {
   const availability = getModeAvailability(table, capabilities);
-  // Small tables reload wholesale: cheaper than change tracking, and self-healing.
-  // Requires a known count: "unknown" must not be treated as "small".
-  if (table.approxRows != null && table.approxRows <= SMALL_TABLE_ROWS && availability.full_refresh.available) {
-    return "full_refresh";
-  }
+  // CDC first wherever it is possible: it is cheaper in steady state than reading
+  // rows back, and it is the only mode that sees deletes.
   if (availability.cdc.available) return "cdc";
   if (availability.cursor.available) return "cursor";
-  // Only fall back to a full reload when we know the table is small enough to
-  // stand it; an unknown count reaching here means we genuinely cannot say.
-  if (availability.full_refresh.available && table.approxRows != null) return "full_refresh";
   return null;
 }
 

--- a/packages/shared/src/data-sources/modes.ts
+++ b/packages/shared/src/data-sources/modes.ts
@@ -44,9 +44,15 @@ export type DataSourceCursorCandidate = {
 export type DataSourceTableInfo = {
   schemaName: string,
   tableName: string,
-  approxRows: number,
+  /** Null when the source has never been analyzed, which is not the same as empty. */
+  approxRows: number | null,
   primaryKeyColumns: string[],
   cursorCandidates: DataSourceCursorCandidate[],
+  /** `pg_class.relreplident`: 'd' default, 'n' nothing, 'f' full, 'i' using index. */
+  replicaIdentity: string,
+  /** Unlogged tables cannot be added to a publication at all. */
+  isLogged: boolean,
+  isPartitioned: boolean,
 };
 
 export type ModeAvailability = {
@@ -57,7 +63,7 @@ export type ModeAvailability = {
 
 export function getCdcAvailability(
   capabilities: DataSourceCapabilities,
-  table?: Pick<DataSourceTableInfo, "primaryKeyColumns">,
+  table?: Pick<DataSourceTableInfo, "primaryKeyColumns" | "replicaIdentity" | "isLogged" | "isPartitioned">,
 ): ModeAvailability {
   if (capabilities.walLevel !== "logical") {
     return { available: false, reason: "needs wal_level=logical" };
@@ -71,10 +77,27 @@ export function getCdcAvailability(
   if (capabilities.slotsUsed >= capabilities.slotsMax) {
     return { available: false, reason: "no replication slots free" };
   }
-  // Without a key, an UPDATE or DELETE in the WAL carries nothing we can match a
-  // destination row on, so CDC would be no better than an append-only log.
-  if (table != null && table.primaryKeyColumns.length === 0) {
-    return { available: false, reason: "needs a primary key" };
+  if (table != null) {
+    // Without a key, an UPDATE or DELETE in the WAL carries nothing we can match
+    // a destination row on, so CDC would be no better than an append-only log.
+    if (table.primaryKeyColumns.length === 0) {
+      return { available: false, reason: "needs a primary key" };
+    }
+    // Adding a REPLICA IDENTITY NOTHING table to a publication makes the
+    // customer's own UPDATEs and DELETEs start failing. Never worth it.
+    if (table.replicaIdentity === "n") {
+      return { available: false, reason: "needs a replica identity" };
+    }
+    // Postgres refuses to add these to a publication, and one of them would fail
+    // the whole publication statement, taking every other CDC stream with it.
+    if (!table.isLogged) {
+      return { available: false, reason: "table is unlogged" };
+    }
+    // Changes are published under the leaf partition, not the parent we would be
+    // subscribed to, so every change would be silently dropped.
+    if (table.isPartitioned) {
+      return { available: false, reason: "table is partitioned" };
+    }
   }
   return { available: true, reason: null };
 }
@@ -88,7 +111,10 @@ export function getModeAvailability(
     cursor: table.cursorCandidates.length > 0
       ? { available: true, reason: null }
       : { available: false, reason: "no usable column" },
-    full_refresh: table.approxRows > FULL_REFRESH_MAX_ROWS
+    // An unknown row count cannot prove the table is small, but refusing on that
+    // basis would block every freshly restored source. It is allowed, just never
+    // recommended — see getRecommendedMode.
+    full_refresh: table.approxRows != null && table.approxRows > FULL_REFRESH_MAX_ROWS
       ? { available: false, reason: "table too large" }
       : { available: true, reason: null },
   };
@@ -104,10 +130,15 @@ export function getRecommendedMode(
 ): DataSourceSyncMode | null {
   const availability = getModeAvailability(table, capabilities);
   // Small tables reload wholesale: cheaper than change tracking, and self-healing.
-  if (table.approxRows <= SMALL_TABLE_ROWS && availability.full_refresh.available) return "full_refresh";
+  // Requires a known count: "unknown" must not be treated as "small".
+  if (table.approxRows != null && table.approxRows <= SMALL_TABLE_ROWS && availability.full_refresh.available) {
+    return "full_refresh";
+  }
   if (availability.cdc.available) return "cdc";
   if (availability.cursor.available) return "cursor";
-  if (availability.full_refresh.available) return "full_refresh";
+  // Only fall back to a full reload when we know the table is small enough to
+  // stand it; an unknown count reaching here means we genuinely cannot say.
+  if (availability.full_refresh.available && table.approxRows != null) return "full_refresh";
   return null;
 }
 

--- a/packages/shared/src/data-sources/modes.ts
+++ b/packages/shared/src/data-sources/modes.ts
@@ -1,0 +1,128 @@
+/**
+ * Which sync modes a given source table can use, and which one we recommend.
+ *
+ * This lives in shared rather than the backend because the dashboard renders the
+ * same verdicts while the customer is choosing modes, and the two must never
+ * disagree — an option the dashboard offers but the backend rejects is the worst
+ * possible outcome of this screen.
+ */
+
+export type DataSourceSyncMode = "full_refresh" | "cursor" | "cdc";
+
+export const DATA_SOURCE_SYNC_MODES = ["cdc", "cursor", "full_refresh"] as const satisfies readonly DataSourceSyncMode[];
+
+/**
+ * Above this a full reload on every sync puts sustained load on the customer's
+ * database, so we refuse the mode rather than let them find out in production.
+ */
+export const FULL_REFRESH_MAX_ROWS = 2_000_000;
+
+/** Below this, reloading the whole table is cheaper than tracking changes, and it can never drift. */
+export const SMALL_TABLE_ROWS = 100_000;
+
+/** What the capability probe learned about the source server. */
+export type DataSourceCapabilities = {
+  version: string,
+  /** `logical` is the only value that permits logical decoding. */
+  walLevel: string,
+  /** Whether the role we were given has REPLICATION (or is a superuser). */
+  hasReplication: boolean,
+  /** Slots cannot be created on a hot standby, whatever wal_level says. */
+  inRecovery: boolean,
+  slotsUsed: number,
+  slotsMax: number,
+  probedAtMillis: number,
+};
+
+export type DataSourceCursorCandidate = {
+  column: string,
+  dataType: string,
+  /** An unindexed cursor still works, but every sync sequentially scans the table. */
+  indexed: boolean,
+};
+
+export type DataSourceTableInfo = {
+  schemaName: string,
+  tableName: string,
+  approxRows: number,
+  primaryKeyColumns: string[],
+  cursorCandidates: DataSourceCursorCandidate[],
+};
+
+export type ModeAvailability = {
+  available: boolean,
+  /** Short, user-facing, and specific enough to act on. Null when available. */
+  reason: string | null,
+};
+
+export function getCdcAvailability(
+  capabilities: DataSourceCapabilities,
+  table?: Pick<DataSourceTableInfo, "primaryKeyColumns">,
+): ModeAvailability {
+  if (capabilities.walLevel !== "logical") {
+    return { available: false, reason: "needs wal_level=logical" };
+  }
+  if (!capabilities.hasReplication) {
+    return { available: false, reason: "needs REPLICATION grant" };
+  }
+  if (capabilities.inRecovery) {
+    return { available: false, reason: "not on a read replica" };
+  }
+  if (capabilities.slotsUsed >= capabilities.slotsMax) {
+    return { available: false, reason: "no replication slots free" };
+  }
+  // Without a key, an UPDATE or DELETE in the WAL carries nothing we can match a
+  // destination row on, so CDC would be no better than an append-only log.
+  if (table != null && table.primaryKeyColumns.length === 0) {
+    return { available: false, reason: "needs a primary key" };
+  }
+  return { available: true, reason: null };
+}
+
+export function getModeAvailability(
+  table: DataSourceTableInfo,
+  capabilities: DataSourceCapabilities,
+): Record<DataSourceSyncMode, ModeAvailability> {
+  return {
+    cdc: getCdcAvailability(capabilities, table),
+    cursor: table.cursorCandidates.length > 0
+      ? { available: true, reason: null }
+      : { available: false, reason: "no usable column" },
+    full_refresh: table.approxRows > FULL_REFRESH_MAX_ROWS
+      ? { available: false, reason: "table too large" }
+      : { available: true, reason: null },
+  };
+}
+
+/**
+ * Null when no mode applies — the table cannot be synced as it stands, and the
+ * dashboard says so rather than silently omitting it.
+ */
+export function getRecommendedMode(
+  table: DataSourceTableInfo,
+  capabilities: DataSourceCapabilities,
+): DataSourceSyncMode | null {
+  const availability = getModeAvailability(table, capabilities);
+  // Small tables reload wholesale: cheaper than change tracking, and self-healing.
+  if (table.approxRows <= SMALL_TABLE_ROWS && availability.full_refresh.available) return "full_refresh";
+  if (availability.cdc.available) return "cdc";
+  if (availability.cursor.available) return "cursor";
+  if (availability.full_refresh.available) return "full_refresh";
+  return null;
+}
+
+/**
+ * The cursor column we preselect. Indexed candidates first — an unindexed cursor
+ * makes every sync a sequential scan — then the conventional names, so the common
+ * case needs no thought from the customer.
+ */
+export function getDefaultCursorColumn(table: DataSourceTableInfo): string | null {
+  const preferredNames = ["updated_at", "updatedat", "modified_at", "last_modified", "created_at", "createdat"];
+  const ranked = [...table.cursorCandidates].sort((a, b) => {
+    if (a.indexed !== b.indexed) return a.indexed ? -1 : 1;
+    const aRank = preferredNames.indexOf(a.column.toLowerCase());
+    const bRank = preferredNames.indexOf(b.column.toLowerCase());
+    return (aRank === -1 ? preferredNames.length : aRank) - (bRank === -1 ? preferredNames.length : bRank);
+  });
+  return ranked[0]?.column ?? null;
+}

--- a/packages/shared/src/interface/admin-interface.ts
+++ b/packages/shared/src/interface/admin-interface.ts
@@ -1,5 +1,6 @@
 import * as yup from "yup";
 import type { EnvironmentConfigOverrideOverride } from "../config/schema";
+import type { DataSourceSyncMode } from "../data-sources/modes";
 import { KnownErrors } from "../known-errors";
 import { branchConfigSourceSchema, type ConfigAgentRunApi, type RestrictedReason } from "../schema-fields";
 import { AccessToken, InternalSession, RefreshToken } from "../sessions";
@@ -61,6 +62,75 @@ export type DataWarehouseJson = {
   error: string | null,
   password_updated_at_millis: number | null,
   connection: DataWarehouseConnectionJson,
+};
+
+/** A customer-owned database we pull from, into the project's warehouse. */
+export type DataSourceStreamJson = {
+  id: string,
+  schema_name: string,
+  table_name: string,
+  mode: DataSourceSyncMode,
+  /** Only set when mode is `cursor`. */
+  cursor_column: string | null,
+  primary_key_columns: string[],
+  destination_table: string,
+  status: "pending" | "snapshotting" | "active" | "failed",
+  error: string | null,
+  rows_synced: number,
+  last_synced_at_millis: number | null,
+};
+
+export type DataSourceCapabilitiesJson = {
+  version: string,
+  wal_level: string,
+  has_replication: boolean,
+  in_recovery: boolean,
+  slots_used: number,
+  slots_max: number,
+  probed_at_millis: number,
+};
+
+export type DataSourceJson = {
+  id: string,
+  type: "postgres",
+  host: string,
+  port: number,
+  database: string,
+  username: string,
+  ssl_mode: string,
+  status: "pending" | "active" | "paused" | "failed",
+  error: string | null,
+  sync_interval_seconds: number,
+  /** Null until the source has been probed once. */
+  capabilities: DataSourceCapabilitiesJson | null,
+  last_sync_started_at_millis: number | null,
+  last_sync_finished_at_millis: number | null,
+  streams: DataSourceStreamJson[],
+};
+
+export type DataSourceCatalogTableJson = {
+  schema_name: string,
+  table_name: string,
+  approx_rows: number,
+  primary_key_columns: string[],
+  cursor_candidates: { column: string, data_type: string, indexed: boolean }[],
+  /** Resolved server-side, so the picker never offers a mode the backend would reject. */
+  available_modes: { mode: DataSourceSyncMode, available: boolean, reason: string | null }[],
+  /** Null when no mode applies to this table as it stands. */
+  recommended_mode: DataSourceSyncMode | null,
+  default_cursor_column: string | null,
+};
+
+export type DataSourceCatalogJson = {
+  capabilities: DataSourceCapabilitiesJson,
+  tables: DataSourceCatalogTableJson[],
+};
+
+export type DataSourceStreamConfig = {
+  schema_name: string,
+  table_name: string,
+  mode: DataSourceSyncMode,
+  cursor_column?: string | null,
 };
 
 /** Only returned by provisioning and rotation; the password is not readable elsewhere. */
@@ -341,6 +411,57 @@ export class HexclaveAdminInterface extends HexclaveServerInterface {
   async rotateDataWarehousePassword(): Promise<DataWarehouseCredentialsJson> {
     const response = await this.sendAdminRequest(`/data-warehouse/rotate-password`, { method: "POST" }, null);
     return await response.json();
+  }
+
+  // ─── Data Sources ───────────────────────────────────────────────────────
+
+  async listDataSources(): Promise<DataSourceJson[]> {
+    const response = await this.sendAdminRequest(`/data-sources`, {}, null);
+    const result = await response.json() as { data_sources: DataSourceJson[] };
+    return result.data_sources;
+  }
+
+  /** Verifies the credentials and reads the catalog before anything is stored. */
+  async createDataSource(options: {
+    host: string,
+    port: number,
+    database: string,
+    username: string,
+    password: string,
+    ssl_mode?: string,
+  }): Promise<{ data_source: DataSourceJson, catalog: DataSourceCatalogJson }> {
+    const response = await this.sendAdminRequest(`/data-sources`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(options),
+    }, null);
+    return await response.json();
+  }
+
+  async deleteDataSource(dataSourceId: string): Promise<void> {
+    await this.sendAdminRequest(`/data-sources/${encodeURIComponent(dataSourceId)}`, { method: "DELETE" }, null);
+  }
+
+  async getDataSourceCatalog(dataSourceId: string): Promise<DataSourceCatalogJson> {
+    const response = await this.sendAdminRequest(`/data-sources/${encodeURIComponent(dataSourceId)}/catalog`, {}, null);
+    const result = await response.json() as { catalog: DataSourceCatalogJson };
+    return result.catalog;
+  }
+
+  async setDataSourceStreams(dataSourceId: string, streams: DataSourceStreamConfig[]): Promise<DataSourceJson> {
+    const response = await this.sendAdminRequest(`/data-sources/${encodeURIComponent(dataSourceId)}/streams`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ streams }),
+    }, null);
+    const result = await response.json() as { data_source: DataSourceJson };
+    return result.data_source;
+  }
+
+  async syncDataSource(dataSourceId: string): Promise<DataSourceJson> {
+    const response = await this.sendAdminRequest(`/data-sources/${encodeURIComponent(dataSourceId)}/sync`, { method: "POST" }, null);
+    const result = await response.json() as { data_source: DataSourceJson };
+    return result.data_source;
   }
 
   // ─── Workflows (internal-project gated; see the Workflows v1 spec) ───────

--- a/packages/shared/src/interface/admin-interface.ts
+++ b/packages/shared/src/interface/admin-interface.ts
@@ -86,7 +86,8 @@ export type DataSourceCapabilitiesJson = {
   has_replication: boolean,
   in_recovery: boolean,
   slots_used: number,
-  slots_max: number,
+  /** Null when the source provider does not expose the replication slot budget. */
+  slots_max: number | null,
   probed_at_millis: number,
 };
 

--- a/packages/shared/src/interface/admin-interface.ts
+++ b/packages/shared/src/interface/admin-interface.ts
@@ -111,7 +111,11 @@ export type DataSourceJson = {
 export type DataSourceCatalogTableJson = {
   schema_name: string,
   table_name: string,
-  approx_rows: number,
+  /** Null when the source has never been analyzed — not the same as empty. */
+  approx_rows: number | null,
+  /** `pg_class.relreplident`: 'd' default, 'n' nothing, 'f' full, 'i' using index. */
+  replica_identity: string,
+  is_partitioned: boolean,
   primary_key_columns: string[],
   cursor_candidates: { column: string, data_type: string, indexed: boolean }[],
   /** Resolved server-side, so the picker never offers a mode the backend would reject. */

--- a/packages/template/src/lib/hexclave-app/apps/implementations/admin-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/admin-app-impl.ts
@@ -1,6 +1,6 @@
 import { KnownErrors, HexclaveAdminInterface } from "@hexclave/shared";
 import { getProductionModeErrors } from "@hexclave/shared/dist/helpers/production-mode";
-import { DataWarehouseCredentialsJson, DataWarehouseJson, InternalApiKeyCreateCrudResponse } from "@hexclave/shared/dist/interface/admin-interface";
+import { DataSourceCatalogJson, DataSourceJson, DataSourceStreamConfig, DataWarehouseCredentialsJson, DataWarehouseJson, InternalApiKeyCreateCrudResponse } from "@hexclave/shared/dist/interface/admin-interface";
 import type { AnalyticsClickmapOptions, AnalyticsClickmapResponse, AnalyticsClickmapTokenResponse, MetricsResponse, MetricsUserCounts, UserActivityResponse } from "@hexclave/shared/dist/interface/admin-metrics";
 import { EmailTemplateCrud } from "@hexclave/shared/dist/interface/crud/email-templates";
 import { InternalApiKeysCrud } from "@hexclave/shared/dist/interface/crud/internal-api-keys";
@@ -120,6 +120,9 @@ export class _HexclaveAdminAppImplIncomplete<HasTokenStore extends boolean, Proj
   });
   private readonly _adminDataWarehouseCache = createCache(async () => {
     return await this._interface.getDataWarehouse();
+  });
+  private readonly _adminDataSourcesCache = createCache(async () => {
+    return await this._interface.listDataSources();
   });
   private readonly _adminTeamPermissionDefinitionsCache = createCache(async () => {
     return await this._interface.listTeamPermissionDefinitions();
@@ -558,6 +561,9 @@ export class _HexclaveAdminAppImplIncomplete<HasTokenStore extends boolean, Proj
   useDataWarehouse(): DataWarehouseJson {
     return useAsyncCache(this._adminDataWarehouseCache, [], "adminApp.useDataWarehouse()");
   }
+  useDataSources(): DataSourceJson[] {
+    return useAsyncCache(this._adminDataSourcesCache, [], "adminApp.useDataSources()");
+  }
   // END_PLATFORM
   async listEmailThemes(): Promise<{ id: string, displayName: string }[]> {
     const crud = Result.orThrow(await this._adminEmailThemesCache.getOrWait([], "write-only"));
@@ -616,6 +622,53 @@ export class _HexclaveAdminAppImplIncomplete<HasTokenStore extends boolean, Proj
       connection: result.connection,
     }));
     return result;
+  }
+
+  // ─── Data Sources ───────────────────────────────────────────────────────
+
+  async listDataSources(): Promise<DataSourceJson[]> {
+    return Result.orThrow(await this._adminDataSourcesCache.getOrWait([], "write-only"));
+  }
+
+  async createDataSource(options: {
+    host: string,
+    port: number,
+    database: string,
+    username: string,
+    password: string,
+    sslMode?: string,
+  }): Promise<{ dataSource: DataSourceJson, catalog: DataSourceCatalogJson }> {
+    const result = await this._interface.createDataSource({
+      host: options.host,
+      port: options.port,
+      database: options.database,
+      username: options.username,
+      password: options.password,
+      ssl_mode: options.sslMode,
+    });
+    await this._adminDataSourcesCache.refresh([]);
+    return { dataSource: result.data_source, catalog: result.catalog };
+  }
+
+  async deleteDataSource(dataSourceId: string): Promise<void> {
+    await this._interface.deleteDataSource(dataSourceId);
+    await this._adminDataSourcesCache.refresh([]);
+  }
+
+  async getDataSourceCatalog(dataSourceId: string): Promise<DataSourceCatalogJson> {
+    return await this._interface.getDataSourceCatalog(dataSourceId);
+  }
+
+  async setDataSourceStreams(dataSourceId: string, streams: DataSourceStreamConfig[]): Promise<DataSourceJson> {
+    const dataSource = await this._interface.setDataSourceStreams(dataSourceId, streams);
+    await this._adminDataSourcesCache.refresh([]);
+    return dataSource;
+  }
+
+  async syncDataSource(dataSourceId: string): Promise<DataSourceJson> {
+    const dataSource = await this._interface.syncDataSource(dataSourceId);
+    await this._adminDataSourcesCache.refresh([]);
+    return dataSource;
   }
 
   // ─── Workflows (internal-project gated; see the Workflows v1 spec) ───────

--- a/packages/template/src/lib/hexclave-app/apps/interfaces/admin-app.ts
+++ b/packages/template/src/lib/hexclave-app/apps/interfaces/admin-app.ts
@@ -1,4 +1,4 @@
-import type { DataWarehouseCredentialsJson, DataWarehouseJson } from "@hexclave/shared/dist/interface/admin-interface";
+import type { DataSourceCatalogJson, DataSourceJson, DataSourceStreamConfig, DataWarehouseCredentialsJson, DataWarehouseJson } from "@hexclave/shared/dist/interface/admin-interface";
 import type { AnalyticsClickmapOptions, AnalyticsClickmapResponse, AnalyticsClickmapTokenResponse } from "@hexclave/shared/dist/interface/admin-metrics";
 import type { AdminGetSessionReplayChunkEventsResponse, AdminGetSessionReplayAllEventsResponse } from "@hexclave/shared/dist/interface/crud/session-replays";
 import type { Transaction, TransactionType } from "@hexclave/shared/dist/interface/crud/transactions";
@@ -85,6 +85,7 @@ export type StackAdminApp<HasTokenStore extends boolean = boolean, ProjectId ext
   & AsyncStoreProperty<"emailDrafts", [], { id: string, displayName: string, themeId: string | undefined | false, tsxSource: string, sentAt: Date | null }[], true>
   & AsyncStoreProperty<"workflows", [], AdminWorkflow[], true>
   & AsyncStoreProperty<"dataWarehouse", [], DataWarehouseJson, false>
+  & AsyncStoreProperty<"dataSources", [], DataSourceJson[], true>
   & AsyncStoreProperty<"stripeAccountInfo", [], { account_id: string, charges_enabled: boolean, details_submitted: boolean, payouts_enabled: boolean } | null, false>
   & AsyncStoreProperty<
     "transactions",
@@ -162,6 +163,21 @@ export type StackAdminApp<HasTokenStore extends boolean = boolean, ProjectId ext
     // no read path that can hand it back later.
     provisionDataWarehouse(): Promise<DataWarehouseCredentialsJson>,
     rotateDataWarehousePassword(): Promise<DataWarehouseCredentialsJson>,
+
+    // Data Sources. `createDataSource` returns the catalog it read while
+    // verifying the credentials, so the table picker needs no second round trip.
+    createDataSource(options: {
+      host: string,
+      port: number,
+      database: string,
+      username: string,
+      password: string,
+      sslMode?: string,
+    }): Promise<{ dataSource: DataSourceJson, catalog: DataSourceCatalogJson }>,
+    deleteDataSource(dataSourceId: string): Promise<void>,
+    getDataSourceCatalog(dataSourceId: string): Promise<DataSourceCatalogJson>,
+    setDataSourceStreams(dataSourceId: string, streams: DataSourceStreamConfig[]): Promise<DataSourceJson>,
+    syncDataSource(dataSourceId: string): Promise<DataSourceJson>,
 
     setupPayments(): Promise<{ url: string }>,
     createStripeWidgetAccountSession(): Promise<{ client_secret: string }>,


### PR DESCRIPTION
Builds on #1942. Where that PR gives a project its own ClickHouse database, this one fills it: a customer connects their own PostgreSQL, picks tables, and each one syncs into that warehouse in whichever mode suits it.

Stacked on `feat/data-warehouse` — review that first, or read this diff alone.

## Two sync modes, chosen per table

The mode is not a question we put to the customer cold. A capability probe reads what the server can do and what shape each table is in, and the answer falls out of that — overridable per table.

| Mode | What it does | Sees deletes |
| --- | --- | --- |
| **CDC** | Reads the write-ahead log each interval | Yes |
| **Cursor** | Re-reads rows past a watermark on a column they pick | No |

A full-refresh mode was built and then removed before review. Its limit was on the wrong axis — a row count, when the cost is bytes — and measurement showed how far that misses: 100k rows is 11 MB of scalars or 600 MB of documents, and we were recommending a reload of either every five minutes. Sizing it properly needs table-byte probing and a frequency-aware gate, which is more machinery than the mode earns while these two cover the common cases. The snapshot reader it shared with CDC is still here, so re-adding it later is a swap-in.

**Choosing a cursor column is explained, not assumed.** Any `NOT NULL` timestamp or integer qualifies, but they behave differently: a timestamp the application bumps on every write picks up edits, while an `id` or `created_at` only moves on insert, so edits to existing rows are never synced. That is correct for an append-only table and quietly wrong everywhere else — so the picker says what to choose and flags a non-temporal choice with a warning icon rather than refusing a call only the customer can make.

**CDC without a long-lived process.** Replication slots are durable server-side state, so there is no need to hold a streaming connection open. Every sync connects over ordinary SQL, drains the slot with `pg_logical_slot_peek_binary_changes`, and advances it with `pg_replication_slot_advance` — which drops straight into the existing cron runtime instead of needing a new stateful component.

Peek rather than `get_changes` is the load-bearing detail: the destructive read advances the slot as it returns, so a failure between reading and writing to ClickHouse would lose those changes permanently. We advance only after the destination write succeeds, which makes the whole path at-least-once — and at-least-once is exactly what `ReplacingMergeTree` already tolerates.

That means decoding `pgoutput` ourselves (~240 lines, `apps/backend/src/lib/data-sources/pgoutput.ts`). Chosen over `wal2json` because it is built into every Postgres 10+, including managed servers that will not install an extension for us.

## Shared decision logic

`packages/shared/src/data-sources/modes.ts` decides availability and the recommendation, and **both the backend and the table picker import it**. A mode the dashboard offers but the backend rejects is the worst possible outcome of that screen. Choices are re-validated against a fresh probe on save, so a table that lost its primary key since the picker rendered is refused rather than silently downgraded.

Unavailable reasons ride on the dropdown option itself, so the UI needs no tooltip layer:

```
CDC — needs wal_level=logical    (disabled)
Cursor · updated_at
Full refresh — table too large   (disabled)
```

## Destination shape

`ReplacingMergeTree(_hexclave_version, _hexclave_deleted)` keyed on the source primary key, or append-only `MergeTree` without one.

Versions are the commit LSN for CDC and the cursor value for polling. CDC snapshots are written at **version 0** so any WAL change for the same row wins — which is what makes it safe to create the slot *before* snapshotting. The overlap deduplicates rather than leaving a gap, and a gap would be silent data loss.

## Testing

- **20 API-level e2e tests** over all six endpoints, against a real Postgres source and the real ClickHouse warehouse. Assertions read the destination as the *customer's own warehouse user*, so isolation is exercised, not just the happy path.
- Each e2e test gets a throwaway **database**, not a schema: logical slots are per-database, and a slot leaked by a failing test would pin WAL on the app's own database for everything running alongside.
- 39 unit and integration tests: the `pgoutput` decoder against hand-built byte fixtures, the mode rules, version arithmetic, plus a Postgres integration suite gated behind `HEXCLAVE_DATA_SOURCE_TEST_POSTGRES` (skips in CI; the docker command is in the file header).
- Repo-wide `pnpm typecheck` and `pnpm lint` green.
- Driven end to end by hand against a live stack: connect → probe → choose tables → sync → CDC insert/update/delete → mode switch → disconnect.

## Review found real bugs — and so did running it

Four review agents plus an independent `codex` pass. ~25 findings fixed in `4b6be995c`; the ones that mattered most:

- **Silent truncation.** A 50-batch cap applied to CDC snapshots too, so a table over 500k rows had its LSN cursor written after a partial load and the remainder was never read again.
- **Versions were not comparable within a table.** Cursor versions are epoch microseconds; LSNs are many orders of magnitude smaller. Switching modes froze the destination forever. Streams now rebuild rather than merge.
- **Isolation.** Syncs used the ClickHouse *admin* client, bypassing the per-project user #1942 built as the tenancy boundary. Now the boundary is a ClickHouse privilege and quota, not the correctness of an interpolated database name.
- **Cursor candidates were matched against type names `format_type()` never emits**, so every Prisma-backed source reported "no usable column" and could not sync incrementally at all.
- **`REPLICA IDENTITY NOTHING` tables are refused for CDC** — adding one to a publication makes the customer's own `UPDATE`s start failing.

Three bugs came only from *running* it, not from reading:

- The first sync failed outright: warehouse databases are named by project UUID and the identifier quoter rejected hyphens. The destination path had never executed against a production-shaped name — the tests hardcoded `wh_test`.
- CDC streams silently dropped columns added after setup. The WAL carries no DDL, and the destination schema was only reconciled during the snapshot.
- The cursor watermark went through `Date.toISOString()` — millisecond precision — so a `timestamptz` with microseconds produced a watermark *below* the rows just read, and every sync re-read the whole table forever. Caught by an e2e assertion reaching 51 rows instead of 26.

## Deploy notes

- New migration `20260821000000_add_data_sources` (`DataSource`, `DataSourceStream`, four enums).
- New cron in `apps/backend/vercel.json`: `/api/latest/internal/data-source-sync-step`, every minute. It takes a leased claim, so overlapping invocations cannot sync one source twice.
- Requires a provisioned Data Warehouse and the `data_warehouse` entitlement (team plan and above), checked on every outbound path including the scheduler.

## Known gaps

- **No full-refresh mode**, so a small mutable table on a server without logical replication has no mode that sees edits or deletes. This is the main thing to weigh before this ships broadly.
- **Integer cursors have no safety lag.** Sequence gaps can skip rows; the honest fix is CDC, not a larger lag. The 10-second temporal lag is a mitigation, not a guarantee.
- **`bytea` and array values encode differently** on the snapshot path (base64 / JSON) versus the CDC path (Postgres text literals).
- **Publication creation needs table ownership.** If the role lacks it, the sync fails with the exact `CREATE PUBLICATION` statement for a DBA to run — the industry norm, but real friction on the CDC path.
- **No deletes-reconciliation pass** for polling modes. Cursor mode still cannot see deletes; the UI says so, but the primary-key-only tombstone scan is not built.
- `PAUSED` / `SNAPSHOTTING` and `syncIntervalSeconds` are modelled but unwired.


## Dashboard screenshots

### Configure PostgreSQL streams

![Dark-mode table picker](https://gist.githubusercontent.com/BilalG1/e6a8e5df0770617f0a839a5484c01d6f/raw/table-picker-after-dark.png)

### Synced source status

![Dark-mode source details](https://gist.githubusercontent.com/BilalG1/e6a8e5df0770617f0a839a5484c01d6f/raw/source-detail-after-dark.png)

### Newly discovered tables require explicit opt-in

Existing streams remain selected while a newly discovered table starts unchecked.

![Newly discovered table remains unchecked](https://gist.githubusercontent.com/BilalG1/e6a8e5df0770617f0a839a5484c01d6f/raw/edit-tables-new-table-opt-in-after-dark.png)
