### PR TITLE
fix(tests): repair two test regressions on dev

### DIFF
--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -438,27 +438,27 @@ import.meta.vitest?.test("uncaught /api/ dispatch errors use the global sanitize
   vi.stubEnv("NODE_ENV", "production");
   const request = new Request("http://localhost/api/v1");
   const originalHeaders = request.headers;
-  let headersReadCount = 0;
-  let headerReadThrew = false;
+  let headersIteratedCount = 0;
   // Simulate an unexpected internal failure escaping dispatch for an /api/ request.
-  // This depends on runRequestPipeline reading headers first; after the first throw,
-  // return them because response compression reads request headers after the error handler.
-  Object.defineProperty(request, "headers", {
-    get() {
-      headersReadCount++;
-      if (headersReadCount === 1) {
-        headerReadThrew = true;
+  // The onRequest hook and response compression only call `headers.get(...)`, whereas
+  // runRequestPipeline iterates the headers (to merge header aliases), so making the
+  // first iteration throw fails inside dispatch specifically while leaving the hooks
+  // that run before and after the error handler intact.
+  const originalIterator = originalHeaders[Symbol.iterator].bind(originalHeaders);
+  Object.defineProperty(originalHeaders, Symbol.iterator, {
+    value: function* () {
+      headersIteratedCount++;
+      if (headersIteratedCount === 1) {
         throw new Error("unexpected request header access");
       }
-      return originalHeaders;
+      yield* originalIterator();
     },
   });
 
   try {
     const response = await app.handle(request);
 
-    expect(headerReadThrew).toBe(true);
-    expect(headersReadCount).toBeGreaterThan(1);
+    expect(headersIteratedCount).toBe(1);
     expect({
       status: response.status,
       body: await response.text(),

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.next-server-session.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.next-server-session.test.ts
@@ -26,6 +26,8 @@ function createClientApp() {
 }
 
 describe("StackClientApp Next.js server sessions", () => {
+  // Only the Next.js SDK keys server token stores by the request's cookies() identity.
+  // IF_PLATFORM next
   it("shares one token store and session across cookie helpers from the same request", () => {
     const clientApp = createClientApp();
     const getTokenStore = Reflect.get(clientApp, "_getOrCreateTokenStore");
@@ -38,6 +40,7 @@ describe("StackClientApp Next.js server sessions", () => {
     expect(secondStore).toBe(firstStore);
     expect(getSession.call(clientApp, secondStore)).toBe(getSession.call(clientApp, firstStore));
   });
+  // END_PLATFORM
 
   it("isolates token stores belonging to different requests", () => {
     const clientApp = createClientApp();


### PR DESCRIPTION
Fixes the 4 failing tests on dev (https://github.com/hexclave/hexclave/actions/runs/33819517721/job/100860209446).

- `apps/backend/src/server/app.ts` boundary test: since #2026 the `onRequest` hook reads `request.headers` before dispatch, so throwing from the `headers` getter no longer simulates an error escaping dispatch. The test now throws from the first `Headers[Symbol.iterator]` call, which only `mergeHexclaveHeaderAliases` (inside `runRequestPipeline`) triggers.
- `client-app-impl.next-server-session.test.ts`: the per-request token store sharing is wrapped in `IF_PLATFORM next`, so the test asserting it is now too (it failed in the js/react/tanstack-start copies).

Verified locally: `pnpm test run apps/backend/src/server/app.ts` (9 passed) and `pnpm test run client-app-impl.next-server-session` (js/react/tanstack-start 1 each, next 2, all passing).

Link to Devin session: https://app.devin.ai/sessions/5779f33155de4ea2a934e897076c41ab
Open in Devin Desktop: https://app.devin.ai/desktop/session/5779f33155de4ea2a934e897076c41ab?variant=devin
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no runtime behavior; risk is limited to CI coverage accuracy.
> 
> **Overview**
> Repairs two failing tests after recent request-pipeline and platform-specific SDK behavior changes—**no production code** is modified.
> 
> The backend **uncaught /api/ dispatch error boundary** test no longer throws from a mocked `request.headers` getter (which `onRequest` now touches before dispatch). It instead throws on the **first `Headers[Symbol.iterator]`** call, matching header iteration in `runRequestPipeline` / alias merging while leaving pre/post error-handler `headers.get` paths alone. Assertions now expect a single failed iteration rather than multiple header reads.
> 
> In **`client-app-impl.next-server-session.test.ts`**, the case that **reuses one token store/session for cookie helpers sharing the same request identity** is wrapped in **`IF_PLATFORM next`**, since only the Next.js build keys stores that way; js/react/tanstack-start copies were failing on that assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2baaf58c2142eaf1df2e8b96417505f0ae537568. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two test regressions that were failing on dev.

- Updates the backend boundary test so it throws from the first `Headers` iteration instead of the `headers` getter, since the `onRequest` hook now reads headers before dispatch and the getter throw no longer simulates an error escaping dispatch.
- Restricts the Next.js server session token store sharing test to the Next.js platform, since only that SDK keys token stores by the request's cookies identity.

<sup>Written for commit 2baaf58c2142eaf1df2e8b96417505f0ae537568. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of API error handling to ensure unexpected dispatch failures return a sanitized server error response after a single header inspection.

- **Tests**
  - Expanded coverage for request-scoped server token storage in Next.js environments, confirming consistent behavior across cookie helpers tied to the same request.
  - Added coverage for failures occurring during request header iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->