### PR TITLE
chore(marshal): capture marshal logs in e2e CI and log slow requests / contended lease acquisitions

### DIFF
--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -179,7 +179,14 @@ jobs:
       - name: Start marshal in background
         uses: JarvusInnovations/background-action@2428e7b970a846423095c79d43f759abf979a635 # v1.0.7
         with:
-          run: NODE_ENV=test pnpm run start:marshal &
+          run: |
+            marshal_log="$RUNNER_TEMP/hexclave-marshal.untracked.log"
+            (
+              set +e
+              # Keep service output correlatable with the surrounding GitHub Actions logs.
+              NODE_ENV=test pnpm run start:marshal 2>&1 | TZ=UTC awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' >"$marshal_log"
+              echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/hexclave-marshal-exit-code.untracked.txt"
+            ) &
           wait-on: |
             http://localhost:8147/health
           tail: true
@@ -446,12 +453,30 @@ jobs:
           fi
           tail -n 2000 "$RUNNER_TEMP/hexclave-bulldozer.untracked.log"
 
+      - name: Print marshal diagnostics
+        if: ${{ failure() }}
+        run: |
+          if [[ -f "$RUNNER_TEMP/hexclave-marshal-exit-code.untracked.txt" ]]; then
+            echo "Marshal command exited with code $(<"$RUNNER_TEMP/hexclave-marshal-exit-code.untracked.txt")"
+          else
+            echo "Marshal command is still running; a child process may have exited"
+          fi
+          tail -n 2000 "$RUNNER_TEMP/hexclave-marshal.untracked.log"
+
       - name: Upload bulldozer-js logs
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: e2e-api-bulldozer
           path: ${{ runner.temp }}/hexclave-bulldozer.untracked.log
+          if-no-files-found: warn
+
+      - name: Upload marshal logs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-api-marshal
+          path: ${{ runner.temp }}/hexclave-marshal.untracked.log
           if-no-files-found: warn
 
       - name: Capture bulldozer-js diagnostics

--- a/apps/marshal/src/marshal-app.ts
+++ b/apps/marshal/src/marshal-app.ts
@@ -42,6 +42,9 @@ import type { LogLine } from "./types.js";
 // (which writes the record first); past that, a missing object means the drain was empty or
 // failed and no further lines are ever coming.
 const DURABLE_LOG_GRACE_MS = 30 * 1000;
+// Requests are read-driven (a deployment GET applies a service), so the server log must say
+// which request stalled and for how long; the backend only sees its own client timeout.
+const SLOW_REQUEST_LOG_MS = 10_000;
 
 // Derived from the path the builder is actually given (buildCompletionPath) so the
 // pre-handler auth gate and the route can never disagree — a mismatch rejects every real
@@ -85,11 +88,17 @@ function errorResponse(error: unknown): Response {
   return jsonResponse(500, { error: "internal_error", message: "internal error" });
 }
 
-async function handle(fn: () => Promise<Response | Record<string, unknown>>): Promise<Response | Record<string, unknown>> {
+async function handle(request: Request, fn: () => Promise<Response | Record<string, unknown>>): Promise<Response | Record<string, unknown>> {
+  const startedAt = performance.now();
   try {
     return await fn();
   } catch (error) {
     return errorResponse(error);
+  } finally {
+    const elapsed = performance.now() - startedAt;
+    if (elapsed > SLOW_REQUEST_LOG_MS) {
+      console.warn(`slow marshal request: ${request.method} ${new URL(request.url).pathname} took ${Math.round(elapsed)}ms`);
+    }
   }
 }
 
@@ -184,7 +193,7 @@ export function createMarshalApp() {
     // its source is, which is the only thing that decides whether a multipart
     // slot is worth starting. An older client sends no body and gets exactly the
     // response it always got.
-    .post("/v1/namespaces/:ns/uploads", ({ params, body }) => handle(async () => {
+    .post("/v1/namespaces/:ns/uploads", ({ params, body, request }) => handle(request, async () => {
       const ns = validateNamespace(params.ns);
       const id = randomUUID();
       const slot = await createUploadSlot(ns, id);
@@ -208,12 +217,12 @@ export function createMarshalApp() {
       });
     }))
 
-    .get("/v1/namespaces/:ns", ({ params }) => handle(async () => {
+    .get("/v1/namespaces/:ns", ({ params, request }) => handle(request, async () => {
       const ns = validateNamespace(params.ns);
       return { services: await listServices(ns) };
     }))
 
-    .put("/v1/namespaces/:ns/services/:key", ({ params, body }) => handle(async () => {
+    .put("/v1/namespaces/:ns/services/:key", ({ params, body, request }) => handle(request, async () => {
       const ns = validateNamespace(params.ns);
       const key = validateServiceKey(params.key);
       const spec = validateServiceSpec(body);
@@ -221,13 +230,13 @@ export function createMarshalApp() {
       return { revision: result.revision, changed: result.changed, state: result.state };
     }))
 
-    .get("/v1/namespaces/:ns/services/:key", ({ params }) => handle(async () => {
+    .get("/v1/namespaces/:ns/services/:key", ({ params, request }) => handle(request, async () => {
       const ns = validateNamespace(params.ns);
       const key = validateServiceKey(params.key);
       return await getServiceState(ns, key) as unknown as Record<string, unknown>;
     }))
 
-    .delete("/v1/namespaces/:ns/services/:key", ({ params }) => handle(async () => {
+    .delete("/v1/namespaces/:ns/services/:key", ({ params, request }) => handle(request, async () => {
       const ns = validateNamespace(params.ns);
       const key = validateServiceKey(params.key);
       await deleteService(ns, key);
@@ -236,7 +245,7 @@ export function createMarshalApp() {
 
     // One `hexclave deploy` of one deployment source: build every target in one
     // machine, then apply them in the given dependency order.
-    .post("/v1/namespaces/:ns/sources/:sourceId/deployments", ({ params, body }) => handle(async () => {
+    .post("/v1/namespaces/:ns/sources/:sourceId/deployments", ({ params, body, request }) => handle(request, async () => {
       const ns = validateNamespace(params.ns);
       const sourceId = validateSourceId(params.sourceId);
       return await startSourceDeployment(ns, sourceId, body, builder) as unknown as Record<string, unknown>;
@@ -245,13 +254,13 @@ export function createMarshalApp() {
     // Reading a deployment is also what ADVANCES it: there is no background
     // worker here, so each poll applies at most one more service (see
     // advanceDeployment).
-    .get("/v1/namespaces/:ns/deployments/:id", ({ params }) => handle(async () => {
+    .get("/v1/namespaces/:ns/deployments/:id", ({ params, request }) => handle(request, async () => {
       const ns = validateNamespace(params.ns);
       if (!BUILD_ID_REGEX.test(params.id)) throw new MarshalError(400, "bad_request", "deployment id must be a ULID");
       return await advanceDeployment(ns, params.id) as unknown as Record<string, unknown>;
     }))
 
-    .get("/v1/namespaces/:ns/deployments/:id/logs", ({ params, query }) => handle(async () => {
+    .get("/v1/namespaces/:ns/deployments/:id/logs", ({ params, query, request }) => handle(request, async () => {
       const ns = validateNamespace(params.ns);
       // Validate the id: it flows into an S3 object key, so a traversal id must not escape
       // the deployments/ prefix (defense in depth — the only caller passes a stored ULID).
@@ -316,7 +325,7 @@ export function createMarshalApp() {
       };
     }))
 
-    .get("/v1/namespaces/:ns/services/:key/logs", ({ params, query }) => handle(async () => {
+    .get("/v1/namespaces/:ns/services/:key/logs", ({ params, query, request }) => handle(request, async () => {
       const ns = validateNamespace(params.ns);
       const key = validateServiceKey(params.key);
       const fly = flyClientForNamespaceOrg(resolveNamespaceOrg(ns));
@@ -329,13 +338,13 @@ export function createMarshalApp() {
 
     // Read-only: the "re-check verification now" primitive. A PUT would repoint the hostname,
     // so callers that only want current state must use this.
-    .get("/v1/namespaces/:ns/domains/:hostname", ({ params }) => handle(async () => {
+    .get("/v1/namespaces/:ns/domains/:hostname", ({ params, request }) => handle(request, async () => {
       const ns = validateNamespace(params.ns);
       const hostname = normalizeHostnameOrThrow(params.hostname);
       return await readDomain(ns, hostname) as unknown as Record<string, unknown>;
     }))
 
-    .put("/v1/namespaces/:ns/domains/:hostname", ({ params, body }) => handle(async () => {
+    .put("/v1/namespaces/:ns/domains/:hostname", ({ params, body, request }) => handle(request, async () => {
       const ns = validateNamespace(params.ns);
       const hostname = normalizeHostnameOrThrow(params.hostname);
       const serviceKey = (body as Record<string, unknown> | null)?.service_key;
@@ -343,7 +352,7 @@ export function createMarshalApp() {
       return await attachDomain(ns, hostname, validateServiceKey(serviceKey)) as unknown as Record<string, unknown>;
     }))
 
-    .delete("/v1/namespaces/:ns/domains/:hostname", ({ params, query }) => handle(async () => {
+    .delete("/v1/namespaces/:ns/domains/:hostname", ({ params, query, request }) => handle(request, async () => {
       const ns = validateNamespace(params.ns);
       const hostname = normalizeHostnameOrThrow(params.hostname);
       // Optional ownership fence — see detachDomain. Absent = detach whoever holds it.
@@ -359,7 +368,7 @@ export function createMarshalApp() {
     // `parse: "text"` so a malformed/empty JSON body still reaches the handler (Elysia's
     // default JSON parser would 400 before it, making the registry-HEAD digest fallback
     // unreachable) — the handler parses defensively.
-    .post(`${INTERNAL_COMPLETE_PATH_PREFIX}:deploymentId/complete`, ({ params, query, body, request }) => handle(async () => {
+    .post(`${INTERNAL_COMPLETE_PATH_PREFIX}:deploymentId/complete`, ({ params, query, body, request }) => handle(request, async () => {
       const ns = typeof query.ns === "string" ? query.ns : "";
       const status = query.status === "succeeded" ? "succeeded" : query.status === "failed" ? "failed" : null;
       const token = (request.headers.get("authorization") ?? "").replace(/^Bearer /, "");

--- a/apps/marshal/src/reconciliation-lock.test.ts
+++ b/apps/marshal/src/reconciliation-lock.test.ts
@@ -125,6 +125,27 @@ describe("service reconciliation lease", () => {
       contendedPollMs: 2,
       takeoverGraceMs: 10,
       acquireTimeoutMs: 30,
-    })).rejects.toThrow(ReconciliationLeaseLostError);
+    })).rejects.toThrow(/holder live-owner/);
+  });
+
+  it("logs when a contended lease is acquired after the owner expires", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    stored = {
+      value: { owner_id: "expiring-owner", expires_at_millis: Date.now() + 30 },
+      etag: String(nextEtag++),
+    };
+    try {
+      await withReconciliationLease("ns", "web", async () => {}, {
+        durationMs: 1000,
+        renewIntervalMs: 500,
+        contendedPollMs: 2,
+        takeoverGraceMs: 0,
+        acquireTimeoutMs: 2000,
+      });
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/contended/));
+      expect(warn.mock.calls.some(([message]) => typeof message === "string" && /acquired .* after \d+ms/.test(message))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });

--- a/apps/marshal/src/reconciliation-lock.test.ts
+++ b/apps/marshal/src/reconciliation-lock.test.ts
@@ -4,11 +4,16 @@ import { MutationOutcomeUnknownError } from "./mutation-safety.js";
 
 let stored: { value: ReconciliationLease, etag: string } | null = null;
 let nextEtag = 1;
+let loseCreateOnce = false;
 
 vi.mock("./store.js", () => ({
   readReconciliationLease: vi.fn(async () => stored),
   createReconciliationLease: vi.fn(async (_ns: string, _key: string, lease: ReconciliationLease) => {
     if (stored !== null) return null;
+    if (loseCreateOnce) {
+      loseCreateOnce = false;
+      return null;
+    }
     const etag = String(nextEtag++);
     stored = { value: lease, etag };
     return etag;
@@ -34,6 +39,7 @@ describe("service reconciliation lease", () => {
     vi.clearAllMocks();
     stored = null;
     nextEtag = 1;
+    loseCreateOnce = false;
   });
 
   it("serializes concurrent work for the same service", async () => {
@@ -143,6 +149,24 @@ describe("service reconciliation lease", () => {
         acquireTimeoutMs: 2000,
       });
       expect(warn).toHaveBeenCalledWith(expect.stringMatching(/contended/));
+      expect(warn.mock.calls.some(([message]) => typeof message === "string" && /acquired .* after \d+ms/.test(message))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("logs when a conditional lease create is lost before acquisition", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    loseCreateOnce = true;
+    try {
+      await withReconciliationLease("ns", "web", async () => {}, {
+        durationMs: 1000,
+        renewIntervalMs: 500,
+        contendedPollMs: 2,
+        takeoverGraceMs: 0,
+        acquireTimeoutMs: 2000,
+      });
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/lost conditional lease write/));
       expect(warn.mock.calls.some(([message]) => typeof message === "string" && /acquired .* after \d+ms/.test(message))).toBe(true);
     } finally {
       warn.mockRestore();

--- a/apps/marshal/src/reconciliation-lock.test.ts
+++ b/apps/marshal/src/reconciliation-lock.test.ts
@@ -13,7 +13,7 @@ vi.mock("./store.js", () => ({
     if (loseCreateOnce) {
       loseCreateOnce = false;
       stored = {
-        value: { owner_id: "racer", expires_at_millis: Date.now() + 30 },
+        value: { owner_id: "racer", expires_at_millis: Date.now() + 200 },
         etag: String(nextEtag++),
       };
       return null;
@@ -129,19 +129,21 @@ describe("service reconciliation lease", () => {
       value: { owner_id: "live-owner", expires_at_millis: Date.now() + 60_000 },
       etag: String(nextEtag++),
     };
-    await expect(withReconciliationLease("ns", "web", async () => "never runs", {
+    const promise = withReconciliationLease("ns", "web", async () => "never runs", {
       durationMs: 1000,
       renewIntervalMs: 500,
       contendedPollMs: 2,
       takeoverGraceMs: 10,
       acquireTimeoutMs: 30,
-    })).rejects.toThrow(/holder live-owner/);
+    });
+    await expect(promise).rejects.toBeInstanceOf(ReconciliationLeaseLostError);
+    await expect(promise).rejects.toThrow(/holder live-owner/);
   });
 
   it("logs when a contended lease is acquired after the owner expires", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     stored = {
-      value: { owner_id: "expiring-owner", expires_at_millis: Date.now() + 30 },
+      value: { owner_id: "expiring-owner", expires_at_millis: Date.now() + 200 },
       etag: String(nextEtag++),
     };
     try {

--- a/apps/marshal/src/reconciliation-lock.test.ts
+++ b/apps/marshal/src/reconciliation-lock.test.ts
@@ -12,6 +12,10 @@ vi.mock("./store.js", () => ({
     if (stored !== null) return null;
     if (loseCreateOnce) {
       loseCreateOnce = false;
+      stored = {
+        value: { owner_id: "racer", expires_at_millis: Date.now() + 30 },
+        etag: String(nextEtag++),
+      };
       return null;
     }
     const etag = String(nextEtag++);
@@ -167,6 +171,7 @@ describe("service reconciliation lease", () => {
         acquireTimeoutMs: 2000,
       });
       expect(warn).toHaveBeenCalledWith(expect.stringMatching(/lost conditional lease write/));
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/contended .* holder racer/));
       expect(warn.mock.calls.some(([message]) => typeof message === "string" && /acquired .* after \d+ms/.test(message))).toBe(true);
     } finally {
       warn.mockRestore();

--- a/apps/marshal/src/reconciliation-lock.ts
+++ b/apps/marshal/src/reconciliation-lock.ts
@@ -48,6 +48,11 @@ async function acquireLease(ns: string, key: string, ownerId: string, timings: L
   // maps to a retryable 409 turns contention into an answer the caller can act on.
   const startedAt = performance.now();
   let contentionLogged = false;
+  const logAcquiredAfterContention = (): void => {
+    if (contentionLogged) {
+      console.warn(`marshal lease acquired for ${JSON.stringify(key)} after ${Math.round(performance.now() - startedAt)}ms following contention`);
+    }
+  };
   const deadline = Date.now() + timings.acquireTimeoutMs;
   for (;;) {
     const now = Date.now();
@@ -56,10 +61,12 @@ async function acquireLease(ns: string, key: string, ownerId: string, timings: L
     if (current === null) {
       const etag = await createReconciliationLease(ns, key, desired);
       if (etag !== null) {
-        if (contentionLogged) {
-          console.warn(`marshal lease acquired for ${JSON.stringify(key)} after ${Math.round(performance.now() - startedAt)}ms following contention`);
-        }
+        logAcquiredAfterContention();
         return { etag, value: desired };
+      }
+      if (!contentionLogged) {
+        console.warn(`lost conditional lease write for ${JSON.stringify(key)} in namespace ${JSON.stringify(ns)}: another marshal replica created the lease first`);
+        contentionLogged = true;
       }
     } else if (current.value.expires_at_millis + timings.takeoverGraceMs <= now) {
       // Conditional replacement is the distributed arbiter: exactly one Marshal replica can
@@ -67,10 +74,12 @@ async function acquireLease(ns: string, key: string, ownerId: string, timings: L
       // previous owner could have started immediately before its last confirmed expiry.
       const etag = await replaceReconciliationLease(ns, key, desired, current.etag);
       if (etag !== null) {
-        if (contentionLogged) {
-          console.warn(`marshal lease acquired for ${JSON.stringify(key)} after ${Math.round(performance.now() - startedAt)}ms following contention`);
-        }
+        logAcquiredAfterContention();
         return { etag, value: desired };
+      }
+      if (!contentionLogged) {
+        console.warn(`lost conditional lease write for ${JSON.stringify(key)} in namespace ${JSON.stringify(ns)}: another marshal replica took over the lease first`);
+        contentionLogged = true;
       }
     } else if (!contentionLogged) {
       console.warn(`contended marshal lease for ${JSON.stringify(key)} in namespace ${JSON.stringify(ns)}: holder ${current.value.owner_id}, expires in ${current.value.expires_at_millis - now}ms; takeover grace ${timings.takeoverGraceMs}ms`);

--- a/apps/marshal/src/reconciliation-lock.ts
+++ b/apps/marshal/src/reconciliation-lock.ts
@@ -47,9 +47,10 @@ async function acquireLease(ns: string, key: string, ownerId: string, timings: L
   // same stuck lease stacks another loop in the process. Failing with the error app.ts already
   // maps to a retryable 409 turns contention into an answer the caller can act on.
   const startedAt = performance.now();
-  let contentionLogged = false;
+  let lostWriteLogged = false;
+  let holderLogged = false;
   const logAcquiredAfterContention = (): void => {
-    if (contentionLogged) {
+    if (lostWriteLogged || holderLogged) {
       console.warn(`marshal lease acquired for ${JSON.stringify(key)} after ${Math.round(performance.now() - startedAt)}ms following contention`);
     }
   };
@@ -64,9 +65,9 @@ async function acquireLease(ns: string, key: string, ownerId: string, timings: L
         logAcquiredAfterContention();
         return { etag, value: desired };
       }
-      if (!contentionLogged) {
+      if (!lostWriteLogged) {
         console.warn(`lost conditional lease write for ${JSON.stringify(key)} in namespace ${JSON.stringify(ns)}: another marshal replica created the lease first`);
-        contentionLogged = true;
+        lostWriteLogged = true;
       }
     } else if (current.value.expires_at_millis + timings.takeoverGraceMs <= now) {
       // Conditional replacement is the distributed arbiter: exactly one Marshal replica can
@@ -77,13 +78,13 @@ async function acquireLease(ns: string, key: string, ownerId: string, timings: L
         logAcquiredAfterContention();
         return { etag, value: desired };
       }
-      if (!contentionLogged) {
-        console.warn(`lost conditional lease write for ${JSON.stringify(key)} in namespace ${JSON.stringify(ns)}: another marshal replica took over the lease first`);
-        contentionLogged = true;
+      if (!lostWriteLogged) {
+        console.warn(`lost conditional lease write for ${JSON.stringify(key)} in namespace ${JSON.stringify(ns)}: the lease changed before this marshal replica could take it over`);
+        lostWriteLogged = true;
       }
-    } else if (!contentionLogged) {
+    } else if (!holderLogged) {
       console.warn(`contended marshal lease for ${JSON.stringify(key)} in namespace ${JSON.stringify(ns)}: holder ${current.value.owner_id}, expires in ${current.value.expires_at_millis - now}ms; takeover grace ${timings.takeoverGraceMs}ms`);
-      contentionLogged = true;
+      holderLogged = true;
     }
     if (Date.now() >= deadline) {
       const elapsed = Math.round(performance.now() - startedAt);

--- a/apps/marshal/src/reconciliation-lock.ts
+++ b/apps/marshal/src/reconciliation-lock.ts
@@ -46,6 +46,8 @@ async function acquireLease(ns: string, key: string, ownerId: string, timings: L
   // backend's own APPLY_TIMEOUT_MS abort is invisible from here, and every retry against the
   // same stuck lease stacks another loop in the process. Failing with the error app.ts already
   // maps to a retryable 409 turns contention into an answer the caller can act on.
+  const startedAt = performance.now();
+  let contentionLogged = false;
   const deadline = Date.now() + timings.acquireTimeoutMs;
   for (;;) {
     const now = Date.now();
@@ -53,16 +55,34 @@ async function acquireLease(ns: string, key: string, ownerId: string, timings: L
     const current = await readReconciliationLease(ns, key);
     if (current === null) {
       const etag = await createReconciliationLease(ns, key, desired);
-      if (etag !== null) return { etag, value: desired };
+      if (etag !== null) {
+        if (contentionLogged) {
+          console.warn(`marshal lease acquired for ${JSON.stringify(key)} after ${Math.round(performance.now() - startedAt)}ms following contention`);
+        }
+        return { etag, value: desired };
+      }
     } else if (current.value.expires_at_millis + timings.takeoverGraceMs <= now) {
       // Conditional replacement is the distributed arbiter: exactly one Marshal replica can
       // take over an expired lease. The grace period also drains every bounded Fly write the
       // previous owner could have started immediately before its last confirmed expiry.
       const etag = await replaceReconciliationLease(ns, key, desired, current.etag);
-      if (etag !== null) return { etag, value: desired };
+      if (etag !== null) {
+        if (contentionLogged) {
+          console.warn(`marshal lease acquired for ${JSON.stringify(key)} after ${Math.round(performance.now() - startedAt)}ms following contention`);
+        }
+        return { etag, value: desired };
+      }
+    } else if (!contentionLogged) {
+      console.warn(`contended marshal lease for ${JSON.stringify(key)} in namespace ${JSON.stringify(ns)}: holder ${current.value.owner_id}, expires in ${current.value.expires_at_millis - now}ms; takeover grace ${timings.takeoverGraceMs}ms`);
+      contentionLogged = true;
     }
     if (Date.now() >= deadline) {
-      throw new ReconciliationLeaseLostError(`another reconciliation of ${JSON.stringify(key)} in namespace ${JSON.stringify(ns)} held the lease for longer than ${timings.acquireTimeoutMs}ms; retry`);
+      const elapsed = Math.round(performance.now() - startedAt);
+      // This detail is only for the server log; errorResponse maps the error to a generic 409 body.
+      const holder = current === null
+        ? "holder unknown (conditional write kept losing)"
+        : `holder ${current.value.owner_id}, expires in ${current.value.expires_at_millis - Date.now()}ms`;
+      throw new ReconciliationLeaseLostError(`another reconciliation of ${JSON.stringify(key)} in namespace ${JSON.stringify(ns)} held the lease for longer than ${timings.acquireTimeoutMs}ms (waited ${elapsed}ms; ${holder}); retry`);
     }
     await delay(timings.contendedPollMs);
   }

--- a/apps/marshal/src/services.ts
+++ b/apps/marshal/src/services.ts
@@ -48,6 +48,7 @@ const DEPLOYMENT_ADVANCE_TIMINGS = {
   takeoverGraceMs: RECONCILIATION_TAKEOVER_GRACE_MS,
   acquireTimeoutMs: 1000,
 };
+const SLOW_APPLY_LOG_MS = 10_000;
 const NAMESPACE_REGEX = /^[a-zA-Z0-9_-]{1,64}$/;
 // upload_id flows into an S3 object key (uploads/<ns>/<id>.tar.gz); validate it so a
 // path-traversal id can't escape the prefix. The backend mints these as randomUUIDs.
@@ -1579,6 +1580,7 @@ async function applyNextService(ns: string, deployment: StoredDeployment, lease:
     }
     await lease.assertOwned();
     let state: DeploymentServiceState;
+    const startedAt = performance.now();
     try {
       const applied = await applyServiceSpec(ns, next.service_key, { ...target.spec, source: { image } }, { knownTargets });
       state = deploymentStateForApply(next.service_key, image, applied);
@@ -1587,6 +1589,11 @@ async function applyNextService(ns: string, deployment: StoredDeployment, lease:
       // Same as applyServiceSpecWithLease: log the real error, store only text we wrote.
       console.error(`deployment ${deployment.id}: applying service ${next.service_key} failed`, error);
       state = { service_key: next.service_key, status: "failed", revision: null, url: null, image, error: truncateError(applyErrorMessage(error)) };
+    } finally {
+      const elapsed = performance.now() - startedAt;
+      if (elapsed > SLOW_APPLY_LOG_MS) {
+        console.warn(`deployment ${deployment.id}: applying service ${next.service_key} took ${Math.round(elapsed)}ms`);
+      }
     }
     const updated: StoredDeployment = { ...deployment, services: { ...deployment.services, [next.service_key]: state } };
     if (state.status === "failed") {

--- a/apps/marshal/src/services.ts
+++ b/apps/marshal/src/services.ts
@@ -953,13 +953,21 @@ async function specIsStillOwned(ns: string, key: string, etag: string): Promise<
 }
 
 export async function applyServiceSpec(ns: string, key: string, spec: ServiceSpec, options?: { knownTargets?: Map<string, KnownTarget>, lease?: ReconciliationLeaseGuard }): Promise<ApplyResult> {
-  // A deployment already holds the lease for its whole source, so it passes its
-  // own rather than taking a second one per service — the lease is not
-  // re-entrant, and waiting on itself is a deadlock.
-  if (options?.lease !== undefined) {
-    return await applyServiceSpecWithLease(ns, key, spec, options.lease, options.knownTargets);
+  const startedAt = performance.now();
+  try {
+    // A deployment already holds the lease for its whole source, so it passes its
+    // own rather than taking a second one per service — the lease is not
+    // re-entrant, and waiting on itself is a deadlock.
+    if (options?.lease !== undefined) {
+      return await applyServiceSpecWithLease(ns, key, spec, options.lease, options.knownTargets);
+    }
+    return await withReconciliationLease(ns, key, async (lease) => await applyServiceSpecWithLease(ns, key, spec, lease, options?.knownTargets));
+  } finally {
+    const elapsed = performance.now() - startedAt;
+    if (elapsed > SLOW_APPLY_LOG_MS) {
+      console.warn(`applying service ${JSON.stringify(key)} in namespace ${JSON.stringify(ns)} took ${Math.round(elapsed)}ms`);
+    }
   }
-  return await withReconciliationLease(ns, key, async (lease) => await applyServiceSpecWithLease(ns, key, spec, lease, options?.knownTargets));
 }
 
 async function applyServiceSpecWithLease(ns: string, key: string, spec: ServiceSpec, lease: ReconciliationLeaseGuard, knownTargets?: Map<string, KnownTarget>): Promise<ApplyResult> {
@@ -1580,7 +1588,6 @@ async function applyNextService(ns: string, deployment: StoredDeployment, lease:
     }
     await lease.assertOwned();
     let state: DeploymentServiceState;
-    const startedAt = performance.now();
     try {
       const applied = await applyServiceSpec(ns, next.service_key, { ...target.spec, source: { image } }, { knownTargets });
       state = deploymentStateForApply(next.service_key, image, applied);
@@ -1589,11 +1596,6 @@ async function applyNextService(ns: string, deployment: StoredDeployment, lease:
       // Same as applyServiceSpecWithLease: log the real error, store only text we wrote.
       console.error(`deployment ${deployment.id}: applying service ${next.service_key} failed`, error);
       state = { service_key: next.service_key, status: "failed", revision: null, url: null, image, error: truncateError(applyErrorMessage(error)) };
-    } finally {
-      const elapsed = performance.now() - startedAt;
-      if (elapsed > SLOW_APPLY_LOG_MS) {
-        console.warn(`deployment ${deployment.id}: applying service ${next.service_key} took ${Math.round(elapsed)}ms`);
-      }
     }
     const updated: StoredDeployment = { ...deployment, services: { ...deployment.services, [next.service_key]: state } };
     if (state.status === "failed") {


### PR DESCRIPTION
Marshal produced no output in the e2e CI logs, so a stalled deployment GET could not be diagnosed. This PR:

- e2e workflow: tees Marshal stdout/stderr to a timestamped log (same pattern as bulldozer), prints its tail on failure, uploads it as the `e2e-api-marshal` artifact.
- `handle()`: warns for any Marshal request over 10s (method, path, duration).
- `acquireLease()`: warns once when a lease is contended (holder, time to expiry, takeover grace), warns when it is acquired after contention, and includes the last observed holder / waited time in the `ReconciliationLeaseLostError` message (server log only; the HTTP body stays generic).
- `applyNextService()`: warns when a single service apply exceeds 10s.

No behavior changes beyond logging.

Link to Devin session: https://app.devin.ai/sessions/388c1844257541db9cb98de7426e6278
Open in Devin Desktop: https://app.devin.ai/desktop/session/388c1844257541db9cb98de7426e6278?variant=devin
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging and CI artifact capture only; no changes to deployment, lease, or HTTP behavior beyond more verbose server logs.
> 
> **Overview**
> Improves **Marshal observability** in e2e CI and in the runtime itself, without changing request semantics or HTTP responses.
> 
> The **e2e API workflow** now starts Marshal like Bulldozer: stdout/stderr go to a UTC-timestamped log under `RUNNER_TEMP`, with exit code captured. On failure it prints Marshal diagnostics; on every run it uploads the `e2e-api-marshal` artifact.
> 
> In **Marshal**, `handle()` records per-request duration and **`console.warn`s** when any handled route exceeds **10s** (method, path, ms). **`acquireLease`** logs once on contention (holder, time-to-expiry, takeover grace), warns when the lease is finally acquired after waiting, and enriches **`ReconciliationLeaseLostError`** messages for server logs only—the **409** body stays generic. **`applyNextService`** warns when a single deployment service apply exceeds **10s**. Tests were updated for the richer lease-timeout error and for contention/acquisition warn logging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 500a7abcdc8fe7634c331aa8b36b37cd5c5b8ce3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds marshal diagnostics to e2e CI and logs slow requests and contended lease acquisitions so stalled deployments can be diagnosed. No behavior changes beyond logging.

- The e2e workflow tees marshal stdout/stderr to a timestamped log, prints its tail on failure, and uploads it as the `e2e-api-marshal` artifact.
- Marshal warns for any request over 10s (method, path, duration) and for any single service apply over 10s (including lease acquisition).
- Lease acquisition warns on contention (holder, time to expiry, takeover grace), on a lost conditional create/replace, and on acquisition after contention only when contention was actually observed. The `ReconciliationLeaseLostError` message includes the last holder and wait time (server log only).

<sup>Written for commit 1ddc4bef425e237c2f370a0bfc709d6b193723f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance Monitoring**
  - Added warnings for requests and service operations exceeding 10 seconds, including elapsed time and operation details.
  - Applied slow-operation monitoring consistently across direct service updates and deployment updates.

- **Reliability**
  - Improved lease contention and timeout diagnostics with clearer holder, wait-time, and recovery information.

- **Diagnostics**
  - Enhanced background service failure reporting with timestamped logs, exit-status details, failure output, and downloadable diagnostic artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->