### PR TITLE
Dashboard: attach widgets, actions, and errors to the AI chat as context chips

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/dashboards/[dashboardId]/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/dashboards/[dashboardId]/page-client.tsx
@@ -14,23 +14,26 @@ import {
   DashboardToolUI,
   type AssistantComposerApi,
 } from "@/components/vibe-coding";
-import { ToolCallContent } from "@/components/vibe-coding/chat-adapters";
+import { ToolCallContent, type DashboardChip } from "@/components/vibe-coding/chat-adapters";
+import type { AppId } from "@/lib/apps-frontend";
 import { useUpdateConfig } from "@/components/config-update";
 import { useDashboardUser } from "@/lib/dashboard-user";
+import { getPublicEnvVar } from "@/lib/env";
 import { cn } from "@/lib/utils";
 import {
   ChatCircleIcon,
+  CursorClickIcon,
   FloppyDiskIcon,
   PencilSimpleIcon,
   TrashIcon,
+  WarningIcon,
   XIcon,
 } from "@phosphor-icons/react";
 import { ALL_APPS } from "@hexclave/shared/dist/apps/apps-config";
 import { typedEntries } from "@hexclave/shared/dist/utils/objects";
 import { throwErr } from "@hexclave/shared/dist/utils/errors";
-import type { AppId } from "@/lib/apps-frontend";
 import { runAsynchronouslyWithAlert } from "@hexclave/shared/dist/utils/promises";
-import { getPublicEnvVar } from "@/lib/env";
+import { generateUuid } from "@hexclave/shared/dist/utils/uuids";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { PageLayout } from "../../page-layout";
@@ -145,8 +148,9 @@ function DashboardDetailContent({
 
   // Coalesce duplicate error reports — React re-renders a crashed component several times,
   // and uncaught-error listeners can fire twice for the same exception. We only surface the
-  // first unique error per 2-second window so the composer isn't stomped on repeatedly.
+  // first unique error per 2-second window so the chip bar isn't spammed.
   const lastErrorRef = useRef<{ signature: string, at: number } | null>(null);
+
   const handleDashboardRuntimeError = useCallback(
     (err: DashboardRuntimeError) => {
       const signature = `${err.message}::${(err.stack ?? "").slice(0, 200)}`;
@@ -156,54 +160,83 @@ function DashboardDetailContent({
       }
       lastErrorRef.current = { signature, at: now };
 
-      // Build a compact fix-request prompt. We keep the stack to ~1200 chars so the
-      // agent gets enough context to localize the bug without drowning in frame noise.
-      const stackSlice = (err.stack ?? "").trim().slice(0, 1200);
-      const componentStackSlice = (err.componentStack ?? "").trim().slice(0, 400);
-      const prefill = [
-        "The dashboard just crashed at runtime. Please diagnose and fix it.",
-        "",
-        "Error:",
-        err.message,
-        stackSlice ? `\nStack:\n${stackSlice}` : "",
-        componentStackSlice ? `\nComponent stack:${componentStackSlice}` : "",
-      ]
-        .filter(Boolean)
-        .join("\n");
-
-      // Open the chat panel if it's closed so the user sees the pre-filled composer.
-      // The iframe panel doesn't unmount when chat toggles, so no reload cost.
       setIsChatOpen(true);
-      composerApiRef.current?.setText(prefill);
+
+      const errorChip: DashboardChip = {
+        kind: "error",
+        id: generateUuid(),
+        message: err.message,
+        stack: err.stack,
+        componentStack: err.componentStack,
+      };
+      setPendingChips((prev) => [...prev, errorChip]);
+
+      const api = composerApiRef.current;
+      if (api && api.getText().trim().length === 0) {
+        api.setText("could you please fix this error");
+      }
 
       toast({
         variant: "destructive",
         title: "Dashboard crashed",
-        description: "Error added to chat — hit send to fix it.",
+        description: "Error added as a chip — hit send to fix it.",
       });
     },
     [toast],
   );
 
+  const [pendingChips, setPendingChips] = useState<DashboardChip[]>([]);
+  const pendingChipsRef = useRef<DashboardChip[]>([]);
+  useEffect(() => {
+    pendingChipsRef.current = pendingChips;
+  }, [pendingChips]);
+
+  const getPendingChips = useCallback(() => pendingChipsRef.current, []);
+  const consumePendingChips = useCallback(() => {
+    pendingChipsRef.current = [];
+    setPendingChips([]);
+  }, []);
+  const removePendingChip = useCallback((id: string) => {
+    setPendingChips((prev) => {
+      const next = prev.filter((c) => c.id !== id);
+      pendingChipsRef.current = next;
+      return next;
+    });
+  }, []);
+
   const handleWidgetSelected = useCallback(
     (selection: WidgetSelection) => {
-      const api = composerApiRef.current;
-      if (!api) return;
-
       setIsChatOpen(true);
+      const { heading, selectorPath, outerHTMLSnippet } = selection.metadata;
+      const name = (heading && heading.trim().length > 0 && heading.trim().length <= 60)
+        ? heading.trim()
+        : "Widget";
 
-      const { heading, tagName, rect, textPreview } = selection.metadata;
-      const name = heading ?? `${tagName} (${rect.width}×${rect.height})`;
-      const domContext = [
-        `[Widget: ${name}]`,
-        textPreview ? `Content: ${textPreview.slice(0, 200)}` : "",
-      ].filter(Boolean).join("\n");
+      setPendingChips((prev) => [
+        ...prev,
+        { kind: "widget", id: generateUuid(), name, selectorPath, outerHTMLSnippet },
+      ]);
 
-      const currentText = api.getText();
-      api.setText(domContext + "\n" + currentText);
+      const api = composerApiRef.current;
+      if (api && api.getText().trim().length === 0) {
+        api.setText("please update this widget");
+      }
     },
     [],
   );
+
+  const handleAddComponent = useCallback(() => {
+    setIsChatOpen(true);
+    setPendingChips((prev) => {
+      if (prev.some((c) => c.kind === "action-add-component")) return prev;
+      return [...prev, { kind: "action-add-component", id: generateUuid() }];
+    });
+
+    const api = composerApiRef.current;
+    if (api && api.getText().trim().length === 0) {
+      api.setText("please add a component");
+    }
+  }, []);
 
   useEffect(() => {
     if (!hasUnsavedChanges) return;
@@ -368,6 +401,7 @@ function DashboardDetailContent({
             onReady={handleIframeReady}
             onRuntimeError={handleDashboardRuntimeError}
             onWidgetSelected={handleWidgetSelected}
+            onAddComponentClicked={handleAddComponent}
             isChatOpen={isChatOpen}
           />
         </div>
@@ -450,7 +484,12 @@ function DashboardDetailContent({
               />
               <div className="flex-1 min-h-0">
                 <AssistantChat
-                  chatAdapter={createDashboardChatAdapter(backendBaseUrl, currentTsxSource, handleCodeUpdate, currentUser, enabledAppIds, projectId, handleRunStart, handleRunEnd)}
+                  chatAdapter={createDashboardChatAdapter(backendBaseUrl, currentTsxSource, handleCodeUpdate, currentUser, enabledAppIds, projectId, handleRunStart, handleRunEnd, getPendingChips, consumePendingChips)}
+                  composerTopContent={
+                    pendingChips.length > 0
+                      ? <ChipBar chips={pendingChips} onRemove={removePendingChip} />
+                      : undefined
+                  }
                   historyAdapter={createHistoryAdapter(adminApp, dashboardId)}
                   toolComponents={<DashboardToolUI setCurrentCode={(code) => setCurrentTsxSource(stampEsmVersion(code, packageJson.version))} currentCode={currentTsxSource} />}
                   useOffWhiteLightMode
@@ -495,6 +534,64 @@ const DASHBOARD_COMPOSER_PLACEHOLDER = {
     "revenue and subscription growth",
   ],
 } as const;
+
+function ChipBar({
+  chips,
+  onRemove,
+}: {
+  chips: DashboardChip[],
+  onRemove: (id: string) => void,
+}) {
+  return (
+    <div className="shrink-0 px-3 pt-2.5 pb-1 flex items-center gap-1.5 flex-wrap">
+      {chips.map((c) => {
+        if (c.kind === "widget") {
+          return (
+            <button
+              key={c.id}
+              type="button"
+              onClick={() => onRemove(c.id)}
+              title={`${c.name} — click to remove. Sent with your next message.`}
+              className="group inline-flex items-center gap-1.5 max-w-[200px] pl-1.5 pr-1 py-0.5 rounded-full bg-primary/[0.08] hover:bg-primary/[0.14] ring-1 ring-primary/15 hover:ring-primary/25 text-primary text-xs transition-colors"
+            >
+              <CursorClickIcon className="h-3 w-3 shrink-0" weight="fill" />
+              <span className="truncate font-medium">{c.name}</span>
+              <XIcon className="h-2.5 w-2.5 shrink-0 opacity-50 group-hover:opacity-100 transition-opacity" weight="bold" />
+            </button>
+          );
+        }
+        if (c.kind === "action-add-component") {
+          return (
+            <button
+              key={c.id}
+              type="button"
+              onClick={() => onRemove(c.id)}
+              title="Add a new component — click to remove."
+              className="group inline-flex items-center gap-1.5 max-w-[200px] pl-2 pr-1 py-0.5 rounded-full bg-emerald-500/10 hover:bg-emerald-500/15 ring-1 ring-emerald-500/20 hover:ring-emerald-500/30 text-emerald-700 dark:text-emerald-400 text-xs transition-colors"
+            >
+              <span className="truncate font-medium">Add component</span>
+              <XIcon className="h-2.5 w-2.5 shrink-0 opacity-50 group-hover:opacity-100 transition-opacity" weight="bold" />
+            </button>
+          );
+        }
+        // error
+        return (
+          <button
+            key={c.id}
+            type="button"
+            onClick={() => onRemove(c.id)}
+            title={`${c.message} — click to remove. Sent with your next message.`}
+            className="group inline-flex items-center gap-1.5 max-w-[200px] pl-1.5 pr-1 py-0.5 rounded-full bg-red-500/10 hover:bg-red-500/15 ring-1 ring-red-500/20 hover:ring-red-500/30 text-red-700 dark:text-red-400 text-xs transition-colors"
+          >
+            <WarningIcon className="h-3 w-3 shrink-0" weight="fill" />
+            <span className="truncate font-medium">Error</span>
+            <XIcon className="h-2.5 w-2.5 shrink-0 opacity-50 group-hover:opacity-100 transition-opacity" weight="bold" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
 
 function ChatPanelHeader({
   displayName,

--- a/apps/dashboard/src/components/assistant-ui/thread.tsx
+++ b/apps/dashboard/src/components/assistant-ui/thread.tsx
@@ -65,6 +65,7 @@ export const Thread: FC<{
   runningStatusMessages?: string[],
   composerAttachments?: boolean,
   attachmentAdapter?: AttachmentAdapter,
+  composerTopContent?: React.ReactNode,
   /** Custom welcome / empty-state node. Defaults to the email-template welcome. */
   welcome?: ReactNode,
   /** Overrides for the assistant message content slots (Text / tools / etc.). */
@@ -77,7 +78,7 @@ export const Thread: FC<{
    * general-purpose dashboard AI chats (command center, companion widget).
    */
   agentEjectFooter?: boolean,
-}> = ({ useOffWhiteLightMode = false, composerPlaceholder, hideMessageActions = false, runningStatusMessages, composerAttachments = false, attachmentAdapter, welcome, assistantContentComponents, autoFocusComposer = true, agentEjectFooter = false }) => {
+}> = ({ useOffWhiteLightMode = false, composerPlaceholder, hideMessageActions = false, runningStatusMessages, composerAttachments = false, attachmentAdapter, composerTopContent, welcome, assistantContentComponents, autoFocusComposer = true, agentEjectFooter = false }) => {
   return (
     <HideMessageActionsContext.Provider value={hideMessageActions}>
       <HasRunningStatusContext.Provider value={!!runningStatusMessages}>
@@ -119,7 +120,7 @@ export const Thread: FC<{
 
                   <div className="sticky bottom-0 mt-2 flex w-full max-w-[var(--thread-max-width)] flex-col items-center justify-end pt-6 pb-3">
                     <ThreadScrollToBottom />
-                    <Composer placeholder={composerPlaceholder} autoFocus={autoFocusComposer} />
+                    <Composer placeholder={composerPlaceholder} topContent={composerTopContent} autoFocus={autoFocusComposer} useOffWhiteLightMode={useOffWhiteLightMode} />
                     {agentEjectFooter && <AgentEjectFooter />}
                   </div>
                 </ThreadPrimitive.Viewport>
@@ -529,11 +530,15 @@ const ComposerStaticInput: FC<{ placeholder?: string, autoFocus?: boolean }> = (
   );
 };
 
-const Composer: FC<{ placeholder?: ComposerPlaceholder, autoFocus?: boolean }> = ({ placeholder, autoFocus = true }) => {
+const Composer: FC<{ placeholder?: ComposerPlaceholder, topContent?: React.ReactNode, autoFocus?: boolean, useOffWhiteLightMode?: boolean }> = ({ placeholder, topContent, autoFocus = true, useOffWhiteLightMode = false }) => {
   const attachmentsEnabled = useComposerAttachmentsEnabled();
   return (
-    <ComposerPrimitive.Root className="group/composer relative flex w-full flex-col rounded-2xl border border-black/[0.08] dark:border-foreground/[0.08] bg-white/95 dark:bg-background/80 shadow-sm ring-1 ring-black/[0.06] dark:ring-white/[0.06] transition-all duration-150 hover:transition-none focus-within:ring-2 focus-within:ring-blue-500/20 focus-within:border-blue-500/30">
+    <ComposerPrimitive.Root className={cn(
+      "group/composer relative flex w-full flex-col rounded-2xl border border-border/20 dark:border-foreground/[0.08] shadow-sm ring-1 ring-foreground/[0.04] transition-all duration-150 hover:transition-none focus-within:ring-2 focus-within:ring-blue-500/20 focus-within:border-blue-500/30",
+      useOffWhiteLightMode ? "bg-card backdrop-blur-xl dark:bg-background/80" : "bg-background/95 dark:bg-background/80",
+    )}>
       {attachmentsEnabled && <ComposerAttachmentsRow />}
+      {topContent}
       {typeof placeholder === "object" ? (
         <ComposerAnimatedInput
           prefix={placeholder.prefix}

--- a/apps/dashboard/src/components/commands/ask-ai.tsx
+++ b/apps/dashboard/src/components/commands/ask-ai.tsx
@@ -82,6 +82,7 @@ const AIChatPreviewInner = memo(function AIChatPreview({
           </div>
         )}
         <Thread
+          useOffWhiteLightMode
           composerPlaceholder="Ask a follow-up question..."
           runningStatusMessages={RUNNING_STATUS_MESSAGES}
           assistantContentComponents={assistantContentComponents}

--- a/apps/dashboard/src/components/commands/create-dashboard/dashboard-sandbox-host.tsx
+++ b/apps/dashboard/src/components/commands/create-dashboard/dashboard-sandbox-host.tsx
@@ -281,17 +281,33 @@ function getSandboxDocument(artifact: DashboardArtifact, baseUrl: string, dashbo
         --ring: 240 4.9% 83.9%;
       }
       :root, .dark { --page-background: transparent; }
-      html, body {
+      html {
+        width: 100%;
+        height: 100%;
+        overflow-x: hidden;
+      }
+      body {
         margin: 0;
         padding: 0;
         width: 100%;
-        height: 100%;
+        min-height: 100%;
         overflow-x: hidden;
         font-family: Inter, system-ui, -apple-system, Segoe UI, sans-serif;
         background: var(--page-background);
         color: hsl(var(--foreground));
+        /* Flex column so #root fills remaining height when content is short, and
+           the add-component button (last body child) sits naturally at the bottom
+           of the scrollable region when content is tall. Without flex, #root's
+           height:100% would push the button below the viewport unreachable. */
+        display: flex;
+        flex-direction: column;
       }
-      #root { width: 100%; height: 100%; overflow-x: hidden; }
+      #root {
+        width: 100%;
+        overflow-x: hidden;
+        flex: 1 0 auto;
+        min-height: 0;
+      }
       * { box-sizing: border-box; }
       .dark { color-scheme: dark; }
       html, body, #root { scrollbar-width: none; }
@@ -329,6 +345,39 @@ function getSandboxDocument(artifact: DashboardArtifact, baseUrl: string, dashbo
       }
       .widget-overlay-btn:hover { transform: scale(1.08); }
       .widget-overlay.active .widget-overlay-btn { opacity: 1; }
+
+      /* "Add a component" affordance — sits at the bottom of the dashboard content,
+         inside the iframe so it scrolls naturally with the page (NOT sticky). Dashed
+         border matches the widget overlay so it reads as part of the same editor
+         language. Visible only in edit mode (chat open) — toggled via
+         window.__chatOpen. */
+      .add-component-btn {
+        display: none;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        flex-shrink: 0;
+        width: calc(100% - 48px);
+        max-width: calc(80rem - 48px);
+        margin: 16px auto 12px;
+        padding: 14px 16px;
+        background: transparent;
+        border: 2px dashed hsl(var(--primary) / 0.35);
+        border-radius: 12px;
+        color: hsl(var(--muted-foreground));
+        font-family: Inter, system-ui, -apple-system, Segoe UI, sans-serif;
+        font-size: 13px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease;
+      }
+      .add-component-btn.visible { display: flex; }
+      .add-component-btn:hover {
+        border-color: hsl(var(--primary) / 0.6);
+        color: hsl(var(--primary));
+        background: hsl(var(--primary) / 0.04);
+      }
+      .add-component-btn .plus-icon { width: 16px; height: 16px; }
     </style>
   </head>
   <body>
@@ -380,6 +429,13 @@ function getSandboxDocument(artifact: DashboardArtifact, baseUrl: string, dashbo
       // Controls visibility flag — only true in the full dashboard viewer (not cmd+K preview)
       window.__showControls = ${showControls};
       window.__chatOpen = ${initialChatOpen};
+      // Inline <script> tags earlier in <body> (widget overlay, add-component button) run
+      // synchronously as the parser hits them — BEFORE this text/babel block runs on
+      // DOMContentLoaded. Those scripts install listeners for 'chat-state-change' and
+      // call their syncVisibility() once at install time, where window.__chatOpen is
+      // still undefined. Re-dispatch the event now so they pick up the real flag and
+      // show/hide themselves correctly on first mount.
+      window.dispatchEvent(new Event('chat-state-change'));
 
       // Theme syncing and chat state from parent window
       window.addEventListener('message', (event) => {
@@ -498,7 +554,7 @@ function getSandboxDocument(artifact: DashboardArtifact, baseUrl: string, dashbo
         render() {
           if (this.state.hasError) {
             return (
-              <div className="p-6 text-red-500">
+              <div className="p-6 text-red-500" data-stack-no-widget="true">
                 <h2 className="text-xl font-bold mb-2">Dashboard Error</h2>
                 <pre className="text-sm bg-red-950/20 p-4 rounded overflow-auto">
                   {this.state.error?.message || 'Unknown error'}
@@ -577,18 +633,19 @@ function getSandboxDocument(artifact: DashboardArtifact, baseUrl: string, dashbo
         const Dashboard = new Function('React', 'ReactDOM', 'DashboardUI', 'Recharts', 'hexclaveServerApp', compiledSource + '\\nreturn Dashboard;')(
           React, ReactDOM, DashboardUI, Recharts, window.hexclaveServerApp,
         );
-        
+
+
         if (typeof Dashboard !== 'function') {
           throw new Error('Dashboard component not found in generated code');
         }
-        
+
         const root = ReactDOM.createRoot(rootElement);
         root.render(
           <ErrorBoundary>
             <Dashboard />
           </ErrorBoundary>
         );
-        
+
         parent.postMessage({ type: "stack-ai-dashboard-ready" }, "*");
       }).catch(error => {
         const message = error instanceof Error ? error.message : "Failed to initialize dashboard";
@@ -600,7 +657,7 @@ function getSandboxDocument(artifact: DashboardArtifact, baseUrl: string, dashbo
         
         const root = ReactDOM.createRoot(rootElement);
         root.render(
-          <div className="p-6 text-red-500">
+          <div className="p-6 text-red-500" data-stack-no-widget="true">
             <h2 className="text-xl font-bold mb-2">Failed to load dashboard</h2>
             <pre className="text-sm bg-red-950/20 p-4 rounded">
               {message}
@@ -635,10 +692,19 @@ function getSandboxDocument(artifact: DashboardArtifact, baseUrl: string, dashbo
       function findWidget(el) {
         var current = el;
         var root = document.getElementById('root');
+        // Error screens (ErrorBoundary fallback, init-failure UI) are marked with
+        // data-stack-no-widget so the user can't "chip" an error widget — that would
+        // just round-trip the rendered error text back to the AI, which is useless.
+        if (el && typeof el.closest === 'function' && el.closest('[data-stack-no-widget]')) {
+          return null;
+        }
         while (current && current !== root && current !== document.body) {
           if (current === overlay || overlay.contains(current)) {
             current = current.parentElement;
             continue;
+          }
+          if (current.hasAttribute && current.hasAttribute('data-stack-no-widget')) {
+            return null;
           }
           var rect = current.getBoundingClientRect();
           if (rect.width < 80 || rect.height < 50) { current = current.parentElement; continue; }
@@ -678,7 +744,10 @@ function getSandboxDocument(artifact: DashboardArtifact, baseUrl: string, dashbo
         currentWidget = null;
       }
 
+      var lastCursor = null;
+
       document.addEventListener('mousemove', function (e) {
+        lastCursor = { x: e.clientX, y: e.clientY };
         if (!window.__chatOpen) return;
         if (overlay.contains(e.target)) return;
         var widget = findWidget(e.target);
@@ -686,8 +755,62 @@ function getSandboxDocument(artifact: DashboardArtifact, baseUrl: string, dashbo
         else if (!widget) hideOverlay();
       });
 
+      /* Scroll doesn't fire mousemove, so without this the overlay stays pinned at
+         the old viewport coordinates while the widget underneath scrolls away. Use
+         elementFromPoint at the cursor's last known position to figure out what's
+         actually under the cursor now and re-target or hide accordingly. Captured
+         on scroll with passive:true so it doesn't slow scrolling. */
+      function reevaluateFromScroll() {
+        if (!window.__chatOpen) { hideOverlay(); return; }
+        if (!lastCursor) { hideOverlay(); return; }
+        var el = document.elementFromPoint(lastCursor.x, lastCursor.y);
+        if (!el || overlay.contains(el)) return;
+        var widget = findWidget(el);
+        if (widget) showOverlay(widget);
+        else hideOverlay();
+      }
+      window.addEventListener('scroll', reevaluateFromScroll, { passive: true, capture: true });
+
       document.addEventListener('mouseleave', function () { hideOverlay(); });
       window.addEventListener('chat-state-change', function () { if (!window.__chatOpen) hideOverlay(); });
+
+      /* Build a CSS-ish selector path from #root down to the widget, capped at 10
+         segments so it stays AI-digestible. Each segment is the tag plus the first
+         className token (if any), plus a nth-of-type suffix only when the parent has
+         sibling tags of the same name. The path lets the AI ground the patch on a
+         real chunk of structure rather than inferring from heading text alone. */
+      function buildSelectorPath(el) {
+        var rootEl = document.getElementById('root');
+        var segments = [];
+        var node = el;
+        while (node && node !== rootEl && node !== document.body && segments.length < 10) {
+          var tag = node.tagName.toLowerCase();
+          var classToken = '';
+          if (typeof node.className === 'string') {
+            var firstClass = node.className.trim().split(/\s+/)[0];
+            if (firstClass && !/^widget-overlay/.test(firstClass)) {
+              classToken = '.' + firstClass;
+            }
+          }
+          var nthSelector = '';
+          var parent = node.parentElement;
+          if (parent) {
+            var sameTagSiblings = [];
+            for (var i = 0; i < parent.children.length; i++) {
+              if (parent.children[i].tagName === node.tagName) {
+                sameTagSiblings.push(parent.children[i]);
+              }
+            }
+            if (sameTagSiblings.length > 1) {
+              var idx = sameTagSiblings.indexOf(node) + 1;
+              nthSelector = ':nth-of-type(' + idx + ')';
+            }
+          }
+          segments.unshift(tag + classToken + nthSelector);
+          node = node.parentElement;
+        }
+        return segments.join(' > ');
+      }
 
       /* ── Send DOM metadata to parent ── */
       btn.addEventListener('click', function (e) {
@@ -695,19 +818,46 @@ function getSandboxDocument(artifact: DashboardArtifact, baseUrl: string, dashbo
         e.preventDefault();
         if (!currentWidget) return;
 
-        var heading = currentWidget.querySelector('h1,h2,h3,h4,h5,h6');
+        var heading = currentWidget.querySelector('h1,h2,h3,h4,h5,h6')
+          || currentWidget.querySelector('span.font-semibold');
         var widgetRect = currentWidget.getBoundingClientRect();
+        var outerHTML = '';
+        try { outerHTML = (currentWidget.outerHTML || '').slice(0, 300); } catch (_) {}
         var metadata = {
           heading: heading ? heading.textContent.trim() : null,
           tagName: currentWidget.tagName.toLowerCase(),
           classes: (typeof currentWidget.className === 'string' ? currentWidget.className : '').slice(0, 300),
           textPreview: (currentWidget.textContent || '').trim().slice(0, 500),
           rect: { width: Math.round(widgetRect.width), height: Math.round(widgetRect.height) },
+          selectorPath: buildSelectorPath(currentWidget),
+          outerHTMLSnippet: outerHTML,
         };
 
         window.parent.postMessage({ type: 'dashboard-widget-selected', metadata: metadata }, '*');
         hideOverlay();
       });
+    })();
+    </script>
+
+    <!-- "Add a component" button — appended as a sibling of #root so it sits at the
+         bottom of the dashboard content and scrolls into view (NOT sticky/fixed).
+         Visibility tracks window.__chatOpen so it only appears in edit mode. -->
+    <script>
+    (function () {
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'add-component-btn';
+      btn.innerHTML = '<svg class="plus-icon" viewBox="0 0 256 256" fill="currentColor"><path d="M224,128a8,8,0,0,1-8,8H136v80a8,8,0,0,1-16,0V136H40a8,8,0,0,1,0-16h80V40a8,8,0,0,1,16,0v80h80A8,8,0,0,1,224,128Z"/></svg><span>Add a component</span>';
+      function syncVisibility() {
+        if (window.__chatOpen) btn.classList.add('visible');
+        else btn.classList.remove('visible');
+      }
+      btn.addEventListener('click', function () {
+        window.parent.postMessage({ type: 'dashboard-add-component-clicked' }, '*');
+      });
+      document.body.appendChild(btn);
+      syncVisibility();
+      window.addEventListener('chat-state-change', syncVisibility);
     })();
     </script>
   </body>
@@ -737,6 +887,12 @@ export type WidgetSelection = {
     classes: string,
     textPreview: string,
     rect: { width: number, height: number },
+    /** CSS-style selector chain from #root down to the clicked widget. Capped at 10
+        segments. Lets the AI ground a patch on a real chunk of structure. */
+    selectorPath: string,
+    /** First ~300 chars of the widget's outerHTML — verbatim rendered markup the AI
+        can match against when locating the JSX node in source. */
+    outerHTMLSnippet: string,
   },
 };
 
@@ -748,6 +904,7 @@ export const DashboardSandboxHost = memo(function DashboardSandboxHost({
   onReady,
   onRuntimeError,
   onWidgetSelected,
+  onAddComponentClicked,
   isChatOpen,
 }: {
   artifact: DashboardArtifact,
@@ -760,6 +917,9 @@ export const DashboardSandboxHost = memo(function DashboardSandboxHost({
   onRuntimeError?: (err: DashboardRuntimeError) => void,
   /** Fires when the user clicks "Add to chat" on a widget overlay in the iframe. */
   onWidgetSelected?: (selection: WidgetSelection) => void,
+  /** Fires when the user clicks the in-iframe "Add a component" button at the bottom
+      of the dashboard. Parent pushes an action chip into the composer chip bar. */
+  onAddComponentClicked?: () => void,
   isChatOpen?: boolean,
 }) {
   const iframeRef = useRef<HTMLIFrameElement>(null);
@@ -775,6 +935,8 @@ export const DashboardSandboxHost = memo(function DashboardSandboxHost({
   onRuntimeErrorRef.current = onRuntimeError;
   const onWidgetSelectedRef = useRef(onWidgetSelected);
   onWidgetSelectedRef.current = onWidgetSelected;
+  const onAddComponentClickedRef = useRef(onAddComponentClicked);
+  onAddComponentClickedRef.current = onAddComponentClicked;
   const user = useDashboardUser();
   const { resolvedTheme } = useTheme();
 
@@ -907,8 +1069,15 @@ export const DashboardSandboxHost = memo(function DashboardSandboxHost({
               width: typeof event.data.metadata?.rect?.width === "number" ? event.data.metadata.rect.width : 0,
               height: typeof event.data.metadata?.rect?.height === "number" ? event.data.metadata.rect.height : 0,
             },
+            selectorPath: typeof event.data.metadata?.selectorPath === "string" ? event.data.metadata.selectorPath : "",
+            outerHTMLSnippet: typeof event.data.metadata?.outerHTMLSnippet === "string" ? event.data.metadata.outerHTMLSnippet : "",
           },
         });
+        return;
+      }
+
+      if (type === "dashboard-add-component-clicked") {
+        onAddComponentClickedRef.current?.();
         return;
       }
 

--- a/apps/dashboard/src/components/vibe-coding/assistant-chat.tsx
+++ b/apps/dashboard/src/components/vibe-coding/assistant-chat.tsx
@@ -32,6 +32,8 @@ type AssistantChatProps = {
   runningStatusMessages?: string[],
   /** Enable image attachment UI (subject to shared MAX_IMAGES_PER_MESSAGE/MAX_IMAGE_BYTES_PER_FILE). */
   composerAttachments?: boolean,
+  /** Content rendered inside the composer box, above the textarea. Used for widget chips. */
+  composerTopContent?: React.ReactNode,
   /**
    * Called once the composer runtime is mounted. Parent stores the handle in a ref
    * and can then call `setText(...)` imperatively. Fires inside the runtime provider
@@ -64,6 +66,7 @@ export default function AssistantChat({
   hideMessageActions = false,
   runningStatusMessages,
   composerAttachments = false,
+  composerTopContent,
   onComposerReady,
 }: AssistantChatProps) {
   const attachmentAdapter = useMemo(
@@ -92,6 +95,7 @@ export default function AssistantChat({
             runningStatusMessages={runningStatusMessages}
             composerAttachments={composerAttachments}
             attachmentAdapter={attachmentAdapter}
+            composerTopContent={composerTopContent}
           />
         </TooltipProvider>
         {toolComponents}

--- a/apps/dashboard/src/components/vibe-coding/chat-adapters.ts
+++ b/apps/dashboard/src/components/vibe-coding/chat-adapters.ts
@@ -4,19 +4,77 @@ import { buildHexclaveHeaders, type CurrentUser } from "@/lib/api-headers";
 import type { AppId } from "@/lib/apps-frontend";
 import {
   type ChatModelAdapter,
+  type ChatModelRunOptions,
+  type ChatModelRunResult,
   type ExportedMessageRepository,
   type ThreadHistoryAdapter,
 } from "@assistant-ui/react";
 import { StackAdminApp } from "@hexclave/next";
 import { ChatContent } from "@hexclave/shared/dist/interface/admin-interface";
 import type { EditableMetadata } from "@hexclave/shared/dist/utils/jsx-editable-transpiler";
-
+import {
+  parseJsonEventStream,
+  readUIMessageStream,
+  uiMessageChunkSchema,
+  type UIMessage,
+  type UIMessageChunk,
+} from "ai";
 export type ToolCallContent = Extract<ChatContent[number], { type: "tool-call" }>;
 
 const isToolCall = (content: { type: string }): content is ToolCallContent => {
   return content.type === "tool-call";
 };
 
+export type DashboardWidgetContext = {
+  kind: "widget",
+  id: string,
+  name: string,
+  selectorPath: string,
+  outerHTMLSnippet: string,
+};
+
+export type DashboardActionContext = {
+  kind: "action-add-component",
+  id: string,
+};
+
+export type DashboardErrorContext = {
+  kind: "error",
+  id: string,
+  message: string,
+  stack?: string,
+  componentStack?: string,
+};
+
+export type DashboardChip =
+  | DashboardWidgetContext
+  | DashboardActionContext
+  | DashboardErrorContext;
+
+/** Maps thread messages to the backend wire format; merges `attachments` into `content`. */
+function formatThreadMessagesForBackend(
+  messages: readonly { role: string, content: readonly { type: string }[], attachments?: readonly { content?: readonly unknown[] }[] }[],
+): Array<{ role: string, content: unknown }> {
+  const formatted: Array<{ role: string, content: unknown }> = [];
+  for (const msg of messages) {
+    const textContent = msg.content.filter((c) => !isToolCall(c));
+    const attachmentContent: unknown[] = [];
+    if (msg.attachments) {
+      for (const attachment of msg.attachments) {
+        if (Array.isArray(attachment.content)) {
+          attachmentContent.push(...attachment.content);
+        }
+      }
+    }
+    const combined = [...textContent, ...attachmentContent];
+    if (combined.length > 0) {
+      formatted.push({ role: msg.role, content: combined });
+    }
+  }
+  return formatted;
+}
+
+/** Normalizes model JSX: strip fences, decode basic entities, fix `;` vs `,` between object props. */
 function sanitizeGeneratedCode(code: string): string {
   let result = code.trim();
 
@@ -56,6 +114,231 @@ function sanitizeAiContent(content: ChatContent): ChatContent {
     }
     return item;
   });
+}
+
+/**
+ * Sends a request to the AI query endpoint and returns the parsed content.
+ */
+async function sendAiRequest(
+  backendBaseUrl: string,
+  currentUser: CurrentUser | undefined,
+  body: {
+    quality: string,
+    speed: string,
+    systemPrompt: string,
+    tools: string[],
+    messages: Array<{ role: string, content: unknown }>,
+    projectId?: string,
+  },
+  abortSignal?: AbortSignal,
+): Promise<ChatContent> {
+  const authHeaders = await buildHexclaveHeaders(currentUser);
+
+  const response = await fetch(`${backendBaseUrl}/api/latest/ai/query/generate`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...authHeaders },
+    ...(abortSignal ? { signal: abortSignal } : {}),
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new Error(`AI request failed: ${response.status} ${response.statusText}`);
+  }
+
+  const json = await response.json() as { content?: ChatContent };
+  return Array.isArray(json.content) ? json.content : [];
+}
+
+/**
+ * Sends a request to the AI streaming endpoint and returns a stream of UIMessageChunks
+ * (as produced by the Vercel AI SDK's `streamText().toUIMessageStreamResponse()`).
+ */
+async function sendAiStreamRequest(
+  backendBaseUrl: string,
+  currentUser: CurrentUser | undefined,
+  body: {
+    quality: string,
+    speed: string,
+    systemPrompt: string,
+    tools: string[],
+    messages: Array<{ role: string, content: unknown }>,
+    projectId?: string,
+  },
+  abortSignal?: AbortSignal,
+): Promise<ReadableStream<UIMessageChunk>> {
+  const authHeaders = await buildHexclaveHeaders(currentUser);
+
+  const response = await fetch(`${backendBaseUrl}/api/latest/ai/query/stream`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "text/event-stream",
+      ...authHeaders,
+    },
+    ...(abortSignal ? { signal: abortSignal } : {}),
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error(`AI stream request failed: ${response.status} ${response.statusText}`);
+  }
+
+  return parseJsonEventStream({
+    stream: response.body,
+    schema: uiMessageChunkSchema,
+  }).pipeThrough(
+    new TransformStream<
+      { success: true, value: UIMessageChunk, rawValue: unknown } | { success: false, error: unknown, rawValue: unknown },
+      UIMessageChunk
+    >({
+      transform(parseResult, controller) {
+        if (parseResult.success) {
+          controller.enqueue(parseResult.value);
+        }
+      },
+    }),
+  );
+}
+
+/**
+ * Converts a UIMessage's parts (as emitted by `readUIMessageStream`) into our
+ * ChatContent shape so the existing tool UI / sanitizer pipeline keeps working.
+ */
+function uiPartsToChatContent(parts: UIMessage["parts"]): ChatContent {
+  const result: ChatContent = [];
+  for (const part of parts) {
+    if (part.type === "text") {
+      if (part.text) {
+        result.push({ type: "text", text: part.text });
+      }
+      continue;
+    }
+
+    if (part.type === "dynamic-tool") {
+      const toolPart = part as { toolCallId: string, toolName: string, input?: unknown, output?: unknown };
+      const input = toolPart.input ?? {};
+      result.push({
+        type: "tool-call",
+        toolCallId: toolPart.toolCallId,
+        toolName: toolPart.toolName,
+        args: input,
+        argsText: typeof input === "string" ? input : JSON.stringify(input),
+        result: toolPart.output ?? null,
+      });
+      continue;
+    }
+
+    if (typeof part.type === "string" && part.type.startsWith("tool-")) {
+      const toolName = part.type.slice("tool-".length);
+      const toolPart = part as { toolCallId: string, input?: unknown, output?: unknown };
+      const input = toolPart.input ?? {};
+      result.push({
+        type: "tool-call",
+        toolCallId: toolPart.toolCallId,
+        toolName,
+        args: input,
+        argsText: typeof input === "string" ? input : JSON.stringify(input),
+        result: toolPart.output ?? null,
+      });
+      continue;
+    }
+  }
+  return result;
+}
+
+/**
+ * Streaming dashboard generation: yields progressively updated ChatContent as the AI
+ * streams text and tool-call input. Each yield represents the full current state of
+ * the assistant message (not an incremental delta).
+ */
+export async function* streamDashboardCode(
+  backendBaseUrl: string,
+  currentUser: CurrentUser | undefined,
+  messages: Array<{ role: string, content: unknown }>,
+  options?: {
+    currentTsxSource?: string,
+    abortSignal?: AbortSignal,
+    enabledAppIds?: AppId[],
+    projectId?: string,
+  },
+): AsyncGenerator<ChatContent, void, undefined> {
+  const contextMessages = await buildDashboardMessages(
+    backendBaseUrl,
+    currentUser,
+    messages,
+    options?.currentTsxSource,
+    options?.enabledAppIds,
+  );
+
+  // Only give the agent the sql-query and read-config tools when we know which
+  // project to scope them to. Without projectId, they would fall back to the
+  // internal project — wrong target.
+  const tools = options?.projectId
+    ? ["update-dashboard", "sql-query", "read-config"]
+    : ["update-dashboard"];
+
+  const chunkStream = await sendAiStreamRequest(
+    backendBaseUrl,
+    currentUser,
+    {
+      quality: "smart",
+      speed: "fast",
+      systemPrompt: "create-dashboard",
+      tools,
+      messages: [...contextMessages, ...messages],
+      projectId: options?.projectId,
+    },
+    options?.abortSignal,
+  );
+
+  for await (const message of readUIMessageStream({ stream: chunkStream })) {
+    if (options?.abortSignal?.aborted) return;
+    yield sanitizeAiContent(uiPartsToChatContent(message.parts));
+  }
+}
+
+/**
+ * One-shot dashboard generation: builds context, calls AI, returns the tool call content.
+ * Used by both the cmd+K preview and the dashboard chat adapter.
+ */
+export async function generateDashboardCode(
+  backendBaseUrl: string,
+  currentUser: CurrentUser | undefined,
+  messages: Array<{ role: string, content: unknown }>,
+  options?: {
+    currentTsxSource?: string,
+    abortSignal?: AbortSignal,
+    enabledAppIds?: AppId[],
+    projectId?: string,
+  },
+): Promise<{ content: ChatContent, toolCall: ToolCallContent | undefined }> {
+  const contextMessages = await buildDashboardMessages(
+    backendBaseUrl,
+    currentUser,
+    messages,
+    options?.currentTsxSource,
+    options?.enabledAppIds,
+  );
+  const tools = options?.projectId
+    ? ["update-dashboard", "sql-query", "read-config"]
+    : ["update-dashboard"];
+  const rawContent = await sendAiRequest(
+    backendBaseUrl,
+    currentUser,
+    {
+      quality: "smart",
+      speed: "fast",
+      systemPrompt: "create-dashboard",
+      tools,
+      messages: [...contextMessages, ...messages],
+      projectId: options?.projectId,
+    },
+    options?.abortSignal,
+  );
+
+  const toolCall = rawContent.find(isToolCall);
+
+  return { content: rawContent, toolCall };
 }
 
 const CONTEXT_MAP = {
@@ -154,44 +437,91 @@ export function createDashboardChatAdapter(
   projectId?: string,
   onRunStart?: () => void,
   onRunEnd?: () => void,
+  getPendingChips?: () => DashboardChip[],
+  consumePendingChips?: () => void,
 ): ChatModelAdapter {
-  const tools = projectId
-    ? ["update-dashboard", "sql-query", "read-config"]
-    : ["update-dashboard"];
+  return {
+    async *run({ messages, abortSignal }: ChatModelRunOptions): AsyncGenerator<ChatModelRunResult, void> {
+      onRunStart?.();
+      try {
+        const formattedMessages = formatThreadMessagesForBackend(messages);
+        const chips = getPendingChips?.() ?? [];
+        if (chips.length > 0) {
+          const chipBlock = chips.map((c) => {
+            if (c.kind === "widget") {
+              return `[Widget: ${c.name}]\nPath: ${c.selectorPath}\nHTML: ${c.outerHTMLSnippet}`;
+            }
+            if (c.kind === "action-add-component") {
+              return `[Action: Add a new component to the dashboard]`;
+            }
+            // Bound stack/componentStack so a 5KB trace can't blow up the prompt.
+            const stackSlice = c.stack ? `\nStack:\n${c.stack.slice(0, 1200)}` : "";
+            const componentStackSlice = c.componentStack
+              ? `\nComponent stack:${c.componentStack.slice(0, 400)}`
+              : "";
+            return `[Error: The dashboard crashed at runtime — please diagnose and fix.]\nMessage: ${c.message}${stackSlice}${componentStackSlice}`;
+          }).join("\n\n");
+          const chipPart = { type: "text" as const, text: chipBlock };
+          let chipAttached = false;
 
-  return createUnifiedAiChatAdapter({
-    backendBaseUrl,
-    currentUser,
-    systemPrompt: "create-dashboard",
-    tools,
-    quality: "smart",
-    speed: "fast",
-    projectId,
-    sanitizeContent: sanitizeAiContent,
-    transformMessages: async (messages) => {
-      const contextMessages = await buildDashboardMessages(
-        backendBaseUrl,
-        currentUser,
-        messages,
-        currentTsxSource,
-        enabledAppIds,
-      );
-      return [...contextMessages, ...messages];
-    },
-    onRunStart,
-    onRunEnd,
-    onFinish: ({ assistantContent }) => {
-      const finalToolCall = assistantContent.find(
-        (item): item is ToolCallContent => isToolCall(item) && item.toolName === "updateDashboard",
-      );
-      if (finalToolCall) {
-        onToolCall(finalToolCall);
+          for (let i = formattedMessages.length - 1; i >= 0; i--) {
+            if (formattedMessages[i].role !== "user") continue;
+            const orig = formattedMessages[i].content;
+            formattedMessages[i] = {
+              ...formattedMessages[i],
+              content: Array.isArray(orig) ? [chipPart, ...orig] : [chipPart],
+            };
+            chipAttached = true;
+            break;
+          }
+          if (!chipAttached) {
+            formattedMessages.push({ role: "user", content: [chipPart] });
+          }
+        }
+
+        let latestContent: ChatContent = [];
+        let chipsConsumed = chips.length === 0;
+        for await (const content of streamDashboardCode(
+          backendBaseUrl,
+          currentUser,
+          formattedMessages,
+          {
+            currentTsxSource,
+            abortSignal,
+            enabledAppIds,
+            projectId,
+          },
+        )) {
+          if (!chipsConsumed) {
+            consumePendingChips?.();
+            chipsConsumed = true;
+          }
+          latestContent = content;
+          yield { content };
+        }
+
+        let lastFullReplacement: ToolCallContent | null = null;
+
+        for (const item of latestContent) {
+          if (!isToolCall(item)) continue;
+          if (item.toolName === "updateDashboard" && typeof item.args?.content === "string") {
+            lastFullReplacement = item;
+          }
+        }
+
+        if (lastFullReplacement) {
+          onToolCall(lastFullReplacement);
+        }
+      } catch (error) {
+        if (abortSignal.aborted) {
+          return;
+        }
+        throw new Error("Failed to get AI response. Please try again.");
+      } finally {
+        onRunEnd?.();
       }
     },
-    onError: () => {
-      throw new Error("Failed to get AI response. Please try again.");
-    },
-  });
+  };
 }
 
 export async function applyWysiwygEdit(

--- a/apps/dashboard/src/lib/ai-dashboard/shared-prompt.ts
+++ b/apps/dashboard/src/lib/ai-dashboard/shared-prompt.ts
@@ -1,6 +1,16 @@
 import { BUNDLED_DASHBOARD_UI_TYPES, BUNDLED_TYPE_DEFINITIONS } from "@/generated/bundled-type-definitions";
 import { ALL_APPS_FRONTEND, type AppId, getItemPath, hasNavigationItems } from "@/lib/apps-frontend";
-import { buildHexclaveHeaders, type CurrentUser } from "@/lib/api-headers";
+import type { CurrentUser } from "@/lib/api-headers";
+
+export type DashboardMessagePart = {
+  type: "text",
+  text: string,
+  providerOptions?: Record<string, unknown>,
+};
+export type DashboardMessage = {
+  role: string,
+  content: string | DashboardMessagePart[],
+};
 
 /**
  * Builds a formatted list of available dashboard routes based on enabled apps.
@@ -17,7 +27,7 @@ export function buildAvailableRoutes(enabledAppIds: AppId[]): string {
   routes.push({ path: "/project-settings", label: "Project Settings" });
 
   // Dynamic routes from enabled apps
-  for (const appId of enabledAppIds) {
+  for (const appId of [...enabledAppIds].sort()) {
     const appFrontend = ALL_APPS_FRONTEND[appId as keyof typeof ALL_APPS_FRONTEND];
     if (!hasNavigationItems(appFrontend)) {
       continue;
@@ -35,74 +45,8 @@ export function buildAvailableRoutes(enabledAppIds: AppId[]): string {
   return `\nAVAILABLE DASHBOARD ROUTES (use ONLY these with window.dashboardNavigate):\n${routeList}\nDo NOT use any paths not listed above.`;
 }
 
-export async function selectRelevantFiles(
-  prompt: string,
-  backendBaseUrl: string,
-  currentUser?: CurrentUser,
-): Promise<string[]> {
-  const availableFiles = BUNDLED_TYPE_DEFINITIONS.map((f: { path: string }) => f.path);
-
-  const systemPromptText = `You are a code assistant helping to generate dashboard code for Hexclave.
-
-Your task is to select which Hexclave SDK type definition files you'll need to generate the requested dashboard.
-
-IMPORTANT GUIDELINES:
-- DO NOT be conservative in file selection - when in doubt, INCLUDE the file
-- If a file might be relevant to the dashboard, SELECT IT
-- For user/team dashboards: select users and/or teams files
-- For project info: select projects files
-- Always select server-app.ts as it contains the main SDK interface
-- It's better to include extra files than to miss necessary types
-
-Available files:
-${availableFiles.map(f => `- ${f}`).join('\n')}
-
-Respond with ONLY a JSON object: { "selectedFiles": ["file1.ts", "file2.ts"] }
-No markdown, no explanation — just the JSON.`;
-
-  try {
-    const authHeaders = await buildHexclaveHeaders(currentUser);
-    const response = await fetch(`${backendBaseUrl}/api/latest/ai/query/generate`, {
-      method: "POST",
-      headers: { "content-type": "application/json", ...authHeaders },
-      body: JSON.stringify({
-        quality: "dumb",
-        speed: "fast",
-        systemPrompt: "command-center-ask-ai",
-        tools: [],
-        messages: [{
-          role: "user",
-          content: `${systemPromptText}\n\nDashboard request: "${prompt}"\n\nWhich type definition files do you need? When uncertain, err on the side of INCLUDING more files rather than fewer.`,
-        }],
-      }),
-    });
-
-    const result = await response.json() as { content?: Array<{ type: string, text?: string }> };
-    const content = Array.isArray(result.content) ? result.content : [];
-    const textBlock = content.find((b) => b.type === "text");
-    const responseText = textBlock?.text;
-
-    if (!responseText) {
-      return availableFiles;
-    }
-
-    const jsonMatch = responseText.match(/\{[\s\S]*"selectedFiles"[\s\S]*\}/);
-    if (!jsonMatch) {
-      return availableFiles;
-    }
-
-    const parsed = JSON.parse(jsonMatch[0]) as { selectedFiles?: string[] };
-    if (!Array.isArray(parsed.selectedFiles) || parsed.selectedFiles.length === 0) {
-      return availableFiles;
-    }
-
-    const selected = parsed.selectedFiles.filter((f) => availableFiles.includes(f));
-
-    return selected;
-  } catch (e) {
-    console.log("[selectRelevantFiles] failed, returning all files:", e);
-    return availableFiles;
-  }
+function getAllTypeDefinitionFiles(): string[] {
+  return BUNDLED_TYPE_DEFINITIONS.map((f: { path: string }) => f.path);
 }
 
 function stripComments(source: string): string {
@@ -134,32 +78,15 @@ ${fileContents.join('\n')}
   `.trim();
 }
 
-function extractUserPromptText(messages: Array<{ role: string, content: unknown }>): string {
-  const lastUserMessage = [...messages].reverse().find(m => m.role === "user");
-  if (typeof lastUserMessage?.content === "string") {
-    return lastUserMessage.content;
-  }
-  if (Array.isArray(lastUserMessage?.content)) {
-    const textPart = (lastUserMessage.content as Array<{ type: string, text?: string }>).find(c => c.type === "text");
-    return textPart?.text ?? "dashboard";
-  }
-  return "dashboard";
-}
-
-export async function buildDashboardMessages(
-  backendBaseUrl: string,
-  currentUser: CurrentUser | undefined,
-  messages: Array<{ role: string, content: unknown }>,
+export function buildDashboardMessages(
+  _backendBaseUrl: string,
+  _currentUser: CurrentUser | undefined,
+  _messages: Array<{ role: string, content: unknown }>,
   currentSource?: string,
   enabledAppIds?: AppId[],
-): Promise<Array<{ role: string, content: string }>> {
-  const promptForFileSelection = extractUserPromptText(messages);
-  const selectedFiles = await selectRelevantFiles(promptForFileSelection, backendBaseUrl, currentUser);
-  const typeDefinitions = loadSelectedTypeDefinitions(selectedFiles);
-
+): Promise<DashboardMessage[]> {
+  const typeDefinitions = loadSelectedTypeDefinitions(getAllTypeDefinitionFiles());
   const availableRoutes = enabledAppIds ? buildAvailableRoutes(enabledAppIds) : "";
-
-  const contextMessages: Array<{ role: string, content: string }> = [];
 
   const dashboardUiDocsHeader = [
     "DashboardUI component documentation (READ THIS BEFORE USING ANY COMPONENT):",
@@ -172,27 +99,45 @@ export async function buildDashboardMessages(
     "bare type signatures are NOT enough to use the components correctly.",
   ].join("\n");
 
+  const cachedText = `Here are the type definitions for the Hexclave SDK:\n${typeDefinitions}\n\n${dashboardUiDocsHeader}\n${BUNDLED_DASHBOARD_UI_TYPES}`;
+  const contextMessages: DashboardMessage[] = [];
+
+  contextMessages.push({
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text: cachedText,
+        providerOptions: {
+          openrouter: { cacheControl: { type: "ephemeral" } },
+        },
+      },
+    ],
+  });
+  contextMessages.push({
+    role: "assistant",
+    content: "I have the SDK reference material and UI component types. What dashboard would you like me to create or edit?",
+  });
+
+  const tailParts: string[] = [];
+  if (availableRoutes) {
+    tailParts.push(availableRoutes.trimStart());
+  }
   if (currentSource != null && currentSource.length > 0) {
+    tailParts.push(`Here is the current dashboard source code:\n\`\`\`tsx\n${currentSource}\n\`\`\``);
+  }
+  if (tailParts.length > 0) {
     contextMessages.push({
       role: "user",
-      content: `Here is the current dashboard source code:\n\`\`\`tsx\n${currentSource}\n\`\`\`\n\nHere are the type definitions:\n${typeDefinitions}\n\n${dashboardUiDocsHeader}\n${BUNDLED_DASHBOARD_UI_TYPES}${availableRoutes}`,
+      content: tailParts.join("\n\n"),
     });
     contextMessages.push({
       role: "assistant",
-      content: "I understand the current dashboard code, type definitions, and available routes. I've also read the JSDoc on every DashboardUI component I plan to use and will follow each component's canonical pattern. What changes would you like to make?",
-    });
-  } else {
-    contextMessages.push({
-      role: "user",
-      content: `Here are the type definitions for the Hexclave SDK:\n${typeDefinitions}\n\n${dashboardUiDocsHeader}\n${BUNDLED_DASHBOARD_UI_TYPES}${availableRoutes}`,
-    });
-    contextMessages.push({
-      role: "assistant",
-      content: "I have the type definitions and available routes. I've also read the JSDoc on every DashboardUI component I plan to use and will follow each component's canonical pattern. What dashboard would you like me to create?",
+      content: "Got it. What changes would you like me to make?",
     });
   }
 
-  return contextMessages;
+  return Promise.resolve(contextMessages);
 }
 
 export { BUNDLED_DASHBOARD_UI_TYPES };


### PR DESCRIPTION
Split out of #1502, which had grown to cover two unrelated features. This is the dashboard half; the SpacetimeDB telemetry re-architecture stays there.

## What this does

Lets you attach what you're pointing at to the dashboard AI chat, instead of describing it in prose.

Three kinds of context chip:

| Chip | Carries |
|---|---|
| widget | name, CSS selector path from `#root`, HTML snippet |
| add-component action | the action id |
| runtime error | message, stack, component stack |

`dashboard-sandbox-host.tsx` does the detection inside the iframe — hover/click tracking over rendered widgets, a selector path capped at 10 segments with `:nth-of-type` disambiguation, and the widget's heading as its display name. `page-client.tsx` owns the chip lifecycle and renders the chip bar into the composer through a new `composerTopContent` slot on `thread.tsx`.

Two deliberate guards:

- **Error screens can't be chipped.** They're marked `data-stack-no-widget`, because chipping one would round-trip the *rendered* error text back to the model, which is useless. The error chip carries the real stack instead.
- **Error capture is debounced** to the first unique error per 2-second window, so a crashing dashboard can't spam the chip bar.

## Also in here

- Drops `selectRelevantFiles()` — an LLM round-trip that pre-selected which SDK type definitions the generator would need. Net −55 lines in `shared-prompt.ts`.
- Sorts `enabledAppIds` before building the prompt. Unsorted iteration changed the prompt prefix per request, which was busting prompt caching.

## Reviewer note: existing dashboards

The sandbox root CSS changed so the add-component button stays reachable:

| | Before | After |
|---|---|---|
| `html, body` | `height: 100%` | `min-height: 100%`, flex column |
| `#root` | `height: 100%` | `flex: 1 0 auto; min-height: 0` |

Existing dashboards whose top-level element relies on `h-full` cascading from `#root` may lay out differently, since `height: 100%` no longer resolves against a definite parent. Short-content dashboards are unaffected; full-bleed layouts are where to look. **Worth eyeballing two or three existing dashboards on the preview deploy before merging.**

## Independence from #1502

None of the seven files import the internal tool, SpacetimeDB, or the module bindings, and the `/ai/query` response contract they consume (`{ content, finalText, conversationId }`) is unchanged between `dev` and that branch. Either PR can land first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach widgets, add-component actions, and runtime errors to the dashboard AI chat as context chips so the model gets concrete context without prose. Previously users typed descriptions; now chips carry the widget path/HTML, the action intent, or the real error stack, with guards to prevent noisy or useless inputs.

- Three chip types: widget (name + selector path from `#root` + HTML snippet), add-component action, and runtime error (message + stack + component stack). Error screens are marked `data-stack-no-widget` and errors dedupe to the first unique error per 2s.
- The sandbox iframe adds a hover/click overlay that reevaluates on scroll and an in-page “Add a component” button shown only when chat is open; both post events back to the host.
- The composer renders a chip bar via a new `composerTopContent` slot; chips send with the next message and can be removed.
- The dashboard chat adapter prepends chip text to the user message and now streams responses; it still applies the final `updateDashboard` tool call.
- Prompt context is simpler and deterministic: remove `selectRelevantFiles()` and always include bundled types; sort `enabledAppIds` before building routes.

**Review notes**

- Verify chip flows: select a widget, click “Add a component,” and trigger a runtime error; confirm chips attach, dedupe, and send once.
- Check the in-iframe overlay tracks the cursor during scroll and that error screens cannot be chipped.
- Inspect a few existing dashboards: sandbox root CSS switched to body flex with `#root` min-height 0; full-bleed layouts relying on `h-full` from `#root` may change.

<sup>Written for commit 07bf011fd6ac8748ed4310a2475595724009e711. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Runtime errors and selected widgets now appear as removable chips above the dashboard composer.
  - Added an “Add a component” action directly within the dashboard preview.
  - Dashboard generation now supports streamed AI responses for faster feedback.
  - Widget selections include richer context to improve generated dashboard updates.

- **Bug Fixes**
  - Improved widget overlay behavior while scrolling.
  - Prevented error screens from being selected as widgets.

- **Style**
  - Improved composer and chat appearance in off-white light mode.
  - Improved layout of the dashboard preview and component action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->