### PR TITLE
chore(ai): retarget MODEL_SELECTION_MATRIX to glm-5.3-flash and gpt-5.6-sol

### DIFF
--- a/apps/backend/src/lib/ai/models.ts
+++ b/apps/backend/src/lib/ai/models.ts
@@ -18,32 +18,32 @@ const MODEL_SELECTION_MATRIX: Record<
 > = {
   dumb: {
     slow: {
-      authenticated: { modelId: "z-ai/glm-4.5-air" },
-      unauthenticated: { modelId: "nvidia/nemotron-3-super-120b-a12b" },
+      authenticated: { modelId: "z-ai/glm-5.3-flash" },
+      unauthenticated: { modelId: "z-ai/glm-5.3-flash:floor" },
     },
     fast: {
-      authenticated: { modelId: "openai/gpt-oss-120b:nitro" },
-      unauthenticated: { modelId: "nvidia/nemotron-3-super-120b-a12b:nitro" },
+      authenticated: { modelId: "z-ai/glm-5.3-flash:nitro" },
+      unauthenticated: { modelId: "z-ai/glm-5.3-flash" },
     },
   },
   smart: {
     slow: {
-      authenticated: { modelId: "openai/gpt-5.5" },
-      unauthenticated: { modelId: "z-ai/glm-5.2:nitro" },
+      authenticated: { modelId: "openai/gpt-5.6-sol" },
+      unauthenticated: { modelId: "z-ai/glm-5.3-flash" },
     },
     fast: {
-      authenticated: { modelId: "openai/gpt-5.5" },
-      unauthenticated: { modelId: "z-ai/glm-5.2:nitro" },
+      authenticated: { modelId: "openai/gpt-5.6-sol:nitro" },
+      unauthenticated: { modelId: "z-ai/glm-5.3-flash" },
     },
   },
   smartest: {
     slow: {
-      authenticated: { modelId: "openai/gpt-5.5" },
-      unauthenticated: { modelId: "z-ai/glm-5.2:nitro" },
+      authenticated: { modelId: "openai/gpt-5.6-sol" },
+      unauthenticated: { modelId: "z-ai/glm-5.3-flash" },
     },
     fast: {
-      authenticated: { modelId: "openai/gpt-5.5" },
-      unauthenticated: { modelId: "z-ai/glm-5.2:nitro" },
+      authenticated: { modelId: "openai/gpt-5.6-sol:nitro" },
+      unauthenticated: { modelId: "z-ai/glm-5.3-flash" },
     },
   },
 };


### PR DESCRIPTION
## Why
Ask Hexclave and the dashboard AI routes should call current OpenRouter slugs. This retarget sat in the observability working tree by accident. Land it on `dev` on its own.

## Scope
`apps/backend/src/lib/ai/models.ts` only.

`MODEL_SELECTION_MATRIX` now uses:
- `z-ai/glm-5.3-flash` for every dumb cell, with `:floor` on unauthenticated slow and `:nitro` on authenticated fast
- `openai/gpt-5.6-sol` for authenticated smart and smartest, with `:nitro` on fast
- `z-ai/glm-5.3-flash` for unauthenticated smart and smartest

`ALLOWED_MODEL_IDS` is derived from the matrix. The AI proxy allowlist updates with it.

Observability work from #1976 is out of this PR. `stack/observability-base` no longer has this file change.

## Tradeoffs
Unauthenticated dumb traffic leaves Nemotron. Unauthenticated smart and smartest leave `z-ai/glm-5.2:nitro`. Authenticated smart and smartest leave `openai/gpt-5.5`. Cost and quality follow the new slugs.

## Blast Radius
`selectModel` feeds `/api/latest/ai/query/[mode]`. `ALLOWED_MODEL_IDS` gates `/api/latest/integrations/ai-proxy`. Old matrix slugs drop out of the allowlist. Direct clients that still send those slugs get rejected. The committed copy of this file on `stack/observability-base` already matched `origin/dev`, so this PR does not conflict with that branch.

## Verification
Diff against `origin/dev` is twelve `modelId` strings in one file. The `stack/observability-base` working tree no longer contains the change. Backend and e2e tests do not hardcode the old slugs.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retargets `MODEL_SELECTION_MATRIX` to current OpenRouter slugs so Ask Hexclave and dashboard AI routes stop sending deprecated model IDs. The matrix now maps dumb and unauthenticated smart/smartest routes to `z-ai/glm-5.3-flash`, and authenticated smart/smartest routes to `openai/gpt-5.6-sol`, with `:floor`/`:nitro` speed-tier variants.

**Side effects**
- `ALLOWED_MODEL_IDS` is derived from the matrix, so the AI proxy allowlist drops the old slugs and rejects direct clients that still send them.
- Unauthenticated dumb traffic moves off Nemotron, and authenticated smart/smartest traffic moves off GPT-5.5.
- The committed copy on `stack/observability-base` already matches `origin/dev`, so this PR does not conflict with that branch.

<sup>Written for commit 853e6f712cdd261bf4cd93681412d6a319708fed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated AI model selection across quality, speed, and authentication settings.
  * Improved model routing for faster and more capable responses.
  * Replaced several outdated model options with newer alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->