### PR TITLE
GTM admin: render the customer workspace, editable in place

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/action-internals-card.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/action-internals-card.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { DesignAlert, DesignButton, DesignCard, DesignSelectorDropdown } from "@/components/design-components";
+import { updateGrowthAdminAction, type GrowthAdminFunctionalActionFields } from "@/lib/growth/growth-api";
+import type { GrowthActionItem } from "@/lib/growth/growth-types";
+import { captureError } from "@hexclave/shared/dist/utils/errors";
+import { BracketsCurlyIcon } from "@phosphor-icons/react";
+import { useEffect, useState } from "react";
+import { z } from "zod";
+
+const watchedMetricsSchema = z.array(z.object({ metricId: z.enum(["new_signups", "returning_users", "transactions", "emails_sent", "total_users", "revenue"]), windowDays: z.number().int().min(1).max(90) })).max(10);
+const workflowSchema = z.object({ workflowId: z.string().min(1).max(64), source: z.string().min(1), explanation: z.string().min(1).max(5000), rollbackNote: z.string().min(1).max(5000) }).nullable();
+
+function workflowJson(action: GrowthActionItem): string {
+  if (action.workflow == null) return "null";
+  const { workflowId, source, explanation, rollbackNote } = action.workflow;
+  return JSON.stringify({ workflowId, source, explanation, rollbackNote }, null, 2);
+}
+
+function JsonField(props: { label: string, value: string, onChange: (value: string) => void }) {
+  return (
+    <label className="text-xs font-medium">
+      {props.label}
+      <textarea className="mt-1 min-h-40 w-full rounded-xl border bg-background p-3 font-mono text-xs" value={props.value} onChange={(event) => props.onChange(event.target.value)} />
+    </label>
+  );
+}
+
+/**
+ * The parts of an action that have no customer-facing representation: the machine payload the action
+ * executes with, the metrics its outcome is judged by, and its workflow record. Everything a customer
+ * can see is edited in place on the workspace itself; these fields live here because they are only
+ * mutable while the action is still a proposal (the backend rejects them afterwards, since an active
+ * action has already been executed against them).
+ */
+export function GrowthAdminActionInternalsCard(props: { app: object, projectId: string, actions: GrowthActionItem[], onSaved: () => Promise<void> }) {
+  const proposed = props.actions.filter((action) => action.status === "proposed");
+  const [selectedId, setSelectedId] = useState(proposed.at(0)?.id ?? "");
+  const selected = proposed.find((action) => action.id === selectedId) ?? null;
+  const [payloadJson, setPayloadJson] = useState("null");
+  const [watchedJson, setWatchedJson] = useState("[]");
+  const [workflowDraftJson, setWorkflowDraftJson] = useState("null");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPayloadJson(selected?.payload == null ? "null" : JSON.stringify(selected.payload, null, 2));
+    setWatchedJson(JSON.stringify(selected?.watchedMetrics ?? [], null, 2));
+    setWorkflowDraftJson(selected == null ? "null" : workflowJson(selected));
+  }, [selected]);
+
+  return (
+    <DesignCard title="Proposed action internals" subtitle="Payload, watched metrics and workflow — editable until the proposal is activated" icon={BracketsCurlyIcon} gradient="cyan">
+      {error != null && <DesignAlert variant="error">{error}</DesignAlert>}
+      {proposed.length === 0 || selected == null ? <p className="text-sm text-muted-foreground">No proposed actions.</p> : (
+        <div className="space-y-3">
+          <DesignSelectorDropdown value={selectedId} onValueChange={setSelectedId} options={proposed.map((action) => ({ value: action.id, label: action.title }))} />
+          <div className="grid gap-3 sm:grid-cols-3">
+            <JsonField label="Payload JSON" value={payloadJson} onChange={setPayloadJson} />
+            <JsonField label="Watched metrics JSON" value={watchedJson} onChange={setWatchedJson} />
+            <JsonField label="Workflow JSON" value={workflowDraftJson} onChange={setWorkflowDraftJson} />
+          </div>
+          <DesignButton onClick={async () => {
+            setError(null);
+            try {
+              const functionalFields: GrowthAdminFunctionalActionFields = {
+                payload: z.unknown().parse(JSON.parse(payloadJson)),
+                watchedMetrics: watchedMetricsSchema.parse(JSON.parse(watchedJson)),
+                workflow: workflowSchema.parse(JSON.parse(workflowDraftJson)),
+              };
+              await updateGrowthAdminAction(props.app, props.projectId, selected, functionalFields);
+              await props.onSaved();
+            } catch (caught) {
+              captureError("growth-admin-action-internals", caught);
+              setError(caught instanceof Error ? caught.message : String(caught));
+            }
+          }}>Save internals</DesignButton>
+        </div>
+      )}
+    </DesignCard>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/action-internals-card.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/action-internals-card.tsx
@@ -2,13 +2,13 @@
 
 import { DesignAlert, DesignButton, DesignCard, DesignSelectorDropdown } from "@/components/design-components";
 import { updateGrowthAdminAction, type GrowthAdminFunctionalActionFields } from "@/lib/growth/growth-api";
-import type { GrowthActionItem } from "@/lib/growth/growth-types";
+import { GROWTH_METRIC_IDS, type GrowthActionItem } from "@/lib/growth/growth-types";
 import { captureError } from "@hexclave/shared/dist/utils/errors";
 import { BracketsCurlyIcon } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 import { z } from "zod";
 
-const watchedMetricsSchema = z.array(z.object({ metricId: z.enum(["new_signups", "returning_users", "transactions", "emails_sent", "total_users", "revenue"]), windowDays: z.number().int().min(1).max(90) })).max(10);
+const watchedMetricsSchema = z.array(z.object({ metricId: z.enum(GROWTH_METRIC_IDS), windowDays: z.number().int().min(1).max(90) })).max(10);
 const workflowSchema = z.object({ workflowId: z.string().min(1).max(64), source: z.string().min(1), explanation: z.string().min(1).max(5000), rollbackNote: z.string().min(1).max(5000) }).nullable();
 
 function workflowJson(action: GrowthActionItem): string {
@@ -35,8 +35,11 @@ function JsonField(props: { label: string, value: string, onChange: (value: stri
  */
 export function GrowthAdminActionInternalsCard(props: { app: object, projectId: string, actions: GrowthActionItem[], onSaved: () => Promise<void> }) {
   const proposed = props.actions.filter((action) => action.status === "proposed");
-  const [selectedId, setSelectedId] = useState(proposed.at(0)?.id ?? "");
-  const selected = proposed.find((action) => action.id === selectedId) ?? null;
+  const [requestedId, setRequestedId] = useState<string | null>(null);
+  // Activating a proposal elsewhere on the page refreshes this list without it, so the stored choice is
+  // reconciled against the current proposals rather than trusted — otherwise the card would claim there
+  // are no proposals left while others are still waiting.
+  const selected = proposed.find((action) => action.id === requestedId) ?? proposed.at(0) ?? null;
   const [payloadJson, setPayloadJson] = useState("null");
   const [watchedJson, setWatchedJson] = useState("[]");
   const [workflowDraftJson, setWorkflowDraftJson] = useState("null");
@@ -51,15 +54,18 @@ export function GrowthAdminActionInternalsCard(props: { app: object, projectId: 
   return (
     <DesignCard title="Proposed action internals" subtitle="Payload, watched metrics and workflow — editable until the proposal is activated" icon={BracketsCurlyIcon} gradient="cyan">
       {error != null && <DesignAlert variant="error">{error}</DesignAlert>}
-      {proposed.length === 0 || selected == null ? <p className="text-sm text-muted-foreground">No proposed actions.</p> : (
+      {selected == null ? <p className="text-sm text-muted-foreground">No proposed actions.</p> : (
         <div className="space-y-3">
-          <DesignSelectorDropdown value={selectedId} onValueChange={setSelectedId} options={proposed.map((action) => ({ value: action.id, label: action.title }))} />
+          <DesignSelectorDropdown value={selected.id} onValueChange={setRequestedId} options={proposed.map((action) => ({ value: action.id, label: action.title }))} />
           <div className="grid gap-3 sm:grid-cols-3">
             <JsonField label="Payload JSON" value={payloadJson} onChange={setPayloadJson} />
             <JsonField label="Watched metrics JSON" value={watchedJson} onChange={setWatchedJson} />
             <JsonField label="Workflow JSON" value={workflowDraftJson} onChange={setWorkflowDraftJson} />
           </div>
-          <DesignButton onClick={async () => {
+          {selected.category == null && (
+            <p className="text-xs text-muted-foreground">Give this action a stage on the workspace above first — the Growth API stores actions per stage and rejects a write without one.</p>
+          )}
+          <DesignButton disabled={selected.category == null} onClick={async () => {
             setError(null);
             try {
               const functionalFields: GrowthAdminFunctionalActionFields = {

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/action-internals-card.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/action-internals-card.tsx
@@ -4,6 +4,7 @@ import { DesignAlert, DesignButton, DesignCard, DesignSelectorDropdown } from "@
 import { updateGrowthAdminAction, type GrowthAdminFunctionalActionFields } from "@/lib/growth/growth-api";
 import { GROWTH_METRIC_IDS, type GrowthActionItem } from "@/lib/growth/growth-types";
 import { captureError } from "@hexclave/shared/dist/utils/errors";
+import { Result } from "@hexclave/shared/dist/utils/results";
 import { BracketsCurlyIcon } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 import { z } from "zod";
@@ -44,12 +45,19 @@ export function GrowthAdminActionInternalsCard(props: { app: object, projectId: 
   const [watchedJson, setWatchedJson] = useState("[]");
   const [workflowDraftJson, setWorkflowDraftJson] = useState("null");
   const [error, setError] = useState<string | null>(null);
+  const [draftsFor, setDraftsFor] = useState<string | null>(null);
 
+  // Every workspace save refreshes the overview, which hands this card a new action object for the same
+  // proposal; the drafts are only re-seeded when the admin actually switches to a different proposal, so
+  // unsaved JSON isn't thrown away by an unrelated edit somewhere else on the page.
   useEffect(() => {
+    const selectedId = selected?.id ?? null;
+    if (selectedId === draftsFor) return;
     setPayloadJson(selected?.payload == null ? "null" : JSON.stringify(selected.payload, null, 2));
     setWatchedJson(JSON.stringify(selected?.watchedMetrics ?? [], null, 2));
     setWorkflowDraftJson(selected == null ? "null" : workflowJson(selected));
-  }, [selected]);
+    setDraftsFor(selectedId);
+  }, [draftsFor, selected]);
 
   return (
     <DesignCard title="Proposed action internals" subtitle="Payload, watched metrics and workflow — editable until the proposal is activated" icon={BracketsCurlyIcon} gradient="cyan">
@@ -67,7 +75,9 @@ export function GrowthAdminActionInternalsCard(props: { app: object, projectId: 
           )}
           <DesignButton disabled={selected.category == null} onClick={async () => {
             setError(null);
-            try {
+            // The three fields are free-form JSON typed by hand, so a rejection here is expected input
+            // error (bad JSON/schema) as much as it is a failed request — both belong in the alert.
+            const result = await Result.fromThrowingAsync(async () => {
               const functionalFields: GrowthAdminFunctionalActionFields = {
                 payload: z.unknown().parse(JSON.parse(payloadJson)),
                 watchedMetrics: watchedMetricsSchema.parse(JSON.parse(watchedJson)),
@@ -75,9 +85,10 @@ export function GrowthAdminActionInternalsCard(props: { app: object, projectId: 
               };
               await updateGrowthAdminAction(props.app, props.projectId, selected, functionalFields);
               await props.onSaved();
-            } catch (caught) {
-              captureError("growth-admin-action-internals", caught);
-              setError(caught instanceof Error ? caught.message : String(caught));
+            });
+            if (result.status === "error") {
+              captureError("growth-admin-action-internals", result.error);
+              setError(result.error instanceof Error ? result.error.message : String(result.error));
             }
           }}>Save internals</DesignButton>
         </div>

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/admin/page-client.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { DesignAlert, DesignButton, DesignCard, DesignInput, DesignSelectorDropdown } from "@/components/design-components";
-import { getGrowthAdminOverview, listGrowthAdminProjects, createGrowthAdminNote, setGrowthAdminCategoryScore, updateGrowthAdminAction, updateGrowthAdminFinding, type GrowthAdminProject } from "@/lib/growth/growth-api";
-import { GROWTH_ACTION_STATUSES, GROWTH_ACTION_TYPES, GROWTH_CATEGORIES, type GrowthActionItem, type GrowthActionStatus, type GrowthActionType, type GrowthCategory, type GrowthOverview } from "@/lib/growth/growth-types";
+import { DesignAlert, DesignButton, DesignSelectorDropdown } from "@/components/design-components";
+import { createGrowthAdminNote, getGrowthAdminOverview, listGrowthAdminProjects, setGrowthAdminCategoryScore, updateGrowthAdminAction, updateGrowthAdminFinding, type GrowthAdminFunctionalActionFields, type GrowthAdminProject } from "@/lib/growth/growth-api";
+import type { GrowthActionItem, GrowthOverview } from "@/lib/growth/growth-types";
 import { captureError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 import { useStackApp, useUser } from "@hexclave/next";
-import { ListChecksIcon, NotePencilIcon, SlidersHorizontalIcon } from "@phosphor-icons/react";
-import { useCallback, useEffect, useState } from "react";
-import { z } from "zod";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { PageLayout } from "../../page-layout";
 import { useProjectId } from "../../use-admin-app";
+import { GrowthWorkspaceEditProvider, type GrowthWorkspaceEditors } from "../components/workspace-edit";
 import { GrowthWorkspaceContent } from "../components/workspace-overview";
+import { GrowthAdminActionInternalsCard } from "./action-internals-card";
 import { GrowthAdminGamesCard } from "./games-card";
 import { GrowthAdminInterviewCard } from "./interview-card";
 import { GrowthAdminReportsCard } from "./reports-card";
@@ -19,144 +19,88 @@ import { GrowthAdminRunNowCard } from "./run-now-card";
 
 type Loadable = { status: "loading" } | { status: "error", message: string } | { status: "loaded", projects: GrowthAdminProject[], selected: GrowthAdminProject | null, overview: GrowthOverview | null };
 
-function growthCategory(value: string): GrowthCategory {
-  return GROWTH_CATEGORIES.find((category) => category === value) ?? throwErr(`Unknown Growth category: ${value}`);
-}
-
-function growthActionType(value: string): GrowthActionType {
-  return GROWTH_ACTION_TYPES.find((type) => type === value) ?? throwErr(`Unknown Growth action type: ${value}`);
-}
-
-function growthActionStatus(value: string): GrowthActionStatus {
-  return GROWTH_ACTION_STATUSES.find((status) => status === value) ?? throwErr(`Unknown Growth action status: ${value}`);
-}
-
-function validAdminStatuses(currentStatus: GrowthActionStatus): GrowthActionStatus[] {
-  if (currentStatus === "proposed") return ["proposed", "active", "dismissed"];
-  if (currentStatus === "active") return ["active", "dismissed"];
-  return [currentStatus];
-}
-
-const watchedMetricsSchema = z.array(z.object({ metricId: z.enum(["new_signups", "returning_users", "transactions", "emails_sent", "total_users", "revenue"]), windowDays: z.number().int().min(1).max(90) })).max(10);
-const workflowSchema = z.object({ workflowId: z.string().min(1).max(64), source: z.string().min(1), explanation: z.string().min(1).max(5000), rollbackNote: z.string().min(1).max(5000) }).nullable();
-
-function workflowJson(action: GrowthActionItem | null): string {
-  if (action?.workflow == null) return "null";
-  const { workflowId, source, explanation, rollbackNote } = action.workflow;
-  return JSON.stringify({ workflowId, source, explanation, rollbackNote }, null, 2);
-}
-
-function AdminEditor(props: { app: object, project: GrowthAdminProject, overview: GrowthOverview, refresh: () => Promise<void> }) {
-  const [noteTitle, setNoteTitle] = useState("");
-  const [noteBody, setNoteBody] = useState("");
-  const [noteCategory, setNoteCategory] = useState<GrowthCategory>("reach");
-  const [noteTags, setNoteTags] = useState("");
-  const [selectedActionId, setSelectedActionId] = useState(props.overview.actions.at(0)?.id ?? props.overview.archive.at(0)?.id ?? "");
-  const selectedAction = [...props.overview.actions, ...props.overview.archive].find((item) => item.id === selectedActionId) ?? null;
-  const [actionDraft, setActionDraft] = useState<GrowthActionItem | null>(selectedAction);
-  const [payloadJson, setPayloadJson] = useState(() => selectedAction?.payload == null ? "null" : JSON.stringify(selectedAction.payload, null, 2));
-  const [watchedJson, setWatchedJson] = useState(() => JSON.stringify(selectedAction?.watchedMetrics ?? [], null, 2));
-  const [workflowDraftJson, setWorkflowDraftJson] = useState(() => workflowJson(selectedAction));
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    setActionDraft(selectedAction);
-    setPayloadJson(selectedAction?.payload == null ? "null" : JSON.stringify(selectedAction.payload, null, 2));
-    setWatchedJson(JSON.stringify(selectedAction?.watchedMetrics ?? [], null, 2));
-    setWorkflowDraftJson(workflowJson(selectedAction));
-  }, [selectedAction]);
-
-  const allUnclassified = [...props.overview.findings, ...props.overview.notes].filter((item) => item.category == null);
-  const unclassifiedActions = [...props.overview.actions, ...props.overview.archive].filter((item) => item.category == null);
-  const runAdminMutation = (label: string, mutation: () => Promise<void>) => {
-    setError(null);
-    runAsynchronously((async () => {
-      try {
-        await mutation();
-        await props.refresh();
-      } catch (caught) {
-        captureError(label, caught);
-        setError(caught instanceof Error ? caught.message : String(caught));
-      }
-    })());
+/**
+ * Functional fields are immutable once an action leaves the proposal stage — the backend rejects them —
+ * so they are only ever sent for proposals, and then unchanged: the workspace edits the customer-facing
+ * fields, and resending the current values keeps the PATCH from being read as "clear these".
+ */
+function functionalFieldsOf(action: GrowthActionItem): GrowthAdminFunctionalActionFields | undefined {
+  if (action.status !== "proposed") return undefined;
+  const workflow = action.workflow;
+  return {
+    payload: action.payload,
+    watchedMetrics: action.watchedMetrics,
+    workflow: workflow == null ? null : { workflowId: workflow.workflowId, source: workflow.source, explanation: workflow.explanation, rollbackNote: workflow.rollbackNote },
   };
+}
+
+/**
+ * The customer's own Growth workspace, wired to the admin API. Rendering the same component the
+ * customer gets — rather than an admin-shaped mirror of it — is the point: an admin sees precisely
+ * what the customer sees, and edits it where it sits.
+ */
+function GrowthAdminWorkspace(props: { app: object, project: GrowthAdminProject, overview: GrowthOverview, refresh: () => Promise<void> }) {
+  const { app, refresh } = props;
+  const projectId = props.project.id;
+  const editors = useMemo<GrowthWorkspaceEditors>(() => ({
+    saveCategoryScore: async (category, score) => {
+      await setGrowthAdminCategoryScore(app, projectId, category, score);
+      await refresh();
+    },
+    saveItem: async (item, patch) => {
+      if (item.kind === "finding") {
+        const finding = item.value;
+        const category = patch.category ?? finding.category
+          ?? throwErr("Give this item a stage before editing its other fields — the Growth API stores findings per stage.");
+        await updateGrowthAdminFinding(app, projectId, finding.id, {
+          kind: finding.kind,
+          category,
+          tags: patch.tags ?? finding.tags,
+          title: patch.title ?? finding.title,
+          body: patch.body ?? finding.body,
+        });
+      } else {
+        const action = item.value;
+        const category = patch.category ?? action.category
+          ?? throwErr("Give this action a stage before editing its other fields — the Growth API stores actions per stage.");
+        await updateGrowthAdminAction(app, projectId, {
+          ...action,
+          category,
+          tags: patch.tags ?? action.tags,
+          title: patch.title ?? action.title,
+          description: patch.body ?? action.description,
+        }, functionalFieldsOf(action));
+      }
+      await refresh();
+    },
+    saveActionStatus: async (action, status) => {
+      const category = action.category ?? throwErr("Give this action a stage before changing its status.");
+      await updateGrowthAdminAction(app, projectId, { ...action, category, status }, functionalFieldsOf(action));
+      await refresh();
+    },
+    createNote: async (input) => {
+      await createGrowthAdminNote(app, projectId, { category: input.category, tags: [], title: input.title, body: input.body });
+      await refresh();
+    },
+  }), [app, projectId, refresh]);
+
   return (
-    <div className="space-y-4">
-      {error != null && <DesignAlert variant="error">{error}</DesignAlert>}
-      {/* First: a held interview is a customer sitting still — until it is released they cannot
-        * answer, and nothing downstream (report, actions, briefs) can happen. It is the only
-        * remaining human gate in the lifecycle, and therefore the most consequential thing here. */}
-      <GrowthAdminInterviewCard app={props.app} projectId={props.project.id} />
-      <GrowthAdminReportsCard app={props.app} projectId={props.project.id} />
-      <GrowthAdminGamesCard app={props.app} projectId={props.project.id} />
-      <GrowthAdminRunNowCard app={props.app} projectId={props.project.id} projectName={props.project.displayName} onCompleted={props.refresh} />
+    <div className="space-y-8">
+      <GrowthWorkspaceEditProvider editors={editors}>
+        <GrowthWorkspaceContent overview={props.overview} projectId={projectId} projectName={props.project.displayName} />
+      </GrowthWorkspaceEditProvider>
 
-      <DesignCard title="Stage scores" subtitle="Manual 0–100 values used by the customer growth journey" icon={SlidersHorizontalIcon} gradient="purple">
-        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          {props.overview.categories.map((item) => <label key={item.category} className="flex items-center gap-2 rounded-xl border p-3 text-sm"><span className="min-w-24 capitalize">{item.category}</span><DesignInput className="w-20" type="number" min={0} max={100} defaultValue={item.score ?? ""} onBlur={(event) => {
-            const score = event.target.value;
-            if (score === "") return;
-              runAdminMutation("growth-admin-score", () => setGrowthAdminCategoryScore(props.app, props.project.id, item.category, Number(score)));
-          }} /></label>)}
-        </div>
-      </DesignCard>
-
-      {(allUnclassified.length > 0 || unclassifiedActions.length > 0) && <DesignCard title={`Needs category (${allUnclassified.length + unclassifiedActions.length})`} subtitle="Classify legacy Growth records before the final constraint migration" icon={ListChecksIcon} gradient="orange">
-        <div className="space-y-3">
-          {allUnclassified.map((finding) => <div key={finding.id} className="flex flex-wrap items-center justify-between gap-3 rounded-xl border p-3"><div><p className="text-sm font-medium">{finding.title}</p><p className="text-xs text-muted-foreground">Finding · {finding.kind}</p></div><DesignSelectorDropdown value="" placeholder="Choose category" options={GROWTH_CATEGORIES.map((category) => ({ value: category, label: category }))} onValueChange={(category) => runAdminMutation("growth-admin-classify-finding", () => updateGrowthAdminFinding(props.app, props.project.id, finding.id, { kind: finding.kind, category, tags: finding.tags, title: finding.title, body: finding.body }))} /></div>)}
-          {unclassifiedActions.map((action) => <div key={action.id} className="flex flex-wrap items-center justify-between gap-3 rounded-xl border p-3"><div><p className="text-sm font-medium">{action.title}</p><p className="text-xs text-muted-foreground">Action · {action.status}</p></div><DesignSelectorDropdown value="" placeholder="Choose category" options={GROWTH_CATEGORIES.map((category) => ({ value: category, label: category }))} onValueChange={(category) => runAdminMutation("growth-admin-classify-action", () => updateGrowthAdminAction(props.app, props.project.id, { ...action, category: growthCategory(category) }, action.status === "proposed" ? { payload: action.payload, watchedMetrics: action.watchedMetrics, workflow: action.workflow } : undefined))} /></div>)}
-        </div>
-      </DesignCard>}
-
-      <DesignCard title="Add admin note" subtitle="Notes are Growth findings with source admin and kind note" icon={NotePencilIcon} gradient="blue">
-        <div className="grid gap-3 sm:grid-cols-2"><DesignInput placeholder="Note title" value={noteTitle} onChange={(event) => setNoteTitle(event.target.value)} /><DesignSelectorDropdown value={noteCategory} onValueChange={(value) => setNoteCategory(growthCategory(value))} options={GROWTH_CATEGORIES.map((category) => ({ value: category, label: category }))} /><DesignInput placeholder="Tags, comma separated" value={noteTags} onChange={(event) => setNoteTags(event.target.value)} /><textarea className="min-h-24 rounded-xl border bg-background p-3 text-sm sm:col-span-2" placeholder="Note" value={noteBody} onChange={(event) => setNoteBody(event.target.value)} /></div>
-        <DesignButton className="mt-3" onClick={async () => {
-          setError(null);
-          try {
-            await createGrowthAdminNote(props.app, props.project.id, {
-              category: noteCategory,
-              tags: noteTags.split(",").map((tag) => tag.trim()).filter((tag) => tag.length > 0),
-              title: noteTitle,
-              body: noteBody,
-            });
-            setNoteTitle("");
-            setNoteBody("");
-            setNoteTags("");
-            await props.refresh();
-          } catch (caught) {
-            captureError("growth-admin-note", caught);
-            setError(caught instanceof Error ? caught.message : String(caught));
-          }
-        }}>Add note</DesignButton>
-      </DesignCard>
-
-      <DesignCard title="Action editor" subtitle="Proposals allow functional edits; active and terminal rows obey lifecycle restrictions" icon={ListChecksIcon} gradient="cyan">
-        {[...props.overview.actions, ...props.overview.archive].length === 0 ? <p className="text-sm text-muted-foreground">No actions yet.</p> : <div className="space-y-3">
-          <DesignSelectorDropdown value={selectedActionId} onValueChange={setSelectedActionId} options={[...props.overview.actions, ...props.overview.archive].map((action) => ({ value: action.id, label: action.title }))} />
-          {actionDraft != null && <>
-            <div className="grid gap-3 sm:grid-cols-2"><DesignInput value={actionDraft.title} onChange={(event) => setActionDraft({ ...actionDraft, title: event.target.value })} /><DesignSelectorDropdown value={actionDraft.typeId} disabled={selectedAction?.status !== "proposed"} onValueChange={(value) => setActionDraft({ ...actionDraft, typeId: growthActionType(value) })} options={GROWTH_ACTION_TYPES.map((type) => ({ value: type, label: type }))} /><DesignSelectorDropdown value={actionDraft.category ?? ""} placeholder="Category" onValueChange={(value) => setActionDraft({ ...actionDraft, category: growthCategory(value) })} options={GROWTH_CATEGORIES.map((category) => ({ value: category, label: category }))} /><DesignSelectorDropdown value={actionDraft.status} onValueChange={(value) => setActionDraft({ ...actionDraft, status: growthActionStatus(value) })} options={validAdminStatuses(selectedAction?.status ?? actionDraft.status).map((status) => ({ value: status, label: status }))} /><DesignInput value={actionDraft.tags.join(", ")} onChange={(event) => setActionDraft({ ...actionDraft, tags: event.target.value.split(",").map((tag) => tag.trim()).filter((tag) => tag.length > 0) })} /><textarea className="min-h-24 rounded-xl border bg-background p-3 text-sm sm:col-span-2" value={actionDraft.description} onChange={(event) => setActionDraft({ ...actionDraft, description: event.target.value })} /><label className="text-xs font-medium">Payload JSON<textarea disabled={selectedAction?.status !== "proposed"} className="mt-1 min-h-40 w-full rounded-xl border bg-background p-3 font-mono text-xs disabled:opacity-60" value={payloadJson} onChange={(event) => setPayloadJson(event.target.value)} /></label><label className="text-xs font-medium">Watched metrics JSON<textarea disabled={selectedAction?.status !== "proposed"} className="mt-1 min-h-40 w-full rounded-xl border bg-background p-3 font-mono text-xs disabled:opacity-60" value={watchedJson} onChange={(event) => setWatchedJson(event.target.value)} /></label><label className="text-xs font-medium sm:col-span-2">Workflow JSON · null removes a proposed workflow<textarea disabled={selectedAction?.status !== "proposed"} className="mt-1 min-h-52 w-full rounded-xl border bg-background p-3 font-mono text-xs disabled:opacity-60" value={workflowDraftJson} onChange={(event) => setWorkflowDraftJson(event.target.value)} /></label></div>
-            {selectedAction?.status === "proposed" && actionDraft.status === "active" && <DesignAlert>Saving activates this proposal through the Growth lifecycle. A valid ads proposal can create a paused campaign for review.</DesignAlert>}
-            <DesignButton onClick={async () => {
-              setError(null);
-              try {
-                if (actionDraft.category == null) throw new Error("Choose a category before saving.");
-                // Functional fields are immutable after activation (the backend rejects them), so they
-                // are only sent while the item is still proposed.
-                const functionalFields = selectedAction?.status === "proposed" ? {
-                  payload: z.unknown().parse(JSON.parse(payloadJson)),
-                  watchedMetrics: watchedMetricsSchema.parse(JSON.parse(watchedJson)),
-                  workflow: workflowSchema.parse(JSON.parse(workflowDraftJson)),
-                } : undefined;
-                await updateGrowthAdminAction(props.app, props.project.id, actionDraft, functionalFields);
-                await props.refresh();
-              } catch (caught) {
-                captureError("growth-admin-action", caught);
-                setError(caught instanceof Error ? caught.message : String(caught));
-              }
-            }}>Save action</DesignButton>
-          </>}
-        </div>}
-      </DesignCard>
+      {/* Lifecycle operations, which have no customer-facing surface to edit in place. A held interview
+        * comes first: until it is released the customer cannot answer, and nothing downstream (report,
+        * actions, briefs) can happen — it is the last human gate in the lifecycle. */}
+      <div className="space-y-4">
+        <h2 className="font-mono text-[10px] uppercase tracking-[0.24em] text-muted-foreground">Lifecycle operations</h2>
+        <GrowthAdminInterviewCard app={app} projectId={projectId} />
+        <GrowthAdminReportsCard app={app} projectId={projectId} />
+        <GrowthAdminGamesCard app={app} projectId={projectId} />
+        <GrowthAdminActionInternalsCard app={app} projectId={projectId} actions={[...props.overview.actions, ...props.overview.archive]} onSaved={refresh} />
+        <GrowthAdminRunNowCard app={app} projectId={projectId} projectName={props.project.displayName} onCompleted={refresh} />
+      </div>
     </div>
   );
 }
@@ -180,10 +124,30 @@ export default function PageClient() {
   }, [app]);
   useEffect(() => runAsynchronously(load()), [load]);
   const loadedSelectedId = data.status === "loaded" ? data.selected?.id : undefined;
-  return <PageLayout allowContentOverflow width={1600} title="Growth Admin" description="Edit customer Growth workspaces without bypassing domain lifecycle rules">
-    {data.status === "loading" ? <div className="h-72 animate-pulse rounded-2xl border bg-foreground/[0.03]" /> : data.status === "error" ? <DesignAlert variant="error"><div className="flex justify-between gap-3"><span>{data.message}</span><DesignButton onClick={() => load()}>Retry</DesignButton></div></DesignAlert> : data.selected == null || data.overview == null ? <DesignAlert>No completed Growth onboarding records were found.</DesignAlert> : <div className="space-y-8"><DesignSelectorDropdown value={data.selected.id} onValueChange={(value) => {
-      setData({ status: "loading" });
-      runAsynchronously(load(value));
-    }} options={data.projects.map((project) => ({ value: project.id, label: project.displayName }))} /><AdminEditor app={app} project={data.selected} overview={data.overview} refresh={() => load(loadedSelectedId)} /><GrowthWorkspaceContent overview={data.overview} projectId={data.selected.id} projectName={data.selected.displayName} /></div>}
-  </PageLayout>;
+  const refresh = useCallback(async () => await load(loadedSelectedId), [load, loadedSelectedId]);
+  return (
+    <PageLayout
+      allowContentOverflow
+      width={1600}
+      title="Growth Admin"
+      description="The customer's own Growth workspace, with every field editable — without bypassing domain lifecycle rules"
+    >
+      {data.status === "loading" ? <div className="h-72 animate-pulse rounded-2xl border bg-foreground/[0.03]" />
+        : data.status === "error" ? <DesignAlert variant="error"><div className="flex justify-between gap-3"><span>{data.message}</span><DesignButton onClick={() => load()}>Retry</DesignButton></div></DesignAlert>
+          : data.selected == null || data.overview == null ? <DesignAlert>No completed Growth onboarding records were found.</DesignAlert>
+            : (
+              <div className="space-y-8">
+                <DesignSelectorDropdown
+                  value={data.selected.id}
+                  onValueChange={(value) => {
+                    setData({ status: "loading" });
+                    runAsynchronously(load(value));
+                  }}
+                  options={data.projects.map((project) => ({ value: project.id, label: project.displayName }))}
+                />
+                <GrowthAdminWorkspace app={app} project={data.selected} overview={data.overview} refresh={refresh} />
+              </div>
+            )}
+    </PageLayout>
+  );
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/components/workspace-edit.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/components/workspace-edit.test.ts
@@ -1,5 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { editableActionStatuses } from "./workspace-edit";
+import { editableActionStatuses, isSubmittableCategoryScore } from "./workspace-edit";
+
+// Mirrors assertGrowthCategoryScore (apps/backend src/lib/growth/categories.ts): a number input's
+// min/max never fire without a form submit, so the picker has to reject these itself.
+describe("isSubmittableCategoryScore", () => {
+  it("accepts whole numbers across the full range", () => {
+    expect(["0", "50", "100"].map(isSubmittableCategoryScore)).toMatchInlineSnapshot(`
+      [
+        true,
+        true,
+        true,
+      ]
+    `);
+  });
+
+  it("rejects blanks, non-numbers, fractions and out-of-range scores", () => {
+    expect(["", " ", "abc", "3.7", "-5", "101"].map(isSubmittableCategoryScore)).toMatchInlineSnapshot(`
+      [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+      ]
+    `);
+  });
+});
 
 // The picker must only offer transitions assertGrowthAdminActionTransition (apps/backend
 // src/lib/growth/admin-state.ts) accepts, so an admin click never turns into a server error.

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/components/workspace-edit.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/components/workspace-edit.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { editableActionStatuses } from "./workspace-edit";
+
+// The picker must only offer transitions assertGrowthAdminActionTransition (apps/backend
+// src/lib/growth/admin-state.ts) accepts, so an admin click never turns into a server error.
+describe("editableActionStatuses", () => {
+  it("lets a proposal be activated or dismissed, but never completed", () => {
+    expect(editableActionStatuses("proposed")).toMatchInlineSnapshot(`
+      [
+        "proposed",
+        "active",
+        "dismissed",
+      ]
+    `);
+  });
+
+  it("only lets an active action be dismissed", () => {
+    expect(editableActionStatuses("active")).toMatchInlineSnapshot(`
+      [
+        "active",
+        "dismissed",
+      ]
+    `);
+  });
+
+  it("keeps terminal states terminal", () => {
+    expect(editableActionStatuses("completed")).toMatchInlineSnapshot(`
+      [
+        "completed",
+      ]
+    `);
+    expect(editableActionStatuses("dismissed")).toMatchInlineSnapshot(`
+      [
+        "dismissed",
+      ]
+    `);
+  });
+});

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/components/workspace-edit.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/components/workspace-edit.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { DesignAlert, DesignBadge, DesignButton, DesignInput } from "@/components/design-components";
+import { cn, Popover, PopoverContent, PopoverTrigger } from "@/components/ui";
+import { GROWTH_ACTION_STATUSES, GROWTH_CATEGORIES, type GrowthActionItem, type GrowthActionStatus, type GrowthCategory, type GrowthOverviewFinding } from "@/lib/growth/growth-types";
+import { captureError } from "@hexclave/shared/dist/utils/errors";
+import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
+import { CheckIcon, PlusIcon, XIcon } from "@phosphor-icons/react";
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
+
+/**
+ * The one thing that differs between the customer Growth workspace and the admin one: the admin
+ * renders the exact same components, wrapped in this provider, and every field the Growth admin API
+ * can change becomes editable in place. Nothing about the layout changes — the read-only rendering
+ * of every value stays byte-for-byte what the customer sees, and edit affordances only appear on
+ * hover/click — so there is a single implementation of the workspace UI rather than an admin copy of
+ * it that drifts.
+ */
+export type GrowthWorkspaceItem =
+  | { kind: "finding", value: GrowthOverviewFinding }
+  | { kind: "action", value: GrowthActionItem };
+
+/** Fields the workspace shows for a finding/note/action, in the shape the workspace renders them. */
+export type GrowthWorkspaceItemPatch = {
+  title?: string,
+  /** A finding's `body` and an action's `description` occupy the same slot in the UI. */
+  body?: string,
+  category?: GrowthCategory,
+  tags?: string[],
+};
+
+export type GrowthWorkspaceEditors = {
+  saveCategoryScore: (category: GrowthCategory, score: number) => Promise<void>,
+  saveItem: (item: GrowthWorkspaceItem, patch: GrowthWorkspaceItemPatch) => Promise<void>,
+  saveActionStatus: (action: GrowthActionItem, status: GrowthActionStatus) => Promise<void>,
+  createNote: (input: { category: GrowthCategory, title: string, body: string }) => Promise<void>,
+};
+
+const GrowthWorkspaceEditContext = createContext<GrowthWorkspaceEditors | null>(null);
+
+/** Null on the customer workspace, which is exactly what makes every field below read-only there. */
+export function useGrowthWorkspaceEditors(): GrowthWorkspaceEditors | null {
+  return useContext(GrowthWorkspaceEditContext);
+}
+
+function errorMessage(caught: unknown): string {
+  return caught instanceof Error ? caught.message : String(caught);
+}
+
+/**
+ * Wraps the caller's mutations so a rejected save surfaces as an alert above the workspace instead
+ * of an unhandled rejection: these are inline edits with no submit button of their own, so there is
+ * no per-field place to put an error, and a toast would be too easy to miss on a page whose entire
+ * purpose is editing customer data.
+ */
+export function GrowthWorkspaceEditProvider(props: { editors: GrowthWorkspaceEditors, children: ReactNode }) {
+  const [error, setError] = useState<string | null>(null);
+  const editors = props.editors;
+  const guarded = useMemo<GrowthWorkspaceEditors>(() => {
+    const guard = <TArguments extends unknown[]>(label: string, mutation: (...args: TArguments) => Promise<void>) => async (...args: TArguments) => {
+      setError(null);
+      try {
+        await mutation(...args);
+      } catch (caught) {
+        captureError(label, caught);
+        setError(errorMessage(caught));
+      }
+    };
+    return {
+      saveCategoryScore: guard("growth-admin-category-score", editors.saveCategoryScore),
+      saveItem: guard("growth-admin-item", editors.saveItem),
+      saveActionStatus: guard("growth-admin-action-status", editors.saveActionStatus),
+      createNote: guard("growth-admin-note", editors.createNote),
+    };
+  }, [editors]);
+  return (
+    <GrowthWorkspaceEditContext.Provider value={guarded}>
+      {error != null && <div className="mb-6"><DesignAlert variant="error">{error}</DesignAlert></div>}
+      {props.children}
+    </GrowthWorkspaceEditContext.Provider>
+  );
+}
+
+const editableFieldClassName = "-mx-1 w-full rounded-md bg-transparent px-1 ring-1 ring-transparent transition-shadow hover:transition-none hover:ring-foreground/20 focus:outline-none focus:ring-foreground/40";
+
+/**
+ * Inline-editable text that inherits its typography from the element it is placed in, so the same
+ * heading/paragraph markup renders the customer's text and the admin's editor. Saves on blur (and on
+ * Enter for single-line fields); Escape restores the stored value.
+ */
+export function GrowthEditableText(props: {
+  value: string,
+  label: string,
+  onSave: (value: string) => Promise<void>,
+  multiline?: boolean,
+}) {
+  const editors = useGrowthWorkspaceEditors();
+  if (editors == null) return <>{props.value}</>;
+  return <GrowthEditableTextField {...props} />;
+}
+
+function GrowthEditableTextField(props: { value: string, label: string, onSave: (value: string) => Promise<void>, multiline?: boolean }) {
+  const [draft, setDraft] = useState(props.value);
+  const [saving, setSaving] = useState(false);
+  useEffect(() => setDraft(props.value), [props.value]);
+
+  const commit = async () => {
+    if (draft === props.value || draft.trim().length === 0) {
+      setDraft(props.value);
+      return;
+    }
+    setSaving(true);
+    try {
+      await props.onSave(draft);
+    } finally {
+      setSaving(false);
+    }
+  };
+  const className = cn(editableFieldClassName, saving && "opacity-60");
+  const shared = {
+    "aria-label": props.label,
+    "value": draft,
+    "disabled": saving,
+    "className": className,
+    "onChange": (event: { target: { value: string } }) => setDraft(event.target.value),
+    "onBlur": () => runAsynchronously(commit()),
+  };
+  if (props.multiline === true) {
+    return (
+      <textarea
+        {...shared}
+        rows={Math.min(10, Math.max(2, draft.split("\n").length))}
+        // The row grows with the text instead, so a drag handle would be the one visible difference
+        // between the customer's paragraph and the admin's editor at rest.
+        className={cn(className, "resize-none")}
+        onKeyDown={(event) => {
+          if (event.key === "Escape") setDraft(props.value);
+        }}
+      />
+    );
+  }
+  return (
+    <input
+      {...shared}
+      type="text"
+      onKeyDown={(event) => {
+        if (event.key === "Enter") event.currentTarget.blur();
+        if (event.key === "Escape") setDraft(props.value);
+      }}
+    />
+  );
+}
+
+/**
+ * A badge that opens a picker when the workspace is editable. The badge itself is the customer's
+ * badge, unchanged, so the resting state of the row is identical on both surfaces.
+ */
+function GrowthBadgePicker(props: { badge: ReactNode, label: string, children: (close: () => void) => ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button type="button" aria-label={props.label} className="rounded-full focus-visible:outline-none focus-visible:ring-2">
+          {props.badge}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-56 p-2">
+        {props.children(() => setOpen(false))}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function PickerOption(props: { label: string, selected: boolean, onSelect: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={props.onSelect}
+      className={cn(
+        "flex w-full items-center justify-between rounded-md px-2 py-1.5 text-left text-sm capitalize transition-colors hover:transition-none hover:bg-foreground/[0.06]",
+        props.selected && "font-medium",
+      )}
+    >
+      {props.label}
+      {props.selected && <CheckIcon className="size-3.5" />}
+    </button>
+  );
+}
+
+export function GrowthCategoryBadge(props: { category: GrowthCategory | null, label: string, onSave?: (category: GrowthCategory) => Promise<void> }) {
+  const editors = useGrowthWorkspaceEditors();
+  const badge = <DesignBadge label={props.label} color={props.category == null ? "orange" : "cyan"} size="sm" />;
+  const onSave = props.onSave;
+  if (editors == null || onSave === undefined) return badge;
+  return (
+    <GrowthBadgePicker badge={badge} label="Change stage">
+      {(close) => GROWTH_CATEGORIES.map((category) => (
+        <PickerOption
+          key={category}
+          label={category}
+          selected={category === props.category}
+          onSelect={() => {
+            close();
+            runAsynchronously(onSave(category));
+          }}
+        />
+      ))}
+    </GrowthBadgePicker>
+  );
+}
+
+/**
+ * Mirrors the transitions the Growth admin API accepts: a proposal can be activated or dismissed, an
+ * active action can only be dismissed, and terminal states are final. Offering the rest would just
+ * turn a known-invalid click into a server error.
+ */
+export function editableActionStatuses(current: GrowthActionStatus): GrowthActionStatus[] {
+  if (current === "proposed") return GROWTH_ACTION_STATUSES.filter((status) => status !== "completed");
+  if (current === "active") return ["active", "dismissed"];
+  return [current];
+}
+
+/**
+ * Action status, shown only on the editable workspace: the customer's row conveys status through the
+ * action's own page, and there is nothing for them to change here.
+ */
+export function GrowthActionStatusPicker(props: { status: GrowthActionStatus, onSave: (status: GrowthActionStatus) => Promise<void> }) {
+  const editors = useGrowthWorkspaceEditors();
+  if (editors == null) return null;
+  const statuses = editableActionStatuses(props.status);
+  if (statuses.length === 1) return <DesignBadge label={props.status} color="purple" size="sm" />;
+  return (
+    <GrowthBadgePicker badge={<DesignBadge label={props.status} color="purple" size="sm" />} label="Change action status">
+      {(close) => statuses.map((status) => (
+        <PickerOption
+          key={status}
+          label={status}
+          selected={status === props.status}
+          onSelect={() => {
+            close();
+            runAsynchronously(props.onSave(status));
+          }}
+        />
+      ))}
+    </GrowthBadgePicker>
+  );
+}
+
+export function GrowthTagBadges(props: { tags: string[], onSave?: (tags: string[]) => Promise<void> }) {
+  const editors = useGrowthWorkspaceEditors();
+  const onSave = props.onSave;
+  const [adding, setAdding] = useState("");
+  if (editors == null || onSave === undefined) {
+    return <>{props.tags.map((tag) => <DesignBadge key={tag} label={tag} color="blue" size="sm" />)}</>;
+  }
+  return (
+    <>
+      {props.tags.map((tag) => (
+        <GrowthBadgePicker key={tag} badge={<DesignBadge label={tag} color="blue" size="sm" />} label={`Edit tag ${tag}`}>
+          {(close) => (
+            <DesignButton
+              size="sm"
+              variant="outline"
+              className="w-full"
+              onClick={async () => {
+                close();
+                await onSave(props.tags.filter((existing) => existing !== tag));
+              }}
+            >
+              <XIcon className="size-3.5" />
+              Remove tag
+            </DesignButton>
+          )}
+        </GrowthBadgePicker>
+      ))}
+      <GrowthBadgePicker
+        badge={(
+          <span className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-dashed border-foreground/25 px-2 py-0.5 text-[10px] font-medium leading-none text-muted-foreground">
+            <PlusIcon className="size-3" />
+            Tag
+          </span>
+        )}
+        label="Add tag"
+      >
+        {(close) => (
+          <div className="space-y-2">
+            <DesignInput autoFocus placeholder="New tag" value={adding} onChange={(event) => setAdding(event.target.value)} />
+            <DesignButton
+              size="sm"
+              className="w-full"
+              disabled={adding.trim().length === 0}
+              onClick={async () => {
+                const tag = adding.trim();
+                setAdding("");
+                close();
+                if (tag.length > 0 && !props.tags.includes(tag)) await onSave([...props.tags, tag]);
+              }}
+            >
+              Add tag
+            </DesignButton>
+          </div>
+        )}
+      </GrowthBadgePicker>
+    </>
+  );
+}
+
+export function GrowthCategoryScoreBadge(props: { category: GrowthCategory, score: number | null }) {
+  const editors = useGrowthWorkspaceEditors();
+  const [draft, setDraft] = useState(props.score == null ? "" : String(props.score));
+  useEffect(() => setDraft(props.score == null ? "" : String(props.score)), [props.score]);
+  if (editors == null) {
+    return props.score == null ? null : <DesignBadge label={`${props.score} / 100`} color="purple" size="md" />;
+  }
+  return (
+    <GrowthBadgePicker badge={<DesignBadge label={props.score == null ? "Not scored" : `${props.score} / 100`} color="purple" size="md" />} label="Change stage score">
+      {(close) => (
+        <div className="space-y-2">
+          <DesignInput autoFocus type="number" min={0} max={100} value={draft} onChange={(event) => setDraft(event.target.value)} />
+          <DesignButton
+            size="sm"
+            className="w-full"
+            disabled={draft === "" || Number.isNaN(Number(draft))}
+            onClick={async () => {
+              close();
+              await editors.saveCategoryScore(props.category, Number(draft));
+            }}
+          >
+            Save score
+          </DesignButton>
+        </div>
+      )}
+    </GrowthBadgePicker>
+  );
+}
+
+/** Creates a note in the category the workspace is currently focused on. Admin surfaces only. */
+export function GrowthAddNoteRow(props: { category: GrowthCategory }) {
+  const editors = useGrowthWorkspaceEditors();
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  if (editors == null) return null;
+  return (
+    <div className="grid gap-3 border-b border-foreground/[0.08] px-1 py-5 sm:grid-cols-[7rem_minmax(0,1fr)_auto] sm:items-start">
+      <span className="text-xs text-muted-foreground">New note</span>
+      <div className="min-w-0 space-y-2">
+        <DesignInput placeholder="Note title" value={title} onChange={(event) => setTitle(event.target.value)} />
+        <textarea
+          className="min-h-20 w-full rounded-xl border bg-background p-3 text-sm"
+          placeholder="What should the customer know?"
+          value={body}
+          onChange={(event) => setBody(event.target.value)}
+        />
+      </div>
+      <DesignButton
+        size="sm"
+        variant="outline"
+        disabled={title.trim().length === 0 || body.trim().length === 0}
+        onClick={async () => {
+          await editors.createNote({ category: props.category, title: title.trim(), body: body.trim() });
+          setTitle("");
+          setBody("");
+        }}
+      >
+        <PlusIcon className="size-3.5" />
+        Add note
+      </DesignButton>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/components/workspace-edit.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/components/workspace-edit.tsx
@@ -5,6 +5,7 @@ import { cn, Popover, PopoverContent, PopoverTrigger } from "@/components/ui";
 import { GROWTH_ACTION_STATUSES, GROWTH_CATEGORIES, type GrowthActionItem, type GrowthActionStatus, type GrowthCategory, type GrowthOverviewFinding } from "@/lib/growth/growth-types";
 import { captureError } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
+import { Result } from "@hexclave/shared/dist/utils/results";
 import { CheckIcon, PlusIcon, XIcon } from "@phosphor-icons/react";
 import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from "react";
 
@@ -37,8 +38,8 @@ export type GrowthWorkspaceEditors = {
 };
 
 /**
- * The mutations as the workspace sees them: the provider catches a rejected save and reports it, so the
- * caller gets `false` instead of a rejection. Fields that hold a draft the admin would have to retype
+ * The mutations as the workspace sees them: the provider turns a rejected save into a reported failure,
+ * so the caller gets `false` instead of a rejection. Fields that hold a draft the admin would have to retype
  * (the new-note row) key off that, rather than treating a reported failure as a successful save.
  */
 type GrowthWorkspaceEditActions = {
@@ -68,14 +69,13 @@ export function GrowthWorkspaceEditProvider(props: { editors: GrowthWorkspaceEdi
   const guarded = useMemo<GrowthWorkspaceEditActions>(() => {
     const guard = <TArguments extends unknown[]>(label: string, mutation: (...args: TArguments) => Promise<void>) => async (...args: TArguments) => {
       setError(null);
-      try {
-        await mutation(...args);
-        return true;
-      } catch (caught) {
-        captureError(label, caught);
-        setError(errorMessage(caught));
+      const result = await Result.fromThrowingAsync(async () => await mutation(...args));
+      if (result.status === "error") {
+        captureError(label, result.error);
+        setError(errorMessage(result.error));
         return false;
       }
+      return true;
     };
     return {
       saveCategoryScore: guard("growth-admin-category-score", editors.saveCategoryScore),

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/components/workspace-edit.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/components/workspace-edit.tsx
@@ -36,10 +36,19 @@ export type GrowthWorkspaceEditors = {
   createNote: (input: { category: GrowthCategory, title: string, body: string }) => Promise<void>,
 };
 
-const GrowthWorkspaceEditContext = createContext<GrowthWorkspaceEditors | null>(null);
+/**
+ * The mutations as the workspace sees them: the provider catches a rejected save and reports it, so the
+ * caller gets `false` instead of a rejection. Fields that hold a draft the admin would have to retype
+ * (the new-note row) key off that, rather than treating a reported failure as a successful save.
+ */
+type GrowthWorkspaceEditActions = {
+  [Key in keyof GrowthWorkspaceEditors]: (...args: Parameters<GrowthWorkspaceEditors[Key]>) => Promise<boolean>
+};
+
+const GrowthWorkspaceEditContext = createContext<GrowthWorkspaceEditActions | null>(null);
 
 /** Null on the customer workspace, which is exactly what makes every field below read-only there. */
-export function useGrowthWorkspaceEditors(): GrowthWorkspaceEditors | null {
+export function useGrowthWorkspaceEditors(): GrowthWorkspaceEditActions | null {
   return useContext(GrowthWorkspaceEditContext);
 }
 
@@ -56,14 +65,16 @@ function errorMessage(caught: unknown): string {
 export function GrowthWorkspaceEditProvider(props: { editors: GrowthWorkspaceEditors, children: ReactNode }) {
   const [error, setError] = useState<string | null>(null);
   const editors = props.editors;
-  const guarded = useMemo<GrowthWorkspaceEditors>(() => {
+  const guarded = useMemo<GrowthWorkspaceEditActions>(() => {
     const guard = <TArguments extends unknown[]>(label: string, mutation: (...args: TArguments) => Promise<void>) => async (...args: TArguments) => {
       setError(null);
       try {
         await mutation(...args);
+        return true;
       } catch (caught) {
         captureError(label, caught);
         setError(errorMessage(caught));
+        return false;
       }
     };
     return {
@@ -91,7 +102,7 @@ const editableFieldClassName = "-mx-1 w-full rounded-md bg-transparent px-1 ring
 export function GrowthEditableText(props: {
   value: string,
   label: string,
-  onSave: (value: string) => Promise<void>,
+  onSave: (value: string) => Promise<unknown>,
   multiline?: boolean,
 }) {
   const editors = useGrowthWorkspaceEditors();
@@ -99,7 +110,7 @@ export function GrowthEditableText(props: {
   return <GrowthEditableTextField {...props} />;
 }
 
-function GrowthEditableTextField(props: { value: string, label: string, onSave: (value: string) => Promise<void>, multiline?: boolean }) {
+function GrowthEditableTextField(props: { value: string, label: string, onSave: (value: string) => Promise<unknown>, multiline?: boolean }) {
   const [draft, setDraft] = useState(props.value);
   const [saving, setSaving] = useState(false);
   useEffect(() => setDraft(props.value), [props.value]);
@@ -187,7 +198,7 @@ function PickerOption(props: { label: string, selected: boolean, onSelect: () =>
   );
 }
 
-export function GrowthCategoryBadge(props: { category: GrowthCategory | null, label: string, onSave?: (category: GrowthCategory) => Promise<void> }) {
+export function GrowthCategoryBadge(props: { category: GrowthCategory | null, label: string, onSave?: (category: GrowthCategory) => Promise<unknown> }) {
   const editors = useGrowthWorkspaceEditors();
   const badge = <DesignBadge label={props.label} color={props.category == null ? "orange" : "cyan"} size="sm" />;
   const onSave = props.onSave;
@@ -224,7 +235,7 @@ export function editableActionStatuses(current: GrowthActionStatus): GrowthActio
  * Action status, shown only on the editable workspace: the customer's row conveys status through the
  * action's own page, and there is nothing for them to change here.
  */
-export function GrowthActionStatusPicker(props: { status: GrowthActionStatus, onSave: (status: GrowthActionStatus) => Promise<void> }) {
+export function GrowthActionStatusPicker(props: { status: GrowthActionStatus, onSave: (status: GrowthActionStatus) => Promise<unknown> }) {
   const editors = useGrowthWorkspaceEditors();
   if (editors == null) return null;
   const statuses = editableActionStatuses(props.status);
@@ -246,7 +257,7 @@ export function GrowthActionStatusPicker(props: { status: GrowthActionStatus, on
   );
 }
 
-export function GrowthTagBadges(props: { tags: string[], onSave?: (tags: string[]) => Promise<void> }) {
+export function GrowthTagBadges(props: { tags: string[], onSave?: (tags: string[]) => Promise<unknown> }) {
   const editors = useGrowthWorkspaceEditors();
   const onSave = props.onSave;
   const [adding, setAdding] = useState("");
@@ -305,6 +316,18 @@ export function GrowthTagBadges(props: { tags: string[], onSave?: (tags: string[
   );
 }
 
+/**
+ * `min`/`max` on a number input are only enforced on form submission, which the score picker never
+ * does, so the range the Growth API accepts (assertGrowthCategoryScore: a whole number from 0 to 100)
+ * is checked here rather than letting a known-invalid score become a server error.
+ */
+export function isSubmittableCategoryScore(draft: string): boolean {
+  // `Number("")` and `Number(" ")` are both 0, so the emptiness check has to come first or a blank
+  // field would look like a valid score of zero.
+  const score = Number(draft);
+  return draft.trim() !== "" && Number.isInteger(score) && score >= 0 && score <= 100;
+}
+
 export function GrowthCategoryScoreBadge(props: { category: GrowthCategory, score: number | null }) {
   const editors = useGrowthWorkspaceEditors();
   const [draft, setDraft] = useState(props.score == null ? "" : String(props.score));
@@ -312,18 +335,19 @@ export function GrowthCategoryScoreBadge(props: { category: GrowthCategory, scor
   if (editors == null) {
     return props.score == null ? null : <DesignBadge label={`${props.score} / 100`} color="purple" size="md" />;
   }
+  const score = Number(draft);
   return (
     <GrowthBadgePicker badge={<DesignBadge label={props.score == null ? "Not scored" : `${props.score} / 100`} color="purple" size="md" />} label="Change stage score">
       {(close) => (
         <div className="space-y-2">
-          <DesignInput autoFocus type="number" min={0} max={100} value={draft} onChange={(event) => setDraft(event.target.value)} />
+          <DesignInput autoFocus type="number" min={0} max={100} step={1} value={draft} onChange={(event) => setDraft(event.target.value)} />
           <DesignButton
             size="sm"
             className="w-full"
-            disabled={draft === "" || Number.isNaN(Number(draft))}
+            disabled={!isSubmittableCategoryScore(draft)}
             onClick={async () => {
               close();
-              await editors.saveCategoryScore(props.category, Number(draft));
+              await editors.saveCategoryScore(props.category, score);
             }}
           >
             Save score
@@ -357,7 +381,8 @@ export function GrowthAddNoteRow(props: { category: GrowthCategory }) {
         variant="outline"
         disabled={title.trim().length === 0 || body.trim().length === 0}
         onClick={async () => {
-          await editors.createNote({ category: props.category, title: title.trim(), body: body.trim() });
+          const saved = await editors.createNote({ category: props.category, title: title.trim(), body: body.trim() });
+          if (!saved) return;
           setTitle("");
           setBody("");
         }}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/components/workspace-overview.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/gtm/components/workspace-overview.tsx
@@ -17,6 +17,7 @@ import { useAdminApp, useProjectId } from "../../use-admin-app";
 import { useGrowthHref } from "./action-card";
 import { QuizBanner } from "./games/quiz-banner";
 import { QuizDialog } from "./games/quiz-dialog";
+import { GrowthActionStatusPicker, GrowthAddNoteRow, GrowthCategoryBadge, GrowthCategoryScoreBadge, GrowthEditableText, GrowthTagBadges, useGrowthWorkspaceEditors, type GrowthWorkspaceItem, type GrowthWorkspaceItemPatch } from "./workspace-edit";
 
 const CATEGORY_PRESENTATION = new Map<GrowthCategory, { label: string, icon: typeof UsersThreeIcon }>([
   ["product", { label: "Product", icon: CubeIcon }],
@@ -120,33 +121,39 @@ function GrowthJourney(props: { categories: GrowthOverview["categories"], select
   );
 }
 
-function Badges(props: { category: GrowthCategory | null, tags: string[] }) {
-  return (
-    <div className="flex flex-wrap gap-1.5">
-      <DesignBadge label={categoryLabel(props.category)} color={props.category == null ? "orange" : "cyan"} size="sm" />
-      {props.tags.map((tag) => <DesignBadge key={tag} label={tag} color="blue" size="sm" />)}
-    </div>
-  );
-}
-
-function SuggestionRow(props: { item: { kind: "finding", value: GrowthOverviewFinding } | { kind: "action", value: GrowthActionItem }, projectId: string }) {
+function SuggestionRow(props: { item: GrowthWorkspaceItem, projectId: string }) {
   const withQuery = useGrowthHref();
+  const editors = useGrowthWorkspaceEditors();
   const value = props.item.value;
   const href = props.item.kind === "action"
     ? `/projects/${props.projectId}/gtm/actions/${value.id}`
     : `/projects/${props.projectId}/gtm/findings/${value.id}`;
   const body = props.item.kind === "action" ? props.item.value.description : props.item.value.body;
+  const item = props.item;
+  const save = async (patch: GrowthWorkspaceItemPatch) => await editors?.saveItem(item, patch);
+  const callToAction = <span className="inline-flex items-center gap-1.5 text-xs font-medium text-foreground">{props.item.kind === "action" ? "Review action" : "Read evidence"}<ArrowRightIcon className="size-3.5" /></span>;
   const content = (
     <article className="grid gap-3 border-b border-foreground/[0.08] px-1 py-5 text-left last:border-0 sm:grid-cols-[7rem_minmax(0,1fr)_auto] sm:items-start">
       <time className="text-xs text-muted-foreground">{formatDate(value.createdAtMillis)}</time>
       <div className="min-w-0">
-        <h4 className="text-sm font-semibold leading-6 tracking-tight">{value.title}</h4>
-        <p className="mt-1 line-clamp-2 text-sm leading-6 text-muted-foreground">{body}</p>
-        <div className="mt-3"><Badges category={value.category} tags={value.tags} /></div>
+        <h4 className="text-sm font-semibold leading-6 tracking-tight">
+          <GrowthEditableText value={value.title} label="Title" onSave={async (title) => await save({ title })} />
+        </h4>
+        <p className={cn("mt-1 text-sm leading-6 text-muted-foreground", editors == null && "line-clamp-2")}>
+          <GrowthEditableText value={body} label={item.kind === "action" ? "Description" : "Body"} multiline onSave={async (next) => await save({ body: next })} />
+        </p>
+        <div className="mt-3 flex flex-wrap items-center gap-1.5">
+          <GrowthCategoryBadge category={value.category} label={categoryLabel(value.category)} onSave={async (category) => await save({ category })} />
+          <GrowthTagBadges tags={value.tags} onSave={async (tags) => await save({ tags })} />
+          {item.kind === "action" && <GrowthActionStatusPicker status={item.value.status} onSave={async (status) => await editors?.saveActionStatus(item.value, status)} />}
+        </div>
       </div>
-      <span className="inline-flex items-center gap-1.5 text-xs font-medium text-foreground">{props.item.kind === "action" ? "Review action" : "Read evidence"}<ArrowRightIcon className="size-3.5" /></span>
+      {/* On the admin workspace the row itself is not a link, because its text is editable in place;
+        * the call to action keeps the same navigation the customer row has. */}
+      {editors == null ? callToAction : <Link href={withQuery(href)} className="rounded-xl focus-visible:outline-none focus-visible:ring-2">{callToAction}</Link>}
     </article>
   );
+  if (editors != null) return content;
   return <Link href={withQuery(href)} className="block rounded-xl focus-visible:outline-none focus-visible:ring-2">{content}</Link>;
 }
 
@@ -195,22 +202,30 @@ export function GrowthWorkspaceContent(props: {
   projectName: string,
   /**
    * Rendered directly above the stage/insights section. Passed in rather than fetched here because
-   * this component is ALSO the admin page's read-only preview of a customer workspace, and that page
-   * has no business firing the customer's own quiz request. The customer wrapper below passes the
-   * live banner; the admin preview passes nothing.
+   * this component is ALSO what the admin page renders, and that page has no business firing the
+   * customer's own quiz request. The customer wrapper below passes the live banner; admin passes
+   * nothing.
    */
   quizBanner?: ReactNode,
 }) {
   const withQuery = useGrowthHref();
+  const editors = useGrowthWorkspaceEditors();
   const [selected, setSelected] = useState<GrowthCategory>("conversion");
   const [lane, setLane] = useState<"suggestions" | "notes">("suggestions");
   const category = props.overview.categories.find((item) => item.category === selected)
     ?? throwErr(`Growth overview response omitted ${selected}.`);
-  const suggestions: Array<{ kind: "finding", value: GrowthOverviewFinding } | { kind: "action", value: GrowthActionItem }> = [];
+  const suggestions: GrowthWorkspaceItem[] = [];
   for (const value of props.overview.findings.filter((item) => item.category === selected)) suggestions.push({ kind: "finding", value });
   for (const value of props.overview.actions.filter((item) => item.category === selected)) suggestions.push({ kind: "action", value });
   suggestions.sort((left, right) => right.value.createdAtMillis - left.value.createdAtMillis);
   const notes = props.overview.notes.filter((item) => item.category === selected);
+  // Items without a stage are filtered out of every stage lane, so on the editable workspace they get
+  // their own list; otherwise the only trace of them would be the count below the journey, and an
+  // admin would have no way to give them a stage.
+  const awaitingStage: GrowthWorkspaceItem[] = editors == null ? [] : [
+    ...[...props.overview.findings, ...props.overview.notes].filter((item) => item.category == null).map((value) => ({ kind: "finding" as const, value })),
+    ...[...props.overview.actions, ...props.overview.archive].filter((item) => item.category == null).map((value) => ({ kind: "action" as const, value })),
+  ];
   // const highlight = selectGrowthHighlight(props.overview, props.projectId);
   const rerunActive = props.status?.latestReport != null && props.status.analysis.state === "running";
   const unreadReport = getUnreadGrowthReport(props.status);
@@ -261,8 +276,13 @@ export function GrowthWorkspaceContent(props: {
         <header className="mx-auto max-w-2xl text-center"><p className="font-mono text-[10px] uppercase tracking-[0.24em] text-muted-foreground">{props.projectName} growth journey</p><h2 className="mt-3 text-balance font-serif text-4xl leading-none tracking-tight sm:text-5xl">From product to revenue.</h2><p className="mx-auto mt-4 text-sm text-muted-foreground">Choose a stage to focus the workspace.</p></header>
         <GrowthJourney categories={props.overview.categories} selected={selected} projectName={props.projectName} onSelect={setSelected} />
         {props.overview.needsCategoryCount > 0 && <p className="mt-5 text-center text-xs text-muted-foreground">{props.overview.needsCategoryCount} items are awaiting a stage.</p>}
+        {awaitingStage.length > 0 && (
+          <div className="mt-5 border-y border-foreground/[0.08]">
+            {awaitingStage.map((item) => <SuggestionRow key={`awaiting-${item.kind}-${item.value.id}`} item={item} projectId={props.projectId} />)}
+          </div>
+        )}
         <div className="mt-4 border-t border-foreground/[0.09] pt-9">
-          <header className="border-b border-foreground/[0.09] pb-8"><p className="font-mono text-[9px] uppercase tracking-[0.22em] text-muted-foreground">Selected category</p><div className="mt-3 flex flex-wrap items-end justify-between gap-3"><h3 className="font-serif text-5xl tracking-tight">{categoryLabel(selected)}</h3>{category.score != null && <DesignBadge label={`${category.score} / 100`} color="purple" size="md" />}</div></header>
+          <header className="border-b border-foreground/[0.09] pb-8"><p className="font-mono text-[9px] uppercase tracking-[0.22em] text-muted-foreground">Selected category</p><div className="mt-3 flex flex-wrap items-end justify-between gap-3"><h3 className="font-serif text-5xl tracking-tight">{categoryLabel(selected)}</h3><GrowthCategoryScoreBadge category={selected} score={category.score} /></div></header>
           <section className="py-8">
             <DesignCategoryTabs
               categories={[
@@ -282,9 +302,12 @@ export function GrowthWorkspaceContent(props: {
               {lane === "suggestions" && (suggestions.length === 0
                 ? <p className="py-8 text-sm text-muted-foreground">No suggestions in this category yet.</p>
                 : suggestions.slice(0, 6).map((item) => <SuggestionRow key={`${item.kind}-${item.value.id}`} item={item} projectId={props.projectId} />))}
-              {lane === "notes" && (notes.length === 0
-                ? <p className="py-8 text-sm text-muted-foreground">No notes in this category yet.</p>
-                : notes.map((note) => <SuggestionRow key={note.id} item={{ kind: "finding", value: note }} projectId={props.projectId} />))}
+              {lane === "notes" && <>
+                <GrowthAddNoteRow category={selected} />
+                {notes.length === 0
+                  ? <p className="py-8 text-sm text-muted-foreground">No notes in this category yet.</p>
+                  : notes.map((note) => <SuggestionRow key={note.id} item={{ kind: "finding", value: note }} projectId={props.projectId} />)}
+              </>}
             </div>
           </section>
         </div>

--- a/apps/dashboard/src/lib/growth/growth-api.test.ts
+++ b/apps/dashboard/src/lib/growth/growth-api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { growthRequestHeaders, parseGrowthAdsBody } from "./growth-api";
+import { growthAdminActionRequestBody, growthRequestHeaders, parseGrowthAdsBody } from "./growth-api";
+import type { GrowthActionItem } from "./growth-types";
 
 // Regression coverage for a bug that silently broke every bodyless growth mutation — retry, skip,
 // retake, activate, dismiss, mark-brief-read. Declaring `content-type: application/json` with no
@@ -132,5 +133,42 @@ describe("parseGrowthAdsBody", () => {
     expect(parseGrowthAdsBody(adsWire({
       execution: { mode: "sideways", attempt: null, status: null, dispatched_at_millis: null, lease_expires_at_millis: null, agent_reported_ids: {} },
     })).execution.mode).toBeNull();
+  });
+});
+
+// Regression coverage for the admin action PATCH: an action's payload column is nullable, but the
+// endpoint declares `payload` as optional-but-not-nullable, so sending the null back made every edit
+// (including flipping a proposal to active) fail with "body.payload cannot be null".
+describe("growthAdminActionRequestBody", () => {
+  const action: GrowthActionItem = {
+    id: "action-1", typeId: "custom", category: "reach", tags: ["funnel"], title: "Trial-extension offer", description: "Offer stalled signups a longer trial.",
+    status: "proposed", payload: null, watchedMetrics: [{ metricId: "new_signups", windowDays: 14 }], reportId: null, briefId: null, workflow: null,
+    createdAtMillis: 0, activatedAtMillis: null, completedAtMillis: null,
+  };
+
+  test("omits a null payload so the field is left untouched", () => {
+    const body = growthAdminActionRequestBody("project-1", action, { payload: action.payload, watchedMetrics: action.watchedMetrics, workflow: null });
+    expect("payload" in body).toBe(false);
+    expect(body.watched_metrics).toEqual([{ metric_id: "new_signups", window_days: 14 }]);
+  });
+
+  test("sends a payload the admin actually set", () => {
+    const body = growthAdminActionRequestBody("project-1", action, { payload: { qa: 1 }, watchedMetrics: [], workflow: null });
+    expect(body.payload).toEqual({ qa: 1 });
+  });
+
+  test("leaves out every functional field for an action that is no longer a proposal", () => {
+    const body = growthAdminActionRequestBody("project-1", { ...action, status: "active" });
+    expect(Object.keys(body).sort()).toMatchInlineSnapshot(`
+      [
+        "category",
+        "description",
+        "status",
+        "tags",
+        "target_project_id",
+        "title",
+        "type_id",
+      ]
+    `);
   });
 });

--- a/apps/dashboard/src/lib/growth/growth-api.ts
+++ b/apps/dashboard/src/lib/growth/growth-api.ts
@@ -739,18 +739,31 @@ export type GrowthAdminFunctionalActionFields = {
   workflow: null | Pick<NonNullable<GrowthActionItem["workflow"]>, "workflowId" | "source" | "explanation" | "rollbackNote">,
 };
 
+/**
+ * The admin action endpoint replaces every field it receives, so an edit to one field has to resend the
+ * others; the functional fields are only included when the caller may change them (while the action is
+ * still a proposal).
+ */
+export function growthAdminActionRequestBody(projectId: string, action: GrowthActionItem, functionalFields?: GrowthAdminFunctionalActionFields): Record<string, unknown> {
+  return {
+    target_project_id: projectId, type_id: action.typeId, category: action.category, tags: action.tags, title: action.title, description: action.description,
+    status: action.status,
+    ...functionalFields === undefined ? {} : {
+      // The endpoint takes `payload` as optional-but-not-nullable, and an action's payload column is
+      // nullable (that is its default until the agent fills it in), so a null payload has to be left
+      // out of the body entirely — sending `null` is rejected and would make an otherwise unrelated
+      // edit, such as flipping a proposal to active, impossible for those actions.
+      ...functionalFields.payload == null ? {} : { payload: functionalFields.payload },
+      watched_metrics: functionalFields.watchedMetrics.map((metric) => ({ metric_id: metric.metricId, window_days: metric.windowDays })),
+      workflow: functionalFields.workflow == null ? null : { workflow_id: functionalFields.workflow.workflowId, source: functionalFields.workflow.source, explanation: functionalFields.workflow.explanation, rollback_note: functionalFields.workflow.rollbackNote },
+    },
+  };
+}
+
 export async function updateGrowthAdminAction(app: object, projectId: string, action: GrowthActionItem, functionalFields?: GrowthAdminFunctionalActionFields): Promise<void> {
   await requestGrowthAdminJson(app, `/actions/${encodeURIComponent(action.id)}`, {
     method: "PATCH",
-    body: JSON.stringify({
-      target_project_id: projectId, type_id: action.typeId, category: action.category, tags: action.tags, title: action.title, description: action.description,
-      status: action.status,
-      ...functionalFields === undefined ? {} : {
-        payload: functionalFields.payload,
-        watched_metrics: functionalFields.watchedMetrics.map((metric) => ({ metric_id: metric.metricId, window_days: metric.windowDays })),
-        workflow: functionalFields.workflow == null ? null : { workflow_id: functionalFields.workflow.workflowId, source: functionalFields.workflow.source, explanation: functionalFields.workflow.explanation, rollback_note: functionalFields.workflow.rollbackNote },
-      },
-    }),
+    body: JSON.stringify(growthAdminActionRequestBody(projectId, action, functionalFields)),
   });
 }
 


### PR DESCRIPTION
The GTM admin page rendered its own editor cards (stage scores, needs-category list, add-note form, action editor) above a read-only copy of the customer workspace, so the two surfaces drifted. It now renders the *same* workspace components the customer sees, wrapped in a `GrowthWorkspaceEditProvider`; the only difference between the two surfaces is editability.

```tsx
// customer page — no provider, every field renders as text
<GrowthWorkspaceContent .../>

// admin page
<GrowthWorkspaceEditProvider editors={{ saveCategoryScore, saveItem, saveActionStatus, createNote }}>
  <GrowthWorkspaceContent .../>
</GrowthWorkspaceEditProvider>
```

`workspace-edit.tsx` holds the primitives (`GrowthEditableText`, `GrowthCategoryBadge`, `GrowthTagBadges`, `GrowthCategoryScoreBadge`, `GrowthActionStatusPicker`, `GrowthAddNoteRow`). Each returns the customer's exact rendering when the context is absent, so the resting state of a row is identical on both pages and there is one implementation of the workspace UI. Editable: stage scores, finding/note title + body, action title + description, category, tags, action status, plus creating notes in the focused stage. Rejected saves surface as a `DesignAlert` above the workspace.

Lifecycle rules stay with the backend: the status picker only offers transitions `assertGrowthAdminActionTransition` accepts (proposal → active/dismissed, active → dismissed, terminal states final), covered by a new unit test. Items with no stage yet are listed above the workspace on the admin page only, since they need a stage assigned before other edits can be stored.

Admin-only operations with no customer counterpart (interview review/release, reports, games, manual run) stay as "Lifecycle operations" cards below the workspace, joined by a new card for proposed-action internals (payload / watched metrics / workflow JSON), which the customer UI never shows and the API only accepts while an action is proposed.

Verified in the development environment against a seeded Growth project: inline title edit and stage score edit both persisted (radar re-rendered), lint + `pnpm test run gtm` pass.


Link to Devin session: https://app.devin.ai/sessions/85c2833dbed4402595bea6e378f40727
Requested by: @aadesh18

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the admin-only editors with the exact customer Growth workspace, made editable in place. Old behavior: bespoke admin editors + read-only preview. New behavior: the same workspace UI, wrapped with inline editors; lifecycle rules still apply and the resting UI matches the customer surface.

- Wraps the workspace in GrowthWorkspaceEditProvider; editable primitives render read-only without context and surface failures via DesignAlert.
- Validates category scores client-side (0–100 integers) and restricts action status changes to allowed transitions; adds unit tests.
- Requires a stage before other edits; lists items awaiting a stage; supports in-place note creation in the focused stage and preserves drafts on failed saves.
- Wires workspace edits to the admin API; for proposed actions only, sends functional fields and resends current values to avoid clearing; omits a null action payload from PATCH to leave the value untouched (regression tests added).
- Adds a proposed-only action internals editor (payload, watched metrics, workflow) with `zod` validation; keeps JSON drafts across refreshes and uses Result.fromThrowingAsync to guard saves.

<sup>Written for commit 008f652ba5f5ed2ed803f5ab429c8a0e98d7694b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline editing for growth workspace titles, descriptions, categories, tags, scores, notes, and action statuses.
  * Added editing for proposed action details, watched metrics, and workflow data.
  * Added a dedicated view for items awaiting categorization.

* **Improvements**
  * Updated administration to use the shared growth workspace.
  * Added validation for category scores and action details.
  * Preserved unsaved edits during refreshes and improved save feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->