### PR TITLE
Open project secrets dialog from query param

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/project-settings/secrets/page-client.test.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/project-settings/secrets/page-client.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import PageClient from "./page-client";
+
+const searchParamsState = vi.hoisted(() => ({ current: new URLSearchParams() }));
+const project = vi.hoisted(() => ({
+  id: "project-1",
+  listProjectSecrets: vi.fn(async () => []),
+  setProjectSecret: vi.fn(async () => undefined),
+  deleteProjectSecret: vi.fn(async () => undefined),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsState.current,
+}));
+
+vi.mock("../../use-admin-app", () => ({
+  useAdminApp: () => ({
+    useProject: () => project,
+  }),
+}));
+
+describe("Project secrets settings page", () => {
+  beforeEach(() => {
+    searchParamsState.current = new URLSearchParams();
+    project.listProjectSecrets.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("opens the set-secret dialog when addSecret is true", async () => {
+    searchParamsState.current = new URLSearchParams("addSecret=true");
+
+    render(<PageClient />);
+
+    expect(await screen.findByRole("heading", { name: "Set secret" })).toBeTruthy();
+    expect(await screen.findByPlaceholderText("e.g. OPENAI_API_KEY")).toBeTruthy();
+  });
+
+  it("keeps the set-secret dialog closed without addSecret=true", () => {
+    render(<PageClient />);
+
+    expect(screen.queryByRole("dialog")).toBeNull();
+  });
+});

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/project-settings/secrets/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/project-settings/secrets/page-client.tsx
@@ -24,6 +24,7 @@ import { PROJECT_SECRET_KEY_REGEX } from "@hexclave/shared/dist/project-secrets"
 import { runAsynchronouslyWithAlert } from "@hexclave/shared/dist/utils/promises";
 import { yupString } from "@hexclave/shared/dist/schema-fields";
 import { stringCompare } from "@hexclave/shared/dist/utils/strings";
+import { useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as yup from "yup";
 import { PageLayout } from "../../page-layout";
@@ -143,9 +144,12 @@ function formatUpdatedAt(millis: number): string {
 export default function PageClient() {
   const hexclaveAdminApp = useAdminApp();
   const project = hexclaveAdminApp.useProject();
+  const searchParams = useSearchParams();
+  const addSecret = searchParams.get("addSecret") === "true";
 
   const [rows, setRows] = useState<SecretRow[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
+  const [isSetSecretDialogOpen, setIsSetSecretDialogOpen] = useState(addSecret);
   // Refreshes race: the "Set secret" button is usable while the slow
   // mount-time load is still in flight, and this page has no periodic poll to
   // self-correct — so a superseded response writing its stale snapshot last
@@ -181,6 +185,8 @@ export default function PageClient() {
         title="Project secrets"
         actions={
           <SetSecretDialog
+            open={isSetSecretDialogOpen}
+            onOpenChange={setIsSetSecretDialogOpen}
             trigger={<Button>Set secret</Button>}
             onDone={refresh}
           />


### PR DESCRIPTION
Adds support for opening the project secrets set-secret dialog by default when addSecret=true is present in the project settings URL. Includes focused coverage for the query-param and default-closed states. Verified with focused Vitest, targeted ESLint, authenticated browser testing, and the dashboard build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opens the Set secret dialog automatically when the project settings URL includes `addSecret=true`, so users can be deep-linked directly to the dialog. Previously the dialog always started closed; now it opens on load when the param is present and stays closed otherwise.

<sup>Written for commit 4d153cffe75472c232c0e2cd30f6f896a8b6caa7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The project secrets page can now automatically open the “Set secret” dialog when accessed with the appropriate link parameter.

- **Tests**
  - Added coverage verifying the dialog opens when requested and remains closed by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->