### PR TITLE
[Refactor][Fix]: SDK API url fallback logic rework

### DIFF
--- a/apps/backend/src/server/middleware.ts
+++ b/apps/backend/src/server/middleware.ts
@@ -42,6 +42,8 @@ const corsAllowedResponseHeaders = [
   "content-type",
   "x-stack-actual-status",
   "x-stack-known-error",
+  // Needed so browser SDKs can tell smart-wrapped 4xx from Next/proxy junk and avoid false failover.
+  "x-stack-request-id",
 ];
 
 function withHexclaveHeaderAliases(headers: string[]): string[] {

--- a/packages/shared/src/interface/client-interface.test.ts
+++ b/packages/shared/src/interface/client-interface.test.ts
@@ -7,14 +7,12 @@ import { ApiUrlsFailedError, HexclaveClientInterface } from "./client-interface"
 function createClientInterface(options?: {
   baseUrl?: string,
   apiUrls?: string[],
-  probeRate?: number,
 }) {
   const apiUrls = options?.apiUrls ?? [options?.baseUrl ?? "https://api.example.com"];
   return new HexclaveClientInterface({
     clientVersion: "test",
     getBaseUrl: () => apiUrls[0],
     getApiUrls: () => apiUrls,
-    probeRate: options?.probeRate,
     extraRequestHeaders: {},
     projectId: "project-id",
     publishableClientKey: "publishable-client-key",
@@ -401,7 +399,7 @@ describe("_withFallback", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Normal mode — iterating through URLs in order
+  // Ring walk — iterating through URLs in order
   // ---------------------------------------------------------------------------
 
   it("uses primary when it is healthy", async () => {
@@ -441,12 +439,37 @@ describe("_withFallback", () => {
     expect(log.every(u => urlIndex(urls, u) === 0)).toBe(true);
   });
 
-  it("does not retry or fall back on non-KnownError 4xx responses", async () => {
+  it("sticks on the host that returned KnownError after an outage hop", async () => {
+    const urls = urlList(3);
+    const iface = createClientInterface({ apiUrls: urls });
+
+    // url-0 down, url-1 returns KnownError → stick on url-1 even though the call "failed"
+    const log1: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      log1.push(url);
+      if (urlIndex(urls, url) === 0) throw new TypeError("Failed to fetch");
+      return createKnownErrorResponse(new KnownErrors.UserNotFound());
+    }));
+    await expect(sendRequest(iface)).rejects.toThrow();
+    expect(log1.map(u => urlIndex(urls, u))).toEqual([0, 1]);
+
+    // Next request goes straight to url-1
+    const log2 = mockFetch(() => "ok");
+    await sendRequest(iface);
+    expect(log2.length).toBe(1);
+    expect(urlIndex(urls, log2[0])).toBe(1);
+  });
+
+  it("does not fall back on smart-wrapped 4xx responses", async () => {
     const urls = urlList(3);
     const log: string[] = [];
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
       log.push(input.toString());
-      return createTextResponse("Payments are not set up", { status: 402 });
+      return createTextResponse("Payments are not set up", {
+        status: 402,
+        headers: { "x-hexclave-request-id": "req-123" },
+      });
     }));
 
     const iface = createClientInterface({ apiUrls: urls });
@@ -455,8 +478,33 @@ describe("_withFallback", () => {
     expect(urlIndex(urls, log[0])).toBe(0);
   });
 
+  it("falls back on non-smart 4xx responses (no request-id)", async () => {
+    const urls = urlList(3);
+    const log: string[] = [];
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      log.push(url);
+      if (urlIndex(urls, url) === 0) {
+        return createTextResponse("<html>Not Found</html>", {
+          status: 404,
+          headers: { "Content-Type": "text/html" },
+        });
+      }
+      return createJsonResponse({ display_name: "test" });
+    }));
+
+    const iface = createClientInterface({ apiUrls: urls });
+    await sendRequest(iface);
+    expect(log.length).toBe(2);
+    expect(urlIndex(urls, log[0])).toBe(0);
+    expect(urlIndex(urls, log[1])).toBe(1);
+  });
+
   it("wraps non-KnownError 4xx responses as normal errors", async () => {
-    const response = createTextResponse("Payments are not set up", { status: 402 });
+    const response = createTextResponse("Payments are not set up", {
+      status: 402,
+      headers: { "x-hexclave-request-id": "req-123" },
+    });
     vi.stubGlobal("fetch", vi.fn(async () => response));
 
     const iface = createClientInterface({ apiUrls: urlList(1) });
@@ -479,14 +527,17 @@ describe("_withFallback", () => {
     expect(attempts).toBe(1);
   });
 
-  it("falls back on non-KnownError 5xx responses", async () => {
+  it("falls back on non-KnownError 5xx responses even with request-id", async () => {
     const urls = urlList(3);
     const log: string[] = [];
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
       const url = input.toString();
       log.push(url);
       if (urlIndex(urls, url) === 0) {
-        return createTextResponse("Server unavailable", { status: 503 });
+        return createTextResponse("Server unavailable", {
+          status: 503,
+          headers: { "x-hexclave-request-id": "req-123" },
+        });
       }
       return createJsonResponse({ display_name: "test" });
     }));
@@ -498,13 +549,16 @@ describe("_withFallback", () => {
     expect(urlIndex(urls, log[1])).toBe(1);
   });
 
-  it("does not fall back on wrapped non-KnownError 4xx refresh token responses", async () => {
+  it("does not fall back on smart-wrapped 4xx refresh token responses", async () => {
     const urls = urlList(3);
     const log: string[] = [];
     vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
       const url = input instanceof Request ? input.url : input.toString();
       log.push(url);
-      return createTextResponse("Payments are not set up", { status: 402 });
+      return createTextResponse("Payments are not set up", {
+        status: 402,
+        headers: { "x-hexclave-request-id": "req-123" },
+      });
     }));
 
     const iface = createClientInterface({ apiUrls: urls });
@@ -593,103 +647,51 @@ describe("_withFallback", () => {
   });
 
   // ---------------------------------------------------------------------------
-  // Sticky mode — remembering the working fallback
+  // Current target — stay on the working host until it fails
   // ---------------------------------------------------------------------------
 
-  it("enters sticky mode: subsequent requests skip straight to the working fallback", async () => {
+  it("remembers the working URL: subsequent requests go straight there", async () => {
     const urls = urlList(4);
-    const iface = createClientInterface({ apiUrls: urls, probeRate: 0 });
+    const iface = createClientInterface({ apiUrls: urls });
 
-    // url-0,1,2 down → sticky on url-3
+    // url-0,1,2 down → current target becomes url-3
     mockFetch((u) => urlIndex(urls, u) === 3 ? "ok" : "fail");
     await sendRequest(iface);
 
-    // Next request goes directly to url-3 (probeRate=0 means no probe)
+    // Next request goes directly to url-3 (no primary probe)
     const log = mockFetch(() => "ok");
     await sendRequest(iface);
 
     expect(log.length).toBe(1);
     expect(urlIndex(urls, log[0])).toBe(3);
+    expect(iface.getCurrentTargetApiUrl()).toBe(`${urls[3]}/api/v1`);
   });
 
-  it("probes primary and exits sticky mode when probe succeeds", async () => {
+  it("walks the ring from the current target when it fails", async () => {
     const urls = urlList(3);
-    const iface = createClientInterface({ apiUrls: urls, probeRate: 1 });
+    const iface = createClientInterface({ apiUrls: urls });
 
-    // url-0 down → sticky on url-1
-    mockFetch((u) => urlIndex(urls, u) === 0 ? "fail" : "ok");
+    // Fail over to url-1
+    mockFetch((u) => urlIndex(urls, u) === 1 ? "ok" : "fail");
     await sendRequest(iface);
 
-    // url-0 recovers. probeRate=1 → always probes → probe succeeds → exits sticky
-    const log = mockFetch(() => "ok");
+    // url-1 and url-2 down, url-0 up → circular order is 1, 2, 0 (not restart-from-0)
+    const log = mockFetch((u) => urlIndex(urls, u) === 0 ? "ok" : "fail");
     await sendRequest(iface);
-    expect(urlIndex(urls, log[0])).toBe(0);
 
-    // Next request should go to url-0 directly (no longer sticky)
-    const log2 = mockFetch(() => "ok");
-    await sendRequest(iface);
-    expect(log2.length).toBe(1);
-    expect(urlIndex(urls, log2[0])).toBe(0);
+    expect(log.map(u => urlIndex(urls, u))).toEqual([1, 2, 0]);
+    expect(iface.getCurrentTargetApiUrl()).toBe(`${urls[0]}/api/v1`);
   });
 
-  it("halves probe rate on each failed probe", async () => {
-    const urls = urlList(2);
-    const iface = createClientInterface({ apiUrls: urls, probeRate: 1 });
-
-    // Enter sticky on url-1, url-0 stays permanently down
-    mockFetch((u) => urlIndex(urls, u) === 0 ? "fail" : "ok");
-    await sendRequest(iface);
-
-    // probeRate=1 → probes url-0, fails → rate becomes 0.5
-    mockFetch((u) => urlIndex(urls, u) === 0 ? "fail" : "ok");
-    await sendRequest(iface);
-
-    // probeRate=0.5 → probes (random < 0.5), fails → rate becomes 0.25
-    const randomMock = vi.spyOn(Math, "random").mockReturnValue(0.4);
-    mockFetch((u) => urlIndex(urls, u) === 0 ? "fail" : "ok");
-    await sendRequest(iface);
-
-    // rate=0.25, random=0.3 ≥ 0.25 → should NOT probe primary
-    randomMock.mockReturnValue(0.3);
-    const log = mockFetch(() => "ok");
-    await sendRequest(iface);
-
-    expect(log.length).toBe(1);
-    expect(urlIndex(urls, log[0])).toBe(1);
-
-    randomMock.mockRestore();
-  });
-
-  // ---------------------------------------------------------------------------
-  // Sticky URL goes down — falls through to full iteration
-  // ---------------------------------------------------------------------------
-
-  it("falls through to full iteration when sticky URL also goes down", async () => {
-    const urls = urlList(3);
-    const iface = createClientInterface({ apiUrls: urls, probeRate: 0 });
-
-    // url-0,1 down → sticky on url-2
-    mockFetch((u) => urlIndex(urls, u) === 2 ? "ok" : "fail");
-    await sendRequest(iface);
-
-    // Now url-2 also down, url-1 recovers
-    const log = mockFetch((u) => urlIndex(urls, u) === 1 ? "ok" : "fail");
-    await sendRequest(iface);
-
-    // Should have tried sticky url-2 (failed), then iterated 0→1 (found url-1)
-    expect(log.some(u => urlIndex(urls, u) === 2)).toBe(true);
-    expect(log.some(u => urlIndex(urls, u) === 1)).toBe(true);
-  });
-
-  it("re-enters sticky on the new working URL after fallthrough", async () => {
+  it("re-targets the new working URL after a ring walk", async () => {
     const urls = urlList(4);
-    const iface = createClientInterface({ apiUrls: urls, probeRate: 0 });
+    const iface = createClientInterface({ apiUrls: urls });
 
-    // sticky on url-3
+    // current target → url-3
     mockFetch((u) => urlIndex(urls, u) === 3 ? "ok" : "fail");
     await sendRequest(iface);
 
-    // url-3 dies, url-2 recovers → should re-sticky on url-2
+    // url-3 dies, url-2 recovers → ring from 3: 3, 0, 1, 2
     mockFetch((u) => urlIndex(urls, u) === 2 ? "ok" : "fail");
     await sendRequest(iface);
 
@@ -701,41 +703,132 @@ describe("_withFallback", () => {
     expect(urlIndex(urls, log[0])).toBe(2);
   });
 
-  it("throws when sticky URL fails and all URLs fail in iteration", async () => {
+  it("throws after 2 × N attempts starting from the current target", async () => {
     const urls = urlList(3);
-    const iface = createClientInterface({ apiUrls: urls, probeRate: 0 });
+    const iface = createClientInterface({ apiUrls: urls });
 
-    // sticky on url-1
+    // current target → url-1
     mockFetch((u) => urlIndex(urls, u) === 1 ? "ok" : "fail");
     await sendRequest(iface);
 
-    // Everything is now down
+    // Everything is now down — 2 laps × 3 URLs = 6 (not sticky+iterate = 7)
     const log = mockFetch(() => "fail");
     await expect(sendRequest(iface)).rejects.toThrow();
 
-    // sticky attempt (1) + 2 passes × 3 URLs (6) = 7
-    expect(log.length).toBe(7);
+    expect(log.length).toBe(6);
+    expect(log.map(u => urlIndex(urls, u))).toEqual([1, 2, 0, 1, 2, 0]);
+  });
+});
+
+/**
+ * Live QA against localhost:8102 + :8110.
+ *   LIVE_FALLBACK_QA=1 pnpm test run packages/shared/src/interface/client-interface.test.ts
+ *
+ * Start fallback backend first:
+ *   BACKEND_PORT=8110 STACK_BACKEND_DEV_DISABLE_WATCH=true pnpm -C apps/backend exec dotenv -c development -- tsx src/server/server.ts
+ */
+describe.runIf(process.env.LIVE_FALLBACK_QA === "1")("live circular fallback QA", () => {
+  const PRIMARY = "http://localhost:8102";
+  const FALLBACK = "http://localhost:8110";
+  const DEAD = "http://localhost:8098";
+  const DEAD2 = "http://localhost:8097";
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
-  it("does not probe primary when sticky URL fails (probe only before sticky attempt)", async () => {
-    const urls = urlList(3);
-    const iface = createClientInterface({ apiUrls: urls, probeRate: 1 });
+  async function health(url: string) {
+    try {
+      return (await fetch(`${url}/health`)).ok;
+    } catch {
+      return false;
+    }
+  }
 
-    // sticky on url-2, url-0 stays down
-    mockFetch((u) => urlIndex(urls, u) === 2 ? "ok" : "fail");
-    await sendRequest(iface);
+  function origins(log: string[]) {
+    return log.map((u) => new URL(u).origin);
+  }
 
-    // url-0 still down, url-2 also dies, url-1 is the only one up
-    // probeRate=1 → probes url-0 first (fails), then tries sticky url-2 (fails),
-    // then full iteration finds url-1
-    const log = mockFetch((u) => urlIndex(urls, u) === 1 ? "ok" : "fail");
-    await sendRequest(iface);
+  it("requires both backends up", async () => {
+    expect(await health(PRIMARY), "8102 should be up").toBe(true);
+    expect(await health(FALLBACK), "8110 should be up").toBe(true);
+  });
 
-    const hitOrder = log.map(u => urlIndex(urls, u));
-    // probe url-0, sticky url-2, then iteration: 0, 1 (succeeds)
-    expect(hitOrder[0]).toBe(0);  // probe
-    expect(hitOrder[1]).toBe(2);  // sticky attempt
-    expect(hitOrder).toContain(1);  // found during iteration
+  it("fails over from dead primary to live fallback and sticks", async () => {
+    const iface = createClientInterface({ apiUrls: [DEAD, FALLBACK] });
+    const hits: string[] = [];
+    const realFetch = globalThis.fetch.bind(globalThis);
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      hits.push(url);
+      return await realFetch(input, init);
+    });
+
+    const session = iface.createSession({ refreshToken: null, accessToken: null });
+    await iface.sendClientRequest("/users/me", { method: "GET" }, session).catch(() => null);
+    expect(origins(hits)[0]).toBe(DEAD);
+    expect(origins(hits)).toContain(FALLBACK);
+    expect(iface.getCurrentTargetApiUrl()).toContain("8110");
+
+    hits.length = 0;
+    await iface.sendClientRequest("/users/me", { method: "GET" }, session).catch(() => null);
+    expect(origins(hits)).toEqual([FALLBACK]);
+  });
+
+  it("when current fallback dies, rings back to primary", async () => {
+    const iface = createClientInterface({ apiUrls: [PRIMARY, FALLBACK] });
+    const realFetch = globalThis.fetch.bind(globalThis);
+    const hits: string[] = [];
+
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      hits.push(url);
+      if (url.includes("8102")) throw new TypeError("Failed to fetch (simulated primary outage)");
+      return await realFetch(input, init);
+    });
+    const session = iface.createSession({ refreshToken: null, accessToken: null });
+    await iface.sendClientRequest("/users/me", { method: "GET" }, session).catch(() => null);
+    expect(iface.getCurrentTargetApiUrl()).toContain("8110");
+
+    hits.length = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      hits.push(url);
+      if (url.includes("8110")) throw new TypeError("Failed to fetch (simulated fallback outage)");
+      return await realFetch(input, init);
+    });
+    await iface.sendClientRequest("/users/me", { method: "GET" }, session).catch(() => null);
+
+    expect(origins(hits)[0]).toBe(FALLBACK);
+    expect(origins(hits)).toContain(PRIMARY);
+    expect(iface.getCurrentTargetApiUrl()).toContain("8102");
+  });
+
+  it("both healthy → primary only", async () => {
+    const iface = createClientInterface({ apiUrls: [PRIMARY, FALLBACK] });
+    const hits: string[] = [];
+    const realFetch = globalThis.fetch.bind(globalThis);
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input instanceof Request ? input.url : String(input);
+      hits.push(url);
+      return await realFetch(input, init);
+    });
+    const session = iface.createSession({ refreshToken: null, accessToken: null });
+    await iface.sendClientRequest("/users/me", { method: "GET" }, session).catch(() => null);
+    expect(origins(hits)).toEqual([PRIMARY]);
+  });
+
+  it("all down → ApiUrlsFailedError after 2×n attempts", async () => {
+    const iface = createClientInterface({ apiUrls: [DEAD, DEAD2] });
+    const hits: string[] = [];
+    const realFetch = globalThis.fetch.bind(globalThis);
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      hits.push(String(input));
+      return await realFetch(input, init);
+    });
+    const session = iface.createSession({ refreshToken: null, accessToken: null });
+    await expect(iface.sendClientRequest("/users/me", { method: "GET" }, session)).rejects.toBeInstanceOf(ApiUrlsFailedError);
+    expect(hits).toHaveLength(4);
   });
 });
 

--- a/packages/shared/src/interface/client-interface.ts
+++ b/packages/shared/src/interface/client-interface.ts
@@ -222,6 +222,13 @@ export class HexclaveClientInterface {
   }
 
   /**
+   * @deprecated Use {@link getCurrentTargetApiUrl} instead.
+   */
+  getBestApiUrl(): string {
+    return this.getCurrentTargetApiUrl();
+  }
+
+  /**
    * Routes a request through an ordered URL ring with automatic failover.
    *
    * Starts at `_currentTargetApiUrl` (or primary if unset). On an outage-like

--- a/packages/shared/src/interface/client-interface.ts
+++ b/packages/shared/src/interface/client-interface.ts
@@ -81,12 +81,6 @@ export type ClientInterfaceOptions = {
    * A single-element array means no fallback occurs.
    */
   getApiUrls: () => string[],
-  /**
-   * When a fallback succeeds and becomes the active server, this is the initial probability
-   * (0–1) that any given request will probe the primary to check if it's back.
-   * Halves on each failed probe, resets on success. Default: 0.3 (30%).
-   */
-  probeRate?: number,
   extraRequestHeaders: Record<string, string>,
   projectId: string,
   prepareRequest?: () => Promise<void>,
@@ -187,15 +181,13 @@ export class HexclaveClientInterface {
   private _requestListeners = new Set<RequestListener>();
 
   /**
-   * Fallback state. When null, we're in normal mode (primary first).
-   * When set, we skip straight to `stickyIndex` and only probe primary occasionally.
+   * Last API URL that succeeded for this client. Requests start here and only
+   * move to the next URL in the ring when the current host looks like an outage.
+   * Null means we have never succeeded yet — start at the primary (index 0).
    */
-  private _sticky: { index: number, probeRate: number } | null = null;
-  private readonly _initialProbeRate: number;
+  private _currentTargetApiUrl: string | null = null;
 
-  constructor(public readonly options: ClientInterfaceOptions) {
-    this._initialProbeRate = options.probeRate ?? 0.3;
-  }
+  constructor(public readonly options: ClientInterfaceOptions) {}
 
   addRequestListener(listener: RequestListener): () => void {
     this._requestListeners.add(listener);
@@ -217,38 +209,27 @@ export class HexclaveClientInterface {
   }
 
   /**
-   * Returns the best-known-good API URL: the sticky fallback if we're in
-   * fallback mode, otherwise the primary. Use for browser-navigated URLs
-   * (e.g. OAuth authorize) where _withFallback can't help.
+   * Returns the current target API URL for browser-navigated URLs (e.g. OAuth
+   * authorize) where `_withFallback` can't iterate hosts. Falls back to the
+   * primary if the remembered URL is no longer in the list.
    */
-  getBestApiUrl(): string {
+  getCurrentTargetApiUrl(): string {
     const apiUrls = this.getApiUrls();
-    if (this._sticky && apiUrls[this._sticky.index]) {
-      return apiUrls[this._sticky.index];
+    if (this._currentTargetApiUrl != null && apiUrls.includes(this._currentTargetApiUrl)) {
+      return this._currentTargetApiUrl;
     }
     return apiUrls[0];
   }
 
   /**
-   * Routes a request through an ordered URL list with automatic failover.
+   * Routes a request through an ordered URL ring with automatic failover.
    *
-   * The URL list is [primary, ...fallbacks]. The logic has two modes:
+   * Starts at `_currentTargetApiUrl` (or primary if unset). On an outage-like
+   * failure, walks `(start + k) % n` for two full laps. On success, remembers
+   * that URL as the new current target. KnownErrors and smart-wrapped 4xx
+   * responses are never retried on another host (application-level errors).
    *
-   * **Normal mode** (`_sticky` is null) — try each URL in order. If a
-   * non-primary URL succeeds, enter sticky mode on that index.
-   *
-   * **Sticky mode** — a previous request already failed over. We remember
-   * which URL worked and go there directly. Occasionally (controlled by a
-   * decaying probe rate) we probe the primary to see if it recovered:
-   *   - Probe succeeds → exit sticky mode, use result.
-   *   - Probe fails → halve probe rate, use sticky URL.
-   *   - Sticky URL fails → exit sticky mode, do a full iteration.
-   *
-   * In both modes, a full iteration tries every URL once per pass for 2
-   * passes before giving up. KnownErrors and 4xx API responses (except 429)
-   * are never retried (they're application-level, not network-level).
-   *
-   * Single-URL lists skip all of this and use 5-retry behavior directly.
+   * Single-URL lists skip the ring and use 5-retry behavior directly.
    */
   protected async _withFallback<T>(cb: (apiUrl: string, retryOptions: { maxAttempts: number, skipDiagnostics: boolean }) => Promise<T>): Promise<T> {
     const apiUrls = this.getApiUrls();
@@ -258,24 +239,59 @@ export class HexclaveClientInterface {
       return await cb(apiUrls[0], { maxAttempts: 5, skipDiagnostics: false });
     }
 
-    // If we're in sticky mode, try the remembered URL (with an optional primary probe first).
-    if (this._sticky) {
-      const result = await this._tryStickyUrl(apiUrls, cb);
-      if (result !== undefined) return result;
-      // Sticky URL failed — _sticky was cleared, fall through to full iteration.
+    const start = Math.max(0, this._currentTargetApiUrl != null ? apiUrls.indexOf(this._currentTargetApiUrl) : 0);
+    const errorsByUrl = new Map<number, Error>();
+
+    for (let k = 0; k < apiUrls.length * 2; k++) {
+      const i = (start + k) % apiUrls.length;
+      try {
+        const result = await cb(apiUrls[i], { maxAttempts: 1, skipDiagnostics: true });
+        this._currentTargetApiUrl = apiUrls[i];
+        return result;
+      } catch (e) {
+        if (this._shouldSkipFallback(e)) {
+          // Host answered with an application-level error (KnownError / smart 4xx),
+          // so it's alive — stick here instead of hammering a dead earlier host next time.
+          this._currentTargetApiUrl = apiUrls[i];
+          throw e;
+        }
+        errorsByUrl.set(i, e instanceof Error ? e : new Error(String(e)));
+      }
     }
 
-    // Full iteration: try every URL in order, 2 passes.
-    return await this._iterateUrls(apiUrls, cb);
+    throw new ApiUrlsFailedError(apiUrls.map((url, i) => ({
+      url,
+      error: errorsByUrl.get(i) ?? throwErr(`Missing failure for API URL ${url}`),
+    })));
   }
 
+  /**
+   * Returns true when the error is an application-level response that should
+   * not hop to another host. Outages (network TypeError, 5xx, non-smart 4xx)
+   * return false so the ring walk continues.
+   */
   private _shouldSkipFallback(error: unknown) {
-    return error instanceof KnownError || this._isNonRetryableApiResponseError(error);
+    if (error instanceof KnownError) return true;
+
+    const response = this._getApiResponseFromError(error);
+    if (response == null) return false;
+
+    // 5xx -> hop (this host looks sick).
+    if (response.status >= 500) return false;
+
+    // Smart-wrapped 4xx -> our API answered; hopping won't help.
+    if (response.status >= 400 && response.status < 500) {
+      return this._isSmartWrappedResponse(response);
+    }
+
+    return false;
   }
 
-  private _isNonRetryableApiResponseError(error: unknown) {
-    const response = this._getApiResponseFromError(error);
-    return response != null && response.status >= 400 && response.status < 500;
+  private _isSmartWrappedResponse(response: Response) {
+    return response.headers.has("x-hexclave-request-id")
+      || response.headers.has("x-stack-request-id")
+      || response.headers.has("x-hexclave-known-error")
+      || response.headers.has("x-stack-known-error");
   }
 
   private _getApiResponseFromError(error: unknown, seenErrors = new Set<Error>()): Response | null {
@@ -288,69 +304,6 @@ export class HexclaveClientInterface {
 
     seenErrors.add(error);
     return this._getApiResponseFromError(error.cause, seenErrors);
-  }
-
-  /**
-   * Attempts the sticky URL, optionally probing primary first.
-   * Returns the result on success, or `undefined` if we should fall through to full iteration.
-   */
-  private async _tryStickyUrl<T>(
-    apiUrls: string[],
-    cb: (apiUrl: string, retryOptions: { maxAttempts: number, skipDiagnostics: boolean }) => Promise<T>,
-  ): Promise<T | undefined> {
-    const sticky = this._sticky!;
-
-    // Probabilistically probe primary to check if it's back.
-    if (Math.random() < sticky.probeRate) {
-      try {
-        const result = await cb(apiUrls[0], { maxAttempts: 1, skipDiagnostics: true });
-        this._sticky = null;
-        return result;
-      } catch (e) {
-        if (this._shouldSkipFallback(e)) throw e;
-        sticky.probeRate = Math.max(sticky.probeRate * 0.5, 0.01);
-      }
-    }
-
-    // Try the sticky URL itself.
-    try {
-      return await cb(apiUrls[sticky.index], { maxAttempts: 1, skipDiagnostics: true });
-    } catch (e) {
-      if (this._shouldSkipFallback(e)) throw e;
-      this._sticky = null;
-      return undefined;
-    }
-  }
-
-  /**
-   * Tries every URL in order for up to 2 passes.
-   * If a non-primary URL (index > 0) succeeds, enters sticky mode on it.
-   */
-  private async _iterateUrls<T>(
-    apiUrls: string[],
-    cb: (apiUrl: string, retryOptions: { maxAttempts: number, skipDiagnostics: boolean }) => Promise<T>,
-  ): Promise<T> {
-    const errorsByUrl = new Map<number, Error>();
-
-    for (let pass = 0; pass < 2; pass++) {
-      for (let i = 0; i < apiUrls.length; i++) {
-        try {
-          const result = await cb(apiUrls[i], { maxAttempts: 1, skipDiagnostics: true });
-          if (i > 0) {
-            this._sticky = { index: i, probeRate: this._initialProbeRate };
-          }
-          return result;
-        } catch (e) {
-          if (this._shouldSkipFallback(e)) throw e;
-          errorsByUrl.set(i, e instanceof Error ? e : new Error(String(e)));
-        }
-      }
-    }
-
-    throw new ApiUrlsFailedError(apiUrls.map((url, i) => ({
-      url,
-      error: errorsByUrl.get(i) ?? throwErr(`Missing failure for API URL ${url}`),
-    })));
   }
 
   getAnalyticsApiUrl() {
@@ -1453,7 +1406,7 @@ export class HexclaveClientInterface {
       throw new Error("Admin session token is currently not supported for OAuth");
     }
     const clientSecret = this.options.publishableClientKey ?? publishableClientKeyNotNecessarySentinel;
-    const url = new URL(this.getBestApiUrl() + "/auth/oauth/authorize/" + options.provider.toLowerCase());
+    const url = new URL(this.getCurrentTargetApiUrl() + "/auth/oauth/authorize/" + options.provider.toLowerCase());
     url.searchParams.set("client_id", this.projectId);
     url.searchParams.set("client_secret", clientSecret);
     url.searchParams.set("redirect_uri", updatedRedirectUrl.toString());


### PR DESCRIPTION
### Summary of Changes
We got rid of the 30% chance to go back to primary. You stay on the api you last had a successful request with until it fails, and then you walk the list of urls in a circular manner.
There used to be a bug where if you were trying to switch back to primary and you got a smart request wrapped 400, it would treat it as a failure even though that could be a valid request. That has now been fixed.
We now fallback on 500s, non smart request wrapped 400s, and type error- failed to fetch cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors SDK API URL failover to a deterministic ring and exposes smart-error headers to browsers. Old: sticky fallback with a 30% primary probe and ambiguous 4xx; new: start from the last successful host, walk (start + k) % n on outage-like failures, and do not hop on smart-wrapped 4xx/KnownError.

- Simplifies `_withFallback`: removes sticky/probe logic; throws after 2 × n attempts from the current target.
- Outage triggers: 5xx (even with request-id), non-smart 4xx (no request-id), and network TypeError.
- No-hop responses: KnownError and smart-wrapped 4xx (has `x-hexclave-request-id`/`x-stack-request-id` or known-error headers).
- Adds `getCurrentTargetApiUrl()` and switches OAuth authorize to use it; keeps `getBestApiUrl()` as a deprecated alias.
- Adds `x-stack-request-id` to CORS exposed headers so browser SDKs can detect smart-wrapped 4xx.

Migration
- Remove `probeRate` from `HexclaveClientInterface` options.
- Replace `getBestApiUrl()` usage with `getCurrentTargetApiUrl()` where possible.
- If code relied on automatic primary probing, the client now stays on the last successful host until that host fails.

<sup>Written for commit dcab15e69e845b4974f5318df0c33b99813e2edb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved API failover by remembering the most recently successful endpoint and continuing from it during future requests.
  - Added more reliable recovery and circular traversal across available endpoints after service outages.
  - Browser navigation and OAuth authorization links now follow the currently active endpoint.
  - Browser applications can now access request IDs from API responses for easier troubleshooting.

- **Bug Fixes**
  - Application-level errors remain associated with the responding endpoint instead of triggering unnecessary failover.
  - Improved handling of non-success responses and request failures while preserving clear errors when only one endpoint is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->