### PR TITLE
[Feat] Log Client's Targeted host on Error

### DIFF
--- a/apps/backend/src/lib/request-api-url.ts
+++ b/apps/backend/src/lib/request-api-url.ts
@@ -59,17 +59,84 @@ const CLOUD_API_HOST_BY_REQUEST_HOST = new Map<string, string>(
     )),
 );
 
-function normalizeRequestHost(host: string | undefined | null): string | undefined {
+/**
+ * DNS hostnames are at most 253 characters. Longer values are junk (or a
+ * spoofed header dumping a blob into logs/Sentry), not a hostname.
+ */
+const MAX_INBOUND_REQUEST_HOST_LENGTH = 253;
+
+/**
+ * Parse a Host / X-Forwarded-Host value into a lowercase hostname with no port.
+ * Does not map failover hosts (`api2`) to the canonical `api` host — callers
+ * that need branding should use `getApiUrlForHost`.
+ *
+ * Rejects URL-like junk before stripping the port so `https://evil.example`
+ * cannot collapse to `https`.
+ */
+export function normalizeRequestHost(host: string | undefined | null): string | undefined {
   if (!host) return undefined;
   const firstHost = host.split(",")[0]?.trim();
   if (!firstHost) return undefined;
+  // URL pieces in a host header are not a hostname. Check before port-stripping
+  // because `https://evil.example` would otherwise become `https`.
+  if (
+    firstHost.includes("://")
+    || firstHost.includes("/")
+    || firstHost.includes("?")
+    || firstHost.includes("#")
+    || firstHost.includes("@")
+    || /\s/.test(firstHost)
+  ) {
+    return undefined;
+  }
+  let hostname: string | undefined;
   if (firstHost.startsWith("[")) {
     const closingBracketIndex = firstHost.indexOf("]");
     if (closingBracketIndex > 1) {
-      return firstHost.slice(1, closingBracketIndex).toLowerCase();
+      hostname = firstHost.slice(1, closingBracketIndex).toLowerCase();
+    }
+  } else if ((firstHost.match(/:/g) ?? []).length > 1) {
+    // Unbracketed IPv6 (what `URL.hostname` returns). A Host header with a port
+    // must use bracket form (`[::1]:8102`); more than one colon here is the
+    // address itself, not `host:port`.
+    hostname = firstHost.toLowerCase();
+  } else {
+    hostname = firstHost.split(":")[0]?.toLowerCase();
+  }
+  if (!hostname || hostname.length > MAX_INBOUND_REQUEST_HOST_LENGTH) {
+    return undefined;
+  }
+  return hostname;
+}
+
+/**
+ * True when `host` is already a normalized inbound hostname we are willing to
+ * put in logs or Sentry. Used by the Sentry scrubber as a default-deny check
+ * so a crafted `stack-request.host` cannot smuggle a URL through.
+ */
+export function isSafeInboundRequestHost(host: unknown): host is string {
+  return typeof host === "string" && normalizeRequestHost(host) === host;
+}
+
+/**
+ * The hostname the client actually targeted (`api2.hexclave.com`, not the
+ * canonical brand host). Prefer `x-forwarded-host` (edge-set on Vercel / Cloud
+ * Run) over `host` over `request.url`, and never collapse failover aliases.
+ */
+export function getInboundRequestHost(request: Request): string | undefined {
+  let urlHostname: string | undefined;
+  try {
+    urlHostname = new URL(request.url).hostname;
+  } catch {
+    urlHostname = undefined;
+  }
+  for (const candidate of [request.headers.get("x-forwarded-host"), request.headers.get("host"), urlHostname]) {
+    const normalized = normalizeRequestHost(candidate);
+    if (isSafeInboundRequestHost(normalized)) {
+      return normalized;
     }
   }
-  return firstHost.split(":")[0].toLowerCase();
+  return undefined;
 }
 
 /**
@@ -124,4 +191,49 @@ import.meta.vitest?.test("getApiUrlForHost falls back for non-cloud hosts withou
   expect(getApiUrlForHost("p93.localhost:9302")).toBe(fallbackApiUrl);
   expect(getApiUrlForHost("[::1]:8102")).toBe(fallbackApiUrl);
   expect(getApiUrlForHost("customer.example.com")).toBe(fallbackApiUrl);
+});
+
+import.meta.vitest?.test("normalizeRequestHost keeps failover hosts and strips ports", ({ expect }) => {
+  expect(normalizeRequestHost("api2.hexclave.com")).toBe("api2.hexclave.com");
+  expect(normalizeRequestHost("API2.hexclave.com:443")).toBe("api2.hexclave.com");
+  expect(normalizeRequestHost("api2.hexclave.com, api.hexclave.com")).toBe("api2.hexclave.com");
+  expect(normalizeRequestHost("[::1]:8102")).toBe("::1");
+  expect(normalizeRequestHost("::1")).toBe("::1");
+});
+
+import.meta.vitest?.test("normalizeRequestHost drops URL-like and oversized junk", ({ expect }) => {
+  expect(normalizeRequestHost("https://evil.example")).toBeUndefined();
+  expect(normalizeRequestHost("api.hexclave.com/users")).toBeUndefined();
+  expect(normalizeRequestHost("api.hexclave.com?x=1")).toBeUndefined();
+  expect(normalizeRequestHost("user@api.hexclave.com")).toBeUndefined();
+  expect(normalizeRequestHost("api.hexclave.com extra")).toBeUndefined();
+  expect(normalizeRequestHost("")).toBeUndefined();
+  expect(normalizeRequestHost("a".repeat(254))).toBeUndefined();
+});
+
+import.meta.vitest?.test("getInboundRequestHost prefers x-forwarded-host and does not collapse api2", ({ expect }) => {
+  const request = new Request("https://api.hexclave.com/api/latest/users/user-secret?secret=do-not-log", {
+    headers: {
+      "x-forwarded-host": "api2.hexclave.com",
+      host: "internal.example:8102",
+    },
+  });
+  expect(getInboundRequestHost(request)).toBe("api2.hexclave.com");
+});
+
+import.meta.vitest?.test("getInboundRequestHost falls back to host then URL hostname", ({ expect }) => {
+  expect(getInboundRequestHost(new Request("https://api.hexclave.com/x", {
+    headers: { host: "api1.hexclave.com:443" },
+  }))).toBe("api1.hexclave.com");
+  expect(getInboundRequestHost(new Request("https://api.hexclave.com/x"))).toBe("api.hexclave.com");
+});
+
+import.meta.vitest?.test("getInboundRequestHost skips malformed forwarded hosts", ({ expect }) => {
+  const request = new Request("https://api.hexclave.com/x", {
+    headers: {
+      "x-forwarded-host": "https://evil.example",
+      host: "api2.hexclave.com",
+    },
+  });
+  expect(getInboundRequestHost(request)).toBe("api2.hexclave.com");
 });

--- a/apps/backend/src/route-handlers/smart-route-handler.tsx
+++ b/apps/backend/src/route-handlers/smart-route-handler.tsx
@@ -1,6 +1,7 @@
 import "../polyfills";
 
 import { recordRequestStats } from "@/lib/dev-request-stats";
+import { getInboundRequestHost } from "@/lib/request-api-url";
 import { requestContextALS } from "@/lib/runtime/request-context";
 import { isRequestBodyTooLargeError } from "@/server/request-body-limit";
 import * as Sentry from "@sentry/node";
@@ -92,6 +93,7 @@ export function handleApiRequest(handler: (req: Request, options: any, requestId
       // The route pattern (not the concrete path — see RequestContext.normalizedPath for why).
       // Optional access because unit tests may invoke handlers outside the server dispatcher.
       const normalizedPath = requestContextALS.getStore()?.normalizedPath;
+      const host = getInboundRequestHost(req);
       // Sentry's httpIntegration already forks an isolation scope per incoming request (which is
       // what keeps concurrent requests on Fluid Compute / Cloud Run from leaking context into each
       // other), so we only need to attach the request context to that scope — error events must be
@@ -99,16 +101,22 @@ export function handleApiRequest(handler: (req: Request, options: any, requestId
       // values, or the concrete request path here; the former routinely contain credentials and
       // path params can contain customer identifiers. The route pattern is safe (it's the same
       // shape as the http.route span attribute) and is what triage uses to locate the endpoint.
+      // `host` is the inbound API hostname (api vs api2), not a customer identifier.
+      if (host != null) {
+        Sentry.getIsolationScope().setTag("host", host);
+      }
       Sentry.getIsolationScope().setContext("stack-request", {
         requestId,
         method: req.method,
         ...(normalizedPath == null ? {} : { route: normalizedPath }),
+        ...(host == null ? {} : { host }),
       });
       return await traceSpan({
         description: 'handling API request',
         attributes: {
           "stack.request.request-id": requestId,
           "stack.request.method": req.method,
+          ...(host == null ? {} : { "stack.request.host": host }),
           "stack.process.id": processId,
           "stack.process.concurrent-requests": concurrentRequestsInProcess,
         },

--- a/apps/backend/src/sentry-scrubbing.test.ts
+++ b/apps/backend/src/sentry-scrubbing.test.ts
@@ -20,6 +20,7 @@ describe("sanitizeBackendSentryEvent", () => {
       },
       tags: {
         project: "project-secret",
+        host: "api2.hexclave.com",
       },
       transaction: "POST /api/latest/users/user-secret",
       extra: {
@@ -31,6 +32,7 @@ describe("sanitizeBackendSentryEvent", () => {
           requestId: "request-123",
           method: "POST",
           route: "/api/latest/users/[user_id]",
+          host: "api2.hexclave.com",
           authorization: "Bearer secret",
         },
         response: {
@@ -57,6 +59,7 @@ describe("sanitizeBackendSentryEvent", () => {
           "db.statement": "SELECT * FROM users WHERE email = 'user@example.com'",
           "http.request.method": "POST",
           "http.route": "/api/latest/users/{user_id}",
+          "stack.request.host": "api2.hexclave.com",
           "stack.request.path": "/api/latest/users",
           "stack.smart-request.user.primary-email": "user@example.com",
         },
@@ -81,6 +84,7 @@ describe("sanitizeBackendSentryEvent", () => {
         ],
         "contexts": {
           "stack-request": {
+            "host": "api2.hexclave.com",
             "method": "POST",
             "requestId": "request-123",
             "route": "/api/latest/users/[user_id]",
@@ -104,6 +108,7 @@ describe("sanitizeBackendSentryEvent", () => {
             "data": {
               "http.request.method": "POST",
               "http.route": "/api/latest/users/{user_id}",
+              "stack.request.host": "api2.hexclave.com",
             },
             "description": "POST /api/latest/users/{user_id}",
             "span_id": "0123456789abcdef",
@@ -111,7 +116,9 @@ describe("sanitizeBackendSentryEvent", () => {
             "trace_id": "0123456789abcdef0123456789abcdef",
           },
         ],
-        "tags": undefined,
+        "tags": {
+          "host": "api2.hexclave.com",
+        },
         "transaction": "POST /api/latest/users/[user_id]",
         "user": undefined,
       }
@@ -231,6 +238,78 @@ describe("sanitizeBackendSentryEvent", () => {
       },
     });
     expect(JSON.stringify(result)).not.toContain("customer-secret");
+  });
+
+  it("keeps a safe inbound host on stack-request and tags, including when requestId is absent", () => {
+    const result = sanitizeBackendSentryEvent({
+      tags: {
+        host: "api2.hexclave.com",
+        project: "project-secret",
+      },
+      contexts: {
+        "stack-request": {
+          host: "api2.hexclave.com",
+          authorization: "Bearer secret",
+        },
+      },
+    });
+
+    expect(result.tags).toEqual({ host: "api2.hexclave.com" });
+    expect(result.contexts).toEqual({
+      "stack-request": {
+        host: "api2.hexclave.com",
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain("secret");
+  });
+
+  it("drops unsafe host values from tags, stack-request, and span data", () => {
+    const result = sanitizeBackendSentryEvent({
+      tags: {
+        host: "https://api.example.com/api/latest/users?token=secret",
+      },
+      contexts: {
+        "stack-request": {
+          requestId: "request-123",
+          host: "https://api.example.com/api/latest/users?token=secret",
+        },
+        trace: {
+          data: {
+            "stack.request.host": "https://api.example.com/api/latest/users?token=secret",
+            "http.request.method": "GET",
+            "http.route": "/api/latest/users/[user_id]",
+          },
+          span_id: "0123456789abcdef",
+          trace_id: "0123456789abcdef0123456789abcdef",
+        },
+      },
+      spans: [{
+        data: {
+          "stack.request.host": "https://api.example.com/api/latest/users?token=secret",
+          "http.request.method": "GET",
+          "http.route": "/api/latest/users/[user_id]",
+        },
+        description: "GET /api/latest/users/[user_id]",
+        span_id: "0123456789abcdef",
+        start_timestamp: 1,
+        trace_id: "0123456789abcdef0123456789abcdef",
+      }],
+    });
+
+    expect(result.tags).toBeUndefined();
+    expect(result.contexts["stack-request"]).toEqual({
+      requestId: "request-123",
+    });
+    expect(result.contexts.trace.data).toEqual({
+      "http.request.method": "GET",
+      "http.route": "/api/latest/users/[user_id]",
+    });
+    expect(result.spans[0].data).toEqual({
+      "http.request.method": "GET",
+      "http.route": "/api/latest/users/[user_id]",
+    });
+    expect(JSON.stringify(result)).not.toContain("token=secret");
+    expect(JSON.stringify(result)).not.toContain("https://");
   });
 
   it("clears all extras, including ones that look like diagnostics", () => {

--- a/apps/backend/src/sentry-scrubbing.ts
+++ b/apps/backend/src/sentry-scrubbing.ts
@@ -1,4 +1,5 @@
 import { httpMethodNames } from "@/generated/route-modules";
+import { isSafeInboundRequestHost } from "@/lib/request-api-url";
 import { sentryBaseConfig } from "@hexclave/shared/dist/utils/sentry";
 import type { Event, EventHint } from "@sentry/node";
 
@@ -16,6 +17,7 @@ const safeSpanAttributeNames = new Set([
   "stack.process.id",
   "stack.request.method",
   "stack.request.request-id",
+  "stack.request.host",
   "stack.smart-request.access-type",
   "stack.smart-request.client-version.platform",
   "stack.smart-request.client-version.sdk",
@@ -38,9 +40,13 @@ const safeApplicationSpanDescriptions = new Set([
 type BackendSentrySpan = NonNullable<Event["spans"]>[number];
 
 function getSafeSpanData(data: BackendSentrySpan["data"]): BackendSentrySpan["data"] {
-  return Object.fromEntries(
+  const filtered = Object.fromEntries(
     Object.entries(data).filter(([attributeName]) => safeSpanAttributeNames.has(attributeName)),
   );
+  if ("stack.request.host" in filtered && !isSafeInboundRequestHost(filtered["stack.request.host"])) {
+    delete filtered["stack.request.host"];
+  }
+  return filtered;
 }
 
 function getSafeRequestDescription(method: unknown, route: unknown): string | undefined {
@@ -212,7 +218,8 @@ export function sanitizeBackendSentryEvent<T extends Event>(event: T): T {
     };
   }
   event.user = undefined;
-  event.tags = undefined;
+  const inboundHostTag = event.tags?.host;
+  event.tags = isSafeInboundRequestHost(inboundHostTag) ? { host: inboundHostTag } : undefined;
   event.extra = undefined;
 
   event.breadcrumbs = event.breadcrumbs?.map((breadcrumb) => ({
@@ -231,6 +238,10 @@ export function sanitizeBackendSentryEvent<T extends Event>(event: T): T {
   // `route` is the matched route pattern (e.g. `/api/latest/users/[user_id]`), never the
   // concrete path — same safety rationale as the http.route span attribute above.
   const requestRoute = requestContext?.route;
+  // Inbound API hostname (api vs api2). Not PII; still default-deny so a crafted
+  // value cannot smuggle a URL or path through `stack-request.host`.
+  const requestHostCandidate = requestContext?.host;
+  const requestHost = isSafeInboundRequestHost(requestHostCandidate) ? requestHostCandidate : undefined;
   const safeRequestDescription = getSafeRequestDescription(requestMethod, requestRoute);
   const safeTraceDescription = getSafeRequestDescription(
     traceContext?.data?.["http.request.method"],
@@ -261,11 +272,14 @@ export function sanitizeBackendSentryEvent<T extends Event>(event: T): T {
   } else if (event.transaction != null) {
     event.transaction = "backend.request";
   }
-  const safeRequestContext = typeof requestId === "string"
+  const safeRequestContext = typeof requestId === "string" || requestHost != null
     ? {
-      requestId,
-      ...(typeof requestMethod === "string" ? { method: requestMethod } : {}),
-      ...(typeof requestRoute === "string" ? { route: requestRoute } : {}),
+      ...(typeof requestId === "string" ? {
+        requestId,
+        ...(typeof requestMethod === "string" ? { method: requestMethod } : {}),
+        ...(typeof requestRoute === "string" ? { route: requestRoute } : {}),
+      } : {}),
+      ...(requestHost == null ? {} : { host: requestHost }),
     }
     : undefined;
   if (traceContext != null) {

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -1,4 +1,5 @@
 import { httpMethodNames } from "@/generated/route-modules";
+import { getInboundRequestHost } from "@/lib/request-api-url";
 import { serializeSetCookie } from "@/lib/runtime/headers";
 import { parseCookieHeader, requestContextALS, type RequestContext } from "@/lib/runtime/request-context";
 import { node } from "@elysia/node";
@@ -42,6 +43,9 @@ export const app = new Elysia({
     const pathname = new URL(request.url).pathname;
     const staticRequestPath = staticRequestLogPaths.has(pathname) ? pathname : undefined;
     requestLogPaths.set(request, staticRequestPath ?? "<unmatched>");
+    // Attach host before route matching so uncaught 500s (which never reach
+    // handleApiRequest) still tell us which public API hostname was hit.
+    attachInboundRequestHostToSentry(request);
   })
   .mapResponse(({ request, responseValue }) => responseValue instanceof Response
     ? compressResponse(request, responseValue)
@@ -114,7 +118,7 @@ async function dispatch(request: Request) {
   // here instead of registering a second OpenTelemetry provider through Elysia's
   // plugin. The normalized path is safe; the concrete path may contain customer IDs.
   if (isHttpMethod(method)) {
-    updateRequestSpanName(method, match.normalizedPath);
+    updateRequestSpanName(method, match.normalizedPath, getInboundRequestHost(request));
   }
   const context: RequestContext = {
     abortSignal: request.signal,
@@ -178,7 +182,18 @@ async function dispatch(request: Request) {
   });
 }
 
-function updateRequestSpanName(method: typeof httpMethodNames[number], normalizedPath: string) {
+function attachInboundRequestHostToSentry(request: Request) {
+  const host = getInboundRequestHost(request);
+  if (host == null) {
+    return;
+  }
+  Sentry.getIsolationScope().setTag("host", host);
+  Sentry.getIsolationScope().setContext("stack-request", { host });
+  const requestSpan = trace.getActiveSpan();
+  requestSpan?.setAttribute("stack.request.host", host);
+}
+
+function updateRequestSpanName(method: typeof httpMethodNames[number], normalizedPath: string, host: string | undefined) {
   const requestSpan = trace.getActiveSpan();
   if (requestSpan == null) {
     return;
@@ -189,6 +204,9 @@ function updateRequestSpanName(method: typeof httpMethodNames[number], normalize
   Sentry.updateSpanName(requestSpan, `${method} ${normalizedPath}`);
   requestSpan.setAttribute("http.request.method", method);
   requestSpan.setAttribute("http.route", normalizedPath);
+  if (host != null) {
+    requestSpan.setAttribute("stack.request.host", host);
+  }
 }
 
 async function discardHeadResponseBody(method: string, response: Response): Promise<void> {

--- a/apps/backend/src/server/request-log.test.ts
+++ b/apps/backend/src/server/request-log.test.ts
@@ -32,12 +32,32 @@ describe("createRequestCompletionLog", () => {
       service: "stack-backend",
       method: "POST",
       path: "/api/latest/users/[user_id]",
+      host: "api.example.com",
       status: 201,
       requestId: "request-123",
       environment: "production",
       commit: "abc123",
       region: "iad1",
     });
+    expect(JSON.stringify(result)).not.toContain("user-secret");
+    expect(JSON.stringify(result)).not.toContain("do-not-log");
+  });
+
+  it("logs the inbound failover host from x-forwarded-host without collapsing it to the canonical API host", () => {
+    const result = createRequestCompletionLog({
+      request: new Request("https://api.hexclave.com/api/latest/users/user-secret?secret=do-not-log", {
+        method: "POST",
+        headers: {
+          "x-forwarded-host": "api2.hexclave.com",
+        },
+      }),
+      response: new Response(null, { status: 500 }),
+      fallbackStatus: 500,
+      startedAt: performance.now(),
+      normalizedPath: "/api/latest/users/[user_id]",
+    });
+
+    expect(result.host).toBe("api2.hexclave.com");
     expect(JSON.stringify(result)).not.toContain("user-secret");
     expect(JSON.stringify(result)).not.toContain("do-not-log");
   });

--- a/apps/backend/src/server/request-log.ts
+++ b/apps/backend/src/server/request-log.ts
@@ -1,3 +1,4 @@
+import { getInboundRequestHost } from "@/lib/request-api-url";
 import { getEnvVariable, getNodeEnvironment } from "@hexclave/shared/dist/utils/env";
 
 export type RequestCompletionLog = {
@@ -5,6 +6,7 @@ export type RequestCompletionLog = {
   service: "stack-backend",
   method: string,
   path: string,
+  host: string | null,
   status: number | string | undefined,
   durationMs: number | null,
   requestId: string | null,
@@ -31,6 +33,7 @@ export function createRequestCompletionLog(input: {
     service: "stack-backend",
     method: input.request.method,
     path: input.normalizedPath,
+    host: getInboundRequestHost(input.request) ?? null,
     status,
     durationMs: input.startedAt == null ? null : Number((performance.now() - input.startedAt).toFixed(1)),
     requestId,


### PR DESCRIPTION

### Summary of Changes
We take the inbound request's target host and we log it to sentry.
There's a priority order of how we extract that info, first we read from x-forwarded-host because edge servers like vercel can preserve that info on this field, then we read our own host field.
This should be backwards compatible as it is purely additive/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs the hostname a client actually targeted (`api2`, not the canonical `api`) in Sentry error events and request logs, so operational issues isolated to one failover host are visible. Host extraction prefers `x-forwarded-host`, then `Host`, then the request URL, and is purely additive — no existing fields or behavior change.

- Adds a `host` field to request completion logs, a `host` tag and `stack-request.host` context to Sentry events, and a `stack.request.host` span attribute.
- Attaches the host before route matching so uncaught 500s that never reach the route handler still carry it.

**Security**
- The Sentry scrubber and host parser reject anything that isn't a plain hostname, so a crafted `x-forwarded-host` can't smuggle a URL or path into logs.
- Host values are default-deny checked at every write point; malformed or oversized values are dropped.

<sup>Written for commit 01080c92c519a7a970de036fb3ef1e9d0bae5194. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inbound request host tracking to request logs and observability data.
  * Supports forwarded hosts while preserving failover and IPv6 host values.
  * Safe host values are retained in diagnostics; unsafe URL-like values are removed.

* **Bug Fixes**
  * Prevented malformed or malicious host values from being misinterpreted or exposed in telemetry.
  * Added validation for empty, oversized, and invalid hostnames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->