### PR TITLE
fix(backend): don't force prompt=consent for Microsoft OAuth

### DIFF
--- a/apps/backend/src/oauth/providers/base.tsx
+++ b/apps/backend/src/oauth/providers/base.tsx
@@ -338,6 +338,7 @@ export abstract class OAuthBaseProvider {
     public readonly openid?: boolean,
     public readonly alternativeIssuers?: string[],
     public readonly includeScopeInCallbackTokenExchange?: boolean,
+    public readonly noConsentPrompt?: boolean,
   ) {}
 
   protected static async createConstructorArgs(options:
@@ -352,6 +353,7 @@ export abstract class OAuthBaseProvider {
       noPKCE?: boolean,
       alternativeIssuers?: string[],
       includeScopeInCallbackTokenExchange?: boolean,
+      noConsentPrompt?: boolean,
     }
     & (
       | ({
@@ -408,6 +410,7 @@ export abstract class OAuthBaseProvider {
       options.openid,
       options.alternativeIssuers,
       options.includeScopeInCallbackTokenExchange,
+      options.noConsentPrompt,
     ] as const;
   }
 
@@ -425,7 +428,7 @@ export abstract class OAuthBaseProvider {
       state: options.state,
       response_type: "code",
       access_type: "offline",
-      prompt: "consent",
+      ...(this.noConsentPrompt ? {} : { prompt: "consent" }),
       ...this.authorizationExtraParams,
     });
   }

--- a/apps/backend/src/oauth/providers/microsoft.test.ts
+++ b/apps/backend/src/oauth/providers/microsoft.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { GithubProvider } from "./github";
+import { MicrosoftProvider } from "./microsoft";
+
+describe("MicrosoftProvider authorization URL", () => {
+  it("does not force a consent prompt", async () => {
+    const provider = await MicrosoftProvider.create({
+      clientId: "x",
+      clientSecret: "y",
+      microsoftTenantId: "tenant",
+      redirectUri: "http://localhost/cb",
+    });
+    const url = new URL(provider.getAuthorizationUrl({ codeVerifier: "v", state: "s" }));
+
+    expect(url.searchParams.has("prompt")).toBe(false);
+    expect(url.searchParams.has("access_type")).toBe(true);
+    expect(url.searchParams.has("scope")).toBe(true);
+  });
+});
+
+describe("GithubProvider authorization URL", () => {
+  it("still requests a consent prompt", async () => {
+    const provider = await GithubProvider.create({
+      clientId: "x",
+      clientSecret: "y",
+      redirectUri: "http://localhost/cb",
+    });
+    const url = new URL(provider.getAuthorizationUrl({ codeVerifier: "v", state: "s" }));
+
+    expect(url.searchParams.get("prompt")).toBe("consent");
+  });
+});

--- a/apps/backend/src/oauth/providers/microsoft.tsx
+++ b/apps/backend/src/oauth/providers/microsoft.tsx
@@ -31,6 +31,10 @@ export class MicrosoftProvider extends OAuthBaseProvider {
       // it, but connected-account flows with extra provider_scope values have
       // returned AADSTS70011 unless we include the originally requested scopes.
       includeScopeInCallbackTokenExchange: true,
+      // Entra re-prompts for (admin) consent on every sign-in when prompt=consent
+      // is sent, even if the tenant already granted consent; incremental consent
+      // still happens automatically when new scopes are requested.
+      noConsentPrompt: true,
       ...rest,
     }));
   }


### PR DESCRIPTION
`OAuthBaseProvider.getAuthorizationUrl` always sent `prompt=consent`. For Microsoft Entra that re-prompts for (admin) consent on every sign-in, even when the tenant already granted it.

- Add a per-provider `noConsentPrompt` option to `OAuthBaseProvider` (mirrors `noPKCE`); when set, `prompt` is omitted from the authorize URL (providers can still override via `authorizationExtraParams`).
- `MicrosoftProvider` sets `noConsentPrompt: true`. All other providers unchanged.
- Tests: `microsoft.test.ts` asserts Microsoft authorize URLs contain no `prompt` param, and GitHub still sends `prompt=consent`.

Link to Devin session: https://app.devin.ai/sessions/c196c3729a07428eaf9f39cebe67e119
Open in Devin Desktop: https://app.devin.ai/desktop/session/c196c3729a07428eaf9f39cebe67e119?variant=devin
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted OAuth authorize-URL behavior for Microsoft only; default consent prompting is unchanged for other providers.
> 
> **Overview**
> Microsoft Entra sign-in was re-showing **(admin) consent on every login** because authorize URLs always included `prompt=consent`.
> 
> **OAuth base provider** now supports an optional `noConsentPrompt` flag (same pattern as `noPKCE`). When set, `getAuthorizationUrl` omits the `prompt` parameter instead of defaulting to `consent`; providers can still override via `authorizationExtraParams`.
> 
> **Microsoft** enables `noConsentPrompt: true` so tenants that already granted consent are not forced through the prompt again; new scopes should still trigger incremental consent when needed.
> 
> **Tests** assert Microsoft authorize URLs have no `prompt` query param and GitHub continues to send `prompt=consent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0126b1df8a3a1c2622a58dd365916f6c7778412f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops forcing `prompt=consent` for Microsoft OAuth so Entra doesn't re-prompt for admin consent on every sign-in. Adds a per-provider `noConsentPrompt` option to `OAuthBaseProvider`; `MicrosoftProvider` sets it, all other providers keep the old behavior. Tests cover Microsoft (no `prompt`) and GitHub (still `prompt=consent`).

<sup>Written for commit 0126b1df8a3a1c2622a58dd365916f6c7778412f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Microsoft sign-in no longer prompts for administrator consent on every login.
  - Existing consent prompts remain available when additional permissions are required.
  - GitHub sign-in behavior remains unchanged, continuing to request consent as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->