### PR TITLE
Fix client-app-impl.cookie.test failing on dev (missing CookieHelper.identity)

### DIFF
--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cookie.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cookie.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { encodeBase32 } from "@hexclave/shared/dist/utils/bytes";
 import { getTrustedParentDomain } from "@hexclave/shared/dist/utils/redirect-urls";
 import { TextEncoder } from "util";
+import type { CookieHelper } from "../../../cookie";
 import { StackClientApp } from "../interfaces/client-app";
 
 const serverCookieState = vi.hoisted(() => ({
@@ -22,6 +23,7 @@ vi.mock("../../../cookie", () => {
     }
   };
   const helper = {
+    identity: {},
     get: (name: string) => serverCookieState.values.get(name) ?? null,
     getAll,
     set: (name: string, value: string) => setOrDelete(name, value),
@@ -69,7 +71,8 @@ describe("StackClientApp custom refresh cookie updates", () => {
       return domain === "_.example.com" ? "example.com" : null;
     });
     const getOrCreateTokenStore = Reflect.get(clientApp, "_getOrCreateTokenStore");
-    const cookieHelper = {
+    const cookieHelper: CookieHelper = {
+      identity: {},
       get: (name: string) => serverCookieState.values.get(name) ?? null,
       getAll: () => Object.fromEntries(serverCookieState.values),
       set: (name: string, value: string) => serverCookieState.values.set(name, value),
@@ -131,7 +134,8 @@ describe("StackClientApp custom refresh cookie updates", () => {
       return domain === "_.example.com" ? "example.com" : null;
     });
     const getOrCreateTokenStore = Reflect.get(clientApp, "_getOrCreateTokenStore");
-    const cookieHelper = {
+    const cookieHelper: CookieHelper = {
+      identity: {},
       get: (name: string) => serverCookieState.values.get(name) ?? null,
       getAll: () => Object.fromEntries(serverCookieState.values),
       set: (name: string, value: string) => serverCookieState.values.set(name, value),


### PR DESCRIPTION
Fixes the `@hexclave/template` unit test failure on `dev` after #2012 merged (`TypeError: Invalid value used as weak map key` in `_getOrCreateTokenStore`).

#2012 was branched before `CookieHelper.identity` was added (91fafc9), so its mocked cookie helpers in `client-app-impl.cookie.test.ts` lacked the field that `_nextServerCookiesTokenStores` (a WeakMap) now keys on. Adds `identity: {}` to the mocks and types them as `CookieHelper` so future shape changes fail at typecheck.

Link to Devin session: https://app.devin.ai/sessions/b359b398e48f4814b54773f2527b08ca
Open in Devin Desktop: https://app.devin.ai/desktop/session/b359b398e48f4814b54773f2527b08ca?variant=devin
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock updates with no production code or runtime behavior changes.
> 
> **Overview**
> Fixes **`client-app-impl.cookie.test.ts`** failing on `dev` with `TypeError: Invalid value used as weak map key` when `_getOrCreateTokenStore` indexes **`_nextServerCookiesTokenStores`** by **`cookieHelper.identity`**.
> 
> The test’s mocked cookie helpers now include **`identity: {}`**, and inline helpers are annotated as **`CookieHelper`** so missing fields surface at typecheck instead of at runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e606352c6542097a32aed1f2df809e292f2e4dca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `client-app-impl.cookie.test` failure on `dev` where mocked `CookieHelper` objects were missing the `identity` field that `_getOrCreateTokenStore` now uses as a WeakMap key. Adds `identity: {}` to the mocks and types them as `CookieHelper` so future shape changes fail at typecheck.

<sup>Written for commit e606352c6542097a32aed1f2df809e292f2e4dca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated cookie-related test fixtures to remain compatible with the current cookie handling contract.
  - Improved test reliability for client application cookie scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->