### PR TITLE
Ship the complete @swc/helpers package in the RDE dashboard runtime

### DIFF
--- a/packages/cli/scripts/copy-runtime-assets.mjs
+++ b/packages/cli/scripts/copy-runtime-assets.mjs
@@ -83,6 +83,48 @@ const EXCLUDED_RUNTIME_PACKAGES = new Set([
   "@img/colour",
 ]);
 
+// Packages whose staged copy must be the complete published package rather
+// than the file-traced subset. Next's trace resolves @swc/helpers subpath
+// exports to the cjs/ files, but Node runtimes with require(esm) match the
+// "module-sync"/"import" conditions first and load the esm/ files, so a
+// traced (partial) copy crashes the dashboard server at startup with
+// MODULE_NOT_FOUND on @swc/helpers/esm/*.js.
+const FULLY_COPIED_RUNTIME_PACKAGES = ["@swc/helpers"];
+
+function findWorkspaceStorePackageDir(packageName, version) {
+  const pnpmDir = join(repoRoot, "node_modules/.pnpm");
+  if (!existsSync(pnpmDir)) {
+    return undefined;
+  }
+  const prefix = `${packageName.replace("/", "+")}@${version}`;
+  for (const entry of readdirSync(pnpmDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || (entry.name !== prefix && !entry.name.startsWith(`${prefix}_`))) {
+      continue;
+    }
+    const candidate = join(pnpmDir, entry.name, "node_modules", ...packageName.split("/"));
+    if (existsSync(join(candidate, "package.json"))) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+function completeTracedPackages(nodeModulesDir) {
+  for (const packageName of FULLY_COPIED_RUNTIME_PACKAGES) {
+    const stagedDir = join(nodeModulesDir, ...packageName.split("/"));
+    const stagedPackageJsonPath = join(stagedDir, "package.json");
+    if (!existsSync(stagedPackageJsonPath)) {
+      continue;
+    }
+    const version = JSON.parse(readFileSync(stagedPackageJsonPath, "utf8")).version;
+    const source = findWorkspaceStorePackageDir(packageName, version);
+    if (source == null) {
+      throw new Error(`Could not find ${packageName}@${version} in the workspace pnpm store to complete the staged runtime copy.`);
+    }
+    cpSync(source, stagedDir, { recursive: true, dereference: true });
+  }
+}
+
 function hoistPnpmNodeModules(pnpmDir) {
   // The pnpm store keeps a shared `node_modules/` directory for hoisted
   // packages that peer-dep symlinks resolve through. After we dereference all
@@ -302,6 +344,7 @@ function copyDashboardAssets() {
   // same package to top-level would create a second copy after .pnpm removal.
   removePnpmStore(dashboardNodeModules, materializedPackageNames);
   removeExcludedPackages(dashboardNodeModules);
+  completeTracedPackages(dashboardNodeModules);
   removeNftJsonFiles(join(dashboardDist, "apps/dashboard/.next"));
   removeMapFiles(dashboardDist);
 


### PR DESCRIPTION
Fixes `hexclave dev` crashing at dashboard startup with:

```
Error: Cannot find module '...\rde-dashboard-runtime-<port>\node_modules\@swc\helpers\esm\_interop_require_default.js'
```

The staged standalone runtime only contains the files Next's build trace resolved for `@swc/helpers` (the `cjs/` files). Node runtimes with `require(esm)` enabled (v20.19+, v22.12+) match the package's `"module-sync"`/`"import"` export conditions first and resolve the same subpaths to `esm/*.js`, which the trace never included — so the dashboard server dies on boot.

`copy-runtime-assets.mjs` now re-copies the complete published `@swc/helpers` package (version-matched from the workspace pnpm store) over the traced partial copy when staging the runtime.

Verified by extracting the published `dashboard-1.0.102` archive: `require.resolve('@swc/helpers/_/_interop_require_default')` fails with the reported error, and succeeds once the package's `esm/` files are present; also ran the patched staging script against a fixture standalone layout and confirmed the staged runtime ends up with both `cjs/` and `esm/` files.

Link to Devin session: https://app.devin.ai/sessions/96a2a9198462473e98e9db2dcc230c69
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time packaging change only; fails loudly if the pnpm store lacks the version, with no runtime auth or data-path impact.
> 
> **Overview**
> Fixes **dashboard startup crashes** on Node versions with `require(esm)` when the staged standalone runtime only had Next’s file-traced subset of `@swc/helpers` (mostly `cjs/`), while resolution picks `esm/*.js` and hits `MODULE_NOT_FOUND`.
> 
> `copy-runtime-assets.mjs` now defines packages that must be copied in full (starting with `@swc/helpers`), looks up the matching version in the workspace pnpm store, and **overwrites the staged traced copy** with the complete published package during dashboard asset staging—after pnpm cleanup and excluded-package removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508b69f39851f68ffb1065c45ab03039b8ebcf15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop dashboard crashes at startup by staging the full `@swc/helpers` package in the RDE runtime. Previously we only staged traced `cjs/` files; Node with require(esm) resolved `esm/` subpaths and failed with MODULE_NOT_FOUND.

- copy-runtime-assets.mjs now locates the versioned `@swc/helpers` in the workspace pnpm store and copies the complete package over the traced subset.
- The script fails fast if the store copy is missing.
- The staged runtime now includes both `cjs/` and `esm/` helpers; small size increase, fixes `hexclave dev` boot.

<sup>Written for commit 508b69f39851f68ffb1065c45ab03039b8ebcf15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved packaged dashboard runtime reliability by ensuring all required supporting assets are included.
  * Prevented potential runtime failures caused by incomplete asset packaging in distributed CLI builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->