### PR TITLE
Handle missing server hostname when updating custom refresh cookies

### DIFF
--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cookie.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cookie.test.ts
@@ -1,3 +1,4 @@
+// IF_PLATFORM next js
 import { describe, expect, it, vi } from "vitest";
 import { encodeBase32 } from "@hexclave/shared/dist/utils/bytes";
 import { getTrustedParentDomain } from "@hexclave/shared/dist/utils/redirect-urls";
@@ -166,3 +167,4 @@ describe("StackClientApp custom refresh cookie updates", () => {
     expect(serverCookieState.values.has(defaultCookieName)).toBe(true);
   });
 });
+// END_PLATFORM

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cookie.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cookie.test.ts
@@ -100,4 +100,69 @@ describe("StackClientApp custom refresh cookie updates", () => {
     expect.soft(trustedParentLookups).toEqual(["_.example.com"]);
     warnSpy.mockRestore();
   });
+
+  it("recovers the custom cookie after overlapping server updates", async () => {
+    const projectId = "00000000-0000-4000-8000-000000000001";
+    const customCookieName = `hexclave-refresh-${projectId}--custom-${encodeBase32(new TextEncoder().encode("example.com"))}`;
+    const defaultCookieName = `__Host-hexclave-refresh-${projectId}--default`;
+    serverCookieState.values.clear();
+    serverCookieState.values.set(defaultCookieName, JSON.stringify({ refresh_token: "old-refresh", updated_at_millis: 1 }));
+    serverCookieState.values.set(customCookieName, JSON.stringify({ refresh_token: "old-refresh", updated_at_millis: 1 }));
+
+    const clientApp = new StackClientApp({
+      baseUrl: "http://localhost:12345",
+      projectId,
+      publishableClientKey: "stack-pk-test",
+      tokenStore: "memory",
+      redirectMethod: "none",
+      noAutomaticPrefetch: true,
+      devTool: false,
+    });
+    let releaseTrustedParentLookup: (() => void) | undefined;
+    let shouldBlockTrustedParentLookup = true;
+    Reflect.set(clientApp, "_getTrustedParentDomain", async (domain: string) => {
+      if (shouldBlockTrustedParentLookup) {
+        shouldBlockTrustedParentLookup = false;
+        await new Promise<void>((resolve) => {
+          releaseTrustedParentLookup = resolve;
+        });
+      }
+      return domain === "_.example.com" ? "example.com" : null;
+    });
+    const getOrCreateTokenStore = Reflect.get(clientApp, "_getOrCreateTokenStore");
+    const cookieHelper = {
+      get: (name: string) => serverCookieState.values.get(name) ?? null,
+      getAll: () => Object.fromEntries(serverCookieState.values),
+      set: (name: string, value: string) => serverCookieState.values.set(name, value),
+      setOrDelete: (name: string, value: string | null) => {
+        if (value === null) {
+          serverCookieState.values.delete(name);
+        } else {
+          serverCookieState.values.set(name, value);
+        }
+      },
+      delete: (name: string) => serverCookieState.values.delete(name),
+    };
+    const tokenStore = getOrCreateTokenStore.call(clientApp, cookieHelper, "nextjs-cookie");
+
+    tokenStore.set({ accessToken: "first-access", refreshToken: "first-refresh" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    if (releaseTrustedParentLookup == null) {
+      throw new Error("Expected the first custom cookie recovery lookup to be pending.");
+    }
+    tokenStore.set({ accessToken: "second-access", refreshToken: "second-refresh" });
+    releaseTrustedParentLookup();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const customCookieValue = serverCookieState.values.get(customCookieName);
+    expect(customCookieValue).toBeDefined();
+    if (customCookieValue == null) {
+      throw new Error("Expected the custom refresh cookie to be recovered.");
+    }
+    expect(JSON.parse(customCookieValue)).toMatchObject({
+      refresh_token: "second-refresh",
+      updated_at_millis: expect.any(Number),
+    });
+    expect(serverCookieState.values.has(defaultCookieName)).toBe(true);
+  });
 });

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cookie.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cookie.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+import { encodeBase32 } from "@hexclave/shared/dist/utils/bytes";
+import { getTrustedParentDomain } from "@hexclave/shared/dist/utils/redirect-urls";
+import { TextEncoder } from "util";
+import { StackClientApp } from "../interfaces/client-app";
+
+const serverCookieState = vi.hoisted(() => ({
+  values: new Map<string, string>(),
+}));
+
+vi.mock("../../../cookie", () => {
+  const getAll = () => Object.fromEntries(serverCookieState.values);
+  const remove = (name: string) => {
+    serverCookieState.values.delete(name);
+  };
+  const setOrDelete = (name: string, value: string | null) => {
+    if (value === null) {
+      remove(name);
+    } else {
+      serverCookieState.values.set(name, value);
+    }
+  };
+  const helper = {
+    get: (name: string) => serverCookieState.values.get(name) ?? null,
+    getAll,
+    set: (name: string, value: string) => setOrDelete(name, value),
+    setOrDelete,
+    delete: remove,
+  };
+  return {
+    createBrowserCookieHelper: () => helper,
+    createCookieHelper: async () => helper,
+    createPlaceholderCookieHelper: async () => helper,
+    deleteCookie: async (name: string) => remove(name),
+    deleteCookieClient: remove,
+    getCookieClient: (name: string) => serverCookieState.values.get(name) ?? null,
+    isSecure: async () => true,
+    saveVerifierAndState: async () => {
+      throw new Error("saveVerifierAndState is not used in this test");
+    },
+    setOrDeleteCookie: async (name: string, value: string | null) => setOrDelete(name, value),
+    setOrDeleteCookieClient: setOrDelete,
+  };
+});
+
+describe("StackClientApp custom refresh cookie updates", () => {
+  it("preserves the existing custom and default cookies without a server hostname", async () => {
+    expect(getTrustedParentDomain("_.example.com", ["https://example.com", "https://**.example.com"])).toBe("example.com");
+    const projectId = "00000000-0000-4000-8000-000000000000";
+    const customCookieName = `hexclave-refresh-${projectId}--custom-${encodeBase32(new TextEncoder().encode("example.com"))}`;
+    const defaultCookieName = `__Host-hexclave-refresh-${projectId}--default`;
+    serverCookieState.values.clear();
+    serverCookieState.values.set(defaultCookieName, JSON.stringify({ refresh_token: "old-refresh", updated_at_millis: 1 }));
+    serverCookieState.values.set(customCookieName, JSON.stringify({ refresh_token: "old-refresh", updated_at_millis: 1 }));
+
+    const clientApp = new StackClientApp({
+      baseUrl: "http://localhost:12345",
+      projectId,
+      publishableClientKey: "stack-pk-test",
+      tokenStore: "memory",
+      redirectMethod: "none",
+      noAutomaticPrefetch: true,
+      devTool: false,
+    });
+    const trustedParentLookups: string[] = [];
+    Reflect.set(clientApp, "_getTrustedParentDomain", async (domain: string) => {
+      trustedParentLookups.push(domain);
+      return domain === "_.example.com" ? "example.com" : null;
+    });
+    const getOrCreateTokenStore = Reflect.get(clientApp, "_getOrCreateTokenStore");
+    const cookieHelper = {
+      get: (name: string) => serverCookieState.values.get(name) ?? null,
+      getAll: () => Object.fromEntries(serverCookieState.values),
+      set: (name: string, value: string) => serverCookieState.values.set(name, value),
+      setOrDelete: (name: string, value: string | null) => {
+        if (value === null) {
+          serverCookieState.values.delete(name);
+        } else {
+          serverCookieState.values.set(name, value);
+        }
+      },
+      delete: (name: string) => serverCookieState.values.delete(name),
+    };
+    const tokenStore = getOrCreateTokenStore.call(clientApp, cookieHelper, "nextjs-cookie");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    tokenStore.set({ accessToken: "new-access", refreshToken: "new-refresh" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect.soft(warnSpy).not.toHaveBeenCalled();
+    const customCookieValue = serverCookieState.values.get(customCookieName);
+    expect.soft(customCookieValue).toBeDefined();
+    if (customCookieValue != null) {
+      expect.soft(JSON.parse(customCookieValue)).toEqual({
+        refresh_token: "new-refresh",
+        updated_at_millis: expect.any(Number),
+      });
+    }
+    expect.soft(serverCookieState.values.has(defaultCookieName)).toBe(true);
+    expect.soft(trustedParentLookups).toEqual(["_.example.com"]);
+    warnSpy.mockRestore();
+  });
+});

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -1521,7 +1521,12 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       }
     });
   }
-  private _queueCustomRefreshCookieUpdate(refreshToken: string | null, updatedAt: number | null, context: "browser" | "server") {
+  private _queueCustomRefreshCookieUpdate(
+    refreshToken: string | null,
+    updatedAt: number | null,
+    context: "browser" | "server",
+    previousCustomDomains: string[],
+  ) {
     runAsynchronously(async () => {
       this._mostRecentQueuedCookieRefreshIndex++;
       const updateIndex = this._mostRecentQueuedCookieRefreshIndex;
@@ -1531,12 +1536,6 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       } else {
         hostname = await getServerRequestHost();
       }
-      if (!hostname) {
-        console.warn("No hostname found when queueing custom refresh cookie update");
-        return;
-      }
-      const domain = await this._trustedParentDomainCache.getOrWait([hostname], "read-write");
-
       const cookieOptions = { maxAge: 60 * 60 * 24 * 365, noOpIfServerComponent: true };
       const setCookie = async (targetDomain: string, value: string | null) => {
         const name = this._getCustomRefreshCookieName(targetDomain);
@@ -1548,10 +1547,25 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
         }
       };
 
+      const value = refreshToken && updatedAt ? this._formatRefreshCookieValue(refreshToken, updatedAt) : null;
+      if (!hostname) {
+        // Server cookie writes can happen without request headers; use prior custom names to recover
+        // trusted domains, and retain the default cookie because the current host is unknown.
+        const domains = new Set<string>();
+        for (const previousDomain of new Set(previousCustomDomains)) {
+          const domain = await this._trustedParentDomainCache.getOrWait([`_.${previousDomain}`], "read-write");
+          if (updateIndex !== this._mostRecentQueuedCookieRefreshIndex) return;
+          if (domain.status !== "error" && domain.data != null) domains.add(domain.data);
+        }
+        if (updateIndex !== this._mostRecentQueuedCookieRefreshIndex) return;
+        await Promise.all([...domains].map((domain) => setCookie(domain, value)));
+        return;
+      }
+
+      const domain = await this._trustedParentDomainCache.getOrWait([hostname], "read-write");
       if (domain.status === "error" || !domain.data || updateIndex !== this._mostRecentQueuedCookieRefreshIndex) {
         return;
       }
-      const value = refreshToken && updatedAt ? this._formatRefreshCookieValue(refreshToken, updatedAt) : null;
       await setCookie(domain.data, value);
       const isSecure = await isSecureCookieContext();
       const defaultName = this._getRefreshTokenDefaultCookieNameForSecure(isSecure);
@@ -1618,7 +1632,10 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
             const domain = this._getDomainFromCustomRefreshCookieName(name);
             deleteCookieClient(name, domain ? { domain } : {});
           });
-          this._queueCustomRefreshCookieUpdate(refreshToken, updatedAt, "browser");
+          const previousCustomDomains = cookieNamesToDelete
+            .map((name) => this._getDomainFromCustomRefreshCookieName(name))
+            .filter((domain): domain is string => domain !== null);
+          this._queueCustomRefreshCookieUpdate(refreshToken, updatedAt, "browser", previousCustomDomains);
           hasSucceededInWriting = true;
         } catch (e) {
           if (!isBrowserLike()) {
@@ -1691,7 +1708,10 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
                   }),
                 );
               }
-              this._queueCustomRefreshCookieUpdate(refreshToken, updatedAt, "server");
+              const previousCustomDomains = cookieNamesToDelete
+                .map((name) => this._getDomainFromCustomRefreshCookieName(name))
+                .filter((domain): domain is string => domain !== null);
+              this._queueCustomRefreshCookieUpdate(refreshToken, updatedAt, "server", previousCustomDomains);
             });
           });
           return store;

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -630,6 +630,8 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
   private readonly _trustedParentDomainCache = createCache<[string], string | null>(
     async ([domain]) => await this._getTrustedParentDomain(domain)
   );
+  // Retain domains across token-store snapshots because a later update can see cookies already deleted by an earlier update.
+  private readonly _knownCustomRefreshCookieDomains = new Set<string>();
 
   private _anonymousSignUpInProgress: Promise<{ accessToken: string, refreshToken: string }> | null = null;
   private _prefetchedCrossDomainHandoffParams: CrossDomainHandoffParams | null = null;
@@ -1567,6 +1569,7 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
         return;
       }
       await setCookie(domain.data, value);
+      this._knownCustomRefreshCookieDomains.add(domain.data);
       const isSecure = await isSecureCookieContext();
       const defaultName = this._getRefreshTokenDefaultCookieNameForSecure(isSecure);
       if (context === "browser") {
@@ -1635,7 +1638,8 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
           const previousCustomDomains = cookieNamesToDelete
             .map((name) => this._getDomainFromCustomRefreshCookieName(name))
             .filter((domain): domain is string => domain !== null);
-          this._queueCustomRefreshCookieUpdate(refreshToken, updatedAt, "browser", previousCustomDomains);
+          previousCustomDomains.forEach((domain) => this._knownCustomRefreshCookieDomains.add(domain));
+          this._queueCustomRefreshCookieUpdate(refreshToken, updatedAt, "browser", [...this._knownCustomRefreshCookieDomains]);
           hasSucceededInWriting = true;
         } catch (e) {
           if (!isBrowserLike()) {
@@ -1711,7 +1715,8 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
               const previousCustomDomains = cookieNamesToDelete
                 .map((name) => this._getDomainFromCustomRefreshCookieName(name))
                 .filter((domain): domain is string => domain !== null);
-              this._queueCustomRefreshCookieUpdate(refreshToken, updatedAt, "server", previousCustomDomains);
+              previousCustomDomains.forEach((domain) => this._knownCustomRefreshCookieDomains.add(domain));
+              this._queueCustomRefreshCookieUpdate(refreshToken, updatedAt, "server", [...this._knownCustomRefreshCookieDomains]);
             });
           });
           return store;


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->

Server-side token updates can run without access to a request `host` header (e.g. outside a request scope, or on platforms where server request headers aren't available). Previously, `_queueCustomRefreshCookieUpdate` logged `No hostname found when queueing custom refresh cookie update` and bailed — after the caller had already deleted the existing cross-subdomain custom refresh cookies, dropping them until the next browser visit re-created them.

Now, when no hostname is available:
- No warning is logged (this is an expected situation).
- The previously existing custom-cookie domains (derived from the cookie names being replaced) are re-validated against the project's trusted domains and their custom cookies are re-created/updated with the new refresh token.
- The default refresh cookie is kept, since the current host is unknown.

Adds a regression test that reproduces the dropped cookie + warning in a server-like context and verifies the new behavior.

Link to Devin session: https://app.devin.ai/sessions/4f9e2c59526e41cba576c19592e0903c
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes refresh-token cookie persistence in auth-critical SDK paths; behavior is narrower (fallback when host is missing) and covered by a regression test.
> 
> **Overview**
> Fixes a bug where **server-side token updates** without a request `Host` header could **drop cross-subdomain custom refresh cookies** after the SDK had already deleted the old ones.
> 
> **`_queueCustomRefreshCookieUpdate`** now accepts **`previousCustomDomains`** (from the custom cookie names being replaced). When hostname resolution fails, it **no longer warns or exits early**; it re-validates those domains against trusted parents and **rewrites the custom refresh cookies** with the new token. On that path it **does not clear the default refresh cookie**, since the current host is unknown.
> 
> Browser and server cookie token-store updates pass the derived domain list into this helper. A **Vitest regression** covers the no-hostname server case: no `console.warn`, custom cookie updated, default cookie retained.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e98b2122d092b04d060be3ebeaa9451ef2e00741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved refresh-token cookie updates across custom and trusted parent domains.
  - Preserved custom cookie-domain handling during successive token updates.
  - Improved reliability when multiple token updates occur close together.
  - Server-side token updates now continue working when the request hostname is unavailable.
  - The default refresh cookie remains available while custom-domain cookies are updated.
  - Improved compatibility with existing authorization cookie prefixes while supporting the newer prefix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->