### PR TITLE
Fix dev CI: route growth e2e to mock Eve, drop 300s cap on Freestyle requests, update stale snapshots

### DIFF
--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -43,6 +43,11 @@ jobs:
       HEXCLAVE_DATABASE_CONNECTION_STRING: "postgres://postgres:PASSWORD-PLACEHOLDER--uqfEC1hmmv@localhost:8128/stackframe"
       HEXCLAVE_EXTERNAL_DB_SYNC_MAX_DURATION_MS: "20000"
       HEXCLAVE_EXTERNAL_DB_SYNC_DIRECT: "false"
+      # The growth e2e suite's mock Eve listens on this fixed port; the backend's .env.test.local
+      # (a copy of .env.development) points at the Eve dev port instead, and dotenv does not
+      # override process env, so the job must pin the URL here for the mock to ever receive
+      # dispatches (see apps/e2e/tests/backend/endpoints/api/v1/internal/growth/mock-eve.ts).
+      HEXCLAVE_GROWTH_EVE_URL: "http://127.0.0.1:32872"
 
     strategy:
       matrix:

--- a/.github/workflows/fast-fail-tests.yaml
+++ b/.github/workflows/fast-fail-tests.yaml
@@ -203,6 +203,7 @@ jobs:
       HEXCLAVE_DATABASE_CONNECTION_STRING: "postgres://postgres:PASSWORD-PLACEHOLDER--uqfEC1hmmv@localhost:8128/stackframe"
       HEXCLAVE_EXTERNAL_DB_SYNC_MAX_DURATION_MS: "20000"
       HEXCLAVE_EXTERNAL_DB_SYNC_DIRECT: "false"
+      HEXCLAVE_GROWTH_EVE_URL: "http://127.0.0.1:32872"
       SELECTED_TEST_FILES: ${{ needs.select-tests.outputs.test_files }}
 
     steps:

--- a/.github/workflows/setup-tests-with-custom-base-port.yaml
+++ b/.github/workflows/setup-tests-with-custom-base-port.yaml
@@ -47,6 +47,11 @@ jobs:
       STACK_BACKEND_DEV_DISABLE_WATCH: "true"
       HEXCLAVE_EXTERNAL_DB_SYNC_MAX_DURATION_MS: "20000"
       HEXCLAVE_EXTERNAL_DB_SYNC_DIRECT: "false"
+      # The growth e2e suite's mock Eve listens on this fixed port (independent of the base-port
+      # prefix); the backend's .env.development points at the real Eve dev app instead, and dotenv
+      # does not override process env, so the job must pin the URL here for the mock to ever
+      # receive dispatches (see apps/e2e/tests/backend/endpoints/api/v1/internal/growth/mock-eve.ts).
+      HEXCLAVE_GROWTH_EVE_URL: "http://127.0.0.1:32872"
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/setup-tests.yaml
+++ b/.github/workflows/setup-tests.yaml
@@ -45,6 +45,11 @@ jobs:
     env:
       HEXCLAVE_EXTERNAL_DB_SYNC_MAX_DURATION_MS: "20000"
       HEXCLAVE_EXTERNAL_DB_SYNC_DIRECT: "false"
+      # The growth e2e suite's mock Eve listens on this fixed port; the backend's .env.development
+      # points at the real Eve dev app (:8149) instead, and dotenv does not override process env,
+      # so the job must pin the URL here for the mock to ever receive dispatches (see
+      # apps/e2e/tests/backend/endpoints/api/v1/internal/growth/mock-eve.ts).
+      HEXCLAVE_GROWTH_EVE_URL: "http://127.0.0.1:32872"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/apps/backend/src/lib/js-execution.tsx
+++ b/apps/backend/src/lib/js-execution.tsx
@@ -6,6 +6,8 @@ import { HexclaveAssertionError, captureError } from '@hexclave/shared/dist/util
 import { Result } from '@hexclave/shared/dist/utils/results';
 import { Sandbox } from '@vercel/sandbox';
 import { Freestyle as FreestyleClient } from 'freestyle';
+import http from 'node:http';
+import https from 'node:https';
 
 export type ExecuteJavascriptOptions = {
   /** Cancels provider setup, command execution, and fallback attempts. */
@@ -41,6 +43,65 @@ type JsEngine = {
   execute: (code: string, options: ExecuteJavascriptOptions) => Promise<ExecuteResult>,
 };
 
+/**
+ * A minimal fetch replacement for the Freestyle client, built on node:http.
+ *
+ * Node's built-in fetch (undici) aborts any request whose response HEADERS
+ * take longer than 300 seconds to arrive (UND_ERR_HEADERS_TIMEOUT), and that
+ * limit is not configurable through the standard fetch API. Freestyle's
+ * execute endpoint holds the request open until the run finishes, and some
+ * runs legitimately take longer than that (executionTimeoutMs can exceed
+ * 300s — e.g. workflow invocations that long-poll inside the sandbox), so
+ * undici's limit would misreport a still-running execution as a provider
+ * failure. node:http applies no response timeout, leaving the caller's
+ * executionTimeoutMs/AbortSignal as the only time limits.
+ *
+ * Only supports what the Freestyle client actually does — fetch(url, init)
+ * with an optional string body — and fails loudly on anything else.
+ */
+async function fetchWithoutResponseTimeout(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+  if (input instanceof Request) {
+    throw new HexclaveAssertionError("fetchWithoutResponseTimeout does not support Request inputs; pass (url, init) instead");
+  }
+  const url = new URL(input);
+  const requestFn = url.protocol === "https:" ? https.request : http.request;
+  const body = init?.body;
+  if (body != null && typeof body !== "string") {
+    throw new HexclaveAssertionError("fetchWithoutResponseTimeout only supports string request bodies", { bodyType: typeof body });
+  }
+  const headers: Record<string, string> = {};
+  new Headers(init?.headers).forEach((value, key) => {
+    headers[key] = value;
+  });
+  return await new Promise<Response>((resolve, reject) => {
+    const req = requestFn(url, { method: init?.method ?? "GET", headers }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(chunk));
+      res.on("end", () => {
+        const responseHeaders = new Headers();
+        for (let i = 0; i + 1 < res.rawHeaders.length; i += 2) {
+          responseHeaders.append(res.rawHeaders[i], res.rawHeaders[i + 1]);
+        }
+        const bodyBytes = new Uint8Array(Buffer.concat(chunks));
+        resolve(new Response(
+          // Response() rejects non-empty bodies for status codes that forbid them
+          bodyBytes.length === 0 ? null : bodyBytes,
+          { status: res.statusCode, statusText: res.statusMessage, headers: responseHeaders },
+        ));
+      });
+      res.on("error", reject);
+    });
+    req.on("error", reject);
+    const signal = init?.signal;
+    if (signal != null) {
+      const onAbort = () => req.destroy(new Error("Request aborted by the caller's AbortSignal"));
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    }
+    req.end(body ?? undefined);
+  });
+}
+
 function createFreestyleEngine(): JsEngine {
   return {
     name: 'freestyle',
@@ -61,6 +122,7 @@ function createFreestyleEngine(): JsEngine {
       const freestyle = new FreestyleClient({
         apiKey,
         baseUrl,
+        fetch: fetchWithoutResponseTimeout,
       });
 
       const response = await awaitWithAbortSignal(freestyle.serverless.runs.create({

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/growth-workflows.test.ts
@@ -19,10 +19,13 @@ const SERVER_BASE = "/api/v1/internal/growth-server";
 // routes (analysis/tick + analysis/wait) — and those bridge ticks dispatch analysis phases to Eve
 // (played by the in-process mock Eve server) exactly like the deleted v1 cron engine did.
 //
-// IMPORTANT: every test that needs the mock Eve lives in THIS file. The mock's port is fixed by
-// HEXCLAVE_GROWTH_EVE_URL in apps/e2e/.env.development (the backend reads it per-dispatch), and
-// vitest runs test files in separate workers, so a second file binding the same port would flake
-// with EADDRINUSE. Within this file, withMockEve serializes entries via a module-level mutex.
+// IMPORTANT: every test that needs the mock Eve lives in THIS file. The mock's port is fixed at
+// 127.0.0.1:32872 (see mock-eve.ts), and the BACKEND must have HEXCLAVE_GROWTH_EVE_URL pointed at
+// it (it reads the env var per-dispatch) — the CI workflows export it at the job level, and local
+// runs need it exported in the backend's environment too (the backend's .env.development instead
+// points at the real Eve dev app on :8149). Vitest runs test files in separate workers, so a
+// second file binding the same port would flake with EADDRINUSE. Within this file, withMockEve
+// serializes entries via a module-level mutex.
 //
 // Time-dependent orchestration paths — the stuck-phase reaper (15min timeout), the milestone
 // hourly claim, the watchdog's 5-minute resurrection grace, and the stale-brief sweep (3h) — keep

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/mock-eve.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/growth/mock-eve.ts
@@ -3,8 +3,11 @@ import http from "node:http";
 // Mock Eve server for the growth engine e2e suite.
 //
 // The backend dispatches growth agent invocations as HTTP POSTs to
-// getEnvVariable("HEXCLAVE_GROWTH_EVE_URL"), which apps/e2e/.env.development pins to
-// http://127.0.0.1:32872. Because that URL (and therefore the port) is FIXED, only one server can
+// getEnvVariable("HEXCLAVE_GROWTH_EVE_URL"), which must be http://127.0.0.1:32872 in the
+// BACKEND's environment for this mock to receive anything. The e2e process cannot set it for the
+// backend: the CI workflows export it at the job level (dotenv does not override existing process
+// env), and local runs must export it too, because apps/backend/.env.development points at the
+// real Eve dev app on :8149 instead. Because that URL (and therefore the port) is FIXED, only one server can
 // play Eve at a time — so:
 //   - withMockEve serializes concurrent entries within this process via a module-level
 //     promise-chain mutex, and
@@ -134,7 +137,7 @@ export async function withMockEve<T>(fn: (mock: MockEve) => Promise<T>): Promise
         if (error.code === "EADDRINUSE") {
           reject(new Error(
             `mock Eve could not bind ${MOCK_EVE_HOST}:${MOCK_EVE_PORT} — the port is already taken. `
-            + `The port is fixed by HEXCLAVE_GROWTH_EVE_URL in apps/e2e/.env.development, so only ONE e2e file `
+            + `The port is fixed (it must match HEXCLAVE_GROWTH_EVE_URL in the backend's environment), so only ONE e2e file `
             + `(growth-workflows.test.ts) may use withMockEve; if another file started using it, or a stray process `
             + `holds the port, free it before running this suite.`,
           ));

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/mcp.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/mcp.test.ts
@@ -56,7 +56,7 @@ it("internal MCP endpoint should expose the Hexclave docs assistant tool", async
                   "type": "string",
                 },
                 "project": {
-                  "description": "The project the user is working on: its name and, when known, details such as its language, framework, purpose, and project type. Omit when unknown.",
+                  "description": "A plaintext description of the project the user is working on, including its name and, when known, details such as its language, framework, purpose, and project type. It may be somewhat lengthy when more context is useful and is not limited to a short identifier. This helps Hexclave return the correct documentation and answers. Omit when unknown.",
                   "minLength": 1,
                   "type": "string",
                 },
@@ -70,7 +70,7 @@ it("internal MCP endpoint should expose the Hexclave docs assistant tool", async
                   "type": "string",
                 },
                 "user": {
-                  "description": "Who is asking the question, such as the user's name and any other non-sensitive information that could help the Hexclave team identify and assist them. Omit when unknown.",
+                  "description": "A plaintext description of who is asking the question, such as the user's name, company, and any other information that could help the Hexclave team identify and assist them. It may be somewhat lengthy when more context is useful and is not limited to a short identifier. Omit when unknown.",
                   "minLength": 1,
                   "type": "string",
                 },

--- a/packages/shared/src/config/schema.ts
+++ b/packages/shared/src/config/schema.ts
@@ -291,7 +291,7 @@ import.meta.vitest?.test("branchPaymentsSchema lets productLineId schema reject 
         prices: {},
       },
     },
-  }, { abortEarly: false })).rejects.toThrowErrorMatchingInlineSnapshot(`[ValidationError: productLineId must contain only letters, numbers, underscores, and hyphens, and not start with a hyphen]`);
+  }, { abortEarly: false })).rejects.toThrowErrorMatchingInlineSnapshot(`[ValidationError: productLineId must contain only letters, numbers, underscores, and hyphens, and not start with a hyphen, and must not be one of __proto__, constructor, prototype]`);
 });
 
 const branchDomain = yupObject({});


### PR DESCRIPTION
Fixes the dev CI test failures (e.g. https://github.com/hexclave/hexclave/actions/runs/33022604017/job/98357946973).

## Root cause of the timeout cluster

The growth e2e suite's mock Eve listens on a fixed port (`127.0.0.1:32872`), but only `apps/e2e/.env.development` points `HEXCLAVE_GROWTH_EVE_URL` there — the **backend** reads its own `.env.development`, which points at the real Eve dev app (`:8149`). So in CI the backend's growth dispatches never reached the mock:

- `growth-workflows.test.ts` timed out waiting for dispatches (`pollWithTicks` / `waitForDispatch` timeouts),
- dispatches went to the real `eve dev` app (no AI credentials in CI), whose junk work + engine retries saturated backend background tasks — causing the 45s `flush-background-tasks` drain timeouts and the >60s email/verification delays in unrelated tests.

These tests have never passed on dev since they landed.

## Fix

- Export `HEXCLAVE_GROWTH_EVE_URL=http://127.0.0.1:32872` at the job level in `setup-tests.yaml`, `setup-tests-with-custom-base-port.yaml`, and `e2e-api-tests.yaml` (dotenv does not override existing process env, so the job env wins over the backend's `.env.development`).
- Correct the stale comments in `mock-eve.ts` / `growth-workflows.test.ts` that claimed the e2e `.env.development` pins the backend's URL.

## Also: two stale inline snapshots

- `packages/shared/src/config/schema.ts`: `productLineId` validation now also rejects `__proto__`/`constructor`/`prototype` and says so in its error message.
- `mcp.test.ts`: the `tools/list` snapshot updated to the current `user`/`project` parameter descriptions from `apps/mcp/src/mcp-handler.ts`.

## Validation

Lint, typecheck, YAML parse, and the schema (19/19) + MCP (6/6) tests pass locally under Node 24. The growth-workflow path is validated by this PR's `e2e-api-tests` run.

Link to Devin session: https://app.devin.ai/sessions/b079bd71c02a4fa985ffbff9a49c64f0
Open in Devin Desktop: https://app.devin.ai/desktop/session/b079bd71c02a4fa985ffbff9a49c64f0?variant=devin
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 57f1c88b28f0086d440e56ebfc81e44c67c96960. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev CI failures by pointing the backend's growth dispatches at the mock Eve, refreshing two stale snapshots, and bypassing undici's 300s headers timeout in the Freestyle client.

- Exports `HEXCLAVE_GROWTH_EVE_URL` at the job level in `setup-tests.yaml`, `setup-tests-with-custom-base-port.yaml`, `e2e-api-tests.yaml`, and `fast-fail-tests.yaml` so the mock receives dispatches instead of the real Eve dev app.
- Corrects comments in `mock-eve.ts` and `growth-workflows.test.ts` about where the mock URL is configured.
- Updates the `productLineId` validation error snapshot in `schema.ts` and the `tools/list` parameter descriptions snapshot in `mcp.test.ts`.
- Adds a `node:http`-based fetch replacement for the Freestyle client so runs longer than 300s aren't misreported as provider failures; it only supports string bodies and fails loudly on anything else.

<sup>Written for commit 3fecd6fe93e08072719d85e9b552dda66295f8f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test reliability by ensuring growth workflow tests consistently connect to the mock service.
  * Prevented long-running Freestyle executions from being incorrectly reported as provider failures.
  * Updated validation feedback for invalid product line identifiers to clearly identify reserved names.
  * Clarified MCP tool input descriptions for project and user values.

* **Documentation**
  * Updated testing guidance and error messages to reflect the required mock service configuration for local and CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->