### PR TITLE
fix(backend): don't force prompt=consent for custom OIDC providers

### DIFF
--- a/apps/backend/src/oauth/providers/custom-oidc.test.ts
+++ b/apps/backend/src/oauth/providers/custom-oidc.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("openid-client", async (importOriginal) => {
+  const original = await importOriginal<typeof import("openid-client")>();
+  const OriginalIssuer = original.Issuer;
+
+  class MockIssuer extends OriginalIssuer {
+    static discover() {
+      return Promise.resolve(new OriginalIssuer({
+        issuer: "https://idp.example.com",
+        authorization_endpoint: "https://idp.example.com/authorize",
+        token_endpoint: "https://idp.example.com/token",
+        userinfo_endpoint: "https://idp.example.com/userinfo",
+        jwks_uri: "https://idp.example.com/jwks",
+      }));
+    }
+  }
+
+  return {
+    ...original,
+    Issuer: MockIssuer,
+  };
+});
+
+import { CustomOidcProvider } from "./custom-oidc";
+
+describe("CustomOidcProvider authorization URL", () => {
+  it("does not force a consent prompt", async () => {
+    const provider = await CustomOidcProvider.create({
+      clientId: "x",
+      clientSecret: "y",
+      redirectUri: "http://localhost/cb",
+      issuerUrl: "https://idp.example.com",
+    });
+    const url = new URL(provider.getAuthorizationUrl({ codeVerifier: "v", state: "s" }));
+
+    expect(url.searchParams.has("prompt")).toBe(false);
+    expect(url.searchParams.get("scope")).toBe("openid email profile");
+  });
+});

--- a/apps/backend/src/oauth/providers/custom-oidc.tsx
+++ b/apps/backend/src/oauth/providers/custom-oidc.tsx
@@ -21,6 +21,12 @@ export class CustomOidcProvider extends OAuthBaseProvider {
       redirectUri,
       baseScope: scope || "openid email profile",
       openid: true,
+      // Spec-compliant IdPs (Okta, Auth0, Keycloak, Entra via generic OIDC, ...) honor
+      // prompt=consent by ignoring existing grants and re-showing the consent screen on
+      // every sign-in, which for enterprise tenants often turns into an admin-approval
+      // wall. Same reasoning as MicrosoftProvider. Refresh tokens are still issued
+      // whenever the configured scope includes offline_access.
+      noConsentPrompt: true,
       ...rest,
     }));
   }


### PR DESCRIPTION
Follow-up to #2038. Sets `noConsentPrompt: true` on `CustomOidcProvider` so spec-compliant IdPs (Okta, Auth0, Keycloak, Entra via generic OIDC) stop re-showing the consent / admin-approval screen on every sign-in. Refresh tokens are unaffected as long as the configured scope includes `offline_access`.

Adds a unit test that stubs `Issuer.discover` and asserts `prompt` is absent from the authorization URL. No other providers change.

Link to Devin session: https://app.devin.ai/sessions/c196c3729a07428eaf9f39cebe67e119
Open in Devin Desktop: https://app.devin.ai/desktop/session/c196c3729a07428eaf9f39cebe67e119?variant=devin
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow OAuth URL tweak for custom OIDC only, with a regression test; sign-in UX improves but authorization parameters change for existing tenants.
> 
> **Overview**
> **Custom OIDC** sign-in no longer adds `prompt=consent` to the authorization URL, matching the intent behind other providers and avoiding repeat consent or admin-approval screens on every login for Okta, Auth0, Keycloak, and similar IdPs.
> 
> `CustomOidcProvider.create` now passes **`noConsentPrompt: true`** into `OAuthBaseProvider.createConstructorArgs` (the base layer only omits the `prompt` param when that flag is set). Refresh-token behavior is unchanged when scopes include `offline_access`.
> 
> A new **Vitest** suite mocks `Issuer.discover` and checks that `getAuthorizationUrl` has no `prompt` query param and still uses the default `openid email profile` scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fe38b03d9e2e4ef982c0c45cd0c89f8c14f35d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops forcing `prompt=consent` for custom OIDC providers, so spec-compliant IdPs like Okta, Auth0, Keycloak, and Entra no longer re-show the consent or admin-approval screen on every sign-in. Refresh tokens are unaffected as long as the configured scope includes `offline_access`.

- Adds a unit test that stubs `Issuer.discover` and asserts `prompt` is absent from the authorization URL.
- No other providers change.

<sup>Written for commit 1fe38b03d9e2e4ef982c0c45cd0c89f8c14f35d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Custom OpenID Connect sign-in no longer repeatedly prompts users for consent.
  * Refresh-token issuance remains available when offline access is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->