### PR TITLE
all-good: tolerate cancelled docker-server-build-push runs superseded by a newer commit

### DIFF
--- a/.github/workflows/all-good.yaml
+++ b/.github/workflows/all-good.yaml
@@ -176,6 +176,39 @@ jobs:
             printf '%s\n' "$combined"
           }
 
+          # docker-server-build-push.yaml is deliberately serialized per ref (it publishes the moving
+          # `dev`/`latest` image tags), and GitHub keeps at most one queued run per concurrency group.
+          # So when several commits land on dev in quick succession, the runs for the middle commits
+          # are cancelled and only the newest commit is built, which is exactly what we want for a
+          # moving tag: the image that gets published is the newest one. A cancelled run is therefore
+          # not a failure of this commit, as long as a newer run of the same workflow exists on the
+          # same branch (i.e. this run was superseded, not cancelled by hand or by a runner problem).
+          # A run cancelled while still queued never started any jobs, so it leaves no check runs
+          # behind and the check-run gate below is unaffected.
+          function is_superseded_run() {
+            local workflow_file=$1
+            local run_id=$2
+            local response
+            if ! response=$(curl -sS --fail-with-body \
+              --retry 3 \
+              --retry-all-errors \
+              --connect-timeout 10 \
+              --max-time 30 \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${REPO}/actions/workflows/${workflow_file}/runs?event=${EVENT_NAME}&branch=${REF_NAME}&per_page=100"); then
+              echo "Error fetching workflow runs for ${workflow_file} on ${REF_NAME}" >&2
+              return 1
+            fi
+            local newer_count
+            if ! newer_count=$(jq --argjson id "$run_id" '[.workflow_runs[]? | select(.id > $id)] | length' <<< "$response"); then
+              echo "Invalid Actions API response for ${workflow_file}" >&2
+              return 1
+            fi
+            [ "$newer_count" -gt 0 ]
+          }
+
           function count_pending_checks() {
             local response=$1
             echo "$response" | jq '([.check_runs[]? | select(.status != "completed" and .name != "all-good" and .name != "claude-review")] | length) // 0'
@@ -192,6 +225,7 @@ jobs:
             missing_workflows=()
             pending_workflows=()
             failed_workflows=()
+            superseded_workflows=()
 
             for workflow_file in "${expected_workflows[@]}"; do
               workflow_path=".github/workflows/${workflow_file}"
@@ -209,9 +243,19 @@ jobs:
               if [ "$status" != "completed" ]; then
                 pending_workflows+=("${workflow_file} (${status})")
               elif [ "$conclusion" != "success" ] && [ "$conclusion" != "skipped" ] && [ "$conclusion" != "neutral" ]; then
-                failed_workflows+=("${workflow_file} (${conclusion})")
+                run_id=$(jq -r '.id' <<< "$latest")
+                if [ "$workflow_file" = "docker-server-build-push.yaml" ] && [ "$conclusion" = "cancelled" ] && is_superseded_run "$workflow_file" "$run_id"; then
+                  superseded_workflows+=("${workflow_file} (run ${run_id})")
+                else
+                  failed_workflows+=("${workflow_file} (${conclusion})")
+                fi
               fi
             done
+
+            if [ "${#superseded_workflows[@]}" -gt 0 ]; then
+              echo "Expected workflows cancelled because a newer commit on ${REF_NAME} superseded them (not counted as failures):"
+              printf '  - %s\n' "${superseded_workflows[@]}"
+            fi
 
             if [ "${#failed_workflows[@]}" -gt 0 ]; then
               echo "Expected workflow failures:"


### PR DESCRIPTION
`docker-server-build-push.yaml` is serialized per ref (no sha in its concurrency group), and GitHub keeps at most one queued run per group. When several commits land on `dev` within a couple of minutes, the runs for the middle commits get auto-cancelled and `all-good` on those commits fails (e.g. https://github.com/hexclave/hexclave/actions/runs/34146725443/job/101820263066), even though the newest commit's image is what gets published anyway.

`all-good` now treats a `cancelled` `docker-server-build-push.yaml` run as OK if and only if a newer run of that workflow exists on the same branch (`is_superseded_run`). Other cancellations (manual, runner issues) still fail the gate.

Verified by running the extracted script locally against `75f2189e` on `dev`: previously exited 1 with "Expected workflow failures: docker-server-build-push.yaml (cancelled)"; now logs the run as superseded and continues waiting on the remaining workflows.

Link to Devin session: https://app.devin.ai/sessions/7754075a49e24d9da17fa556293833f4
Open in Devin Desktop: https://app.devin.ai/desktop/session/7754075a49e24d9da17fa556293833f4?variant=devin
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI gating logic only in `all-good.yaml`; narrows failure conditions for one workflow without changing build or deploy behavior.
> 
> **Overview**
> **`all-good` no longer fails when `docker-server-build-push.yaml` is `cancelled` on rapid `dev`/`main` pushes**, as long as a newer run of that workflow exists on the same branch.
> 
> The gate adds `is_superseded_run`, which queries the Actions API for runs of that workflow on `REF_NAME` and treats cancellation as acceptable only when at least one run has a higher run id. Those cases are logged under superseded workflows and are excluded from `failed_workflows`; other non-success conclusions (including manual or infra cancellations) still fail the job.
> 
> Inline comments document why per-ref serialization of the docker push workflow makes superseded cancellations expected for moving `dev`/`latest` tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f3ab2f370296c69d30e95ebc3481290f5cfee9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `all-good` so cancelled `docker-server-build-push` runs are no longer treated as failures when a newer run on the same branch superseded them. Manual cancellations or runner issues still fail the gate as before.

<sup>Written for commit 3f3ab2f370296c69d30e95ebc3481290f5cfee9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated workflow status reporting so cancelled build runs superseded by newer runs no longer incorrectly fail the overall checks.
  * Continued treating other unsuccessful workflow runs as failures.
  * Added clearer logging for superseded workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->