### PR TITLE
Fix concat table group ordering and group pagination

### DIFF
--- a/apps/bulldozer-js/src/databases/bulldozer/index.test.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.test.ts
@@ -312,6 +312,38 @@ describe.each(["base", "in-memory"] as const)("Bulldozer (%s)", backend => {
     expect([...reverseFirstPage, ...reverseSecondPage]).toEqual(reverseFull);
   });
 
+  it("closes concat input group iterators when iteration ends early", async () => {
+    let closed = false;
+    const stored = defineStoredTable();
+    const tracked = {
+      ...stored,
+      async * listGroups(options: Parameters<typeof stored.listGroups>[0]) {
+        try {
+          for await (const group of stored.listGroups(options)) yield group;
+        } finally {
+          closed = true;
+        }
+      },
+    };
+    let snapshot = await initializedSnapshot(backend, [[
+      { type: "initTable", tableId: "tracked", table: tracked, inputTables: {} },
+      { type: "initTable", tableId: "other", table: defineStoredTable(), inputTables: {} },
+      { type: "initTable", tableId: "concat", table: defineConcatTable(), inputTables: { a: "tracked", b: "other" } },
+    ]]);
+    snapshot = await set(snapshot, "tracked", "row", "value");
+
+    closed = false;
+    expect(await collect(snapshot.listGroups({ tableId: "concat", range: { limit: 1 } }))).toEqual([{ groupKey: null }]);
+    expect(closed).toBe(true);
+
+    closed = false;
+    for await (const group of snapshot.listGroups({ tableId: "concat", range: {} })) {
+      expect(group).toEqual({ groupKey: null });
+      break;
+    }
+    expect(closed).toBe(true);
+  });
+
   it("left joins rows by derived keys and updates when either side changes", async () => {
     const join = declareLeftJoinTable({
       leftJoinKeyExtractor: async row => (row.rowData as { key: string }).key,

--- a/apps/bulldozer-js/src/databases/bulldozer/index.test.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.test.ts
@@ -350,27 +350,15 @@ describe.each(["base", "in-memory"] as const)("Bulldozer (%s)", backend => {
     const tracked = {
       ...stored,
       listGroups(options: Parameters<typeof stored.listGroups>[0]) {
-        const groups = (async function* () {
-          try {
-            for await (const group of stored.listGroups(options)) yield group;
-          } finally {
-            closed = true;
-          }
-        })();
-        let firstResult: ReturnType<typeof groups.next> | undefined = groups.next();
+        const inner = stored.listGroups(options)[Symbol.asyncIterator]();
         return {
           [Symbol.asyncIterator]() {
             return {
-              async next() {
-                if (firstResult !== undefined) {
-                  const result = firstResult;
-                  firstResult = undefined;
-                  return await result;
-                }
-                return await groups.next();
-              },
+              next: () => inner.next(),
               async return() {
-                return await groups.return();
+                closed = true;
+                const result = await inner.return?.();
+                return result ?? { done: true, value: undefined };
               },
             };
           },

--- a/apps/bulldozer-js/src/databases/bulldozer/index.test.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.test.ts
@@ -269,6 +269,49 @@ describe.each(["base", "in-memory"] as const)("Bulldozer (%s)", backend => {
     ]);
   });
 
+  it("orders and paginates concat groups using the shared input ordering", async () => {
+    const compareGroupKeys = (a: PiledriverObject, b: PiledriverObject) => stringCompare(JSON.stringify(a), JSON.stringify(b));
+    const groupBy = declareGroupByTable({
+      groupKeyExtractor: async row => Number(row.rowData),
+      groupKeyComparator: compareGroupKeys,
+    });
+    let snapshot = await initializedSnapshot(backend, [[
+      { type: "initTable", tableId: "storeA", table: defineStoredTable(), inputTables: {} },
+      { type: "initTable", tableId: "storeB", table: defineStoredTable(), inputTables: {} },
+      { type: "initTable", tableId: "groupsA", table: groupBy, inputTables: { input: "storeA" } },
+      { type: "initTable", tableId: "groupsB", table: groupBy, inputTables: { input: "storeB" } },
+      { type: "initTable", tableId: "concat", table: defineConcatTable(), inputTables: { a: "groupsA", b: "groupsB" } },
+    ]]);
+
+    snapshot = await set(snapshot, "storeA", "a1", 1);
+    snapshot = await set(snapshot, "storeA", "a3", 3);
+    snapshot = await set(snapshot, "storeA", "a4", 4);
+    snapshot = await set(snapshot, "storeB", "b2", 2);
+    snapshot = await set(snapshot, "storeB", "b4", 4);
+
+    const listGroups = async (range: Record<string, PiledriverObject> = {}) =>
+      await collect(snapshot.listGroups({ tableId: "concat", range }));
+    const lastGroupKey = (groups: { groupKey: PiledriverObject }[]) => {
+      const group = groups.at(-1);
+      if (group === undefined) throw new Error("Expected a non-empty group page");
+      return group.groupKey;
+    };
+    const full = await listGroups();
+    expect(full).toEqual([{ groupKey: 1 }, { groupKey: 2 }, { groupKey: 3 }, { groupKey: 4 }]);
+    expect(full.filter(group => group.groupKey === 4)).toHaveLength(1);
+    expect(await listGroups({ limit: 3 })).toEqual(full.slice(0, 3));
+
+    const firstPage = await listGroups({ limit: 2 });
+    const secondPage = await listGroups({ gt: lastGroupKey(firstPage), limit: 2 });
+    expect([...firstPage, ...secondPage]).toEqual(full);
+
+    const reverseFull = await listGroups({ reverse: true });
+    expect(reverseFull).toEqual([...full].reverse());
+    const reverseFirstPage = await listGroups({ reverse: true, limit: 2 });
+    const reverseSecondPage = await listGroups({ reverse: true, lt: lastGroupKey(reverseFirstPage), limit: 2 });
+    expect([...reverseFirstPage, ...reverseSecondPage]).toEqual(reverseFull);
+  });
+
   it("left joins rows by derived keys and updates when either side changes", async () => {
     const join = declareLeftJoinTable({
       leftJoinKeyExtractor: async row => (row.rowData as { key: string }).key,

--- a/apps/bulldozer-js/src/databases/bulldozer/index.test.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.test.ts
@@ -344,6 +344,61 @@ describe.each(["base", "in-memory"] as const)("Bulldozer (%s)", backend => {
     expect(closed).toBe(true);
   });
 
+  it("closes acquired concat iterators when a later input fails during acquisition", async () => {
+    let closed = false;
+    const stored = defineStoredTable();
+    const tracked = {
+      ...stored,
+      listGroups(options: Parameters<typeof stored.listGroups>[0]) {
+        const groups = (async function* () {
+          try {
+            for await (const group of stored.listGroups(options)) yield group;
+          } finally {
+            closed = true;
+          }
+        })();
+        let firstResult: ReturnType<typeof groups.next> | undefined = groups.next();
+        return {
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                if (firstResult !== undefined) {
+                  const result = firstResult;
+                  firstResult = undefined;
+                  return await result;
+                }
+                return await groups.next();
+              },
+              async return() {
+                return await groups.return();
+              },
+            };
+          },
+        };
+      },
+    };
+    let shouldThrow = false;
+    const throwingStored = defineStoredTable();
+    const throwing = {
+      ...throwingStored,
+      listGroups(options: Parameters<typeof throwingStored.listGroups>[0]) {
+        if (shouldThrow) throw new Error("concat input acquisition failed");
+        return throwingStored.listGroups(options);
+      },
+    };
+    let snapshot = await initializedSnapshot(backend, [[
+      { type: "initTable", tableId: "tracked", table: tracked, inputTables: {} },
+      { type: "initTable", tableId: "throwing", table: throwing, inputTables: {} },
+      { type: "initTable", tableId: "concat", table: defineConcatTable(), inputTables: { a: "tracked", z: "throwing" } },
+    ]]);
+    snapshot = await set(snapshot, "tracked", "row", "value");
+    shouldThrow = true;
+    closed = false;
+
+    await expect(collect(snapshot.listGroups({ tableId: "concat", range: {} }))).rejects.toThrow("concat input acquisition failed");
+    expect(closed).toBe(true);
+  });
+
   it("left joins rows by derived keys and updates when either side changes", async () => {
     const join = declareLeftJoinTable({
       leftJoinKeyExtractor: async row => (row.rowData as { key: string }).key,

--- a/apps/bulldozer-js/src/databases/bulldozer/index.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.ts
@@ -1815,13 +1815,7 @@ export function defineConcatTable(): BulldozerTableImplementation {
         previousGroupKey: PiledriverObject | undefined,
         done: boolean,
       };
-      const states: InputState[] = keys.map(inputTableKey => ({
-        inputTableKey,
-        iterator: inputTables[inputTableKey].listGroups({ range: inputRange })[Symbol.asyncIterator](),
-        current: undefined,
-        previousGroupKey: undefined,
-        done: false,
-      }));
+      const states: InputState[] = [];
       const advance = async (state: InputState) => {
         const next = await state.iterator.next();
         if (next.done) {
@@ -1842,6 +1836,15 @@ export function defineConcatTable(): BulldozerTableImplementation {
         state.current = next.value;
       };
       try {
+        for (const inputTableKey of keys) {
+          states.push({
+            inputTableKey,
+            iterator: inputTables[inputTableKey].listGroups({ range: inputRange })[Symbol.asyncIterator](),
+            current: undefined,
+            previousGroupKey: undefined,
+            done: false,
+          });
+        }
         await Promise.all(states.map(advance));
         let previousCanonicalKey: string | undefined;
         for (;;) {

--- a/apps/bulldozer-js/src/databases/bulldozer/index.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.ts
@@ -1736,6 +1736,18 @@ export function defineFlatMapTable(mapper: (row: { groupKey: PiledriverObject, r
 
 export function defineConcatTable(): BulldozerTableImplementation {
   const inputKeys = (inputTables: Record<string, BulldozerTableImplementationInputTable>) => Object.keys(inputTables).sort();
+  const compareGroupKeysOf = (
+    inputTables: Record<string, BulldozerTableImplementationInputTable>,
+    keys: string[],
+    a: PiledriverObject,
+    b: PiledriverObject,
+  ) => {
+    const inputTableKey = keys.at(0);
+    if (inputTableKey === undefined) throw new Error("Concat table must have at least one input");
+    // Concat inputs descend from a common ancestor table, so their group orderings agree; the
+    // first sorted input key is a deterministic comparator authority for the whole concat.
+    return inputTables[inputTableKey].compareGroupKeys({ a, b });
+  };
   const rowIdentifier = (inputTableKey: string, id: string) => JSON.stringify([inputTableKey, id]);
   const rowSortKey = (concatIndex: number, sortKey: PiledriverObject): PiledriverObject => [concatIndex, sortKey];
   const concatIndex = (keys: string[], inputTableKey: string) => {
@@ -1791,16 +1803,74 @@ export function defineConcatTable(): BulldozerTableImplementation {
       if (range.limit === 0) return;
       let yielded = 0;
       const inputRange = { ...range, limit: undefined };
-      const seen = new Set<string>();
       const keys = inputKeys(inputTables);
-      for (const inputTableKey of range.reverse ? [...keys].reverse() : keys) {
-        for await (const { groupKey } of inputTables[inputTableKey].listGroups({ range: inputRange })) {
-          const canonicalKey = canonicalGroupKeyString(groupKey);
-          if (seen.has(canonicalKey)) continue;
-          seen.add(canonicalKey);
-          yield { groupKey };
-          if (range.limit !== undefined && ++yielded >= range.limit) return;
+      if (keys.length === 0) throw new Error("Concat table must have at least one input");
+      const compareTotal = (a: PiledriverObject, b: PiledriverObject) =>
+        compareGroupKeysOf(inputTables, keys, a, b) || compareStrings(canonicalGroupKeyString(a), canonicalGroupKeyString(b));
+      type InputState = {
+        inputTableKey: string,
+        iterator: AsyncIterator<{ groupKey: PiledriverObject }>,
+        current: { groupKey: PiledriverObject } | undefined,
+        previousGroupKey: PiledriverObject | undefined,
+      };
+      const states: InputState[] = keys.map(inputTableKey => ({
+        inputTableKey,
+        iterator: inputTables[inputTableKey].listGroups({ range: inputRange })[Symbol.asyncIterator](),
+        current: undefined,
+        previousGroupKey: undefined,
+      }));
+      const advance = async (state: InputState) => {
+        const next = await state.iterator.next();
+        if (next.done) {
+          state.current = undefined;
+          return;
         }
+        if (
+          state.previousGroupKey !== undefined
+          && (range.reverse
+            ? compareTotal(state.previousGroupKey, next.value.groupKey) < 0
+            : compareTotal(state.previousGroupKey, next.value.groupKey) > 0)
+        ) {
+          throw new Error(`Concat input table ${state.inputTableKey} yielded groups out of order`);
+        }
+        state.previousGroupKey = next.value.groupKey;
+        state.current = next.value;
+      };
+      await Promise.all(states.map(advance));
+      let previousCanonicalKey: string | undefined;
+      for (;;) {
+        let selected: InputState | undefined;
+        for (const state of states) {
+          if (state.current === undefined) continue;
+          if (
+            selected === undefined
+          ) {
+            selected = state;
+            continue;
+          }
+          const selectedCurrent = selected.current;
+          if (selectedCurrent === undefined) throw new Error(`Concat input table ${selected.inputTableKey} lost its current group`);
+          if (
+            range.reverse
+              ? compareTotal(state.current.groupKey, selectedCurrent.groupKey) > 0
+              : compareTotal(state.current.groupKey, selectedCurrent.groupKey) < 0
+          ) {
+            selected = state;
+          }
+        }
+        if (selected === undefined) return;
+        const selectedCurrent = selected.current;
+        if (selectedCurrent === undefined) throw new Error(`Concat input table ${selected.inputTableKey} lost its current group`);
+        const groupKey = selectedCurrent.groupKey;
+        const canonicalKey = canonicalGroupKeyString(groupKey);
+        if (canonicalKey === previousCanonicalKey) {
+          await advance(selected);
+          continue;
+        }
+        previousCanonicalKey = canonicalKey;
+        yield { groupKey };
+        if (range.limit !== undefined && ++yielded >= range.limit) return;
+        await advance(selected);
       }
     },
     async * listRowsInGroup({ inputTables, groupKey, range }) {
@@ -1883,7 +1953,7 @@ export function defineConcatTable(): BulldozerTableImplementation {
       };
     },
     compareGroupKeys({ serializedTable, inputTables, a, b }): number {
-      return 0;
+      return compareGroupKeysOf(inputTables, inputKeys(inputTables), a, b);
     },
     compareSortKeys({ serializedTable, inputTables, a, b }): number {
       return compareOutputSortKeys(inputTables, inputKeys(inputTables), a, b);

--- a/apps/bulldozer-js/src/databases/bulldozer/index.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.ts
@@ -1839,38 +1839,30 @@ export function defineConcatTable(): BulldozerTableImplementation {
       await Promise.all(states.map(advance));
       let previousCanonicalKey: string | undefined;
       for (;;) {
-        let selected: InputState | undefined;
+        let selected: { state: InputState, groupKey: PiledriverObject } | undefined;
         for (const state of states) {
-          if (state.current === undefined) continue;
+          const current = state.current;
+          if (current === undefined) continue;
           if (
             selected === undefined
+            || (range.reverse
+              ? compareTotal(current.groupKey, selected.groupKey) > 0
+              : compareTotal(current.groupKey, selected.groupKey) < 0)
           ) {
-            selected = state;
-            continue;
-          }
-          const selectedCurrent = selected.current;
-          if (selectedCurrent === undefined) throw new Error(`Concat input table ${selected.inputTableKey} lost its current group`);
-          if (
-            range.reverse
-              ? compareTotal(state.current.groupKey, selectedCurrent.groupKey) > 0
-              : compareTotal(state.current.groupKey, selectedCurrent.groupKey) < 0
-          ) {
-            selected = state;
+            selected = { state, groupKey: current.groupKey };
           }
         }
         if (selected === undefined) return;
-        const selectedCurrent = selected.current;
-        if (selectedCurrent === undefined) throw new Error(`Concat input table ${selected.inputTableKey} lost its current group`);
-        const groupKey = selectedCurrent.groupKey;
-        const canonicalKey = canonicalGroupKeyString(groupKey);
-        if (canonicalKey === previousCanonicalKey) {
-          await advance(selected);
-          continue;
+        // Equal group keys are adjacent in the merged stream (the canonical-string tie-break makes
+        // the order total), so comparing against the previously yielded key is enough to dedupe
+        // groups that several inputs share — no set of all seen keys needed.
+        const canonicalKey = canonicalGroupKeyString(selected.groupKey);
+        if (canonicalKey !== previousCanonicalKey) {
+          previousCanonicalKey = canonicalKey;
+          yield { groupKey: selected.groupKey };
+          if (range.limit !== undefined && ++yielded >= range.limit) return;
         }
-        previousCanonicalKey = canonicalKey;
-        yield { groupKey };
-        if (range.limit !== undefined && ++yielded >= range.limit) return;
-        await advance(selected);
+        await advance(selected.state);
       }
     },
     async * listRowsInGroup({ inputTables, groupKey, range }) {

--- a/apps/bulldozer-js/src/databases/bulldozer/index.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.ts
@@ -1805,6 +1805,8 @@ export function defineConcatTable(): BulldozerTableImplementation {
       const inputRange = { ...range, limit: undefined };
       const keys = inputKeys(inputTables);
       if (keys.length === 0) throw new Error("Concat table must have at least one input");
+      const comparatorInputKey = keys.at(0);
+      if (comparatorInputKey === undefined) throw new Error("Concat table must have at least one input");
       const compareTotal = (a: PiledriverObject, b: PiledriverObject) =>
         compareGroupKeysOf(inputTables, keys, a, b) || compareStrings(canonicalGroupKeyString(a), canonicalGroupKeyString(b));
       type InputState = {
@@ -1812,57 +1814,68 @@ export function defineConcatTable(): BulldozerTableImplementation {
         iterator: AsyncIterator<{ groupKey: PiledriverObject }>,
         current: { groupKey: PiledriverObject } | undefined,
         previousGroupKey: PiledriverObject | undefined,
+        done: boolean,
       };
       const states: InputState[] = keys.map(inputTableKey => ({
         inputTableKey,
         iterator: inputTables[inputTableKey].listGroups({ range: inputRange })[Symbol.asyncIterator](),
         current: undefined,
         previousGroupKey: undefined,
+        done: false,
       }));
       const advance = async (state: InputState) => {
         const next = await state.iterator.next();
         if (next.done) {
+          state.done = true;
           state.current = undefined;
           return;
         }
+        state.done = false;
         if (
           state.previousGroupKey !== undefined
           && (range.reverse
             ? compareTotal(state.previousGroupKey, next.value.groupKey) < 0
             : compareTotal(state.previousGroupKey, next.value.groupKey) > 0)
         ) {
-          throw new Error(`Concat input table ${state.inputTableKey} yielded groups out of order`);
+          throw new Error(`Concat input table ${state.inputTableKey} yielded group keys out of order according to input table ${comparatorInputKey}'s comparator. Concat requires all of its inputs to agree on group key ordering, because it pushes group range bounds down into each input.`);
         }
         state.previousGroupKey = next.value.groupKey;
         state.current = next.value;
       };
-      await Promise.all(states.map(advance));
-      let previousCanonicalKey: string | undefined;
-      for (;;) {
-        let selected: { state: InputState, groupKey: PiledriverObject } | undefined;
-        for (const state of states) {
-          const current = state.current;
-          if (current === undefined) continue;
-          if (
-            selected === undefined
-            || (range.reverse
-              ? compareTotal(current.groupKey, selected.groupKey) > 0
-              : compareTotal(current.groupKey, selected.groupKey) < 0)
-          ) {
-            selected = { state, groupKey: current.groupKey };
+      try {
+        await Promise.all(states.map(advance));
+        let previousCanonicalKey: string | undefined;
+        for (;;) {
+          let selected: { state: InputState, groupKey: PiledriverObject } | undefined;
+          for (const state of states) {
+            const current = state.current;
+            if (current === undefined) continue;
+            if (
+              selected === undefined
+              || (range.reverse
+                ? compareTotal(current.groupKey, selected.groupKey) > 0
+                : compareTotal(current.groupKey, selected.groupKey) < 0)
+            ) {
+              selected = { state, groupKey: current.groupKey };
+            }
           }
+          if (selected === undefined) return;
+          // Equal group keys are adjacent in the merged stream (the canonical-string tie-break makes
+          // the order total), so comparing against the previously yielded key is enough to dedupe
+          // groups that several inputs share — no set of all seen keys needed.
+          const canonicalKey = canonicalGroupKeyString(selected.groupKey);
+          if (canonicalKey !== previousCanonicalKey) {
+            previousCanonicalKey = canonicalKey;
+            yield { groupKey: selected.groupKey };
+            if (range.limit !== undefined && ++yielded >= range.limit) return;
+          }
+          await advance(selected.state);
         }
-        if (selected === undefined) return;
-        // Equal group keys are adjacent in the merged stream (the canonical-string tie-break makes
-        // the order total), so comparing against the previously yielded key is enough to dedupe
-        // groups that several inputs share — no set of all seen keys needed.
-        const canonicalKey = canonicalGroupKeyString(selected.groupKey);
-        if (canonicalKey !== previousCanonicalKey) {
-          previousCanonicalKey = canonicalKey;
-          yield { groupKey: selected.groupKey };
-          if (range.limit !== undefined && ++yielded >= range.limit) return;
-        }
-        await advance(selected.state);
+      } finally {
+        // Manual async-iterator use does not provide for-await's automatic cleanup on early return.
+        await Promise.all(states.map(async state => {
+          if (!state.done) await state.iterator.return?.(undefined);
+        }));
       }
     },
     async * listRowsInGroup({ inputTables, groupKey, range }) {

--- a/apps/bulldozer-js/src/databases/bulldozer/index.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.ts
@@ -1804,7 +1804,6 @@ export function defineConcatTable(): BulldozerTableImplementation {
       let yielded = 0;
       const inputRange = { ...range, limit: undefined };
       const keys = inputKeys(inputTables);
-      if (keys.length === 0) throw new Error("Concat table must have at least one input");
       const comparatorInputKey = keys.at(0);
       if (comparatorInputKey === undefined) throw new Error("Concat table must have at least one input");
       const compareTotal = (a: PiledriverObject, b: PiledriverObject) =>


### PR DESCRIPTION
`defineConcatTable` was dishonest about group order, which makes group pagination on a concat table silently lossy:

- `compareGroupKeys` returned a constant `0`, i.e. "all group keys sort equivalently".
- `listGroups` yielded groups input-by-input (all of input `a`'s groups, then input `b`'s), deduping with an unbounded `Set` of every canonical key seen.
- ...while still forwarding the caller's group range (`gt`/`gte`/`lt`/`lte`) down to each input, where it *is* interpreted in that input's real group order.

So a caller paginating groups with `gt = last key seen` loses every group that sorts before the bound in an input's order but appears later in concat's input-by-input order. Latent on `dev` — nothing paginates concat groups today — but it breaks any caller that starts to, including a per-table integrity checker.

Fix, mirroring the pattern already used for the group maps in this file (`compareGroupKeys(a, b) || compareStrings(canonicalGroupKeyString(a), canonicalGroupKeyString(b))`):

- `compareGroupKeys` delegates to a designated input (the first sorted input key) instead of claiming ties. Concat inputs always descend from a common ancestor table, so their group orderings agree; `defineJoinTable` already delegates to `left` the same way.
- `listGroups` merges the inputs' group streams in that total order instead of concatenating them, keeping the range pushdown and applying `limit` at the concat level. Group order is now real, so group ranges mean the same thing to concat and to its inputs.
- Dedup becomes adjacent-only (equal keys are necessarily adjacent in the merged stream), which removes the unbounded `seen` set — memory no longer grows with the number of groups.
- Each input's stream is asserted non-decreasing (non-increasing when reversed) under that order, naming the offending input table if it ever isn't, so a disagreeing input fails loudly rather than dropping groups.

No change to the persisted format: row sort keys stay `[concatIndex, inputSortKey]`, the membership map is untouched, no migration.

Test added in `apps/bulldozer-js/src/databases/bulldozer/index.test.ts` over a concat whose two inputs' group keys interleave (`a` owns 1/3/4, `b` owns 2/4): full iteration is comparator-ordered, the shared group appears once, and `gt`/`lt` pagination reassembles exactly the unbundled iteration in both directions. It fails before this change (`[1, 3, 4, 2]` instead of `[1, 2, 3, 4]`, and pagination drops groups) and passes after.


Link to Devin session: https://app.devin.ai/sessions/5e117d519d2043d9b6f7867ccba8d11f
Open in Devin Desktop: https://app.devin.ai/desktop/session/5e117d519d2043d9b6f7867ccba8d11f?variant=devin
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes observable semantics of `listGroups` and `compareGroupKeys` on concat tables in bulldozer-js; correctness fix for pagination but any caller that depended on input-major group order would see different iteration.
> 
> **Overview**
> **Concat tables now expose a real, shared group order** instead of yielding all groups from each input sequentially while pretending every group key compares equal.
> 
> `defineConcatTable` **delegates `compareGroupKeys`** to the first sorted input (same assumption as other operators: inputs share ancestor ordering). **`listGroups` merges** each input’s group stream in that total order (with canonical-key tie-break), honors **`limit` / `gt` / `lt` / `reverse`** at the concat layer, **dedupes only adjacent** equal keys (drops the unbounded `seen` set), and **throws** if an input yields groups out of order.
> 
> A new integration test covers interleaved group keys across two inputs, shared groups appearing once, and forward/reverse pagination reassembling the full list. **No on-disk format change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b2bccc1d4357db7e6dfa5c6343911119767926. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes concat table group pagination, which was silently lossy: `compareGroupKeys` claimed all keys sort equally while `listGroups` yielded groups input-by-input, so `gt`/`lt` pagination dropped groups.

- `listGroups` now merges the inputs' sorted streams in the total shared order, dedupes adjacent equal keys, and applies `limit` and range at the concat level.
- `compareGroupKeys` delegates to the first sorted input, valid because concat inputs share a common ancestor ordering.
- Inputs yielding out of order now throw, and input iterators are closed when iteration ends early, including when acquiring a later input's iterator fails.
- No persisted format change or migration; tests cover interleaved keys, forward/reverse pagination, and iterator cleanup.

<sup>Written for commit 62886f80402f7a0987e643e829064a127818c48f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Concatenated grouped data is merged in a consistent, deterministic order across all inputs.
  - Duplicate group keys are combined automatically.
  - Forward and reverse pagination support limits and range boundaries consistently.
  - Invalid or out-of-order grouped inputs produce clearer errors.

- **Bug Fixes**
  - Grouped data iteration now closes cleanly when limits are reached, iteration stops early, or an error occurs during input setup.

- **Tests**
  - Added coverage for ordering, deduplication, pagination, and iterator cleanup across concatenated grouped data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->