### PR TITLE
Add an internal Deploy Admin page with a platform fusebox

### DIFF
--- a/apps/backend/prisma/migrations/20260907000000_deployments_platform_config/migration.sql
+++ b/apps/backend/prisma/migrations/20260907000000_deployments_platform_config/migration.sql
@@ -1,0 +1,26 @@
+-- Platform-wide switches for the Deployments app, as a singleton row.
+--
+-- A table of its own rather than a column on ExternalDbSyncMetadata: the two
+-- features share nothing but the singleton pattern, and a deployments fusebox
+-- living in a table named after the DB-sync pipeline is exactly the confusion an
+-- emergency switch must not cause during the incident it exists for.
+--
+-- `deploymentsEnabled` defaults to true and NO ROW IS INSERTED here: the reader
+-- treats a missing row as the defaults, so this migration cannot turn deploys
+-- off, and the row appears the first time an operator flips something.
+--
+-- The unique index is created inline rather than CONCURRENTLY in a migration of
+-- its own (as the external-db-sync indexes were): the table is empty by
+-- construction, so there is nothing to lock.
+CREATE TABLE "DeploymentsPlatformConfig" (
+    "id" TEXT NOT NULL DEFAULT gen_random_uuid(),
+    "singleton" "BooleanTrue" NOT NULL DEFAULT 'TRUE'::"BooleanTrue",
+    "deploymentsEnabled" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "DeploymentsPlatformConfig_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DeploymentsPlatformConfig_singleton_key" ON "DeploymentsPlatformConfig"("singleton");

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -2023,6 +2023,39 @@ model DeploymentSourceUpload {
 }
 
 
+// Platform-wide (cross-tenant) switches for the Deployments app.
+//
+// A singleton: one row for the whole Hexclave instance, matching
+// ExternalDbSyncMetadata's shape. Not per-project and not per-tenancy — this is
+// the operator's control over the alpha as a whole, and a per-project override
+// is deliberately not modelled until something needs one.
+//
+// Its own table rather than a column on ExternalDbSyncMetadata: the two features
+// share nothing but the singleton pattern, and a deployments switch living in a
+// table named after the DB-sync pipeline is exactly the confusion an emergency
+// switch must not cause.
+//
+// Every column defaults to today's behaviour, and a MISSING row reads as those
+// defaults (see getDeploymentsPlatformConfig) — so this table needs no backfill
+// and there is no window in which deploys are off because nobody has written to
+// it yet.
+model DeploymentsPlatformConfig {
+  id String @id @default(dbgenerated("gen_random_uuid()"))
+
+  singleton BooleanTrue @unique @default(TRUE)
+
+  // The emergency fusebox. False = no NEW deployment may be created anywhere on
+  // this instance: the deploy and upload routes refuse with a 503. Deliberately
+  // narrow — deployments already in flight run to completion, status and logs
+  // stay readable, and tearing services down keeps working, because an operator
+  // flipping this during an incident needs those more than ever.
+  deploymentsEnabled Boolean @default(true)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+
 // ─── Workflows ──────────────────────────────────────────────────────────────
 //
 // Durable, event-triggered workflows (Hexclave Workflows v1). All tables are

--- a/apps/backend/src/app/api/latest/deployments/deployments/route.tsx
+++ b/apps/backend/src/app/api/latest/deployments/deployments/route.tsx
@@ -1,5 +1,6 @@
 import { assertGlobalDeploymentCapacity, assertServicesAllowedByPlan, createDeployment, definitionFromServiceRow, deploymentToApiShape, encryptDeploymentRedactionSecrets, getServiceVolume, isTerminalDeploymentStatus, refreshDeploymentFromMarshal, resolveEnvVars, startDeployment } from "@/lib/deployments";
 import { getMarshalDeploymentsConfigOrNull } from "@/lib/deployments/marshal-client";
+import { assertDeploymentsEnabled } from "@/lib/deployments/platform-config";
 import { runtimeFromStored } from "@/lib/deployments/runtime";
 import { getPrismaClientForTenancy, retryTransaction } from "@/prisma-client";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
@@ -144,6 +145,11 @@ export const POST = createSmartRouteHandler({
     if (getMarshalDeploymentsConfigOrNull() == null) {
       throw new StatusError(400, "Deploy is not configured on this Hexclave instance. Configure HEXCLAVE_MARSHAL_API_KEY (and HEXCLAVE_MARSHAL_URL) first.");
     }
+    // The operator's fusebox, checked here for the same reason as the line
+    // above: it must refuse before this request consumes the upload. Unlike the
+    // capacity guard below it does not care what this deploy would provision —
+    // "off" means no new deployment at all.
+    await assertDeploymentsEnabled();
     const prisma = await getPrismaClientForTenancy(auth.tenancy);
 
     const plannedServiceIds = body.levels.flat();

--- a/apps/backend/src/app/api/latest/deployments/deployments/route.tsx
+++ b/apps/backend/src/app/api/latest/deployments/deployments/route.tsx
@@ -218,6 +218,7 @@ export const POST = createSmartRouteHandler({
       Object.fromEntries(definitionsByServiceId),
       source.builderMemoryMb === null ? undefined : { memory: deploymentMemoryFromMb(source.builderMemoryMb) ?? undefined },
       runtimeFromStored(source.runtime),
+      source.sourceId,
     );
 
     // Platform capacity, before the upload is consumed and before anything is

--- a/apps/backend/src/app/api/latest/deployments/services/route.tsx
+++ b/apps/backend/src/app/api/latest/deployments/services/route.tsx
@@ -102,7 +102,7 @@ export const PUT = createSmartRouteHandler({
         throw new StatusError(400, `The memory size ${JSON.stringify(definition.memory)} of service ${JSON.stringify(serviceId)} is not available for a ${JSON.stringify(definition.type)} service on this project's runtime — it can be ${available.join(", ")}.`);
       }
     }
-    await assertServicesAllowedByPlan(auth.tenancy, body.services, body.builder, runtime);
+    await assertServicesAllowedByPlan(auth.tenancy, body.services, body.builder, runtime, body.source_id);
     const prisma = await getPrismaClientForTenancy(auth.tenancy);
     const syncId = randomUUID();
     // One transaction: the sync detaches volumes before re-attaching them, so a

--- a/apps/backend/src/app/api/latest/deployments/uploads/route.tsx
+++ b/apps/backend/src/app/api/latest/deployments/uploads/route.tsx
@@ -1,5 +1,6 @@
 import { marshalNamespaceForTenancy } from "@/lib/deployments";
 import { getMarshalClientOrThrow, sanitizeMarshalError } from "@/lib/deployments/marshal-client";
+import { assertDeploymentsEnabled } from "@/lib/deployments/platform-config";
 import { getPrismaClientForTenancy } from "@/prisma-client";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { adaptSchema, serverOrHigherAuthTypeSchema, yupArray, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
@@ -48,6 +49,11 @@ export const POST = createSmartRouteHandler({
     }).defined(),
   }),
   handler: async ({ auth, body }) => {
+    // Before anything is allocated: an upload only exists to be deployed, so
+    // while the platform fusebox is off there is no point taking the tarball —
+    // and failing here is what makes the CLI stop in a second rather than after
+    // pushing a source it could never deploy.
+    await assertDeploymentsEnabled();
     const prisma = await getPrismaClientForTenancy(auth.tenancy);
     // Opportunistically drop expired references. Their objects are covered by
     // the Marshal bucket's uploads/ lifecycle rule because an abandoned CLI

--- a/apps/backend/src/app/api/latest/internal/deployments-admin/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/deployments-admin/route.tsx
@@ -1,0 +1,171 @@
+// The internal Deploy Admin page's whole backend: cross-project statistics for
+// the deployments alpha, plus the platform fusebox that pauses it.
+//
+// One route with two handlers rather than four routes, because the page loads
+// everything in one request and writes exactly one thing.
+//
+// AUTHORIZATION, the important part: this returns data about EVERY project, so
+// being signed into the internal project is not enough — the internal project's
+// publishable key is public, and on an instance with open dashboard sign-up
+// anyone can make themselves an internal-project account. ensurePlatformAdmin is
+// what actually gates it (membership of the team that owns the internal
+// project); the project check below only keeps the route off other projects'
+// dashboards. See @/lib/platform-admin.
+
+import { getDeploymentsPlatformConfig, updateDeploymentsPlatformConfig } from "@/lib/deployments/platform-config";
+import { getDeploymentsPlatformStats, listRecentDeploymentsAcrossProjects, DEPLOYMENT_LIST_LIMIT } from "@/lib/deployments/platform-stats";
+import { ensurePlatformAdmin } from "@/lib/platform-admin";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { KnownErrors } from "@hexclave/shared";
+import {
+  adaptSchema,
+  clientOrHigherAuthTypeSchema,
+  yupArray,
+  yupBoolean,
+  yupMixed,
+  yupNumber,
+  yupObject,
+  yupString,
+} from "@hexclave/shared/dist/schema-fields";
+
+const INTERNAL_PROJECT_ID = "internal";
+
+const authSchema = yupObject({
+  type: clientOrHigherAuthTypeSchema.defined(),
+  tenancy: adaptSchema.defined(),
+  user: adaptSchema,
+  project: adaptSchema.defined(),
+}).defined();
+
+const statsSchema = yupObject({
+  projects_with_provisioned_services: yupNumber().defined(),
+  provisioned_services: yupNumber().defined(),
+  max_deployed_services: yupNumber().defined(),
+  deployments_total: yupNumber().defined(),
+  deployments_recent: yupNumber().defined(),
+  builds_total: yupNumber().defined(),
+  builds_recent: yupNumber().defined(),
+  deployments_in_flight: yupNumber().defined(),
+  deployments_succeeded_recent: yupNumber().defined(),
+  deployments_failed_recent: yupNumber().defined(),
+  sources_by_runtime: yupArray(yupObject({
+    runtime: yupString().defined(),
+    count: yupNumber().defined(),
+  }).defined()).defined(),
+  recent_window_days: yupNumber().defined(),
+}).defined();
+
+const fuseboxSchema = yupObject({
+  deployments_enabled: yupBoolean().defined(),
+}).defined();
+
+const overviewResponseSchema = yupObject({
+  statusCode: yupNumber().oneOf([200]).defined(),
+  bodyType: yupString().oneOf(["json"]).defined(),
+  body: yupObject({
+    fusebox: fuseboxSchema,
+    stats: statsSchema,
+    // yupMixed rather than a spelled-out deployment schema: the rows are
+    // whatever deploymentToApiShape returns, and restating that shape here would
+    // give it a second definition to drift from.
+    deployments: yupArray(yupMixed().defined()).defined(),
+    deployments_limit: yupNumber().defined(),
+  }).defined(),
+});
+
+/**
+ * Both handlers' gate. The user check is not redundant with the auth schema:
+ * client auth is satisfied by a publishable key alone, so without it a request
+ * with no user at all would reach ensurePlatformAdmin.
+ */
+async function ensureInternalPlatformAdmin(auth: { project: { id: string }, user?: unknown }): Promise<void> {
+  if (auth.project.id !== INTERNAL_PROJECT_ID) {
+    throw new KnownErrors.ExpectedInternalProject();
+  }
+  if (!auth.user) {
+    throw new KnownErrors.UserAuthenticationRequired();
+  }
+  await ensurePlatformAdmin(auth.user as Parameters<typeof ensurePlatformAdmin>[0]);
+}
+
+export const GET = createSmartRouteHandler({
+  metadata: {
+    summary: "Deployments platform overview",
+    description: "Cross-project statistics for the Deployments app, the newest deployments across every project, and the current state of the platform fusebox. Internal, platform-admin only.",
+    tags: ["Deploy"],
+    hidden: true,
+  },
+  request: yupObject({
+    auth: authSchema,
+    method: yupString().oneOf(["GET"]).defined(),
+  }),
+  response: overviewResponseSchema,
+  handler: async ({ auth }) => {
+    await ensureInternalPlatformAdmin(auth);
+    const [config, stats, deployments] = await Promise.all([
+      getDeploymentsPlatformConfig(),
+      getDeploymentsPlatformStats(),
+      listRecentDeploymentsAcrossProjects(),
+    ]);
+    return {
+      statusCode: 200,
+      bodyType: "json" as const,
+      body: {
+        fusebox: { deployments_enabled: config.deploymentsEnabled },
+        stats: {
+          projects_with_provisioned_services: stats.projectsWithProvisionedServices,
+          provisioned_services: stats.provisionedServices,
+          max_deployed_services: stats.maxDeployedServices,
+          deployments_total: stats.deploymentsTotal,
+          deployments_recent: stats.deploymentsRecent,
+          builds_total: stats.buildsTotal,
+          builds_recent: stats.buildsRecent,
+          deployments_in_flight: stats.deploymentsInFlight,
+          deployments_succeeded_recent: stats.deploymentsSucceededRecent,
+          deployments_failed_recent: stats.deploymentsFailedRecent,
+          sources_by_runtime: stats.sourcesByRuntime,
+          recent_window_days: stats.recentWindowDays,
+        },
+        deployments: deployments.map((row) => ({
+          project_id: row.projectId,
+          project_display_name: row.projectDisplayName,
+          runtime: row.runtime,
+          ...row.deployment,
+        })),
+        deployments_limit: DEPLOYMENT_LIST_LIMIT,
+      },
+    };
+  },
+});
+
+export const POST = createSmartRouteHandler({
+  metadata: {
+    summary: "Update the deployments platform fusebox",
+    description: "Turns the creation of new deployments on or off across this whole Hexclave instance. Internal, platform-admin only.",
+    tags: ["Deploy"],
+    hidden: true,
+  },
+  request: yupObject({
+    auth: authSchema,
+    body: yupObject({
+      deployments_enabled: yupBoolean().defined(),
+    }).defined(),
+    method: yupString().oneOf(["POST"]).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: fuseboxSchema,
+  }),
+  handler: async ({ auth, body }) => {
+    await ensureInternalPlatformAdmin(auth);
+    const config = await updateDeploymentsPlatformConfig({
+      deploymentsEnabled: body.deployments_enabled,
+    });
+    return {
+      statusCode: 200,
+      bodyType: "json" as const,
+      body: { deployments_enabled: config.deploymentsEnabled },
+    };
+  },
+});

--- a/apps/backend/src/lib/deployments/index.tsx
+++ b/apps/backend/src/lib/deployments/index.tsx
@@ -41,12 +41,14 @@
 
 import { getPlanIdForProjectOrNull } from "@/lib/plan-entitlements";
 import { Tenancy } from "@/lib/tenancies";
-import { PrismaClientTransaction, globalPrismaClient } from "@/prisma-client";
+import { PrismaClientTransaction, getPrismaClientForTenancy, globalPrismaClient } from "@/prisma-client";
 import type { DeploymentStatus, Prisma } from "@/generated/prisma/client";
 import { readProjectSecretValue } from "@/lib/project-secrets";
 import {
   DEFAULT_BUILDER_MEMORY,
   DEFAULT_SERVERLESS_MEMORY,
+  FREE_PLAN_MAX_VOLUMES_PER_PROJECT,
+  FREE_PLAN_MAX_VOLUME_SIZE_GB,
   DEPLOYMENT_CONNECTION_VALUE_REGEX,
   DEPLOYMENT_ENV_VAR_KEY_REGEX,
   DeploymentBuilderDefinition,
@@ -282,7 +284,7 @@ export async function getServiceVolume(prisma: PrismaClientTransaction, tenancy:
 }
 
 /**
- * The Free plan's deployment entitlements. Two rules, one plan read.
+ * The Free plan's deployment entitlements. Three rules, one plan read.
  *
  * A `server` is paid-only, whatever its `minInstances`. A server is a VM that
  * runs from the moment it is applied until the service is torn down: GCP offers
@@ -310,9 +312,27 @@ export async function getServiceVolume(prisma: PrismaClientTransaction, tenancy:
  *     a team could sync while paid, downgrade, and keep deploying always-on
  *     machines with the old sync id.
  *
- * `persistentVolumes` is deliberately NOT gated: disks are available on every
- * plan for now. That is a pricing decision, not an oversight. In practice only
- * a `server` may hold one, so the type gate above already reserves them.
+ * `persistentVolumes` ARE gated, by count and by size: a Free project may hold
+ * FREE_PLAN_MAX_VOLUMES_PER_PROJECT disk(s) of at most
+ * FREE_PLAN_MAX_VOLUME_SIZE_GB GB each.
+ *
+ * This used to read "only a `server` may hold a disk, so the type gate above
+ * already reserves them". That was true when GCP was the only runtime. It is
+ * not true now: `serverIsPaidOnly` is GCP-only, so on Fly — the DEFAULT runtime
+ * — a `server` with an explicit `minInstances: 0` passes every other rule here
+ * and may mount a disk, which left disks ungated on the runtime most projects
+ * actually use.
+ *
+ * Disks need their own rule rather than leaning on a compute gate because they
+ * are the one resource that keeps billing after the project stops using it. A
+ * suspended machine costs nothing; a provisioned volume bills on its size
+ * whether or not anything mounts it, and tearing a service down DETACHES its
+ * disk instead of destroying it (see deleteService in the Fly provider), so an
+ * abandoned volume outlives the service that created it.
+ *
+ * That is also why the count is over the PROJECT's stored volume rows rather
+ * than over the services in front of us: unmounted disks are exactly the ones a
+ * definition-only count would miss, and they cost the same as mounted ones.
  *
  * FUTURE: this gates new DEPLOYS, not machines already running. A team can
  * subscribe, deploy always-on services, cancel, and keep those machines
@@ -325,6 +345,13 @@ export async function assertServicesAllowedByPlan(
   services: Record<string, DeploymentServiceDefinition>,
   builder?: DeploymentBuilderDefinition | undefined,
   runtime: DeploymentRuntime = DEFAULT_DEPLOYMENT_RUNTIME,
+  // The deploy file these services belong to (`deploymentGroupId`), needed only
+  // by the volume count: a disk this very call is re-declaring already has a row,
+  // and counting the row AND the declaration would refuse every re-deploy of a
+  // project's one legitimate volume. Optional so a caller with no source in hand
+  // still gets every other rule; it then counts conservatively (every stored row
+  // is treated as a disk this call is not re-declaring).
+  sourceId?: string | undefined,
 ): Promise<void> {
   const entries = Object.entries(services);
 
@@ -385,16 +412,78 @@ export async function assertServicesAllowedByPlan(
   // The size itself, not a flag: the message quotes it, and carrying the value
   // rather than a boolean is what keeps the two in step.
   const oversizedBuilderMemory = builder?.memory !== undefined && builder.memory !== DEFAULT_BUILDER_MEMORY ? builder.memory : null;
-  if (serverServices.length === 0 && alwaysOnServices.length === 0 && oversizedServices.length === 0 && oversizedBuilderMemory === null) return;
+  // Every disk this call declares. Read through singleVolume so it sees exactly
+  // what the sync will store — a service may hold at most one, so this is one
+  // entry per service that asks for a disk at all.
+  const declaredVolumes = entries
+    .flatMap(([serviceId, definition]) => {
+      const volume = singleVolume(definition);
+      return volume === null ? [] : [{ serviceId, volumeId: volume.volumeId, sizeGb: volume.sizeGb }];
+    })
+    .sort((a, b) => stringCompare(a.serviceId, b.serviceId));
+  const oversizedVolumes = declaredVolumes.filter((volume) => volume.sizeGb > FREE_PLAN_MAX_VOLUME_SIZE_GB);
+  if (
+    serverServices.length === 0
+    && alwaysOnServices.length === 0
+    && oversizedServices.length === 0
+    && oversizedBuilderMemory === null
+    // Declaring a disk at all is enough to need the plan read: how many the
+    // project already holds is a question only the Free branch below can answer.
+    && declaredVolumes.length === 0
+  ) return;
 
   // Null = this project isn't plan-gated at all (self-hosted, or plan limits
   // disabled) or the plan couldn't be read. All of those must fail open —
   // deploying can't depend on the billing store being reachable.
   if (await getPlanIdForProjectOrNull(tenancy.project) !== "free") return;
 
+  // How many disks this project would hold once this call lands. Stored rows
+  // rather than declarations, plus the declarations that have no row yet: a
+  // volume row outlives the service that mounted it (removing a service detaches
+  // its disk, it does not destroy it), so the rows ARE the disks Fly is billing
+  // for, mounted or not.
+  //
+  // Not transactional — the sync's own transaction opens after this returns, so
+  // two concurrent syncs could each see room for the last disk. Deliberately
+  // accepted, exactly as assertGlobalDeploymentCapacity accepts it: the window
+  // is one extra disk on one project, and closing it would mean holding a
+  // serializable transaction across the whole plan read.
+  const existingVolumes = declaredVolumes.length === 0 ? [] : await (async () => {
+    const prisma = await getPrismaClientForTenancy(tenancy);
+    return await prisma.deploymentVolume.findMany({
+      where: { tenancyId: tenancy.id },
+      select: { volumeId: true, sizeGb: true, serviceId: true, source: { select: { sourceId: true } } },
+    });
+  })();
+  // A declared volume that already has a row is the SAME disk, not a second one.
+  // Identity is (source, volumeId), which is what the row is unique on.
+  const newVolumes = declaredVolumes.filter((declared) => !existingVolumes.some(
+    (row) => sourceId !== undefined && row.source.sourceId === sourceId && row.volumeId === declared.volumeId,
+  ));
+  const totalVolumes = existingVolumes.length + newVolumes.length;
+  const volumeCountExceeded = declaredVolumes.length > 0 && totalVolumes > FREE_PLAN_MAX_VOLUMES_PER_PROJECT;
+  // A disk within BOTH caps is the one way to reach here with nothing to say: the
+  // early return above lets any declared volume through so the count can be read,
+  // and a Free project's one legitimate disk then breaks no rule. Without this
+  // the throw below would raise an empty 400 on a perfectly valid deploy.
+  if (
+    serverServices.length === 0
+    && alwaysOnServices.length === 0
+    && oversizedServices.length === 0
+    && oversizedBuilderMemory === null
+    && oversizedVolumes.length === 0
+    && !volumeCountExceeded
+  ) return;
+
   // Both sections can fire at once, and the CLI truncates the whole message at
   // 1000 chars — so name fewer services when there are two remedies to fit.
-  const sections = [serverServices.length > 0, alwaysOnServices.length > 0, oversizedServices.length > 0].filter(Boolean).length;
+  const sections = [
+    serverServices.length > 0,
+    alwaysOnServices.length > 0,
+    oversizedServices.length > 0,
+    oversizedVolumes.length > 0,
+    volumeCountExceeded,
+  ].filter(Boolean).length;
   const cap = sections > 1 ? 3 : 5;
   const lines: string[] = [];
   if (serverServices.length > 0) {
@@ -436,6 +525,45 @@ export async function assertServicesAllowedByPlan(
       "Either:",
       "  - drop `memory` from `builder`; or",
       "  - upgrade your plan at https://app.hexclave.com to build on a bigger machine.",
+    );
+  }
+  if (oversizedVolumes.length > 0) {
+    if (lines.length > 0) lines.push("");
+    const biggest = [...oversizedVolumes].sort((a, b) => b.sizeGb - a.sizeGb || stringCompare(a.serviceId, b.serviceId))[0];
+    lines.push(
+      `Persistent volumes larger than ${FREE_PLAN_MAX_VOLUME_SIZE_GB}GB are not available on the Free plan, but ${oversizedVolumes.length === 1 ? `service ${planGateServiceList(oversizedVolumes.map((volume) => volume.serviceId), cap)} asks` : `services ${planGateServiceList(oversizedVolumes.map((volume) => volume.serviceId), cap)} ask`} for ${oversizedVolumes.length === 1 ? `a ${biggest.sizeGb}GB disk` : `up to ${biggest.sizeGb}GB`}.`,
+      "",
+      // A disk bills on the size it was PROVISIONED at, for as long as it exists,
+      // so "shrink it later" is not a remedy we can offer: volumes are grow-only.
+      "A volume is billed on its size for as long as it exists, and volumes are grow-only — a disk created at this size cannot be made smaller later. Either:",
+      `  - set \`sizeGb\` to ${FREE_PLAN_MAX_VOLUME_SIZE_GB} or less; or`,
+      "  - upgrade your plan at https://app.hexclave.com to use larger disks.",
+    );
+  }
+  if (volumeCountExceeded) {
+    if (lines.length > 0) lines.push("");
+    // Disks nothing mounts AND this call is not re-attaching — an unmounted disk
+    // is invisible in the deploy file, so the count reads as the platform
+    // miscounting unless the message names it. A row this very sync re-declares
+    // is detached only for the instant before it is written back, so it is
+    // excluded rather than reported as abandoned.
+    const unmounted = existingVolumes.filter((row) => row.serviceId === null && !declaredVolumes.some(
+      (declared) => sourceId !== undefined && row.source.sourceId === sourceId && row.volumeId === declared.volumeId,
+    ));
+    lines.push(
+      `The Free plan allows ${FREE_PLAN_MAX_VOLUMES_PER_PROJECT} persistent volume per project, but this project would hold ${totalVolumes}.`,
+      "",
+    );
+    if (unmounted.length > 0) {
+      lines.push(
+        `${unmounted.length === 1 ? "One of them is a disk" : `${unmounted.length} of them are disks`} no service currently mounts: removing a service from a deploy file keeps its volume, so it still exists and is still counted. Contact support to delete ${unmounted.length === 1 ? "it" : "them"}.`,
+        "",
+      );
+    }
+    lines.push(
+      "Either:",
+      `  - hold at most ${FREE_PLAN_MAX_VOLUMES_PER_PROJECT} \`persistentVolumes\` disk, and keep other state in a database or object storage; or`,
+      "  - upgrade your plan at https://app.hexclave.com to run more disks.",
     );
   }
   throw new StatusError(400, lines.join("\n"));

--- a/apps/backend/src/lib/deployments/platform-config.test.tsx
+++ b/apps/backend/src/lib/deployments/platform-config.test.tsx
@@ -1,0 +1,53 @@
+import { StatusError } from "@hexclave/shared/dist/utils/errors";
+import { describe, expect, it, vi } from "vitest";
+import { globalPrismaClient } from "@/prisma-client";
+import { assertDeploymentsEnabled, getDeploymentsPlatformConfig } from "./platform-config";
+
+// Only the singleton read is exercised here, so the mock is that one delegate.
+// The point of these tests is the DEFAULTING and the guard's direction — the
+// two things a wrong answer would silently turn every customer's deploys off.
+vi.mock("@/prisma-client", () => ({
+  globalPrismaClient: {
+    deploymentsPlatformConfig: {
+      findFirst: vi.fn(),
+    },
+  },
+}));
+
+const mockFindFirst = vi.mocked(globalPrismaClient.deploymentsPlatformConfig.findFirst);
+
+describe("getDeploymentsPlatformConfig", () => {
+  it("reads a missing row as everything enabled", async () => {
+    // The normal state of an instance where nobody has ever flipped a switch:
+    // the migration writes no row, so this must not read as "off".
+    mockFindFirst.mockResolvedValue(null as never);
+    await expect(getDeploymentsPlatformConfig()).resolves.toEqual({ deploymentsEnabled: true });
+  });
+
+  it("reads the stored row when one exists", async () => {
+    mockFindFirst.mockResolvedValue({ deploymentsEnabled: false } as never);
+    await expect(getDeploymentsPlatformConfig()).resolves.toEqual({ deploymentsEnabled: false });
+  });
+});
+
+describe("assertDeploymentsEnabled", () => {
+  it("allows deploys while the fusebox is on", async () => {
+    mockFindFirst.mockResolvedValue({ deploymentsEnabled: true } as never);
+    await expect(assertDeploymentsEnabled()).resolves.toBeUndefined();
+  });
+
+  it("allows deploys when no row has ever been written", async () => {
+    mockFindFirst.mockResolvedValue(null as never);
+    await expect(assertDeploymentsEnabled()).resolves.toBeUndefined();
+  });
+
+  it("refuses with a 503 while the fusebox is off", async () => {
+    mockFindFirst.mockResolvedValue({ deploymentsEnabled: false } as never);
+    const error = await assertDeploymentsEnabled().catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(StatusError);
+    // 503, not 403: the caller did nothing wrong and the state is temporary,
+    // which is what tells a CLI user to wait rather than edit their deploy file.
+    expect((error as StatusError).statusCode).toBe(503);
+    expect((error as StatusError).message).toContain("temporarily disabled");
+  });
+});

--- a/apps/backend/src/lib/deployments/platform-config.tsx
+++ b/apps/backend/src/lib/deployments/platform-config.tsx
@@ -1,0 +1,75 @@
+// Platform-wide (cross-tenant) switches for the Deployments app, and the guard
+// that enforces them.
+//
+// These are the OPERATOR's controls over the deployments alpha as a whole, not a
+// project's settings: they live in a singleton row of DeploymentsPlatformConfig
+// and are flipped from the internal dashboard's Deploy Admin page. Nothing here
+// is per-project — see the model's doc comment for why an override table is
+// deliberately not modelled yet.
+
+import { BooleanTrue } from "@/generated/prisma/client";
+import { globalPrismaClient } from "@/prisma-client";
+import { StatusError } from "@hexclave/shared/dist/utils/errors";
+
+export type DeploymentsPlatformConfig = {
+  deploymentsEnabled: boolean,
+};
+
+const configSelect = {
+  deploymentsEnabled: true,
+} as const;
+
+// Matches the Prisma schema defaults, which are today's behaviour. A missing row
+// is the normal state on an instance where nobody has ever flipped a switch, so
+// it has to read as "everything on" rather than as an error.
+const defaultConfig: DeploymentsPlatformConfig = {
+  deploymentsEnabled: true,
+};
+
+export async function getDeploymentsPlatformConfig(): Promise<DeploymentsPlatformConfig> {
+  const result = await globalPrismaClient.deploymentsPlatformConfig.findFirst({
+    where: { singleton: BooleanTrue.TRUE },
+    select: configSelect,
+  });
+  return result ?? defaultConfig;
+}
+
+export async function updateDeploymentsPlatformConfig(updates: DeploymentsPlatformConfig): Promise<DeploymentsPlatformConfig> {
+  // Upsert rather than update: the row is created by the first operator who
+  // flips something, not by the migration (which must not be able to turn
+  // deploys off). Writes are rare and manual, so the upsert's cost is irrelevant.
+  return await globalPrismaClient.deploymentsPlatformConfig.upsert({
+    where: { singleton: BooleanTrue.TRUE },
+    create: { singleton: BooleanTrue.TRUE, ...updates },
+    update: updates,
+    select: configSelect,
+  });
+}
+
+/**
+ * Refuses to create a new deployment while the fusebox is off.
+ *
+ * Called from the two routes that START work — POST /deployments/deployments and
+ * POST /deployments/uploads. The upload is gated too so the CLI fails in a
+ * second instead of after pushing a source tarball it can never deploy.
+ *
+ * Deliberately NOT called from anywhere else: a deployment already in flight
+ * runs to completion, its status and logs stay readable, and tearing services
+ * down (PUT /deployments/services) keeps working — an operator who has just cut
+ * deploys off needs those paths more than ever, not less.
+ *
+ * 503 rather than 403: this is a temporary platform state the caller can do
+ * nothing about, which is also how the global capacity guard answers.
+ */
+export async function assertDeploymentsEnabled(): Promise<void> {
+  const config = await getDeploymentsPlatformConfig();
+  if (config.deploymentsEnabled) return;
+  throw new StatusError(503, [
+    "Deployments are temporarily disabled on this Hexclave instance.",
+    "",
+    // Says whose problem it is and what still works, for the same reason the
+    // capacity guard does: the reader's next move is "wait or ask", not "edit my
+    // deploy file".
+    "This is a platform-wide pause, not a limit on your project, and the Hexclave team is aware of it. Services you already have deployed keep running; please try again later, or contact support if this is blocking you.",
+  ].join("\n"));
+}

--- a/apps/backend/src/lib/deployments/platform-stats.tsx
+++ b/apps/backend/src/lib/deployments/platform-stats.tsx
@@ -1,0 +1,160 @@
+// Cross-tenant statistics for the internal Deploy Admin page.
+//
+// Everything here reads the GLOBAL database directly, across every tenancy —
+// which is what makes it an operator's view of the deployments alpha rather than
+// a project's. It is therefore only ever reachable from an internal-project,
+// platform-admin route.
+//
+// KNOWN LIMITATION, deliberately accepted: a tenancy whose config names its own
+// `sourceOfTruth` keeps its deployment rows in a different database, and nothing
+// here sees them. That is exactly the limitation assertGlobalDeploymentCapacity
+// already lives with (it counts provisioned services the same way), so the
+// numbers here agree with the ceiling they are compared against. The page says
+// so rather than implying a total.
+//
+// No Marshal calls: MarshalClient can only list services one namespace at a
+// time, so reconciling live runtime state would mean a fan-out of one HTTP
+// request per tenancy on every page load. Drift detection is worth having and is
+// deliberately left out of this first cut.
+
+import type { DeploymentStatus } from "@/generated/prisma/client";
+import { globalPrismaClient } from "@/prisma-client";
+import { stringCompare } from "@hexclave/shared/dist/utils/strings";
+import { MAX_GLOBAL_DEPLOYED_SERVICES, deploymentToApiShape, type DeploymentApiShape } from "@/lib/deployments";
+
+/** The trailing window every "recent" number on the page is measured over. */
+export const RECENT_WINDOW_DAYS = 7;
+
+/** How many deployments the page's table lists. Newest first, no pagination. */
+export const DEPLOYMENT_LIST_LIMIT = 100;
+
+// Non-terminal statuses — a deployment the runtime is still working on. Kept as
+// a literal list rather than derived from isTerminalDeploymentStatus because
+// this one has to go into a Prisma `in` filter.
+const IN_FLIGHT_STATUSES = ["QUEUED", "BUILDING", "DEPLOYING"] as const satisfies readonly DeploymentStatus[];
+
+export type DeploymentsPlatformStats = {
+  /** Distinct PROJECTS (not tenancies) holding at least one provisioned service. */
+  projectsWithProvisionedServices: number,
+  provisionedServices: number,
+  maxDeployedServices: number,
+  deploymentsTotal: number,
+  deploymentsRecent: number,
+  buildsTotal: number,
+  buildsRecent: number,
+  deploymentsInFlight: number,
+  deploymentsSucceededRecent: number,
+  deploymentsFailedRecent: number,
+  /** Deployment SOURCES by their runtime ("fly" / "gcp"), newest split first. */
+  sourcesByRuntime: { runtime: string, count: number }[],
+  recentWindowDays: number,
+};
+
+export type DeploymentsPlatformListRow = {
+  projectId: string,
+  projectDisplayName: string,
+  runtime: string,
+  deployment: DeploymentApiShape,
+};
+
+/**
+ * The six headline numbers, plus the runtime split.
+ *
+ * "Builds" is narrower than "deployments": a deployment whose every service runs
+ * an already-built image starts no builder machine and produces no log. The
+ * condition matches what deploymentToApiShape reports as `has_build_logs`, so
+ * the tile and the per-deployment UI cannot disagree.
+ *
+ * CAVEAT worth knowing when reading the number: hasBuildLogs defaults to true,
+ * so every deployment written before prebuilt images existed counts as a build —
+ * which it was.
+ */
+export async function getDeploymentsPlatformStats(): Promise<DeploymentsPlatformStats> {
+  const since = new Date(Date.now() - RECENT_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+  const buildWhere = { marshalBuildId: { not: null }, hasBuildLogs: true } as const;
+
+  const [
+    provisionedServices,
+    provisionedTenancies,
+    deploymentsTotal,
+    deploymentsRecent,
+    buildsTotal,
+    buildsRecent,
+    deploymentsInFlight,
+    recentByStatus,
+    sourceRuntimeGroups,
+  ] = await Promise.all([
+    globalPrismaClient.deploymentService.count({ where: { provisionedAt: { not: null } } }),
+    // Grouped, then resolved to projects below: several tenancies (branches,
+    // organizations) of one project each hold their own services, and counting
+    // them would overstate how many customers are on the alpha.
+    globalPrismaClient.deploymentService.groupBy({
+      by: ["tenancyId"],
+      where: { provisionedAt: { not: null } },
+    }),
+    globalPrismaClient.deployment.count(),
+    globalPrismaClient.deployment.count({ where: { createdAt: { gte: since } } }),
+    globalPrismaClient.deployment.count({ where: buildWhere }),
+    globalPrismaClient.deployment.count({ where: { ...buildWhere, createdAt: { gte: since } } }),
+    globalPrismaClient.deployment.count({ where: { status: { in: [...IN_FLIGHT_STATUSES] } } }),
+    globalPrismaClient.deployment.groupBy({
+      by: ["status"],
+      where: { createdAt: { gte: since } },
+      _count: { _all: true },
+    }),
+    globalPrismaClient.deploymentSource.groupBy({
+      by: ["runtime"],
+      _count: { _all: true },
+    }),
+  ]);
+
+  const projectIds = provisionedTenancies.length === 0 ? [] : (await globalPrismaClient.tenancy.findMany({
+    where: { id: { in: provisionedTenancies.map((group) => group.tenancyId) } },
+    select: { projectId: true },
+  })).map((tenancy) => tenancy.projectId);
+
+  const countForStatus = (status: DeploymentStatus) => recentByStatus.find((group) => group.status === status)?._count._all ?? 0;
+
+  return {
+    projectsWithProvisionedServices: new Set(projectIds).size,
+    provisionedServices,
+    maxDeployedServices: MAX_GLOBAL_DEPLOYED_SERVICES,
+    deploymentsTotal,
+    deploymentsRecent,
+    buildsTotal,
+    buildsRecent,
+    deploymentsInFlight,
+    deploymentsSucceededRecent: countForStatus("SUCCEEDED"),
+    deploymentsFailedRecent: countForStatus("FAILED"),
+    sourcesByRuntime: sourceRuntimeGroups
+      .map((group) => ({ runtime: group.runtime, count: group._count._all }))
+      .sort((a, b) => b.count - a.count || stringCompare(a.runtime, b.runtime)),
+    recentWindowDays: RECENT_WINDOW_DAYS,
+  };
+}
+
+/**
+ * The newest deployments across every project, for the page's table.
+ *
+ * Each row carries the project it belongs to and its source's runtime — the two
+ * things a per-project deployment listing never has to say and an operator's
+ * always does. The deployment itself goes through deploymentToApiShape at
+ * "summary" detail, so the service URLs here are exactly the ones the customer's
+ * own dashboard shows, and the (potentially large) source manifest is left out.
+ */
+export async function listRecentDeploymentsAcrossProjects(limit: number = DEPLOYMENT_LIST_LIMIT): Promise<DeploymentsPlatformListRow[]> {
+  const deployments = await globalPrismaClient.deployment.findMany({
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    include: {
+      source: { select: { sourceId: true, runtime: true } },
+      tenancy: { select: { projectId: true, project: { select: { displayName: true } } } },
+    },
+  });
+  return deployments.map((deployment) => ({
+    projectId: deployment.tenancy.projectId,
+    projectDisplayName: deployment.tenancy.project.displayName,
+    runtime: deployment.source.runtime,
+    deployment: deploymentToApiShape(deployment, "summary"),
+  }));
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/deploy-admin/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/deploy-admin/page-client.tsx
@@ -1,0 +1,413 @@
+"use client";
+
+// Deploy Admin — the operator's view of the deployments alpha, across every
+// project. Internal project only; the backend gates on platform-admin
+// membership, and this page is only reachable from the internal project's
+// sidebar.
+//
+// Two jobs, in the order an operator needs them: the FUSEBOX that pauses new
+// deployments instance-wide, then the numbers that say whether it needs
+// pausing. The deployment list is last because it answers "which one", which is
+// the question you have after the first two.
+
+import {
+  ActionDialog,
+  Alert,
+  AlertDescription,
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Skeleton,
+  Switch,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Typography,
+} from "@/components/ui";
+import { sendInternalUserRequest } from "@/lib/hexclave-app-internals";
+import { useStackApp } from "@hexclave/next";
+import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
+import { ArrowClockwiseIcon } from "@phosphor-icons/react";
+import { useCallback, useEffect, useState } from "react";
+import { PageLayout } from "../page-layout";
+
+const ENDPOINT = "/internal/deployments-admin";
+
+type DeploymentServiceRow = {
+  service_id: string,
+  status: string,
+  url: string | null,
+};
+
+type DeploymentRow = {
+  id: string,
+  number: number,
+  project_id: string,
+  project_display_name: string,
+  runtime: string,
+  deployment_source_id: string,
+  status: string,
+  created_at_millis: number,
+  finished_at_millis: number | null,
+  services: DeploymentServiceRow[],
+};
+
+type Stats = {
+  projects_with_provisioned_services: number,
+  provisioned_services: number,
+  max_deployed_services: number,
+  deployments_total: number,
+  deployments_recent: number,
+  builds_total: number,
+  builds_recent: number,
+  deployments_in_flight: number,
+  deployments_succeeded_recent: number,
+  deployments_failed_recent: number,
+  sources_by_runtime: { runtime: string, count: number }[],
+  recent_window_days: number,
+};
+
+type Overview = {
+  fusebox: { deployments_enabled: boolean },
+  stats: Stats,
+  deployments: DeploymentRow[],
+  deployments_limit: number,
+};
+
+type LoadState =
+  | { status: "loading" }
+  | { status: "forbidden" }
+  | { status: "error", message: string }
+  | { status: "ok", data: Overview };
+
+async function fetchOverview(app: object): Promise<LoadState> {
+  const response = await sendInternalUserRequest(app, ENDPOINT);
+  // 403 is its own state rather than an error string: it means "you are not a
+  // platform admin", which is a fact about the reader, not a failure.
+  if (response.status === 403) return { status: "forbidden" };
+  if (!response.ok) return { status: "error", message: `Request failed (${response.status})` };
+  return { status: "ok", data: await response.json() as Overview };
+}
+
+function formatTime(millis: number): string {
+  return new Date(millis).toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function formatDuration(row: DeploymentRow): string {
+  if (row.finished_at_millis == null) return "—";
+  const seconds = Math.max(0, Math.round((row.finished_at_millis - row.created_at_millis) / 1000));
+  return seconds < 60 ? `${seconds}s` : `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
+}
+
+function statusVariant(status: string): "success" | "destructive" | "info" | "secondary" {
+  switch (status) {
+    case "deployed": { return "success"; }
+    case "failed": { return "destructive"; }
+    case "queued":
+    case "building":
+    case "deploying": { return "info"; }
+    default: { return "secondary"; }
+  }
+}
+
+/** One headline number. `hint` is the second line — a window, a ceiling, a split. */
+function StatTile(props: { label: string, value: string, hint?: string, danger?: boolean }) {
+  return (
+    <div className="rounded-lg border p-4">
+      <Typography type="p" className="text-xs uppercase tracking-wide text-muted-foreground">{props.label}</Typography>
+      <Typography type="p" className={`mt-1 text-2xl font-semibold tabular-nums ${props.danger ? "text-destructive" : ""}`}>
+        {props.value}
+      </Typography>
+      {props.hint && <Typography type="p" className="mt-1 text-xs text-muted-foreground">{props.hint}</Typography>}
+    </div>
+  );
+}
+
+function StatTiles(props: { stats: Stats }) {
+  const { stats } = props;
+  const days = stats.recent_window_days;
+  // Only meaningful once something finished in the window; 0/0 would otherwise
+  // render as a confident "0%" for an instance nobody deployed to.
+  const terminalRecent = stats.deployments_succeeded_recent + stats.deployments_failed_recent;
+  const successRate = terminalRecent === 0 ? null : Math.round((stats.deployments_succeeded_recent / terminalRecent) * 100);
+  const capacityPercent = stats.max_deployed_services === 0
+    ? null
+    : Math.round((stats.provisioned_services / stats.max_deployed_services) * 100);
+
+  return (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+      <StatTile
+        label="Projects deploying"
+        value={String(stats.projects_with_provisioned_services)}
+        hint="with at least one provisioned service"
+      />
+      <StatTile
+        label="Provisioned services"
+        value={`${stats.provisioned_services} / ${stats.max_deployed_services}`}
+        hint={capacityPercent === null ? "platform capacity" : `${capacityPercent}% of platform capacity`}
+        danger={capacityPercent !== null && capacityPercent >= 80}
+      />
+      <StatTile
+        label="Deployments"
+        value={String(stats.deployments_total)}
+        hint={`${stats.deployments_recent} in the last ${days}d`}
+      />
+      <StatTile
+        label="Builds"
+        value={String(stats.builds_total)}
+        hint={`${stats.builds_recent} in the last ${days}d · excludes prebuilt-image deploys`}
+      />
+      <StatTile
+        label="In flight"
+        value={String(stats.deployments_in_flight)}
+        hint="queued, building, or deploying right now"
+      />
+      <StatTile
+        label={`Failed (${days}d)`}
+        value={String(stats.deployments_failed_recent)}
+        hint={successRate === null ? "nothing finished in this window" : `${successRate}% of finished deploys succeeded`}
+        danger={successRate !== null && successRate < 80}
+      />
+    </div>
+  );
+}
+
+function FuseboxCard(props: { enabled: boolean, onChange: (enabled: boolean) => Promise<void> }) {
+  const [confirmingDisable, setConfirmingDisable] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const apply = useCallback(async (enabled: boolean) => {
+    setSaving(true);
+    try {
+      await props.onChange(enabled);
+    } finally {
+      setSaving(false);
+    }
+  }, [props]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-3">
+          New deployments
+          <Badge variant={props.enabled ? "success" : "destructive"}>{props.enabled ? "Enabled" : "Paused"}</Badge>
+        </CardTitle>
+        <CardDescription>
+          The emergency fusebox. While it is off, no new deployment can be created on this instance —
+          deploys already in flight finish, logs stay readable, and tearing services down keeps working.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center justify-between gap-6">
+          <div>
+            <Typography type="p" className="text-sm font-medium">Allow new deployments</Typography>
+            <Typography type="p" className="text-xs text-muted-foreground">
+              Applies to `hexclave deploy` and to source uploads, for every project.
+            </Typography>
+          </div>
+          <Switch
+            checked={props.enabled}
+            disabled={saving}
+            onCheckedChange={(checked) => {
+              // Turning it back ON is safe and immediate; turning it OFF stops
+              // every customer's deploys, so that direction is confirmed.
+              if (!checked) {
+                setConfirmingDisable(true);
+              } else {
+                runAsynchronously(apply(true));
+              }
+            }}
+          />
+        </div>
+        {!props.enabled && (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Deployments are paused platform-wide. Every project&apos;s `hexclave deploy` is failing with a 503.
+            </AlertDescription>
+          </Alert>
+        )}
+      </CardContent>
+      <ActionDialog
+        open={confirmingDisable}
+        onClose={() => setConfirmingDisable(false)}
+        danger
+        title="Pause all new deployments?"
+        description="Every project on this instance will be unable to deploy until you turn this back on. Deployments already in flight will finish."
+        confirmText="I understand that no project will be able to deploy"
+        okButton={{
+          label: "Pause deployments",
+          onClick: async () => {
+            await apply(false);
+            setConfirmingDisable(false);
+          },
+        }}
+        cancelButton
+      />
+    </Card>
+  );
+}
+
+function DeploymentsTable(props: { rows: DeploymentRow[], limit: number }) {
+  if (props.rows.length === 0) {
+    return <Typography type="p" className="text-sm text-muted-foreground">No deployments yet.</Typography>;
+  }
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Project</TableHead>
+            <TableHead>Source</TableHead>
+            <TableHead>#</TableHead>
+            <TableHead>Status</TableHead>
+            <TableHead>Runtime</TableHead>
+            <TableHead>Services &amp; URLs</TableHead>
+            <TableHead>Started</TableHead>
+            <TableHead>Duration</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {props.rows.map((row) => (
+            <TableRow key={row.id}>
+              <TableCell>
+                <div className="font-medium">{row.project_display_name}</div>
+                <div className="font-mono text-xs text-muted-foreground">{row.project_id}</div>
+              </TableCell>
+              <TableCell className="font-mono text-xs">{row.deployment_source_id}</TableCell>
+              <TableCell className="tabular-nums">{row.number}</TableCell>
+              <TableCell><Badge variant={statusVariant(row.status)}>{row.status}</Badge></TableCell>
+              <TableCell><Badge variant="outline">{row.runtime}</Badge></TableCell>
+              <TableCell>
+                <div className="flex flex-col gap-1">
+                  {row.services.map((service) => (
+                    <div key={service.service_id} className="flex items-center gap-2 text-xs">
+                      <span className="font-mono">{service.service_id}</span>
+                      {service.url
+                        ? <a href={service.url} target="_blank" rel="noreferrer" className="text-blue-600 hover:underline dark:text-blue-400">{service.url}</a>
+                        : <span className="text-muted-foreground">{service.status}</span>}
+                    </div>
+                  ))}
+                </div>
+              </TableCell>
+              <TableCell className="whitespace-nowrap text-xs">{formatTime(row.created_at_millis)}</TableCell>
+              <TableCell className="tabular-nums text-xs">{formatDuration(row)}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      {props.rows.length >= props.limit && (
+        <Typography type="p" className="mt-3 text-xs text-muted-foreground">
+          Showing the newest {props.limit} deployments.
+        </Typography>
+      )}
+    </div>
+  );
+}
+
+export default function PageClient() {
+  const app = useStackApp();
+  const [state, setState] = useState<LoadState>({ status: "loading" });
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      setState(await fetchOverview(app));
+    } finally {
+      setRefreshing(false);
+    }
+  }, [app]);
+
+  useEffect(() => {
+    runAsynchronously(load);
+  }, [load]);
+
+  const setFusebox = useCallback(async (enabled: boolean) => {
+    const response = await sendInternalUserRequest(app, ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ deployments_enabled: enabled }),
+    });
+    if (!response.ok) {
+      setState({ status: "error", message: `Failed to update the fusebox (${response.status})` });
+      return;
+    }
+    // Re-read rather than patching local state: the write is the moment the
+    // rest of the numbers are most worth refreshing anyway.
+    await load();
+  }, [app, load]);
+
+  return (
+    <PageLayout
+      title="Deploy Admin"
+      description="Platform-wide view of the Deployments alpha. Counts cover projects on the shared database. Internal only."
+      actions={
+        <Button variant="secondary" onClick={() => runAsynchronously(load)} loading={refreshing}>
+          <ArrowClockwiseIcon className="mr-2 h-4 w-4" />
+          Refresh
+        </Button>
+      }
+    >
+      {state.status === "loading" && (
+        <div className="space-y-4">
+          <Skeleton className="h-40 w-full" />
+          <Skeleton className="h-56 w-full" />
+        </div>
+      )}
+
+      {state.status === "forbidden" && (
+        <Alert>
+          <AlertDescription>
+            This page is only available to Hexclave platform admins.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {state.status === "error" && (
+        <Alert variant="destructive">
+          <AlertDescription>{state.message}</AlertDescription>
+        </Alert>
+      )}
+
+      {state.status === "ok" && (
+        <div className="space-y-6">
+          <FuseboxCard enabled={state.data.fusebox.deployments_enabled} onChange={setFusebox} />
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Overview</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <StatTiles stats={state.data.stats} />
+              <div className="flex flex-wrap items-center gap-2">
+                <Typography type="p" className="text-xs text-muted-foreground">Deployment sources by runtime:</Typography>
+                {state.data.stats.sources_by_runtime.length === 0
+                  ? <Typography type="p" className="text-xs text-muted-foreground">none</Typography>
+                  : state.data.stats.sources_by_runtime.map((entry) => (
+                    <Badge key={entry.runtime} variant="outline">{entry.runtime}: {entry.count}</Badge>
+                  ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Recent deployments</CardTitle>
+              <CardDescription>Newest deployments across every project, with the URLs each one shipped.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <DeploymentsTable rows={state.data.deployments} limit={state.data.deployments_limit} />
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </PageLayout>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/deploy-admin/page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/deploy-admin/page.tsx
@@ -1,0 +1,9 @@
+import PageClient from "./page-client";
+
+export const metadata = {
+  title: "Deploy Admin",
+};
+
+export default function Page() {
+  return <PageClient />;
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sidebar-layout.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sidebar-layout.tsx
@@ -135,6 +135,11 @@ const internalToolsItem: AppSection = {
       href: "/ask-hexclave-history",
       match: (fullUrl: URL) => /^\/projects\/[^\/]+\/ask-hexclave-history(\/.*)?$/.test(fullUrl.pathname),
     },
+    {
+      name: "Deploy Admin",
+      href: "/deploy-admin",
+      match: (fullUrl: URL) => /^\/projects\/[^\/]+\/deploy-admin(\/.*)?$/.test(fullUrl.pathname),
+    },
   ],
 };
 
@@ -523,7 +528,7 @@ function SidebarContent({
     /^\/projects\/[^\/]+\/(project-settings|project-keys|domains)(\/.*)?$/.test(pathname)
   );
   const [isInternalToolsExpanded, setIsInternalToolsExpanded] = useState(() =>
-    /^\/projects\/[^\/]+\/(platform-analytics|external-db-sync|newly-created-projects|ask-hexclave-history)(\/.*)?$/.test(pathname)
+    /^\/projects\/[^\/]+\/(platform-analytics|external-db-sync|newly-created-projects|ask-hexclave-history|deploy-admin)(\/.*)?$/.test(pathname)
   );
   const internalToolsSection = useMemo<AppSection>(() => ({
     ...internalToolsItem,

--- a/apps/e2e/tests/backend/endpoints/api/v1/deployments/deployments.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/deployments/deployments.test.ts
@@ -470,10 +470,11 @@ describe("definition sync", () => {
   });
 
   it("rejects shrinking a volume at sync time, before anything is uploaded", async ({ expect }) => {
-    await Project.createAndSwitch();
+    // Paid: this grows the disk past the Free plan's per-volume ceiling, and the point of
+    // the test is the grow-only rule rather than the plan gate. min_instances is still
+    // written out because a `server` defaults to an always-on instance.
+    await Project.createAndSwitchOnPaidPlan();
     const serviceId = uniqueServiceId("shrink");
-    // min_instances is written out because this project is on the Free plan, which does not
-    // allow an always-on instance — and a `server` defaults to one.
     const definition = (sizeGb: number) => ({
       [serviceId]: { type: "server", ports: { 3000: { protocol: "http" } }, min_instances: 0, max_instances: 1, persistent_volumes: { data: { path: "/data", size_gb: sizeGb } }, env: {} },
     });
@@ -498,6 +499,103 @@ describe("definition sync", () => {
       body: { source_id: sourceId, services: { [serviceId]: { type: "serverless", ports: { 3000: { protocol: "http" } }, max_instances: 1, env: {} } } },
     });
     expect(detached.status).toBe(200);
+  });
+
+  it("caps the Free plan at one volume per project, and at 10GB each", async ({ expect }) => {
+    await Project.createAndSwitch();
+    const planUsage = await niceBackendFetch("/api/v1/internal/plan-usage", { accessType: "admin" });
+    const enforced = (planUsage.body as any)?.are_plan_limits_enforced !== false;
+    const disk = (serviceId: string, sizeGb: number) => ({
+      // A Fly `server` at min_instances 0 suspends rather than staying up, which is what
+      // lets a Free project declare one at all — and so what makes a disk reachable here.
+      [serviceId]: {
+        type: "server", ports: { 3000: { protocol: "http" } }, min_instances: 0, max_instances: 1,
+        persistent_volumes: { data: { path: "/data", size_gb: sizeGb } }, env: {},
+      },
+    });
+    const sync = async (services: Record<string, unknown>, sourceId: string) => await niceBackendFetch("/api/v1/deployments/services", {
+      method: "PUT", accessType: "admin", body: { source_id: sourceId, services },
+    });
+
+    const oneServiceId = uniqueServiceId("vol1");
+    // At the ceiling exactly: 10GB is allowed, so the cap is > rather than >=.
+    expect((await sync(disk(oneServiceId, 10), "vol-cap-src")).status).toBe(200);
+    // Re-syncing the SAME disk is not a second disk — it already has a row, and counting
+    // the row and the declaration would refuse every re-deploy of a project's one volume.
+    expect((await sync(disk(oneServiceId, 10), "vol-cap-src")).status).toBe(200);
+
+    const oversized = await sync(disk(uniqueServiceId("vol2"), 11), "vol-size-src");
+    const second = await sync(disk(uniqueServiceId("vol3"), 1), "vol-count-src");
+    if (!enforced) {
+      expect(oversized.status).toBe(200);
+      expect(second.status).toBe(200);
+      return;
+    }
+    expect(oversized.status).toBe(400);
+    expect(JSON.stringify(oversized.body)).toContain("larger than 10GB are not available on the Free plan");
+    expect(JSON.stringify(oversized.body)).toContain("upgrade your plan");
+    // A second disk in ANOTHER deploy file still counts: the cap is per project, which is
+    // what a per-source count would miss.
+    expect(second.status).toBe(400);
+    expect(JSON.stringify(second.body)).toContain("Free plan allows 1 persistent volume per project");
+    expect(JSON.stringify(second.body)).toContain("upgrade your plan");
+  });
+
+  it("counts a Free project's unmounted disks, and says so", async ({ expect }) => {
+    await Project.createAndSwitch();
+    const planUsage = await niceBackendFetch("/api/v1/internal/plan-usage", { accessType: "admin" });
+    if ((planUsage.body as any)?.are_plan_limits_enforced === false) return;
+    const serviceId = uniqueServiceId("orphan");
+    const { sourceId } = await syncServices({
+      [serviceId]: {
+        type: "server", ports: { 3000: { protocol: "http" } }, min_instances: 0, max_instances: 1,
+        persistent_volumes: { data: { path: "/data", size_gb: 1 } }, env: {},
+      },
+    });
+    // Dropping the volume DETACHES it — the row (and the disk Fly bills for) stays. A
+    // count over the deploy file alone would now see zero disks and let a second one in.
+    await syncServices({ [serviceId]: { type: "serverless", ports: { 3000: { protocol: "http" } }, max_instances: 1, env: {} } }, sourceId);
+
+    const response = await niceBackendFetch("/api/v1/deployments/services", {
+      method: "PUT", accessType: "admin",
+      body: {
+        source_id: sourceId,
+        services: {
+          [uniqueServiceId("next")]: {
+            type: "server", ports: { 3000: { protocol: "http" } }, min_instances: 0, max_instances: 1,
+            persistent_volumes: { data2: { path: "/data", size_gb: 1 } }, env: {},
+          },
+        },
+      },
+    });
+    expect(response.status).toBe(400);
+    const message = JSON.stringify(response.body);
+    expect(message).toContain("Free plan allows 1 persistent volume per project");
+    // The unmounted disk is invisible in the deploy file, so the message has to name it or
+    // the count reads as the platform miscounting.
+    expect(message).toContain("no service currently mounts");
+  });
+
+  it("lets a paid plan hold several volumes, and larger ones", async ({ expect }) => {
+    await Project.createAndSwitchOnPaidPlan();
+    const response = await niceBackendFetch("/api/v1/deployments/services", {
+      method: "PUT",
+      accessType: "admin",
+      body: {
+        source_id: "vol-paid-src",
+        services: {
+          [uniqueServiceId("big")]: {
+            type: "server", ports: { 3000: { protocol: "http" } }, min_instances: 0, max_instances: 1,
+            persistent_volumes: { data: { path: "/data", size_gb: 50 } }, env: {},
+          },
+          [uniqueServiceId("also")]: {
+            type: "server", ports: { 3001: { protocol: "http" } }, min_instances: 0, max_instances: 1,
+            persistent_volumes: { more: { path: "/more", size_gb: 20 } }, env: {},
+          },
+        },
+      },
+    });
+    expect(response.status).toBe(200);
   });
 
   it("rejects a volume on a service that could run more than one instance", async ({ expect }) => {

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/deployments-admin.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/deployments-admin.test.ts
@@ -1,0 +1,94 @@
+import { describe } from "vitest";
+import { it } from "../../../../../helpers";
+import {
+  Auth,
+  INTERNAL_PROJECT_OWNER_TEAM_ID,
+  InternalProjectKeys,
+  Project,
+  Team,
+  backendContext,
+  niceBackendFetch,
+} from "../../../../backend-helpers";
+
+const BASE_PATH = "/api/latest/internal/deployments-admin";
+
+async function signInAsInternalAdmin() {
+  backendContext.set({ projectKeys: InternalProjectKeys, userAuth: null });
+  const { userId } = await Auth.fastSignUp();
+  await Team.addMember(INTERNAL_PROJECT_OWNER_TEAM_ID, userId);
+}
+
+describe("internal deployments admin", () => {
+  it("rejects unauthenticated, customer-project, and non-platform-admin requests", async ({ expect }) => {
+    backendContext.set({ projectKeys: InternalProjectKeys, userAuth: null });
+    const unauthenticated = await niceBackendFetch(BASE_PATH, { accessType: "client" });
+    expect(unauthenticated.status).toBe(401);
+
+    await Project.createAndSwitch();
+    await Auth.fastSignUp();
+    const customerProject = await niceBackendFetch(BASE_PATH, { accessType: "client" });
+    expect([400, 401]).toContain(customerProject.status);
+
+    // The one that matters: a signed-in internal-project user who is NOT on the
+    // platform team. The internal project's publishable key is public, so this
+    // is the account anyone could make for themselves.
+    const customerUserAuth = backendContext.value.userAuth;
+    backendContext.set({ projectKeys: InternalProjectKeys, userAuth: customerUserAuth });
+    const nonPlatformAdmin = await niceBackendFetch(BASE_PATH, { accessType: "client" });
+    expect([401, 403]).toContain(nonPlatformAdmin.status);
+
+    const nonPlatformAdminWrite = await niceBackendFetch(BASE_PATH, {
+      accessType: "client",
+      method: "POST",
+      body: { deployments_enabled: true },
+    });
+    expect([401, 403]).toContain(nonPlatformAdminWrite.status);
+  });
+
+  it("returns platform statistics and the deployment list", async ({ expect }) => {
+    await signInAsInternalAdmin();
+
+    const response = await niceBackendFetch(BASE_PATH, { accessType: "client" });
+    expect(response.status).toBe(200);
+    expect(response.body.fusebox).toMatchObject({ deployments_enabled: expect.any(Boolean) });
+    expect(response.body.stats).toMatchObject({
+      projects_with_provisioned_services: expect.any(Number),
+      provisioned_services: expect.any(Number),
+      max_deployed_services: expect.any(Number),
+      deployments_total: expect.any(Number),
+      deployments_recent: expect.any(Number),
+      builds_total: expect.any(Number),
+      builds_recent: expect.any(Number),
+      deployments_in_flight: expect.any(Number),
+      deployments_succeeded_recent: expect.any(Number),
+      deployments_failed_recent: expect.any(Number),
+      sources_by_runtime: expect.any(Array),
+      recent_window_days: expect.any(Number),
+    });
+    expect(response.body.deployments).toEqual(expect.any(Array));
+    // A build is a deployment that started a builder, so it can never exceed the
+    // deployments it is drawn from — the one invariant between the two tiles.
+    expect(response.body.stats.builds_total).toBeLessThanOrEqual(response.body.stats.deployments_total);
+  });
+
+  it("round-trips the fusebox", async ({ expect }) => {
+    await signInAsInternalAdmin();
+
+    const before = await niceBackendFetch(BASE_PATH, { accessType: "client" });
+    expect(before.status).toBe(200);
+
+    // Writes the SAME value back rather than flipping it, exactly as the
+    // external-db-sync fusebox test does: this row is GLOBAL, so actually
+    // turning deploys off here would fail every deployment test running
+    // concurrently in another worker. The refusal itself is covered by
+    // apps/backend/src/lib/deployments/platform-config.test.tsx, which needs no
+    // shared state to prove both directions.
+    const write = await niceBackendFetch(BASE_PATH, {
+      accessType: "client",
+      method: "POST",
+      body: { deployments_enabled: before.body.fusebox.deployments_enabled },
+    });
+    expect(write.status).toBe(200);
+    expect(write.body).toMatchObject({ deployments_enabled: before.body.fusebox.deployments_enabled });
+  });
+});

--- a/packages/shared/src/deployments.ts
+++ b/packages/shared/src/deployments.ts
@@ -737,6 +737,23 @@ export const MAX_VOLUME_SIZE_GB = 500;
 // more than one mount.
 export const MAX_PERSISTENT_VOLUMES_PER_SERVICE = 1;
 
+// The Free plan's disk entitlement: how many persistent volumes one project may
+// hold in total, and how large each of them may be.
+//
+// Volumes are the one deployment resource that keeps costing after the project
+// stops using it. A suspended machine bills nothing; a provisioned disk bills on
+// its size whether or not anything mounts it, and tearing a service down
+// DETACHES its disk rather than destroying it (see the Fly provider's
+// deleteService), so an abandoned volume outlives the service that made it.
+// That is why disks are capped on Free by count and size rather than left to
+// the always-on gate, which only ever reaches running machines.
+//
+// Counted per PROJECT rather than per service: MAX_PERSISTENT_VOLUMES_PER_SERVICE
+// already holds a service to one disk, so a per-service cap would bound nothing
+// a second service could not simply ask for again.
+export const FREE_PLAN_MAX_VOLUMES_PER_PROJECT = 1;
+export const FREE_PLAN_MAX_VOLUME_SIZE_GB = 10;
+
 // Volume ids become Fly volume names (see appVolumeName in Marshal), which are
 // alphanumeric + underscore and at most 30 characters. The id is capped at 26
 // so a 4-character prefix still fits, and lowercased so two ids cannot differ


### PR DESCRIPTION
Stacked on #2042.

Gives platform admins a cross-project view of the deployments alpha, and a switch that pauses it.

## Screenshots

Captured on the local stack against seeded deployment data (4 deployments, 2 sources, 3 provisioned services) — the numbers on the page are real reads of that data, not mock-ups.

**Normal state** — fusebox on, the six tiles, the runtime split, and the deployment list with the URLs each deploy shipped:

![Deploy Admin, normal state](https://gist.githubusercontent.com/BilalG1/819987508820756163c067be22df8156/raw/deploy-admin-enabled-dark.png)

**Paused** — the badge flips to `Paused`, and a red banner spells out what is happening to customers right now:

![Deploy Admin, deployments paused platform-wide](https://gist.githubusercontent.com/BilalG1/819987508820756163c067be22df8156/raw/deploy-admin-paused-dark.png)

**Turning it off is confirmed; turning it back on is one click.** Pausing every customer's deploys should cost a deliberate second, but un-pausing during an incident should not:

![Confirmation dialog before pausing deployments](https://gist.githubusercontent.com/BilalG1/819987508820756163c067be22df8156/raw/deploy-admin-confirm-dialog.png)

<details>
<summary>Light mode</summary>

![Deploy Admin in light mode](https://gist.githubusercontent.com/BilalG1/819987508820756163c067be22df8156/raw/deploy-admin-enabled-light.png)

</details>

## The fusebox

A new singleton table, `DeploymentsPlatformConfig`, with one column: `deploymentsEnabled Boolean @default(true)`.

Its own table rather than a column on `ExternalDbSyncMetadata` — the two features share nothing but the singleton pattern, and a deployments switch inside a table named after the DB-sync pipeline is exactly the confusion an emergency control must not cause at 3am. `CacheEntry` was considered and rejected too: it is a *cache* with a required `expiresAt`, so a sweeper added later would silently turn deploys back on.

The migration inserts **no row** — a missing row reads as the defaults, so it cannot turn deploys off and there is no window before an operator first writes to it.

Turning it off refuses two routes with a 503:

- `POST /deployments/deployments`
- `POST /deployments/uploads` — gated too, so the CLI fails in a second instead of after pushing a source tarball it can never deploy

Deliberately **not** gated: deployments already in flight, status and log reads, and `PUT /deployments/services` (which is also the teardown path). An operator who has just cut deploys off needs all three more than ever, not less.

## The page

`Internal tools → Deploy Admin`, internal project only. The backend gates on `ensurePlatformAdmin` (membership of the team owning the internal project) rather than merely being signed into it — the internal project's publishable key is public, so an internal-project account alone is not authorization for cross-customer data.

Six numbers, chosen to answer "is the alpha healthy, and does it need pausing":

| Tile | Why |
|---|---|
| Projects deploying | distinct projects with ≥1 provisioned service — who is actually on the alpha |
| Provisioned services / 1000 | the real ceiling `assertGlobalDeploymentCapacity` enforces, which until now only surfaced in Sentry |
| Deployments | all-time + last 7d |
| Builds | deployments that started a builder — narrower than deployments, since an all-prebuilt deploy builds nothing |
| In flight | queued / building / deploying right now |
| Failed (7d) | with the success rate over finished deploys |

Plus the `fly` / `gcp` source split (relevant while #2042's GCP beta rolls out) and the newest 100 deployments across every project, each with the service URLs it shipped.

## Known limitations, stated on the page

- **Counts come from the global database.** A tenancy with its own `sourceOfTruth` is not included. This is the same limitation `assertGlobalDeploymentCapacity` already accepts, which is what keeps the service count and the ceiling it is compared against in agreement.
- **No Marshal calls.** `MarshalClient.listServices` is per-namespace, so live state / drift detection (orphaned Fly apps still costing money) would mean one HTTP request per tenancy on every page load. Worth having, deliberately not in this first cut.

Also left out on purpose, each a column or a small table away if wanted: per-project overrides, a redeploy-only sub-toggle, DB-backed overrides of `HEXCLAVE_MAX_DEPLOYED_SERVICES`, and per-runtime kill switches.

## Testing

- 5 unit tests (`platform-config.test.tsx`) covering both fusebox directions and the missing-row default, with `@/prisma-client` mocked
- 3 e2e tests covering the auth gates and the overview shape

The e2e fusebox test writes the **same** value back rather than flipping it — the row is global, so actually pausing would fail every deployment test running in another worker. That mirrors the existing external-db-sync fusebox test; the refusal itself is covered by the unit test, which needs no shared state.

Verified end to end on the local stack against seeded deployment data:

- fusebox on → upload reaches Marshal
- toggled off **through the UI** → DB row `false`, upload and deploy both 503
- toggled back on → 503 gone, request reaches Marshal again

One bug the run-through caught and fixed: `` urlString`${ENDPOINT}` `` percent-encodes the path's slashes (it escapes *interpolated values*), producing `/api/v1%2Finternal%2F…` and a 404.
