### PR TITLE
fix(hosted-components): make the OTP input reachable and its caret honest

### DIFF
--- a/apps/hosted-components/src/components/ui/input-otp.tsx
+++ b/apps/hosted-components/src/components/ui/input-otp.tsx
@@ -8,6 +8,8 @@ type InputOTPContextValue = {
   maxLength: number,
   disabled?: boolean,
   setValue: (value: string) => void,
+  selectionStart: number,
+  selectionEnd: number,
 };
 
 const InputOTPContext = React.createContext<InputOTPContextValue | null>(null);
@@ -31,13 +33,113 @@ type InputOTPProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "onChange
 const InputOTP = forwardRefIfNeeded<HTMLInputElement, InputOTPProps>(
   ({ className, containerClassName, children, value, onChange, maxLength, disabled, ...props }, ref) => {
     const inputRef = React.useRef<HTMLInputElement | null>(null);
+    const pendingCaretRef = React.useRef<number | null>(null);
+
+    // React rewrites the whole value of a controlled input on every keystroke, which parks the
+    // caret at the end. Put it back where the edit happened, or typing into the middle of a code
+    // jumps to the end after the first character. useLayoutEffect so it never paints in between.
+    React.useLayoutEffect(() => {
+      const input = inputRef.current;
+      const pendingCaret = pendingCaretRef.current;
+      pendingCaretRef.current = null;
+      if (input == null || pendingCaret == null || document.activeElement !== input) {
+        return;
+      }
+      const caret = Math.min(pendingCaret, input.value.length);
+      if (input.selectionStart !== caret || input.selectionEnd !== caret) {
+        input.setSelectionRange(caret, caret);
+      }
+    }, [value]);
+
+    const [selection, setSelection] = React.useState({ start: 0, end: 0 });
+
+    // The caret moves for reasons React never sees (arrow keys, Home/End, clicking, shift-select),
+    // so mirror the input's real selection into state and let the slots render from it.
+    React.useEffect(() => {
+      const syncSelection = () => {
+        const input = inputRef.current;
+        if (input == null) {
+          return;
+        }
+        setSelection({
+          start: input.selectionStart ?? input.value.length,
+          end: input.selectionEnd ?? input.value.length,
+        });
+      };
+
+      syncSelection();
+      document.addEventListener("selectionchange", syncSelection);
+      return () => document.removeEventListener("selectionchange", syncSelection);
+    }, [value]);
 
     const contextValue = React.useMemo<InputOTPContextValue>(() => ({
       value,
       maxLength,
       disabled,
       setValue: onChange,
-    }), [disabled, maxLength, onChange, value]);
+      selectionStart: selection.start,
+      selectionEnd: selection.end,
+    }), [disabled, maxLength, onChange, selection.end, selection.start, value]);
+
+    // The real input is visually hidden, so there is nothing obvious to aim at. Capture typing and
+    // pasting from anywhere on the page and route it into the input, so a user coming back from
+    // their email client can just start typing (or hit cmd+V) without hunting for the field.
+    React.useEffect(() => {
+      if (disabled) {
+        return;
+      }
+
+      const isForeignEditable = (target: EventTarget | null) => {
+        if (!(target instanceof HTMLElement) || target === inputRef.current) {
+          return false;
+        }
+        return target.isContentEditable
+          || target instanceof HTMLInputElement
+          || target instanceof HTMLTextAreaElement
+          || target instanceof HTMLSelectElement;
+      };
+
+      const onDocumentKeyDown = (event: KeyboardEvent) => {
+        const input = inputRef.current;
+        if (input == null || event.defaultPrevented) {
+          return;
+        }
+        // Let shortcuts through, and ignore Space: it is never part of a code, and swallowing it
+        // would stop it from activating whichever button currently has focus.
+        if (event.ctrlKey || event.metaKey || event.altKey || event.key.length !== 1 || event.key === " ") {
+          return;
+        }
+        if (document.activeElement === input || isForeignEditable(event.target)) {
+          return;
+        }
+        event.preventDefault();
+        input.focus();
+        onChange((value + event.key).slice(0, maxLength));
+      };
+
+      const onDocumentPaste = (event: ClipboardEvent) => {
+        const input = inputRef.current;
+        if (input == null || event.defaultPrevented || isForeignEditable(event.target)) {
+          return;
+        }
+        const pasted = (event.clipboardData?.getData("text") ?? "").replace(/\s/g, "");
+        if (pasted === "") {
+          return;
+        }
+        // A pasted code is always the whole code, so replace rather than append -- otherwise
+        // pasting over a half-typed value silently produces a mangled code.
+        event.preventDefault();
+        input.focus();
+        onChange(pasted.slice(0, maxLength));
+      };
+
+      document.addEventListener("keydown", onDocumentKeyDown);
+      document.addEventListener("paste", onDocumentPaste);
+      return () => {
+        document.removeEventListener("keydown", onDocumentKeyDown);
+        document.removeEventListener("paste", onDocumentPaste);
+      };
+    }, [disabled, maxLength, onChange, value]);
 
     return (
       <InputOTPContext.Provider value={contextValue}>
@@ -46,6 +148,10 @@ const InputOTP = forwardRefIfNeeded<HTMLInputElement, InputOTPProps>(
           onClick={() => inputRef.current?.focus()}
         >
           <input
+            // `...props` must be spread FIRST: React 19 passes `ref` as a regular prop, so a
+            // trailing spread would overwrite the callback ref below and leave `inputRef` null,
+            // silently killing the click-to-focus handler above.
+            {...props}
             ref={(node) => {
               inputRef.current = node;
               if (typeof ref === "function") {
@@ -58,8 +164,10 @@ const InputOTP = forwardRefIfNeeded<HTMLInputElement, InputOTPProps>(
             maxLength={maxLength}
             disabled={disabled}
             className={cn("absolute inset-0 h-full w-full cursor-default opacity-0 disabled:cursor-not-allowed", className)}
-            onChange={(event) => onChange(event.target.value.slice(0, maxLength))}
-            {...props}
+            onChange={(event) => {
+              pendingCaretRef.current = event.target.selectionStart;
+              onChange(event.target.value.slice(0, maxLength));
+            }}
           />
           {children}
         </div>
@@ -80,13 +188,20 @@ const InputOTPSlot = forwardRefIfNeeded<HTMLDivElement, React.HTMLAttributes<HTM
   ({ index, className, size = "default", ...props }, ref) => {
     const context = useInputOTPContext();
     const char = context.value.at(index) ?? "";
-    const isActive = context.value.length === index && context.value.length < context.maxLength && !context.disabled;
+    const hasSelectionRange = context.selectionEnd > context.selectionStart;
+    // Follow the real caret rather than assuming it sits after the last character: otherwise the
+    // highlighted box lies about where the next keystroke or deletion will land.
+    const isCaret = !hasSelectionRange && context.selectionStart === index && !context.disabled;
+    const isSelected = hasSelectionRange && index >= context.selectionStart && index < context.selectionEnd && !context.disabled;
+    const isActive = isCaret || isSelected;
 
     return (
       <div
         ref={ref}
         className={cn(
-          "relative flex h-9 w-9 items-center justify-center rounded-md border border-input text-sm",
+          // The slots are purely presentational and paint on top of the visually hidden input;
+          // without `pointer-events-none` a click or tap on a box never reaches the input.
+          "pointer-events-none relative flex h-9 w-9 items-center justify-center rounded-md border border-input text-sm",
           size === "lg" ? "h-10 w-10 text-lg font-medium" : "",
           isActive && "z-10 ring-1 ring-ring",
           className,
@@ -94,7 +209,7 @@ const InputOTPSlot = forwardRefIfNeeded<HTMLDivElement, React.HTMLAttributes<HTM
         {...props}
       >
         {char}
-        {isActive && (
+        {isCaret && char === "" && (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
             <div className="h-4 w-px animate-caret-blink bg-foreground duration-1000" />
           </div>


### PR DESCRIPTION
## The bug

The hosted "Enter the code from your email" field is untypeable in production once focus is lost — which is exactly what happens when you leave the page to go read your email. On mobile it can be untypeable from the very first tap.

The field only ever became typeable via the one-shot autofocus on mount. Clicking the boxes could never restore focus.

## Root causes

Four related problems in `apps/hosted-components/src/components/ui/input-otp.tsx`:

1. **The forwarded ref clobbered the internal one.** React 19 passes `ref` as a regular prop, and `{...props}` was spread *after* `ref={callback}`, so the caller's ref overwrote the callback and left `inputRef` null. The container's `onClick={() => inputRef.current?.focus()}` was a silent no-op. Only `magic-link-sign-in.tsx` passes a ref, which is why this screen was uniquely broken and the MFA screen was not.

2. **The slots buried the input.** The slot divs are `position: relative` and render after the visually hidden `absolute inset-0` input, so they paint on top and swallow every click. Measured in the live DOM: a click at the centre of a box hit `DIV.relative`; only the 8px gaps between boxes reached the input.

Together these meant nothing could focus the input by clicking. On iOS Safari, where a gesture-less `focus()` is ignored, the mount autofocus never fires either — so the field is dead from the first tap.

3. **No way back after leaving the page.** Added document-level capture so typing or pasting anywhere routes into the field.

4. **The highlighted box lied.** `isActive` was hardcoded to `value.length === index`, so it could not track a caret moved with the arrow keys — it claimed the last box while edits landed at the caret.

## Changes

- Spread `{...props}` first so the callback ref (which already forwards to the caller's ref) wins.
- `pointer-events-none` on the slots — they are purely presentational — so clicks and taps land on the input natively.
- Document-level `keydown` + `paste` capture. Paste strips whitespace (codes copied from email carry it) and replaces rather than appends, since a pasted code is always the whole code. Guarded against stealing from another input, from modifier shortcuts, and from Space (which would stop it activating a focused button).
- The highlighted box follows the real selection, including shift-select ranges. The blinking caret renders only in empty boxes.
- Restore the caret after the controlled re-render. React rewrites the whole value on every keystroke, parking the caret at the end, so editing mid-code jumped to the end after one character. This was pre-existing but invisible while the highlight always claimed to be at the end.

`InputOTP` is shared with the MFA screen, which gets the same fixes.

## Verification

Run against a local backend with the real magic-link flow (codes pulled from inbucket).

Before → after, same sequence (blur, then click directly on a box):

| | before | after |
|---|---|---|
| click a box | `activeElement` → `BODY` | `activeElement` → `INPUT` |
| then type | nothing lands | text lands |
| hit-test at box centre | `DIV.relative` | the input |
| container `onClick` | ran, focused nothing | focuses the input |

Also verified:
- Full sign-in by **typing with nothing focused** (`activeElement === BODY`) — authenticates and redirects.
- Full sign-in by **pasting onto `document.body`** — whitespace stripped, auto-submitted, authenticates.
- Typing in the email field on the previous step is **not** hijacked.
- Caret highlight at every position on `ABC`: ring follows caret; blinking bar only in empty boxes; shift-select highlights the range.
- Typing at the leftmost position gives `XABC` with the caret at 1 (previously jumped to 4).

`typecheck` and `lint` both pass on `@hexclave/hosted-components`.

Two gaps worth naming, both harness limitations rather than untested code paths:
- CDP synthetic key events don't perform caret/editing commands, so `ArrowLeft`/`Backspace` couldn't be driven directly. Caret movement was exercised via `setSelectionRange`, which is the identical `selectionchange` → re-render path a real arrow key triggers. Worth one manual arrow-key pass.
- Clipboard write is blocked in the test browser, so paste was exercised with a `ClipboardEvent` carrying a real `DataTransfer`. Same event and code path as an OS cmd+V; only `isTrusted` differs. Worth one manual cmd+V.

## Not included

`MagicLinkOtp`'s `<form>` has no `onSubmit`, so pressing Enter in the OTP field triggers implicit submission — a full page reload that discards the nonce. One line to fix, but out of scope here; happy to fold it in if preferred.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the hosted OTP input typeable and its caret highlight truthful. The field previously became untypeable after losing focus (e.g., when reading email) and was dead on mobile from the first tap. It now accepts clicks, typing anywhere, and pasting, and the highlighted slot follows the real caret.

**Changes**
- Fixed ref prop ordering that nulled the internal ref, making click-to-focus a no-op.
- Made the slot divs `pointer-events-none` so clicks and taps reach the visually hidden input.
- Added document-level keydown and paste capture, guarded to avoid hijacking other inputs, shortcuts, or Space.
- Highlight now tracks the real selection including shift-select; caret is restored after controlled re-render.
- `InputOTP` is shared with the MFA screen, which gets the same fixes.

<sup>Written for commit 0fd8a5b0c628fde41cce18d2feb9af485b06acc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved one-time passcode entry by preserving the caret position while values update.
  - Typing and pasting now consistently populate the passcode input, even when focus is not directly on the visible field.
  - Updated character highlighting and caret indicators to accurately reflect the current selection.
  - Improved compatibility with modern React input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->