### PR TITLE
ci(e2e): stream turbo output so marshal/bulldozer log artifacts contain app logs

### DIFF
--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -163,7 +163,7 @@ jobs:
             (
               set +e
               # Keep service output correlatable with the surrounding GitHub Actions logs.
-              pnpm run start:bulldozer 2>&1 | TZ=UTC awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' >"$bulldozer_log"
+              pnpm run start:bulldozer --log-order=stream 2>&1 | TZ=UTC awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' >"$bulldozer_log"
               echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/hexclave-bulldozer-exit-code.untracked.txt"
             ) &
           wait-on: |
@@ -187,7 +187,7 @@ jobs:
             (
               set +e
               # Keep service output correlatable with the surrounding GitHub Actions logs.
-              NODE_ENV=test pnpm run start:marshal 2>&1 | TZ=UTC awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' >"$marshal_log"
+              NODE_ENV=test pnpm run start:marshal --log-order=stream 2>&1 | TZ=UTC awk '{ print strftime("%Y-%m-%dT%H:%M:%SZ"), $0; fflush() }' >"$marshal_log"
               echo "${PIPESTATUS[0]}" > "$RUNNER_TEMP/hexclave-marshal-exit-code.untracked.txt"
             ) &
           wait-on: |


### PR DESCRIPTION
Turbo defaults to `--log-order=grouped` in CI, which buffers a task's output until the task exits. For long-running `start` tasks that never happens, so the `e2e-api-marshal` and `e2e-api-bulldozer` artifacts only ever contained turbo's preamble (18 lines, no `Marshal listening` / app output) — seen on dev run 34281457159.

Pass `--log-order=stream` to both background starts, matching the other background services in this workflow.

Link to Devin session: https://app.devin.ai/sessions/388c1844257541db9cb98de7426e6278
Open in Devin Desktop: https://app.devin.ai/desktop/session/388c1844257541db9cb98de7426e6278?variant=devin
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes e2e CI log artifacts for the marshal and bulldozer services so they contain application logs. Turbo's default grouped output buffered task output until exit, which never happened for these long-running start tasks.

<sup>Written for commit 0898abf970cbbba4fc91fd44759fb366f57b7946. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved end-to-end test logging by streaming background service output in execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->