### PR TITLE
chore(ai): send every MODEL_SELECTION_MATRIX cell through :nitro

### DIFF
--- a/apps/backend/src/lib/ai/models.ts
+++ b/apps/backend/src/lib/ai/models.ts
@@ -18,32 +18,32 @@ const MODEL_SELECTION_MATRIX: Record<
 > = {
   dumb: {
     slow: {
-      authenticated: { modelId: "z-ai/glm-5.3-flash" },
-      unauthenticated: { modelId: "z-ai/glm-5.3-flash:floor" },
+      authenticated: { modelId: "z-ai/glm-5.3-flash:nitro" },
+      unauthenticated: { modelId: "z-ai/glm-5.3-flash:nitro" },
     },
     fast: {
       authenticated: { modelId: "z-ai/glm-5.3-flash:nitro" },
-      unauthenticated: { modelId: "z-ai/glm-5.3-flash" },
+      unauthenticated: { modelId: "z-ai/glm-5.3-flash:nitro" },
     },
   },
   smart: {
     slow: {
-      authenticated: { modelId: "openai/gpt-5.6-sol" },
-      unauthenticated: { modelId: "z-ai/glm-5.3-flash" },
+      authenticated: { modelId: "openai/gpt-5.6-sol:nitro" },
+      unauthenticated: { modelId: "z-ai/glm-5.3-flash:nitro" },
     },
     fast: {
       authenticated: { modelId: "openai/gpt-5.6-sol:nitro" },
-      unauthenticated: { modelId: "z-ai/glm-5.3-flash" },
+      unauthenticated: { modelId: "z-ai/glm-5.3-flash:nitro" },
     },
   },
   smartest: {
     slow: {
-      authenticated: { modelId: "openai/gpt-5.6-sol" },
-      unauthenticated: { modelId: "z-ai/glm-5.3-flash" },
+      authenticated: { modelId: "openai/gpt-5.6-sol:nitro" },
+      unauthenticated: { modelId: "z-ai/glm-5.3-flash:nitro" },
     },
     fast: {
       authenticated: { modelId: "openai/gpt-5.6-sol:nitro" },
-      unauthenticated: { modelId: "z-ai/glm-5.3-flash" },
+      unauthenticated: { modelId: "z-ai/glm-5.3-flash:nitro" },
     },
   },
 };


### PR DESCRIPTION
## Why
Ask Hexclave and the dashboard AI routes should use OpenRouter nitro for every quality/speed/auth combo. This sat in the observability working tree as a one-off. Land it on `dev` on its own.

## Scope
`apps/backend/src/lib/ai/models.ts` only.

`MODEL_SELECTION_MATRIX` now uses:
- `z-ai/glm-5.3-flash:nitro` for every dumb cell and every unauthenticated cell
- `openai/gpt-5.6-sol:nitro` for authenticated smart and smartest

`ALLOWED_MODEL_IDS` is derived from the matrix. The AI proxy allowlist updates with it.

Observability work is out of this PR. `stack/observability-base` no longer has this file change.

## Tradeoffs
Unauthenticated and slow cells leave the cheaper default / `:floor` slugs. Cost follows nitro. Latency should drop for those cells.

## Blast Radius
`selectModel` feeds `/api/latest/ai/query/[mode]`. `ALLOWED_MODEL_IDS` gates `/api/latest/integrations/ai-proxy`. Old matrix slugs (`z-ai/glm-5.3-flash`, `z-ai/glm-5.3-flash:floor`, `openai/gpt-5.6-sol`) drop out of the allowlist. Direct clients that still send those slugs get rejected.

## Verification
Diff against `origin/dev` is nine `modelId` strings in one file. The `stack/observability-base` working tree no longer contains the change. Backend and e2e tests do not hardcode the old slugs.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes all AI model selections through OpenRouter nitro for every quality, speed, and auth combo. Previously the unauthenticated and slow cells used cheaper default or `:floor` slugs; now every cell uses `:nitro`, so latency should drop but cost follows nitro.

- The AI proxy allowlist derives from the matrix, so the old slugs (`z-ai/glm-5.3-flash`, `z-ai/glm-5.3-flash:floor`, `openai/gpt-5.6-sol`) drop out of it. Direct clients still sending those slugs get rejected.

<sup>Written for commit 5a1fa933ea157edb817a322027524e2d8741703e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the configured AI model variants used by the application.
  * AI requests now use “nitro” model variants for improved routing or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->