### PR TITLE
Read unsigned Marshal control-plane state as-is until the bucket is signed

### DIFF
--- a/apps/marshal/README.md
+++ b/apps/marshal/README.md
@@ -40,14 +40,16 @@ Source uploads never pass through the function: `POST /v1/namespaces/:ns/uploads
 presigned bucket URL that the CLI uploads the tarball to directly.
 
 Domain claims, project-pool entries and its creation ledger, and namespace records are authenticated with
-`HEXCLAVE_MARSHAL_DATA_ENCRYPTION_KEY`, with their object key bound into the MAC. Marshal fails
-closed on the older unsigned shape: before rolling this version into an environment that already
-has `domains/*.json`, `gcp-project-pool/*.json`, `gcp-project-pool-ledger.json`, or
-`tenants/*.json`, migrate or recreate those records from a trusted
-snapshot — `scripts/sign-control-plane-state.ts` signs a bucket's unsigned records in place
-(run it against the production bucket before the first deploy of this version: Fly-era
-`domains/*.json` are unsigned). Automatically trusting and rewriting an unsigned object would authenticate exactly the
-forgery this boundary is intended to detect.
+`HEXCLAVE_MARSHAL_DATA_ENCRYPTION_KEY`, with their object key bound into the MAC. Every write is
+signed and a signed record that fails verification is refused. An UNSIGNED record — the shape every
+Marshal before signing wrote — is currently still read as-is (see `readAuthenticatedControlPlaneState`
+in `src/store.ts`): production's bucket predates the signature, and signing it in place needs the
+key in hand, so this version boots on an unsigned bucket rather than failing closed. That leaves
+records nobody has rewritten without tamper-evidence until `scripts/sign-control-plane-state.ts`
+has been run against the bucket (Fly-era `domains/*.json` are the ones that exist); once it reports
+`unsigned: 0`, the read path should be made to fail closed again. Automatically trusting AND
+rewriting an unsigned object at read time would authenticate exactly the forgery this boundary is
+intended to detect, which is why the script is offline and deliberate.
 
 ## Runtimes
 

--- a/apps/marshal/scripts/sign-control-plane-state.ts
+++ b/apps/marshal/scripts/sign-control-plane-state.ts
@@ -1,13 +1,14 @@
-// Signs a bucket's unsigned control-plane records in place, so a Marshal that fails closed on
-// unsigned state (see readAuthenticatedControlPlaneState in src/store.ts) can be rolled into
-// an environment whose bucket predates the signing.
+// Signs a bucket's unsigned control-plane records in place, for an environment whose bucket
+// predates the signing. Marshal currently still READS unsigned records as-is (see
+// readAuthenticatedControlPlaneState in src/store.ts, and the TODO there): this script is what
+// closes that gap, and once it reports `unsigned: 0` against production the read path can be
+// made to fail closed.
 //
 // Why offline and not at read time: accepting an unsigned object once and signing it would
 // authenticate whatever was in the bucket at that moment — including a forged claim written
-// after a bucket compromise. Run this deliberately, against a bucket you trust, BEFORE the
-// first deploy of the version that requires signatures. Idempotent: an already-signed object
-// is verified and left alone; a signed object that fails verification is reported and left
-// alone too, never re-signed.
+// after a bucket compromise. Run this deliberately, against a bucket you trust. Idempotent: an
+// already-signed object is verified and left alone; a signed object that fails verification is
+// reported and left alone too, never re-signed.
 //
 // Covers every authenticated prefix: domains/*.json (the one prefix a Fly-era bucket holds),
 // tenants/*.json, gcp-project-pool/*.json, and the pool ledger.

--- a/apps/marshal/src/store.test.ts
+++ b/apps/marshal/src/store.test.ts
@@ -106,7 +106,22 @@ describe("authoritative state authentication", () => {
     await expect(readDomainClaimVersioned(claim.hostname)).rejects.toThrow("failed authentication");
   });
 
-  it("authenticates tenant project assignments and rejects unsigned legacy objects", async () => {
+  // TRANSITIONAL — see readAuthenticatedControlPlaneState. A bucket that predates signing holds
+  // bare claims, and until sign-control-plane-state.ts has been run against it those must read
+  // exactly as they always did. When that branch is made to fail closed again, this test flips
+  // to `rejects.toThrow("is unsigned")`.
+  it("still reads a legacy unsigned domain claim as-is", async () => {
+    const claim = {
+      hostname: "app.example.com",
+      ns: "tenant-a",
+      service_key: "web",
+      claimed_at_millis: 1,
+    } satisfies DomainClaim;
+    send.mockResolvedValueOnce({ Body: { transformToString: async () => JSON.stringify(claim) }, ETag: "legacy-etag" });
+    await expect(readDomainClaimVersioned(claim.hostname)).resolves.toEqual({ value: claim, etag: "legacy-etag" });
+  });
+
+  it("authenticates tenant project assignments and still reads unsigned legacy objects", async () => {
     // The assignment reads the namespace record first (none yet), then writes it.
     send.mockRejectedValueOnce(Object.assign(new Error("no such key"), { name: "NoSuchKey" }));
     send.mockResolvedValueOnce({ ETag: "assignment-etag" });
@@ -117,8 +132,9 @@ describe("authoritative state authentication", () => {
     send.mockResolvedValueOnce({ ETag: "assignment-etag", Body: { transformToString: async () => body } });
     await expect(readTenantProjectAssignment("tenant-a")).resolves.toBe("hxc-tenant-a");
 
+    // TRANSITIONAL: unsigned records are trusted as-is until the bucket has been signed offline.
     send.mockResolvedValueOnce({ ETag: "legacy-etag", Body: { transformToString: async () => JSON.stringify({ project_id: "hxc-tenant-b" }) } });
-    await expect(readTenantProjectAssignment("tenant-a")).rejects.toThrow("is unsigned");
+    await expect(readTenantProjectAssignment("tenant-a")).resolves.toBe("hxc-tenant-b");
   });
 
   it("authenticates the project creation-rate ledger", async () => {
@@ -132,8 +148,9 @@ describe("authoritative state authentication", () => {
     send.mockResolvedValueOnce({ ETag: '"v1"', Body: { transformToString: async () => body } });
     await expect(readPoolCreationLedgerVersioned()).resolves.toEqual({ etag: '"v1"', createdAtMillis: [100, 200] });
 
+    // TRANSITIONAL: unsigned records are trusted as-is until the bucket has been signed offline.
     send.mockResolvedValueOnce({ ETag: '"v1"', Body: { transformToString: async () => JSON.stringify({ created_at_millis: [100, 200] }) } });
-    await expect(readPoolCreationLedgerVersioned()).rejects.toThrow("is unsigned");
+    await expect(readPoolCreationLedgerVersioned()).resolves.toEqual({ etag: '"v1"', createdAtMillis: [100, 200] });
   });
 
   it("does not let an unsigned ready-pool record become a signed tenant assignment", async () => {
@@ -155,8 +172,14 @@ describe("authoritative state authentication", () => {
     send.mockResolvedValueOnce({ Body: { transformToString: async () => body }, ETag: "pool-etag" });
     await expect(readPoolProject("hxc-pool-project")).resolves.toEqual({ value: entry, etag: "pool-etag" });
 
-    send.mockResolvedValueOnce({ Body: { transformToString: async () => JSON.stringify(entry) }, ETag: "forged-etag" });
-    await expect(readPoolProject("hxc-pool-project")).rejects.toThrow("is unsigned");
+    // The MAC binds the object key, so a validly signed record copied under another key is
+    // refused — which is what stops a pool entry from being replayed as some other project's.
+    send.mockResolvedValueOnce({ Body: { transformToString: async () => body }, ETag: "moved-etag" });
+    await expect(readPoolProject("hxc-other-project")).rejects.toThrow("failed authentication");
+
+    // TRANSITIONAL: an unsigned record is trusted as-is until the bucket has been signed offline.
+    send.mockResolvedValueOnce({ Body: { transformToString: async () => JSON.stringify(entry) }, ETag: "legacy-etag" });
+    await expect(readPoolProject("hxc-pool-project")).resolves.toEqual({ value: entry, etag: "legacy-etag" });
   });
 });
 

--- a/apps/marshal/src/store.ts
+++ b/apps/marshal/src/store.ts
@@ -144,17 +144,33 @@ function authenticatedControlPlaneState(key: string, value: unknown): Authentica
   };
 }
 
+function isAuthenticatedControlPlaneState(stored: unknown): stored is AuthenticatedControlPlaneState {
+  return isRecord(stored)
+    && stored.authentication_version === 1
+    && "value" in stored
+    && typeof stored.mac_base64 === "string";
+}
+
 function readAuthenticatedControlPlaneState(key: string, stored: unknown): unknown {
-  if (!isRecord(stored)
-    || stored.authentication_version !== 1
-    || !("value" in stored)
-    || typeof stored.mac_base64 !== "string") {
-    // TODO(operations): provide an offline migration command that authenticates a trusted
-    // snapshot before rollout. Doing this automatically at runtime would turn attacker-written
-    // unsigned state into authoritative state, so this path must continue to fail closed.
-    // Deliberately no legacy fallback: accepting an unsigned object once and signing it would
-    // authenticate an attacker's forged claim or project assignment after a bucket compromise.
-    throw new Error(`authoritative state ${JSON.stringify(key)} is unsigned; migrate it before starting this Marshal version`);
+  if (!isAuthenticatedControlPlaneState(stored)) {
+    // TRANSITIONAL: an UNSIGNED object is trusted as-is, exactly as every Marshal before
+    // signing existed trusted it. Production's bucket predates the signature (its Fly-era
+    // `domains/*.json` are bare claims), and signing them in place needs the data encryption
+    // key in hand for `scripts/sign-control-plane-state.ts`, which at the time of writing it is
+    // not. Failing closed here would instead break every deploy, park and teardown of a
+    // service that holds a custom domain the moment this version boots.
+    //
+    // What this gives up, and only this: tamper-evidence on records nobody has rewritten yet.
+    // A record that IS signed is still verified below, so a forged edit to a signed claim is
+    // still refused, and every write signs (see authenticatedControlPlaneState), so the bucket
+    // converges on its own for anything rewritten. Deliberately NOT signed on read: accepting an
+    // unsigned object and then signing it would authenticate whatever was in the bucket at that
+    // moment, forged claim included — which is why the migration is an offline script run
+    // against a bucket someone has decided to trust.
+    //
+    // TODO(security): once sign-control-plane-state.ts has been run against production
+    // (`unsigned: 0` in its report), make this branch throw again so unsigned state fails closed.
+    return stored;
   }
   const serialized = JSON.stringify(stored.value);
   if (!verifyControlPlaneStateAuthentication(serialized, storageKey(key), stored.mac_base64, getConfig().dataEncryptionRootKey)) {


### PR DESCRIPTION
## Why

`origin/dev` (via #2025) makes Marshal HMAC-sign its authoritative control-plane records (`domains/*.json`, `tenants/*.json`, `gcp-project-pool/*.json`, the pool ledger) and **fail closed on any unsigned object at read time**. Production's bucket predates that: every custom-domain claim there is a bare, unsigned JSON object. Signing them in place with `apps/marshal/scripts/sign-control-plane-state.ts` requires `HEXCLAVE_MARSHAL_DATA_ENCRYPTION_KEY`, which is marked Sensitive on Vercel and cannot be read back, and it cannot be rotated without losing every stored service env and re-rolling the fleet.

Without this change, the first boot of the new Marshal breaks every deploy, park, unpark, domain operation and teardown of any service that holds a custom domain (`currentDomainClaimsForService` runs on every apply).

## What

`readAuthenticatedControlPlaneState` now returns an unsigned object as-is — the exact trust every earlier Marshal extended. Everything else is unchanged:

- a **signed** object is still verified; tampering or moving it under another key is still refused (`failed authentication`),
- every **write** still signs, so the bucket converges for anything rewritten,
- nothing is signed on read (that would launder a forged record), so the offline script remains the migration path.

Not behind a flag, on purpose: this is the default until the bucket has been signed. A `TODO(security)` marks where to make the branch throw again once `sign-control-plane-state.ts` reports `unsigned: 0` against production.

Tests: the three `rejects.toThrow("is unsigned")` assertions now assert the legacy object reads back; added an explicit legacy-domain-claim read test (the prod case); the key-binding test now proves its point with a signed record read under the wrong key. README and the script header no longer claim Marshal fails closed.

## Follow-up

1. Recover the key (original generator / secrets manager), run the script dry then `--write` against the prod bucket.
2. Flip `return stored;` back to a `throw` and the four tests back to `rejects.toThrow("is unsigned")`.

## Verification

- `apps/marshal`: 350/350 vitest, `tsc --noEmit` clean, eslint clean on changed files.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows Marshal to read unsigned control-plane state as-is, so the first boot of this version doesn't break custom-domain operations. Production's bucket predates the HMAC signing and can't be signed in place yet; failing closed on unsigned objects would take down every deploy, park, and teardown that touches a custom domain.

Signed records are still verified — tampered or key-moved records are still refused — and every write still signs, so the bucket converges as records get rewritten.

**Migration**
- Run `apps/marshal/scripts/sign-control-plane-state.ts` against production until it reports `unsigned: 0`.
- Then flip the transitional branch in `readAuthenticatedControlPlaneState` (and its tests) back to failing closed.

<sup>Written for commit 66e2adbad8d74a4598d421622848f3fcc77e5381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2054?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

