### PR TITLE
fix(dashboard): complete @swc/helpers in the RDE standalone tree

### DIFF
--- a/apps/dashboard/scripts/complete-standalone-swc-helpers.mjs
+++ b/apps/dashboard/scripts/complete-standalone-swc-helpers.mjs
@@ -1,0 +1,36 @@
+import { cpSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+const SWC_HELPERS_STORE_PREFIX = "@swc+helpers@";
+const ESM_INTEROP_REQUIRE_DEFAULT = join("esm", "_interop_require_default.js");
+
+/**
+ * Next 16.3.1's standalone tracer follows CJS `exports.default` and copies only
+ * `cjs/_interop_require_default.cjs`. Node >= 22.10 then resolves
+ * `module-sync` to `esm/_interop_require_default.js`, and the RDE dashboard
+ * exits before `hexclave dev` can spawn the demo. Replace each traced
+ * `@swc/helpers` copy with the complete package from the repo store.
+ */
+export function completeStandaloneSwcHelpers(standaloneRoot, repoPnpmRoot) {
+  const standalonePnpm = join(standaloneRoot, "node_modules", ".pnpm");
+  if (!existsSync(standalonePnpm)) {
+    throw new Error(`Standalone pnpm store not found at ${standalonePnpm}.`);
+  }
+  if (!existsSync(repoPnpmRoot)) {
+    throw new Error(`Repo pnpm store not found at ${repoPnpmRoot}.`);
+  }
+
+  const helperEntries = readdirSync(standalonePnpm).filter((name) => name.startsWith(SWC_HELPERS_STORE_PREFIX));
+  for (const entry of helperEntries) {
+    const dest = join(standalonePnpm, entry, "node_modules", "@swc", "helpers");
+    const src = join(repoPnpmRoot, entry, "node_modules", "@swc", "helpers");
+    if (existsSync(join(dest, ESM_INTEROP_REQUIRE_DEFAULT))) {
+      continue;
+    }
+    if (!existsSync(src)) {
+      throw new Error(`Repo pnpm store is missing ${entry} at ${src}. Cannot complete the standalone dashboard runtime.`);
+    }
+    rmSync(dest, { recursive: true, force: true });
+    cpSync(src, dest, { recursive: true });
+  }
+}

--- a/apps/dashboard/scripts/complete-standalone-swc-helpers.test.ts
+++ b/apps/dashboard/scripts/complete-standalone-swc-helpers.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { completeStandaloneSwcHelpers } from "./complete-standalone-swc-helpers.mjs";
+
+const ESM_SENTINEL = join("esm", "_interop_require_default.js");
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+  if (tempDir != null) {
+    rmSync(tempDir, { recursive: true, force: true });
+    tempDir = undefined;
+  }
+});
+
+function makeTempDir(): string {
+  tempDir = mkdtempSync(join(tmpdir(), "standalone-swc-helpers-"));
+  return tempDir;
+}
+
+function writeCjsOnlyHelpers(dir: string): void {
+  mkdirSync(join(dir, "cjs"), { recursive: true });
+  writeFileSync(join(dir, "package.json"), JSON.stringify({
+    name: "@swc/helpers",
+    version: "0.5.23",
+    exports: {
+      ".": {
+        "module-sync": "./esm/index.js",
+        default: "./cjs/index.cjs",
+      },
+    },
+  }));
+  writeFileSync(join(dir, "cjs", "_interop_require_default.cjs"), "module.exports = {};\n");
+}
+
+function writeCompleteHelpers(dir: string): void {
+  writeCjsOnlyHelpers(dir);
+  mkdirSync(join(dir, "esm"), { recursive: true });
+  writeFileSync(join(dir, ESM_SENTINEL), "export default {};\n");
+}
+
+function helpersStorePath(root: string, version = "0.5.23"): string {
+  return join(root, "node_modules", ".pnpm", `@swc+helpers@${version}`, "node_modules", "@swc", "helpers");
+}
+
+describe("completeStandaloneSwcHelpers", () => {
+  it("replaces a CJS-only traced package with the complete repo copy", () => {
+    const root = makeTempDir();
+    const standaloneRoot = join(root, "standalone");
+    const repoRoot = join(root, "repo");
+    const repoPnpmRoot = join(repoRoot, "node_modules", ".pnpm");
+    const dest = helpersStorePath(standaloneRoot);
+    const src = helpersStorePath(repoRoot);
+
+    writeCjsOnlyHelpers(dest);
+    writeCompleteHelpers(src);
+
+    expect(existsSync(join(dest, ESM_SENTINEL))).toBe(false);
+
+    completeStandaloneSwcHelpers(standaloneRoot, repoPnpmRoot);
+
+    expect(existsSync(join(dest, ESM_SENTINEL))).toBe(true);
+  });
+
+  it("is a no-op when the ESM sentinel is already present", () => {
+    const root = makeTempDir();
+    const standaloneRoot = join(root, "standalone");
+    const repoPnpmRoot = join(root, "repo-pnpm");
+    const dest = helpersStorePath(standaloneRoot);
+
+    writeCompleteHelpers(dest);
+    mkdirSync(repoPnpmRoot, { recursive: true });
+
+    completeStandaloneSwcHelpers(standaloneRoot, repoPnpmRoot);
+
+    expect(existsSync(join(dest, ESM_SENTINEL))).toBe(true);
+  });
+
+  it("throws when the repo store is missing the traced helpers version", () => {
+    const root = makeTempDir();
+    const standaloneRoot = join(root, "standalone");
+    const repoPnpmRoot = join(root, "repo-pnpm");
+    const dest = helpersStorePath(standaloneRoot);
+
+    writeCjsOnlyHelpers(dest);
+    mkdirSync(repoPnpmRoot, { recursive: true });
+
+    expect(() => completeStandaloneSwcHelpers(standaloneRoot, repoPnpmRoot)).toThrow(/Repo pnpm store is missing @swc\+helpers@0\.5\.23/);
+  });
+
+  it("throws when the standalone pnpm store is missing", () => {
+    const root = makeTempDir();
+    const standaloneRoot = join(root, "standalone");
+    const repoPnpmRoot = join(root, "repo-pnpm");
+    mkdirSync(standaloneRoot, { recursive: true });
+    mkdirSync(repoPnpmRoot, { recursive: true });
+
+    expect(() => completeStandaloneSwcHelpers(standaloneRoot, repoPnpmRoot)).toThrow(/Standalone pnpm store not found/);
+  });
+});

--- a/apps/dashboard/scripts/dev-rde-production.mjs
+++ b/apps/dashboard/scripts/dev-rde-production.mjs
@@ -3,6 +3,7 @@ import { spawn, spawnSync } from "node:child_process";
 import { cpSync, existsSync, rmSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { completeStandaloneSwcHelpers } from "./complete-standalone-swc-helpers.mjs";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const dashboardRoot = resolve(scriptDir, "..");
@@ -48,6 +49,8 @@ runOrExit("pnpm", ["exec", "next", "build"], {
 if (!existsSync(standaloneServerPath)) {
   throw new Error(`Dashboard standalone server was not created at ${standaloneServerPath}.`);
 }
+
+completeStandaloneSwcHelpers(standaloneRoot, resolve(dashboardRoot, "../../node_modules/.pnpm"));
 
 copyIfExists(join(nextOutputRoot, "static"), join(standaloneDashboardRoot, distDir, "static"));
 copyIfExists(join(dashboardRoot, "public"), join(standaloneDashboardRoot, "public"));

--- a/packages/cli/scripts/copy-runtime-assets.mjs
+++ b/packages/cli/scripts/copy-runtime-assets.mjs
@@ -2,6 +2,7 @@
 import { cpSync, existsSync, mkdirSync, readFileSync, readlinkSync, readdirSync, rmSync } from "fs";
 import { dirname, join, relative, resolve } from "path";
 import { fileURLToPath } from "url";
+import { completeStandaloneSwcHelpers } from "../../../apps/dashboard/scripts/complete-standalone-swc-helpers.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(__dirname, "..");
@@ -280,6 +281,8 @@ function copyDashboardAssets() {
     dashboardStaticSrc,
     "Dashboard static assets are missing. Run `pnpm exec turbo run build:rde-standalone --filter=@hexclave/dashboard` before building @hexclave/cli.",
   );
+
+  completeStandaloneSwcHelpers(dashboardStandaloneSrc, join(repoRoot, "node_modules", ".pnpm"));
 
   rmSync(dashboardDist, { recursive: true, force: true });
   cpSync(dashboardStandaloneSrc, dashboardDist, { recursive: true, dereference: true, filter: shouldCopyDashboardFile });


### PR DESCRIPTION
## Summary
- The demo never starts because `hexclave dev` waits on the RDE dashboard, and that standalone server dies on a missing `@swc/helpers` ESM file.
- Next 16.3.1 traces only `cjs/_interop_require_default.cjs`. Node 24 then resolves `module-sync` to `esm/_interop_require_default.js`.
- `completeStandaloneSwcHelpers` copies the full package from the repo pnpm store after the standalone build, then `dev-rde-production.mjs` and `copy-runtime-assets.mjs` call it.

## Test plan
- [x] `pnpm test run complete-standalone-swc-helpers` (4 passed)
- [x] Reproduced `MODULE_NOT_FOUND` on the existing standalone `server.js`
- [x] After a full-package copy, the same `server.js` printed `Ready`
- [ ] `pnpm --dir examples/demo run dev` (needs a dashboard `next build`; not run in this PR)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed standalone dashboard and CLI builds that could fail when traced SWC helper packages were incomplete.
  * Builds now restore missing helper files automatically before packaging runtime assets.

* **Tests**
  * Added coverage for completing incomplete helpers, preserving complete packages, and reporting missing package or store data with clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->