### PR TITLE
Allow trusted domains with a custom port in the dashboard

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/domains/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/domains/page-client.tsx
@@ -10,7 +10,7 @@ import { DataGrid, useDataGridUrlState, useDataSource, type DataGridColumnDef } 
 import { yupString } from "@hexclave/shared/dist/schema-fields";
 import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { typedEntries } from "@hexclave/shared/dist/utils/objects";
-import { isValidHostnameWithWildcards } from "@hexclave/shared/dist/utils/urls";
+import { isValidHostWithWildcards } from "@hexclave/shared/dist/utils/urls";
 import { generateUuid } from "@hexclave/shared/dist/utils/uuids";
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 import React, { useMemo, useState } from "react";
@@ -76,7 +76,7 @@ function EditDialog(props: {
       .test({
         name: 'domain',
         message: (params) => `Invalid domain`,
-        test: (value) => value == null || isValidHostnameWithWildcards(value)
+        test: (value) => value == null || isValidHostWithWildcards(value)
       })
       .test({
         name: 'unique-domain',
@@ -233,6 +233,7 @@ function EditDialog(props: {
                 <li><code>api-*.example.com</code> - matches api-v1.example.com, api-prod.example.com, etc.</li>
                 <li><code>*.*.org</code> - matches mail.example.org, but not example.org</li>
               </ul>
+              <p><strong className="text-foreground">Ports:</strong> Append a port to only match that port (e.g. <code>*.example.com:4250</code>).</p>
             </div>
           </DesignAlert>
           <InputField

--- a/packages/shared/src/utils/urls.tsx
+++ b/packages/shared/src/utils/urls.tsx
@@ -146,7 +146,10 @@ import.meta.vitest?.test("isValidHostnameWithWildcards", ({ expect }) => {
  * `wildcardUrlSchema` accepts for trusted domain base URLs (e.g. `*.example.com:4250`).
  */
 export function isValidHostWithWildcards(host: string) {
-  const portSeparatorIndex = host.lastIndexOf(':');
+  // Bracketed IPv6 literals contain colons themselves; only a colon after the closing bracket separates the port
+  const portSeparatorIndex = host.startsWith('[')
+    ? (host.includes(']:') ? host.lastIndexOf(':') : -1)
+    : host.lastIndexOf(':');
   if (portSeparatorIndex === -1) {
     return isValidHostnameWithWildcards(host);
   }
@@ -162,6 +165,8 @@ import.meta.vitest?.test("isValidHostWithWildcards", ({ expect }) => {
   expect(isValidHostWithWildcards("*.example.com:4250")).toBe(true);
   expect(isValidHostWithWildcards("*.*.ts.net:4250")).toBe(true);
   expect(isValidHostWithWildcards("**.example.com:8080")).toBe(true);
+  expect(isValidHostWithWildcards("[::1]")).toBe(true);
+  expect(isValidHostWithWildcards("[::1]:3000")).toBe(true);
 
   expect(isValidHostWithWildcards("")).toBe(false);
   expect(isValidHostWithWildcards("example.com:")).toBe(false);
@@ -172,6 +177,8 @@ import.meta.vitest?.test("isValidHostWithWildcards", ({ expect }) => {
   expect(isValidHostWithWildcards("example.com:4250/path")).toBe(false);
   expect(isValidHostWithWildcards("https://example.com:4250")).toBe(false);
   expect(isValidHostWithWildcards("*.example..com:4250")).toBe(false);
+  expect(isValidHostWithWildcards("[::1]:")).toBe(false);
+  expect(isValidHostWithWildcards("[::1]:abc")).toBe(false);
 });
 
 export function matchHostnamePattern(pattern: string, hostname: string): boolean {

--- a/packages/shared/src/utils/urls.tsx
+++ b/packages/shared/src/utils/urls.tsx
@@ -156,7 +156,8 @@ export function isValidHostWithWildcards(host: string) {
   const hostname = host.slice(0, portSeparatorIndex);
   const port = host.slice(portSeparatorIndex + 1);
   // Leading zeroes are rejected because URL parsing normalizes ports, so a pattern like `:04250` would never match
-  if (!/^\d{1,5}$/.test(port) || Number(port) > 65535 || String(Number(port)) !== port) return false;
+  const numericPort = Number(port);
+  if (!/^\d{1,5}$/.test(port) || numericPort < 1 || numericPort > 65535 || String(numericPort) !== port) return false;
   return isValidHostnameWithWildcards(hostname);
 }
 import.meta.vitest?.test("isValidHostWithWildcards", ({ expect }) => {
@@ -176,6 +177,7 @@ import.meta.vitest?.test("isValidHostWithWildcards", ({ expect }) => {
   expect(isValidHostWithWildcards("example.com:*")).toBe(false);
   expect(isValidHostWithWildcards("example.com:70000")).toBe(false);
   expect(isValidHostWithWildcards("example.com:04250")).toBe(false);
+  expect(isValidHostWithWildcards("example.com:0")).toBe(false);
   expect(isValidHostWithWildcards("example.com:4250/path")).toBe(false);
   expect(isValidHostWithWildcards("https://example.com:4250")).toBe(false);
   expect(isValidHostWithWildcards("*.example..com:4250")).toBe(false);

--- a/packages/shared/src/utils/urls.tsx
+++ b/packages/shared/src/utils/urls.tsx
@@ -155,7 +155,8 @@ export function isValidHostWithWildcards(host: string) {
   }
   const hostname = host.slice(0, portSeparatorIndex);
   const port = host.slice(portSeparatorIndex + 1);
-  if (!/^\d{1,5}$/.test(port) || Number(port) > 65535) return false;
+  // Leading zeroes are rejected because URL parsing normalizes ports, so a pattern like `:04250` would never match
+  if (!/^\d{1,5}$/.test(port) || Number(port) > 65535 || String(Number(port)) !== port) return false;
   return isValidHostnameWithWildcards(hostname);
 }
 import.meta.vitest?.test("isValidHostWithWildcards", ({ expect }) => {
@@ -174,6 +175,7 @@ import.meta.vitest?.test("isValidHostWithWildcards", ({ expect }) => {
   expect(isValidHostWithWildcards("example.com:abc")).toBe(false);
   expect(isValidHostWithWildcards("example.com:*")).toBe(false);
   expect(isValidHostWithWildcards("example.com:70000")).toBe(false);
+  expect(isValidHostWithWildcards("example.com:04250")).toBe(false);
   expect(isValidHostWithWildcards("example.com:4250/path")).toBe(false);
   expect(isValidHostWithWildcards("https://example.com:4250")).toBe(false);
   expect(isValidHostWithWildcards("*.example..com:4250")).toBe(false);

--- a/packages/shared/src/utils/urls.tsx
+++ b/packages/shared/src/utils/urls.tsx
@@ -141,6 +141,39 @@ import.meta.vitest?.test("isValidHostnameWithWildcards", ({ expect }) => {
   expect(isValidHostnameWithWildcards("*.example..com")).toBe(false);
 });
 
+/**
+ * Like `isValidHostnameWithWildcards`, but additionally accepts an optional numeric `:<port>` suffix, which is what
+ * `wildcardUrlSchema` accepts for trusted domain base URLs (e.g. `*.example.com:4250`).
+ */
+export function isValidHostWithWildcards(host: string) {
+  const portSeparatorIndex = host.lastIndexOf(':');
+  if (portSeparatorIndex === -1) {
+    return isValidHostnameWithWildcards(host);
+  }
+  const hostname = host.slice(0, portSeparatorIndex);
+  const port = host.slice(portSeparatorIndex + 1);
+  if (!/^\d{1,5}$/.test(port) || Number(port) > 65535) return false;
+  return isValidHostnameWithWildcards(hostname);
+}
+import.meta.vitest?.test("isValidHostWithWildcards", ({ expect }) => {
+  expect(isValidHostWithWildcards("example.com")).toBe(true);
+  expect(isValidHostWithWildcards("example.com:4250")).toBe(true);
+  expect(isValidHostWithWildcards("localhost:3000")).toBe(true);
+  expect(isValidHostWithWildcards("*.example.com:4250")).toBe(true);
+  expect(isValidHostWithWildcards("*.*.ts.net:4250")).toBe(true);
+  expect(isValidHostWithWildcards("**.example.com:8080")).toBe(true);
+
+  expect(isValidHostWithWildcards("")).toBe(false);
+  expect(isValidHostWithWildcards("example.com:")).toBe(false);
+  expect(isValidHostWithWildcards(":4250")).toBe(false);
+  expect(isValidHostWithWildcards("example.com:abc")).toBe(false);
+  expect(isValidHostWithWildcards("example.com:*")).toBe(false);
+  expect(isValidHostWithWildcards("example.com:70000")).toBe(false);
+  expect(isValidHostWithWildcards("example.com:4250/path")).toBe(false);
+  expect(isValidHostWithWildcards("https://example.com:4250")).toBe(false);
+  expect(isValidHostWithWildcards("*.example..com:4250")).toBe(false);
+});
+
 export function matchHostnamePattern(pattern: string, hostname: string): boolean {
   // If no wildcards, it's an exact match
   if (!pattern.includes('*')) {


### PR DESCRIPTION
The "Create domain and handler" dialog rejected hosts with a port (e.g. `*.*.ts.net:4250`) as "Invalid domain", even though the backend's `wildcardUrlSchema` and the trusted-domain matcher already accept them.

- `packages/shared`: add `isValidHostWithWildcards` = `isValidHostnameWithWildcards` + optional numeric `:port`, with inline tests.
- Dashboard domains page: validate with the new helper and mention ports in the help text.

`:*` (any port) is deliberately not accepted in the UI since `wildcardUrlSchema` cannot parse it.

Link to Devin session: https://app.devin.ai/sessions/df7f577f2a8840419d11d4cb5b84652c
Open in Devin Desktop: https://app.devin.ai/desktop/session/df7f577f2a8840419d11d4cb5b84652c?variant=devin
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small validation and copy change on trusted-domain UI; no auth or matching logic changes beyond accepting ports the backend already allows.
> 
> **Overview**
> The trusted-domains create/edit dialog no longer rejects hosts that include a numeric port (e.g. `*.*.ts.net:4250`), aligning dashboard validation with what `wildcardUrlSchema` already accepts on the backend.
> 
> **Shared:** Adds `isValidHostWithWildcards`, which delegates to `isValidHostnameWithWildcards` and optionally parses a `:<port>` suffix (1–65535, digits only—no `:*`). Includes inline Vitest coverage.
> 
> **Dashboard:** The domain Yup rule uses the new helper instead of `isValidHostnameWithWildcards`, and the info alert documents that ports can be appended to scope matching to a specific port.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b611eddd24f5f29d6cc097328190a4b379884027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows trusted domains with a custom port (e.g. `*.example.com:4250`) in the dashboard's domain dialog, matching backend validation.

- Adds `isValidHostWithWildcards` in `packages/shared` that accepts an optional numeric port (1–65535), rejects non-canonical ports like `:04250`, and supports bracketed IPv6 hosts.
- Switches the dashboard domain validation to the new helper and documents port matching in the help text.
- `:*` (any port) is deliberately not accepted in the UI since the backend schema can't parse it.

<sup>Written for commit a3be22492cb76a9daa63d11c3729f0ad2913337d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added help text explaining that appending a port, such as `*.example.com:4250`, limits wildcard matching to that port.

- **Bug Fixes**
  - Domain validation now rejects port `0`; supported ports must be between 1 and 65,535.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->