### PR TITLE
Run freestyle-mock jobs in resident guest processes

### DIFF
--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -1425,8 +1425,9 @@ class PersistentResidentRunner {
       };
       if (timeout !== undefined) {
         active.timer = setTimeout(() => {
-          process.kill("SIGKILL");
+          if (this.active !== active) return;
           this.active = null;
+          process.kill("SIGKILL");
           reject(new Error(`resident runner timed out after ${timeout}ms`));
         }, timeout);
       }
@@ -1437,8 +1438,13 @@ class PersistentResidentRunner {
 
   async dispose() {
     const process = this.process;
+    const active = this.active;
     this.process = null;
     this.active = null;
+    if (active) {
+      clearTimeout(active.timer);
+      active.reject(new Error("resident runner is not running"));
+    }
     if (!process) return;
     process.kill("SIGTERM");
     await process.wait().catch(() => {});

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -568,6 +568,7 @@ class DependencyCache {
         hash: "default",
         nodeModulesPath: DEFAULT_NODE_MODULES_DIR,
         isDefault: true,
+        nodeModules: defaultNodeModules,
         release: () => {},
       };
     }
@@ -605,6 +606,7 @@ class DependencyCache {
       hash,
       nodeModulesPath,
       isDefault: false,
+      nodeModules: new Map(Object.entries(normalized)),
       release: () => {
         if (released) return;
         released = true;
@@ -717,6 +719,7 @@ class RuntimeCache {
       hash: dependency.hash,
       isDefault: dependency.isDefault,
       nodeModulesPath: dependency.nodeModulesPath,
+      nodeModules: dependency.nodeModules,
       runtime,
       activeJobs: 0,
       jobsHandled: 0,
@@ -756,12 +759,12 @@ class RuntimeCache {
 
   async disposeRunners(entry) {
     entry.idleRunners = [];
-    entry.runnerCount = 0;
     for (const waiter of entry.runnerWaiters.splice(0)) {
       waiter.resolve();
     }
     const runners = [...entry.runners];
     entry.runners.clear();
+    entry.runnerCount = 0;
     await Promise.all(
       runners.map((runner) =>
         runner.dispose().catch((error) => {
@@ -839,12 +842,24 @@ class RuntimeCache {
       if (entry.runnerCount < MAX_RESIDENT_RUNNERS_PER_RUNTIME) {
         entry.runnerCount++;
         try {
-          const created = await PersistentResidentRunner.create(entry.runtime);
+          const created = await PersistentResidentRunner.create(entry.runtime, {
+            warmupImports: [
+              ...entry.nodeModules.keys(),
+              "react-dom/server",
+            ],
+            onExit: (runner) => this.removeRunner(entry, runner),
+          });
           created.jobsHandled = 0;
           entry.runners.add(created);
+          if (created.exited) {
+            this.removeRunner(entry, created);
+            throw new Error("resident runner exited before completing request");
+          }
           return created;
         } catch (error) {
-          entry.runnerCount--;
+          if (entry.runnerCount > entry.runners.size) {
+            entry.runnerCount--;
+          }
           const waiter = entry.runnerWaiters.shift();
           waiter?.resolve();
           throw error;
@@ -876,13 +891,23 @@ class RuntimeCache {
       else entry.idleRunners.push(runner);
       return;
     }
-    entry.runners.delete(runner);
-    entry.runnerCount--;
+    const removed = this.removeRunner(entry, runner);
+    if (!removed) return;
     await runner.dispose().catch((error) => {
       logInternalError("dispose resident runner", error);
     });
     const waiter = entry.runnerWaiters.shift();
     waiter?.resolve();
+  }
+
+  removeRunner(entry, runner) {
+    const index = entry.idleRunners.indexOf(runner);
+    if (index >= 0) entry.idleRunners.splice(index, 1);
+    if (!entry.runners.delete(runner)) return false;
+    entry.runnerCount--;
+    const waiter = entry.runnerWaiters.shift();
+    waiter?.resolve();
+    return true;
   }
 
   hasSingleDrainingGeneration(hash) {
@@ -998,7 +1023,7 @@ try {
 `;
 }
 
-function makeWrapper(userModulePath, userModuleDir) {
+function makePreludeSource() {
   const bridgeSource = BRIDGE_ENABLED
     ? `
 const bridgedOrigins = ${JSON.stringify(BRIDGED_ORIGINS)};
@@ -1195,19 +1220,24 @@ if (!globalThis.__hexclaveMockPrelude) {
 ${bridgeSource}
   globalThis.__hexclaveMockPrelude = prelude;
 }
+`;
+}
+
+function makeJobBody({ userModulePath, userModuleDir, emitExpression }) {
+  return `
 globalThis.__hexclaveMockPrelude.logs = [];
 globalThis.__hexclaveMockPrelude.logBytes = 0;
 try {
   const userModule = await import(${JSON.stringify(userModulePath)});
   const exported = userModule.default ?? userModule;
   const result = await (typeof exported === "function" ? exported() : exported);
-  globalThis.__return({
+  ${emitExpression}({
     status: "ok",
     result,
     logs: globalThis.__hexclaveMockPrelude.logs,
   });
 } catch (error) {
-  globalThis.__return({
+  ${emitExpression}({
     status: "error",
     error: error?.message || String(error),
     logs: globalThis.__hexclaveMockPrelude.logs,
@@ -1221,56 +1251,41 @@ try {
 `;
 }
 
-function makeRuntimePrelude() {
-  const wrapper = makeWrapper("/unused/user.mjs", "/unused");
-  const bodyMarker = "\ntry {\n";
-  const bodyIndex = wrapper.indexOf(bodyMarker);
-  if (bodyIndex < 0) {
-    throw new Error("Runtime prelude marker is missing");
-  }
-  return wrapper.slice(0, bodyIndex);
+function makeWrapper(userModulePath, userModuleDir) {
+  return `${makePreludeSource()}${makeJobBody({
+    userModulePath,
+    userModuleDir,
+    emitExpression: "globalThis.__return",
+  })}`;
 }
 
 function makeResidentJobModule(userModulePath, userModuleDir) {
-  return `
-${makeRuntimePrelude()}
-globalThis.__hexclaveMockPrelude.logs = [];
-globalThis.__hexclaveMockPrelude.logBytes = 0;
+  return `${makePreludeSource()}
 const emit = (payload) =>
   process.stdout.write(
     ${JSON.stringify(RESULT_PREFIX)} + JSON.stringify(payload) + "\\n",
   );
-try {
-  const userModule = await import(${JSON.stringify(userModulePath)});
-  const exported = userModule.default ?? userModule;
-  const result = await (typeof exported === "function" ? exported() : exported);
-  emit({
-    status: "ok",
-    result,
-    logs: globalThis.__hexclaveMockPrelude.logs,
-  });
-} catch (error) {
-  emit({
-    status: "error",
-    error: error?.message || String(error),
-    logs: globalThis.__hexclaveMockPrelude.logs,
-  });
-} finally {
-  try {
-    const fs = process.getBuiltinModule("node:fs/promises");
-    await fs.rm(${JSON.stringify(userModuleDir)}, { recursive: true, force: true });
-  } catch {}
-}
-`;
+${makeJobBody({
+  userModulePath,
+  userModuleDir,
+  emitExpression: "emit",
+})}`;
 }
 
-const RESIDENT_RUNNER_SOURCE = `
+function makeResidentRunnerSource(warmupImports) {
+  return `
 import { createInterface } from "node:readline";
 
 const readyPrefix = ${JSON.stringify(RESIDENT_RUNNER_READY_PREFIX)};
 const resultPrefix = ${JSON.stringify(RESIDENT_RUNNER_RESULT_PREFIX)};
+const warmupImports = ${JSON.stringify(warmupImports)};
 const fs = process.getBuiltinModule("node:fs/promises");
 
+for (const specifier of warmupImports) {
+  try {
+    await import(specifier);
+  } catch {}
+}
 process.stdout.write(readyPrefix + "\\n");
 const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
 for await (const line of rl) {
@@ -1300,11 +1315,14 @@ for await (const line of rl) {
   }
 }
 `;
+}
 
 class PersistentResidentRunner {
-  constructor(runtime) {
+  constructor(runtime, onExit) {
     this.runtime = runtime;
+    this.onExit = onExit;
     this.process = null;
+    this.exited = false;
     this.stdoutBuffer = "";
     this.active = null;
     this.readyPromise = new Promise((resolve, reject) => {
@@ -1313,27 +1331,34 @@ class PersistentResidentRunner {
     });
   }
 
-  static async create(runtime) {
-    const runner = new PersistentResidentRunner(runtime);
-    runner.process = await runtime.spawn(RESIDENT_RUNNER_SOURCE, {
+  static async create(runtime, { warmupImports, onExit }) {
+    const runner = new PersistentResidentRunner(runtime, onExit);
+    runner.process = await runtime.spawn(
+      makeResidentRunnerSource(warmupImports),
+      {
       onStdout: (chunk) => runner.handleStdout(chunk),
       onStderr: (chunk) => runner.handleStderr(chunk),
-    });
+      },
+    );
     runner.process.wait().then(
       (exitCode) => {
+        runner.exited = true;
         const error = new Error(
           `resident runner exited before completing request: ${exitCode}`,
         );
         runner.rejectReady(error);
         runner.active?.reject(error);
         runner.active = null;
+        runner.onExit?.(runner);
       },
       (error) => {
+        runner.exited = true;
         const normalized =
           error instanceof Error ? error : new Error(String(error));
         runner.rejectReady(normalized);
         runner.active?.reject(normalized);
         runner.active = null;
+        runner.onExit?.(runner);
       },
     );
     await runner.readyPromise;
@@ -1780,8 +1805,17 @@ const defaultEntry = await runtimeCache.acquire({
   hash: "default",
   isDefault: true,
   nodeModulesPath: DEFAULT_NODE_MODULES_DIR,
+  nodeModules: defaultNodeModules,
 });
 runtimeCache.release(defaultEntry);
+const defaultRunnerStartedAt = performance.now();
+const defaultRunner = await runtimeCache.acquireRunner(defaultEntry);
+await runtimeCache.releaseRunner(defaultEntry, defaultRunner, { healthy: true });
+console.log(
+  `freestyle-mock default runner ready in ${Math.round(
+    performance.now() - defaultRunnerStartedAt,
+  )}ms`,
+);
 
 const server = createServer(async (request, response) => {
   const requestStartedAt = performance.now();
@@ -1844,26 +1878,4 @@ server.listen(PORT, () => {
       BRIDGE_ENABLED ? BRIDGED_ORIGINS.join(",") : "disabled"
     })`,
   );
-  const warmupStartedAt = performance.now();
-  jobQueue
-    .submit(
-      `export default async () => {
-        await import("@react-email/components");
-        await import("react-dom/server");
-        return true;
-      }`,
-      { nodeModules: {} },
-      DEFAULT_TIMEOUT_MS,
-    )
-    .then((result) => {
-      if (result.statusCode !== 200) {
-        throw new Error(result.payload.error || "Warm-up failed");
-      }
-      console.log(
-        `freestyle-mock warm-up done in ${Math.round(
-          performance.now() - warmupStartedAt,
-        )}ms`,
-      );
-    })
-    .catch((error) => logInternalError("warm-up", error));
 });

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -36,7 +36,10 @@ if (
 ) {
   throw new Error("HEXCLAVE_FREESTYLE_MOCK_MAX_IN_FLIGHT must be an integer from 1 to 32");
 }
-const MAX_JOBS_PER_RUNTIME = 50;
+// Resident runners now provide the per-job process isolation. The VM only
+// accumulates temporary job directories, which each job removes, so recycling
+// it every 50 jobs would add unnecessary cold restarts.
+const MAX_JOBS_PER_RUNTIME = 500;
 const MAX_JOBS_PER_RESIDENT_RUNNER = 200;
 const configuredMaxResidentRunners =
   process.env.HEXCLAVE_FREESTYLE_MOCK_MAX_RESIDENT_RUNNERS;
@@ -714,6 +717,7 @@ class RuntimeCache {
         },
       };
     }
+    const runtimeStartedAt = performance.now();
     const runtime = await NodeRuntime.create(options);
     const entry = {
       hash: dependency.hash,
@@ -732,7 +736,32 @@ class RuntimeCache {
       runners: new Set(),
     };
     this.entries.set(dependency.hash, entry);
-    return entry;
+    const warmRunnerCount = dependency.isDefault
+      ? MAX_RESIDENT_RUNNERS_PER_RUNTIME
+      : 1;
+    const runnerCreations = Array.from({ length: warmRunnerCount }, () =>
+      this.createRunner(entry),
+    );
+    try {
+      const warmRunners = await Promise.all(runnerCreations);
+      entry.idleRunners.push(...warmRunners);
+      console.log(
+        `freestyle-mock runtime ${entry.hash} ready with ${
+          warmRunners.length
+        } warm runners in ${Math.round(
+          performance.now() - runtimeStartedAt,
+        )}ms`,
+      );
+      return entry;
+    } catch (error) {
+      await Promise.allSettled(runnerCreations);
+      this.entries.delete(dependency.hash);
+      await this.disposeRunners(entry);
+      await runtime.dispose().catch((disposeError) => {
+        logInternalError("dispose failed runtime", disposeError);
+      });
+      throw error;
+    }
   }
 
   evict(entry) {
@@ -840,30 +869,7 @@ class RuntimeCache {
       const runner = entry.idleRunners.pop();
       if (runner) return runner;
       if (entry.runnerCount < MAX_RESIDENT_RUNNERS_PER_RUNTIME) {
-        entry.runnerCount++;
-        try {
-          const created = await PersistentResidentRunner.create(entry.runtime, {
-            warmupImports: [
-              ...entry.nodeModules.keys(),
-              "react-dom/server",
-            ],
-            onExit: (runner) => this.removeRunner(entry, runner),
-          });
-          created.jobsHandled = 0;
-          entry.runners.add(created);
-          if (created.exited) {
-            this.removeRunner(entry, created);
-            throw new Error("resident runner exited before completing request");
-          }
-          return created;
-        } catch (error) {
-          if (entry.runnerCount > entry.runners.size) {
-            entry.runnerCount--;
-          }
-          const waiter = entry.runnerWaiters.shift();
-          waiter?.resolve();
-          throw error;
-        }
+        return await this.createRunner(entry);
       }
       const waiter = {};
       const waiterPromise = new Promise((resolve) => {
@@ -877,6 +883,30 @@ class RuntimeCache {
         if (index >= 0) entry.runnerWaiters.splice(index, 1);
         throw error;
       }
+    }
+  }
+
+  async createRunner(entry) {
+    entry.runnerCount++;
+    try {
+      const created = await PersistentResidentRunner.create(entry.runtime, {
+        warmupImports: [...entry.nodeModules.keys(), "react-dom/server"],
+        onExit: (runner) => this.removeRunner(entry, runner),
+      });
+      created.jobsHandled = 0;
+      entry.runners.add(created);
+      if (created.exited) {
+        this.removeRunner(entry, created);
+        throw new Error("resident runner exited before completing request");
+      }
+      return created;
+    } catch (error) {
+      if (entry.runnerCount > entry.runners.size) {
+        entry.runnerCount--;
+      }
+      const waiter = entry.runnerWaiters.shift();
+      waiter?.resolve();
+      throw error;
     }
   }
 
@@ -1808,14 +1838,6 @@ const defaultEntry = await runtimeCache.acquire({
   nodeModules: defaultNodeModules,
 });
 runtimeCache.release(defaultEntry);
-const defaultRunnerStartedAt = performance.now();
-const defaultRunner = await runtimeCache.acquireRunner(defaultEntry);
-await runtimeCache.releaseRunner(defaultEntry, defaultRunner, { healthy: true });
-console.log(
-  `freestyle-mock default runner ready in ${Math.round(
-    performance.now() - defaultRunnerStartedAt,
-  )}ms`,
-);
 
 const server = createServer(async (request, response) => {
   const requestStartedAt = performance.now();

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -1415,6 +1415,9 @@ class PersistentResidentRunner {
     const path = `/tmp/freestyle-resident-jobs/${id}.mjs`;
     await this.runtime.writeFile(path, code);
     const process = this.process;
+    if (!process) {
+      throw new Error("resident runner is not running");
+    }
     return new Promise((resolve, reject) => {
       const active = {
         id,
@@ -1433,7 +1436,13 @@ class PersistentResidentRunner {
         }, timeout);
       }
       this.active = active;
-      process.writeStdin(`${JSON.stringify({ id, path })}\n`);
+      try {
+        process.writeStdin(`${JSON.stringify({ id, path })}\n`);
+      } catch (error) {
+        clearTimeout(active.timer);
+        if (this.active === active) this.active = null;
+        reject(error);
+      }
     });
   }
 

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -1296,9 +1296,10 @@ function makeWrapper(userModulePath, userModuleDir) {
 
 function makeResidentJobModule(userModulePath, userModuleDir) {
   return `${makePreludeSource()}
+// Guest stdout may not end with a newline, so start the frame on its own line.
 const emit = (payload) =>
   process.stdout.write(
-    ${JSON.stringify(RESULT_PREFIX)} + JSON.stringify(payload) + "\\n",
+    "\\n" + ${JSON.stringify(RESULT_PREFIX)} + JSON.stringify(payload) + "\\n",
   );
 ${makeJobBody({
   userModulePath,
@@ -1330,7 +1331,7 @@ for await (const line of rl) {
     await import(request.path);
     await fs.rm(request.path, { force: true });
     process.stdout.write(
-      resultPrefix +
+      "\\n" + resultPrefix +
         JSON.stringify({ id: request.id, exitCode: 0, stderr: "" }) +
         "\\n",
     );
@@ -1339,7 +1340,7 @@ for await (const line of rl) {
       await fs.rm(request.path, { force: true }).catch(() => {});
     }
     process.stdout.write(
-      resultPrefix +
+      "\\n" + resultPrefix +
         JSON.stringify({
           id: request?.id,
           exitCode: 1,

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -745,6 +745,8 @@ class RuntimeCache {
     try {
       const warmRunners = await Promise.all(runnerCreations);
       entry.idleRunners.push(...warmRunners);
+      // The entry is visible during warmup, so wake waiters to retry now.
+      for (const waiter of entry.runnerWaiters.splice(0)) waiter.resolve();
       console.log(
         `freestyle-mock runtime ${entry.hash} ready with ${
           warmRunners.length
@@ -877,7 +879,10 @@ class RuntimeCache {
         entry.runnerWaiters.push(waiter);
       });
       try {
-        return await awaitAbort(waiterPromise, signal);
+        // A released runner is handed off directly; other wakeups only mean
+        // capacity changed, so retry the idle/create checks above.
+        const handoff = await awaitAbort(waiterPromise, signal);
+        if (handoff) return handoff;
       } catch (error) {
         const index = entry.runnerWaiters.indexOf(waiter);
         if (index >= 0) entry.runnerWaiters.splice(index, 1);
@@ -1354,6 +1359,8 @@ class PersistentResidentRunner {
     this.process = null;
     this.exited = false;
     this.stdoutBuffer = "";
+    this.stdoutDecoder = new TextDecoder();
+    this.stderrDecoder = new TextDecoder();
     this.active = null;
     this.readyPromise = new Promise((resolve, reject) => {
       this.resolveReady = resolve;
@@ -1438,7 +1445,7 @@ class PersistentResidentRunner {
   }
 
   handleStdout(chunk) {
-    this.stdoutBuffer += new TextDecoder().decode(chunk);
+    this.stdoutBuffer += this.stdoutDecoder.decode(chunk, { stream: true });
     for (;;) {
       const newlineIndex = this.stdoutBuffer.indexOf("\n");
       if (newlineIndex < 0) return;
@@ -1474,7 +1481,9 @@ class PersistentResidentRunner {
   }
 
   handleStderr(chunk) {
-    this.active?.stderr.push(new TextDecoder().decode(chunk));
+    this.active?.stderr.push(
+      this.stderrDecoder.decode(chunk, { stream: true }),
+    );
   }
 }
 

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -37,6 +37,22 @@ if (
   throw new Error("HEXCLAVE_FREESTYLE_MOCK_MAX_IN_FLIGHT must be an integer from 1 to 32");
 }
 const MAX_JOBS_PER_RUNTIME = 50;
+const MAX_JOBS_PER_RESIDENT_RUNNER = 200;
+const configuredMaxResidentRunners =
+  process.env.HEXCLAVE_FREESTYLE_MOCK_MAX_RESIDENT_RUNNERS;
+const MAX_RESIDENT_RUNNERS_PER_RUNTIME =
+  configuredMaxResidentRunners == null
+    ? 4
+    : Number(configuredMaxResidentRunners);
+if (
+  !Number.isInteger(MAX_RESIDENT_RUNNERS_PER_RUNTIME) ||
+  MAX_RESIDENT_RUNNERS_PER_RUNTIME < 1 ||
+  MAX_RESIDENT_RUNNERS_PER_RUNTIME > 16
+) {
+  throw new Error(
+    "HEXCLAVE_FREESTYLE_MOCK_MAX_RESIDENT_RUNNERS must be an integer from 1 to 16",
+  );
+}
 const DEFAULT_MAX_NON_DEFAULT_RUNTIMES = 3;
 const configuredMaxNonDefaultRuntimes =
   process.env.HEXCLAVE_FREESTYLE_MOCK_MAX_NON_DEFAULT_RUNTIMES;
@@ -79,6 +95,11 @@ const MODULE_CACHE_DIR =
   process.env.HEXCLAVE_FREESTYLE_MOCK_MODULE_CACHE_DIR || "/app/module-cache";
 const DEFAULT_NODE_MODULES_DIR = "/app/guest-node-modules/node_modules";
 const USER_MODULE_DIR = "/tmp/freestyle-jobs";
+const RESULT_PREFIX = `__HEXCLAVE_MOCK_RESULT_${randomUUID()}__`;
+const RESIDENT_RUNNER_READY_PREFIX =
+  `__HEXCLAVE_MOCK_RESIDENT_READY_${randomUUID()}__`;
+const RESIDENT_RUNNER_RESULT_PREFIX =
+  `__HEXCLAVE_MOCK_RESIDENT_RESULT_${randomUUID()}__`;
 const BRIDGE_ENABLED =
   process.env.HEXCLAVE_FREESTYLE_MOCK_BRIDGE_ENABLED === "true";
 const portPrefix = process.env.NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX || "81";
@@ -224,13 +245,25 @@ function isDeadRuntimeError(error) {
   }
   const message = formatError(error).toLowerCase();
   return (
-    message.includes("resident runner exited before completing request") ||
-    message.includes("resident runner is not running") ||
     message.includes("sidecar protocol stream ended") ||
     message.includes("sidecar exited with code") ||
     message.includes("unknown sidecar vm") ||
     message.includes("no such process")
   );
+}
+
+function isDeadRunnerError(error) {
+  const message = formatError(error).toLowerCase();
+  return (
+    message.includes("resident runner exited before completing request") ||
+    message.includes("resident runner is not running")
+  );
+}
+
+function isResidentRunnerTimeout(error) {
+  return formatError(error)
+    .toLowerCase()
+    .includes("resident runner timed out after");
 }
 
 // @secure-exec/core has a fire-and-forget proc.kill() path without a catch for
@@ -690,6 +723,10 @@ class RuntimeCache {
       lastUsed: performance.now(),
       retiring: false,
       disposePromise: null,
+      idleRunners: [],
+      runnerCount: 0,
+      runnerWaiters: [],
+      runners: new Set(),
     };
     this.entries.set(dependency.hash, entry);
     return entry;
@@ -703,6 +740,7 @@ class RuntimeCache {
     if (entry.disposePromise) return;
     entry.disposePromise = (async () => {
       try {
+        await this.disposeRunners(entry);
         await entry.runtime.dispose();
       } catch (error) {
         logInternalError("dispose detached runtime", error);
@@ -714,6 +752,23 @@ class RuntimeCache {
         }
       }
     })();
+  }
+
+  async disposeRunners(entry) {
+    entry.idleRunners = [];
+    entry.runnerCount = 0;
+    for (const waiter of entry.runnerWaiters.splice(0)) {
+      waiter.resolve();
+    }
+    const runners = [...entry.runners];
+    entry.runners.clear();
+    await Promise.all(
+      runners.map((runner) =>
+        runner.dispose().catch((error) => {
+          logInternalError("dispose resident runner", error);
+        }),
+      ),
+    );
   }
 
   detach(entry) {
@@ -748,6 +803,7 @@ class RuntimeCache {
     if (!candidate) return false;
     this.entries.delete(candidate.hash);
     try {
+      await this.disposeRunners(candidate);
       await candidate.runtime.dispose();
     } catch (error) {
       logInternalError("dispose evicted runtime", error);
@@ -770,6 +826,63 @@ class RuntimeCache {
 
   retire(entry) {
     this.detach(entry);
+  }
+
+  // Every one-shot job pays roughly 1.4s to start a guest process and load
+  // react-email/tailwind. Resident processes trade per-job module-state
+  // isolation for speed; this mock is used by development and CI only, while
+  // production uses real Freestyle VMs.
+  async acquireRunner(entry, signal) {
+    for (;;) {
+      const runner = entry.idleRunners.pop();
+      if (runner) return runner;
+      if (entry.runnerCount < MAX_RESIDENT_RUNNERS_PER_RUNTIME) {
+        entry.runnerCount++;
+        try {
+          const created = await PersistentResidentRunner.create(entry.runtime);
+          created.jobsHandled = 0;
+          entry.runners.add(created);
+          return created;
+        } catch (error) {
+          entry.runnerCount--;
+          const waiter = entry.runnerWaiters.shift();
+          waiter?.resolve();
+          throw error;
+        }
+      }
+      const waiter = {};
+      const waiterPromise = new Promise((resolve) => {
+        waiter.resolve = resolve;
+        entry.runnerWaiters.push(waiter);
+      });
+      try {
+        return await awaitAbort(waiterPromise, signal);
+      } catch (error) {
+        const index = entry.runnerWaiters.indexOf(waiter);
+        if (index >= 0) entry.runnerWaiters.splice(index, 1);
+        throw error;
+      }
+    }
+  }
+
+  async releaseRunner(entry, runner, { healthy }) {
+    if (
+      healthy &&
+      !entry.retiring &&
+      runner.jobsHandled < MAX_JOBS_PER_RESIDENT_RUNNER
+    ) {
+      const waiter = entry.runnerWaiters.shift();
+      if (waiter) waiter.resolve(runner);
+      else entry.idleRunners.push(runner);
+      return;
+    }
+    entry.runners.delete(runner);
+    entry.runnerCount--;
+    await runner.dispose().catch((error) => {
+      logInternalError("dispose resident runner", error);
+    });
+    const waiter = entry.runnerWaiters.shift();
+    waiter?.resolve();
   }
 
   hasSingleDrainingGeneration(hash) {
@@ -1031,59 +1144,73 @@ Object.defineProperty(globalThis, "fetch", {
 `
     : "";
   return `
-const logs = [];
-const MAX_LOG_ENTRIES = 1000;
-const MAX_LOG_MESSAGE_BYTES = 64 * 1024;
-let logBytes = 0;
-const inspectValue = (value) => {
-  try {
-    return JSON.stringify(value, (_, nested) =>
-      typeof nested === "bigint" ? nested.toString() + "n" : nested,
-    ) ?? String(value);
-  } catch {
-    try { return Object.prototype.toString.call(value); } catch { return "<uninspectable>"; }
-  }
-};
-// Guest code can forge or suppress these logs; they are untrusted data.
-for (const type of ["log", "info", "warn", "error", "debug"]) {
-  const original = console[type];
-  console[type] = (...args) => {
-    if (logs.length < MAX_LOG_ENTRIES) {
-      const values = [];
-      for (const arg of args) values.push(inspectValue(arg));
-      let message = values.join(" ");
-      const encoder = new TextEncoder();
-      let encoded = encoder.encode(message);
-      if (encoded.byteLength > MAX_LOG_MESSAGE_BYTES) {
-        const marker = " [log truncated]";
-        const budget = MAX_LOG_MESSAGE_BYTES - encoder.encode(marker).byteLength;
-        let truncated = new TextDecoder().decode(encoded.subarray(0, budget));
-        while (encoder.encode(truncated).byteLength > budget) {
-          truncated = truncated.slice(0, -1);
-        }
-        message = truncated + marker;
-        encoded = encoder.encode(message);
-      }
-      const messageBytes = encoded.byteLength;
-      if (logBytes + messageBytes <= ${MAX_RESULT_BYTES}) {
-        logs.push({ message, type });
-        logBytes += messageBytes;
-      }
-    }
-    original(...args);
+if (!globalThis.__hexclaveMockPrelude) {
+  const prelude = {
+    logs: [],
+    logBytes: 0,
   };
-}
+  const MAX_LOG_ENTRIES = 1000;
+  const MAX_LOG_MESSAGE_BYTES = 64 * 1024;
+  const inspectValue = (value) => {
+    try {
+      return JSON.stringify(value, (_, nested) =>
+        typeof nested === "bigint" ? nested.toString() + "n" : nested,
+      ) ?? String(value);
+    } catch {
+      try { return Object.prototype.toString.call(value); } catch { return "<uninspectable>"; }
+    }
+  };
+  // Guest code can forge or suppress these logs; they are untrusted data.
+  for (const type of ["log", "info", "warn", "error", "debug"]) {
+    const original = console[type];
+    console[type] = (...args) => {
+      if (globalThis.__hexclaveMockPrelude.logs.length < MAX_LOG_ENTRIES) {
+        const values = [];
+        for (const arg of args) values.push(inspectValue(arg));
+        let message = values.join(" ");
+        const encoder = new TextEncoder();
+        let encoded = encoder.encode(message);
+        if (encoded.byteLength > MAX_LOG_MESSAGE_BYTES) {
+          const marker = " [log truncated]";
+          const budget = MAX_LOG_MESSAGE_BYTES - encoder.encode(marker).byteLength;
+          let truncated = new TextDecoder().decode(encoded.subarray(0, budget));
+          while (encoder.encode(truncated).byteLength > budget) {
+            truncated = truncated.slice(0, -1);
+          }
+          message = truncated + marker;
+          encoded = encoder.encode(message);
+        }
+        const messageBytes = encoded.byteLength;
+        if (
+          globalThis.__hexclaveMockPrelude.logBytes + messageBytes <=
+          ${MAX_RESULT_BYTES}
+        ) {
+          globalThis.__hexclaveMockPrelude.logs.push({ message, type });
+          globalThis.__hexclaveMockPrelude.logBytes += messageBytes;
+        }
+      }
+      original(...args);
+    };
+  }
 ${bridgeSource}
+  globalThis.__hexclaveMockPrelude = prelude;
+}
+globalThis.__hexclaveMockPrelude.logs = [];
+globalThis.__hexclaveMockPrelude.logBytes = 0;
 try {
   const userModule = await import(${JSON.stringify(userModulePath)});
   const exported = userModule.default ?? userModule;
   const result = await (typeof exported === "function" ? exported() : exported);
-  globalThis.__return({ status: "ok", result, logs });
+  globalThis.__return({
+    status: "ok",
+    result,
+    logs: globalThis.__hexclaveMockPrelude.logs,
+  });
 } catch (error) {
   globalThis.__return({
     status: "error",
     error: error?.message || String(error),
-    logs,
+    logs: globalThis.__hexclaveMockPrelude.logs,
   });
 } finally {
   try {
@@ -1092,6 +1219,208 @@ try {
   } catch {}
 }
 `;
+}
+
+function makeRuntimePrelude() {
+  const wrapper = makeWrapper("/unused/user.mjs", "/unused");
+  const bodyMarker = "\ntry {\n";
+  const bodyIndex = wrapper.indexOf(bodyMarker);
+  if (bodyIndex < 0) {
+    throw new Error("Runtime prelude marker is missing");
+  }
+  return wrapper.slice(0, bodyIndex);
+}
+
+function makeResidentJobModule(userModulePath, userModuleDir) {
+  return `
+${makeRuntimePrelude()}
+globalThis.__hexclaveMockPrelude.logs = [];
+globalThis.__hexclaveMockPrelude.logBytes = 0;
+const emit = (payload) =>
+  process.stdout.write(
+    ${JSON.stringify(RESULT_PREFIX)} + JSON.stringify(payload) + "\\n",
+  );
+try {
+  const userModule = await import(${JSON.stringify(userModulePath)});
+  const exported = userModule.default ?? userModule;
+  const result = await (typeof exported === "function" ? exported() : exported);
+  emit({
+    status: "ok",
+    result,
+    logs: globalThis.__hexclaveMockPrelude.logs,
+  });
+} catch (error) {
+  emit({
+    status: "error",
+    error: error?.message || String(error),
+    logs: globalThis.__hexclaveMockPrelude.logs,
+  });
+} finally {
+  try {
+    const fs = process.getBuiltinModule("node:fs/promises");
+    await fs.rm(${JSON.stringify(userModuleDir)}, { recursive: true, force: true });
+  } catch {}
+}
+`;
+}
+
+const RESIDENT_RUNNER_SOURCE = `
+import { createInterface } from "node:readline";
+
+const readyPrefix = ${JSON.stringify(RESIDENT_RUNNER_READY_PREFIX)};
+const resultPrefix = ${JSON.stringify(RESIDENT_RUNNER_RESULT_PREFIX)};
+const fs = process.getBuiltinModule("node:fs/promises");
+
+process.stdout.write(readyPrefix + "\\n");
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+for await (const line of rl) {
+  let request;
+  try {
+    request = JSON.parse(line);
+    await import(request.path);
+    await fs.rm(request.path, { force: true });
+    process.stdout.write(
+      resultPrefix +
+        JSON.stringify({ id: request.id, exitCode: 0, stderr: "" }) +
+        "\\n",
+    );
+  } catch (error) {
+    if (request?.path) {
+      await fs.rm(request.path, { force: true }).catch(() => {});
+    }
+    process.stdout.write(
+      resultPrefix +
+        JSON.stringify({
+          id: request?.id,
+          exitCode: 1,
+          stderr: error instanceof Error ? error.stack || error.message : String(error),
+        }) +
+        "\\n",
+    );
+  }
+}
+`;
+
+class PersistentResidentRunner {
+  constructor(runtime) {
+    this.runtime = runtime;
+    this.process = null;
+    this.stdoutBuffer = "";
+    this.active = null;
+    this.readyPromise = new Promise((resolve, reject) => {
+      this.resolveReady = resolve;
+      this.rejectReady = reject;
+    });
+  }
+
+  static async create(runtime) {
+    const runner = new PersistentResidentRunner(runtime);
+    runner.process = await runtime.spawn(RESIDENT_RUNNER_SOURCE, {
+      onStdout: (chunk) => runner.handleStdout(chunk),
+      onStderr: (chunk) => runner.handleStderr(chunk),
+    });
+    runner.process.wait().then(
+      (exitCode) => {
+        const error = new Error(
+          `resident runner exited before completing request: ${exitCode}`,
+        );
+        runner.rejectReady(error);
+        runner.active?.reject(error);
+        runner.active = null;
+      },
+      (error) => {
+        const normalized =
+          error instanceof Error ? error : new Error(String(error));
+        runner.rejectReady(normalized);
+        runner.active?.reject(normalized);
+        runner.active = null;
+      },
+    );
+    await runner.readyPromise;
+    return runner;
+  }
+
+  async exec(code, { timeout } = {}) {
+    await this.readyPromise;
+    if (!this.process) {
+      throw new Error("resident runner is not running");
+    }
+    if (this.active) {
+      throw new Error("resident runner supports one in-flight exec");
+    }
+    const id = randomUUID();
+    const path = `/tmp/freestyle-resident-jobs/${id}.mjs`;
+    await this.runtime.writeFile(path, code);
+    const process = this.process;
+    return new Promise((resolve, reject) => {
+      const active = {
+        id,
+        stdout: [],
+        stderr: [],
+        resolve,
+        reject,
+        timer: undefined,
+      };
+      if (timeout !== undefined) {
+        active.timer = setTimeout(() => {
+          process.kill("SIGKILL");
+          this.active = null;
+          reject(new Error(`resident runner timed out after ${timeout}ms`));
+        }, timeout);
+      }
+      this.active = active;
+      process.writeStdin(`${JSON.stringify({ id, path })}\n`);
+    });
+  }
+
+  async dispose() {
+    const process = this.process;
+    this.process = null;
+    this.active = null;
+    if (!process) return;
+    process.kill("SIGTERM");
+    await process.wait().catch(() => {});
+  }
+
+  handleStdout(chunk) {
+    this.stdoutBuffer += new TextDecoder().decode(chunk);
+    for (;;) {
+      const newlineIndex = this.stdoutBuffer.indexOf("\n");
+      if (newlineIndex < 0) return;
+      const line = this.stdoutBuffer.slice(0, newlineIndex);
+      this.stdoutBuffer = this.stdoutBuffer.slice(newlineIndex + 1);
+      if (line === RESIDENT_RUNNER_READY_PREFIX) {
+        this.resolveReady();
+        continue;
+      }
+      if (!line.startsWith(RESIDENT_RUNNER_RESULT_PREFIX)) {
+        this.active?.stdout.push(`${line}\n`);
+        continue;
+      }
+      const active = this.active;
+      if (!active) continue;
+      let result;
+      try {
+        result = JSON.parse(line.slice(RESIDENT_RUNNER_RESULT_PREFIX.length));
+      } catch (error) {
+        active.reject(error);
+        this.active = null;
+        continue;
+      }
+      if (result.id !== active.id) continue;
+      clearTimeout(active.timer);
+      this.active = null;
+      active.resolve({
+        stdout: active.stdout.join(""),
+        stderr: active.stderr.join("") + result.stderr,
+        exitCode: result.exitCode,
+      });
+    }
+  }
+
+  handleStderr(chunk) {
+    this.active?.stderr.push(new TextDecoder().decode(chunk));
+  }
 }
 
 async function hostFetch(input) {
@@ -1167,53 +1496,140 @@ async function cleanupGuestFiles(runtime, userModuleDir) {
   return null;
 }
 
-async function executeScript(runtime, job) {
+async function executeScript(entry, job) {
+  const runtime = entry.runtime;
   const userModuleDir = `${USER_MODULE_DIR}/${randomUUID()}`;
   const userModulePath = `${userModuleDir}/user.mjs`;
   await runtime.writeFile(userModulePath, job.script);
-  let result;
+  const failed = () => ({
+    statusCode: 500,
+    payload: {
+      error: "Script execution failed",
+      logs: logsFromOutput(job.output),
+    },
+  });
+  const envVars = job.config.envVars || {};
+  if (Object.keys(envVars).length > 0) {
+    let result;
+    try {
+      result = await runtime.run(makeWrapper(userModulePath, userModuleDir), {
+        env: envVars,
+        timeout: job.timeoutMs,
+        signal: job.controller.signal,
+        onStdout: (chunk) => appendOutput(job.output, "stdout", chunk),
+        onStderr: (chunk) => appendOutput(job.output, "stderr", chunk),
+      });
+    } catch (error) {
+      logInternalError("secure-exec execution", error);
+      if (isDeadRuntimeError(error)) throw error;
+      return failed();
+    } finally {
+      job.cleanupError = await cleanupGuestFiles(runtime, userModuleDir);
+    }
+    if (result.exitCode !== 0 || result.value === undefined) {
+      logInternalError("secure-exec nonzero exit", result.stderr || result.exitCode);
+      return failed();
+    }
+    if (result.value.status === "error") {
+      return {
+        statusCode: 500,
+        payload: { error: result.value.error, logs: result.value.logs },
+      };
+    }
+    return {
+      statusCode: 200,
+      payload: {
+        result: truncateResult(result.value.result),
+        logs: result.value.logs,
+      },
+    };
+  }
+
+  job.resident = true;
+  let runner;
   try {
-    result = await runtime.run(makeWrapper(userModulePath, userModuleDir), {
-      env: job.config.envVars || {},
-      timeout: job.timeoutMs,
-      signal: job.controller.signal,
-      onStdout: (chunk) => appendOutput(job.output, "stdout", chunk),
-      onStderr: (chunk) => appendOutput(job.output, "stderr", chunk),
-    });
+    runner = await runtimeCache.acquireRunner(entry, job.controller.signal);
   } catch (error) {
-    logInternalError("secure-exec execution", error);
-    if (isDeadRuntimeError(error)) throw error;
-    return {
-      statusCode: 500,
-      payload: {
-        error: "Script execution failed",
-        logs: logsFromOutput(job.output),
-      },
-    };
-  } finally {
     job.cleanupError = await cleanupGuestFiles(runtime, userModuleDir);
+    if (isDeadRuntimeError(error)) throw error;
+    return failed();
   }
-  if (result.exitCode !== 0 || result.value === undefined) {
-    logInternalError("secure-exec nonzero exit", result.stderr || result.exitCode);
+  job.runner = runner;
+  let result;
+  let payload;
+  let payloadParsed = false;
+  const onAbort = () => {
+    runner.dispose().catch((error) => {
+      logInternalError("dispose aborted resident runner", error);
+    });
+  };
+  job.controller.signal.addEventListener("abort", onAbort, { once: true });
+  try {
+    result = await runner.exec(
+      makeResidentJobModule(userModulePath, userModuleDir),
+      { timeout: job.timeoutMs },
+    );
+  } catch (error) {
+    logInternalError("secure-exec resident execution", error);
+    await runtimeCache.releaseRunner(entry, runner, { healthy: false });
+    job.runner = null;
+    job.cleanupError = await cleanupGuestFiles(runtime, userModuleDir);
+    if (isDeadRuntimeError(error) && !isDeadRunnerError(error)) throw error;
+    if (isResidentRunnerTimeout(error)) {
+      return {
+        statusCode: 500,
+        payload: {
+          error: "Script execution timed out",
+          logs: logsFromOutput(job.output),
+        },
+      };
+    }
+    return failed();
+  } finally {
+    job.controller.signal.removeEventListener("abort", onAbort);
+  }
+
+  const stdoutLines = result.stdout.split(/\r?\n/);
+  for (const [index, line] of stdoutLines.entries()) {
+    if (line.startsWith(RESULT_PREFIX)) {
+      if (payloadParsed) {
+        payloadParsed = false;
+        payload = undefined;
+        break;
+      }
+      try {
+        payload = JSON.parse(line.slice(RESULT_PREFIX.length));
+        payloadParsed =
+          payload !== null && typeof payload === "object";
+      } catch (error) {
+        logInternalError("parse resident result", error);
+      }
+    } else if (index < stdoutLines.length - 1 || line !== "") {
+      appendOutputText(job.output, "stdout", line + "\n");
+    }
+  }
+  appendOutputText(job.output, "stderr", result.stderr);
+
+  const healthy = result.exitCode === 0 && payloadParsed;
+  runner.jobsHandled++;
+  await runtimeCache.releaseRunner(entry, runner, { healthy });
+  job.runner = null;
+  if (!healthy) {
+    logInternalError("secure-exec resident nonzero exit", result.exitCode);
+    job.cleanupError = await cleanupGuestFiles(runtime, userModuleDir);
+    return failed();
+  }
+  if (payload.status === "error") {
     return {
       statusCode: 500,
-      payload: {
-        error: "Script execution failed",
-        logs: logsFromOutput(job.output),
-      },
-    };
-  }
-  if (result.value.status === "error") {
-    return {
-      statusCode: 500,
-      payload: { error: result.value.error, logs: result.value.logs },
+      payload: { error: payload.error, logs: payload.logs },
     };
   }
   return {
     statusCode: 200,
     payload: {
-      result: truncateResult(result.value.result),
-      logs: result.value.logs,
+      result: truncateResult(payload.result),
+      logs: payload.logs,
     },
   };
 }
@@ -1236,6 +1652,8 @@ class JobQueue {
         controller: new AbortController(),
         output: createOutput(),
         entry: null,
+        runner: null,
+        resident: false,
         cleanupError: null,
         timer: null,
         settled: false,
@@ -1271,7 +1689,13 @@ class JobQueue {
 
   armExecutionTimeout(job) {
     job.timer = setTimeout(() => {
-      if (job.entry) this.runtimeCache.retire(job.entry);
+      if (job.runner) {
+        job.runner.dispose().catch((error) => {
+          logInternalError("dispose timed-out resident runner", error);
+        });
+      } else if (!job.resident && job.entry) {
+        this.runtimeCache.retire(job.entry);
+      }
       job.controller.abort(new Error("Execution timed out"));
       this.settle(job, {
         statusCode: 500,
@@ -1328,7 +1752,7 @@ class JobQueue {
       job.entry = entry;
       if (job.timer) clearTimeout(job.timer);
       this.armExecutionTimeout(job);
-      return await executeScript(entry.runtime, job);
+      return await executeScript(entry, job);
     } catch (error) {
       executionError = error;
       throw error;
@@ -1420,4 +1844,26 @@ server.listen(PORT, () => {
       BRIDGE_ENABLED ? BRIDGED_ORIGINS.join(",") : "disabled"
     })`,
   );
+  const warmupStartedAt = performance.now();
+  jobQueue
+    .submit(
+      `export default async () => {
+        await import("@react-email/components");
+        await import("react-dom/server");
+        return true;
+      }`,
+      { nodeModules: {} },
+      DEFAULT_TIMEOUT_MS,
+    )
+    .then((result) => {
+      if (result.statusCode !== 200) {
+        throw new Error(result.payload.error || "Warm-up failed");
+      }
+      console.log(
+        `freestyle-mock warm-up done in ${Math.round(
+          performance.now() - warmupStartedAt,
+        )}ms`,
+      );
+    })
+    .catch((error) => logInternalError("warm-up", error));
 });

--- a/docker/dependencies/freestyle-mock/server.mjs
+++ b/docker/dependencies/freestyle-mock/server.mjs
@@ -1479,6 +1479,9 @@ class PersistentResidentRunner {
       if (result.id !== active.id) continue;
       clearTimeout(active.timer);
       this.active = null;
+      // Flush bytes of a multi-byte char split at the last stderr chunk so
+      // they don't leak into the next job.
+      active.stderr.push(this.stderrDecoder.decode());
       active.resolve({
         stdout: active.stdout.join(""),
         stderr: active.stderr.join("") + result.stderr,


### PR DESCRIPTION
Each `POST /execute/v3/script` on the dev/CI freestyle mock spawned a fresh guest Node process, so every email render paid ~1.4s re-importing `@react-email/components`/`tailwindcss` on top of ~0.45s fixed process cost (~1.9s warm locally, 2–8s in CI). The actual React render is ~90ms.

The mock now keeps a small pool of resident guest processes per runtime (`PersistentResidentRunner`, max 4 per runtime, `HEXCLAVE_FREESTYLE_MOCK_MAX_RESIDENT_RUNNERS`), pre-warmed with the runtime's node_modules imports. Per job: write `user.mjs`, send `{id, path}` over stdin, the runner `import()`s a job module that does the existing console-capture/bridge prelude (idempotent, once per process) and emits the result on stdout behind a per-process random prefix. Runners are killed and replaced on timeout/abort/exit (dead runner ≠ dead runtime; `isDeadRuntimeError` no longer treats resident-runner errors as VM death), retired after 200 jobs (each job's module stays in the ESM cache), and the VM recycle threshold goes 50→500 since it's no longer the isolation unit. Jobs with `envVars` keep the old one-shot path.

Tradeoff: module-level state in guest dependencies persists across jobs within a runner. This mock is only used in development/CI; production uses real Freestyle VMs and is unchanged.

Measured (local, 8 cores): warm render 1.93s → ~45ms at the mock, ~150–250ms end-to-end in the backend's `render:` timing during the emails/workflows e2e suites (median 190ms, was multi-second). Remaining >1s outliers coincide with a non-default runtime being created for the workflow tests. Emails, email-themes, email-templates and workflows e2e suites pass locally (104 passed).

Link to Devin session: https://app.devin.ai/sessions/aff6168203c04c32a53c8388471e1b12
Open in Devin Desktop: https://app.devin.ai/desktop/session/aff6168203c04c32a53c8388471e1b12?variant=devin
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the docker freestyle mock used in development and CI; production rendering is unaffected, with the main behavioral tradeoff being weaker per-job isolation within a resident runner.
> 
> **Overview**
> The dev/CI **freestyle-mock** no longer starts a fresh guest Node process for every script execution. It keeps a **pool of warm resident runners** per runtime (default 4, configurable via `HEXCLAVE_FREESTYLE_MOCK_MAX_RESIDENT_RUNNERS`), pre-imports the runtime’s dependencies, and runs each job by writing `user.mjs` and driving the runner over stdin/stdout with prefixed result lines.
> 
> **Jobs that set `envVars`** still use the original one-shot `runtime.run` path. VM recycle limits move from **50 → 500 jobs** per runtime; runners are recycled after **200 jobs** or on timeout/abort/failure. **Dead-runtime detection** no longer treats resident-runner failures as VM death, so a crashed runner is replaced without evicting the whole runtime.
> 
> Guest wrapper code is split into a **once-per-process prelude** (console capture / bridge) and per-job bodies shared by both execution modes. This trades **module-level state persistence** across jobs on the same runner for much faster email renders in local/CI; production Freestyle is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e4bf56776b78a66fe83557a1949008f41ccf4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs freestyle-mock script jobs in warm resident guest processes so each execution no longer pays fresh Node startup and dependency re-import costs. Warm email renders drop from ~1.9s to ~45ms at the mock (~150–250ms end-to-end in backend render timing); production Freestyle VMs are unchanged.

**Details**
- Resident runners (up to 4 per runtime, `HEXCLAVE_FREESTYLE_MOCK_MAX_RESIDENT_RUNNERS`) pre-warm the runtime's node_modules imports; each job writes `user.mjs` and sends `{id, path}` over stdin.
- Runners are killed on timeout/abort/exit and retired after 200 jobs; disposing a runner rejects its in-flight exec, and exec re-checks the runner is alive after writing the job file so a concurrent dispose can't leave the job hanging.
- A dead runner no longer marks the runtime dead, and the VM recycle threshold moves from 50 to 500 jobs.
- Flushes the stderr decoder at result boundaries so multi-byte characters split across chunks don't leak into the next job.
- Jobs with `envVars` keep the old one-shot path.
- Module-level state in guest dependencies persists across jobs within a runner; acceptable since this mock is only used in development and CI.

<sup>Written for commit 0ed7c5fe1524728735b3455d944ec7cbb6d93762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reused warmed resident runners for jobs without environment variables, reducing repeated startup overhead.
  - Added configurable runner pools, warmup behavior, and per-runner job limits.

- **Configuration**
  - Environment-variable jobs continue to use one-shot execution.
  - Added controls for runner capacity and lifecycle management.

- **Reliability**
  - Improved timeout, failure, cleanup, and unhealthy-process handling.
  - Improved separation of runner status, results, and guest output.
  - Improved handling of split multibyte characters in runner error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->