### PR TITLE
Sign deployment gateway hostnames so only Marshal can mint a routable one

### DIFF
--- a/apps/deployment-gateway/.dockerignore
+++ b/apps/deployment-gateway/.dockerignore
@@ -3,3 +3,4 @@
 !nginx.conf
 !gateway.conf.template
 !15-platform-domain.envsh
+!gateway.js

--- a/apps/deployment-gateway/15-platform-domain.envsh
+++ b/apps/deployment-gateway/15-platform-domain.envsh
@@ -1,6 +1,7 @@
 #!/bin/sh
-# Sourced before nginx's envsubst hook. Validate before converting a literal DNS
-# suffix to a regex so configuration cannot broaden the allowed upstream mapping.
+# Sourced before nginx's envsubst hook. Both values reach gateway.js through nginx.conf's
+# `env` directives; validate them here so a misconfigured gateway refuses to start instead
+# of refusing every hostname at request time.
 set -eu
 domain="${HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN}"
 case "$domain" in
@@ -10,6 +11,11 @@ if [ "${#domain}" -gt 190 ] || ! printf '%s\n' "$domain" | grep -Eq '^([a-z0-9](
     echo 'HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN must be a lowercase DNS domain of at most 190 characters' >&2
     exit 1
 fi
-# Character classes survive nginx's quoted-string parsing without backslash escaping.
-HEXCLAVE_GATEWAY_DOMAIN_PATTERN=$(printf '%s' "$domain" | sed 's/\./[.]/g')
-export HEXCLAVE_GATEWAY_DOMAIN_PATTERN
+key="${HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY:-}"
+case "$key" in
+    *[!0-9a-fA-F]*) key="" ;;
+esac
+if [ "${#key}" -ne 64 ]; then
+    echo 'HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY must be exactly 64 hexadecimal characters (32 bytes), the key Marshal signs platform hostnames with' >&2
+    exit 1
+fi

--- a/apps/deployment-gateway/15-platform-domain.envsh
+++ b/apps/deployment-gateway/15-platform-domain.envsh
@@ -19,3 +19,10 @@ if [ "${#key}" -ne 64 ]; then
     echo 'HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY must be exactly 64 hexadecimal characters (32 bytes), the key Marshal signs platform hostnames with' >&2
     exit 1
 fi
+# The public key from apps/marshal/.env.development: anyone can sign with it, so a gateway
+# holding it routes to any hxc-* app. Marshal refuses it outside mock mode; so does this.
+if [ "$(printf '%s' "$key" | tr 'A-F' 'a-f')" = "a1b2c3d4e5f60718293a4b5c6d7e8f9000112233445566778899aabbccddeeff" ] \
+    && [ "${HEXCLAVE_GATEWAY_ALLOW_DEVELOPMENT_KEY:-}" != "1" ]; then
+    echo 'HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY is the public development key; it requires HEXCLAVE_GATEWAY_ALLOW_DEVELOPMENT_KEY=1 (never in production)' >&2
+    exit 1
+fi

--- a/apps/deployment-gateway/Dockerfile
+++ b/apps/deployment-gateway/Dockerfile
@@ -7,5 +7,6 @@ ENV NGINX_ENVSUBST_FILTER=^HEXCLAVE_GATEWAY_ \
 COPY 15-platform-domain.envsh /docker-entrypoint.d/15-platform-domain.envsh
 RUN chmod +x /docker-entrypoint.d/15-platform-domain.envsh
 COPY nginx.conf /etc/nginx/nginx.conf
+COPY gateway.js /etc/nginx/njs/gateway.js
 COPY gateway.conf.template /etc/nginx/templates/default.conf.template
 EXPOSE 8080

--- a/apps/deployment-gateway/README.md
+++ b/apps/deployment-gateway/README.md
@@ -2,15 +2,21 @@
 
 One Fly app proxies every `<suffix>-<mac>.deploy.built-with-hexclave.com` request to
 `https://hxc-<suffix>.fly.dev`. Marshal uses the existing Fly app identity for `<suffix>`
-and signs it: `<mac>` is the first 12 hex characters of an HMAC-SHA256 over the domain and
+and signs it: `<mac>` is the first 16 hex characters of an HMAC-SHA256 over the domain and
 suffix under `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY`, a key only Marshal and this gateway hold
 (`gateway.js` here, `platformHostnameMac` in `apps/marshal/src/platform-domain-names.ts`).
 Fly app names are global across every Fly organization, so anyone can register an
 `hxc-*` app of the right shape; without the key they cannot produce a hostname the gateway
 routes to it, which keeps our wildcard certificate and domain off content we did not
-deploy. That signature is the ownership check — there is no per-deployment routing table.
-Every other hostname, including vanity names like `login.<domain>`, returns 421. Nginx
-(with its njs module) handles HTTP, streaming uploads/downloads, and WebSockets.
+deploy. There is no per-deployment routing table. Every other hostname, including vanity
+names like `login.<domain>`, returns 421. Nginx (with its njs module) handles HTTP,
+streaming uploads/downloads, and WebSockets.
+
+The signature proves Marshal minted a name, not that Marshal still owns the app behind it.
+Signatures do not expire or revoke: once a service is deleted and Marshal deletes its Fly
+app, the app name is free again, and if Fly lets a stranger re-register it the old URL
+(and any bookmark or OAuth redirect pointing at it) serves their content. Accepted for now;
+closing it means either never deleting apps or an ownership lookup on the request path.
 
 Source and deployment configuration live here. Hosted components remain on Vercel
 under `<project-id>.built-with-hexclave.com`; they are not in this traffic path.
@@ -60,12 +66,17 @@ The gateway's default `.fly.dev` hostname intentionally returns 421: only deploy
 hostnames route traffic. Health checks use `Host: gateway-health.internal` and `/healthz`,
 so no customer URL path is reserved by the gateway.
 
-The gateway refuses to start without a 64-hex-character `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY`.
+The gateway refuses to start without a 64-hex-character `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY`,
+and refuses the public development key from `apps/marshal/.env.development` unless
+`HEXCLAVE_GATEWAY_ALLOW_DEVELOPMENT_KEY=1` (the Docker test sets it; production never does).
 A gateway and Marshal holding different keys route nothing (every hostname is 421), which
 is the failure to look for first when a fresh deployment's platform URL does not answer.
-Rotating the key renames every platform URL Marshal has handed out, so it is rotated on
-compromise, not on a schedule; to rotate, set the new value on the gateway first, then on
-Marshal, and redeploy every public service so the backend learns its new URL.
+Rotating the key is a hard cutover, in either order: the gateway holds one key, so every
+platform URL minted under the old key stops answering as soon as the gateway restarts with
+the new one, and stays dead until its service is redeployed and the backend learns the new
+URL. The first rollout of signed hostnames is the same event for every public service
+deployed under the unsigned shape. Rotate on compromise, not on a schedule; if zero-downtime
+rotation is ever needed, the gateway will need to accept an old and a new key at once.
 
 For a separate preproduction gateway, create another Fly app from the same source and
 use a separate wildcard domain. Set `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN` to the bare

--- a/apps/deployment-gateway/README.md
+++ b/apps/deployment-gateway/README.md
@@ -1,9 +1,16 @@
 # Deployment gateway
 
-One Fly app proxies every `<suffix>.deploy.built-with-hexclave.com` request to
-`https://hxc-<suffix>.fly.dev`. Marshal uses the existing Fly app identity to generate
-these hostnames. Nginx handles HTTP, streaming uploads/downloads, and WebSockets.
-There is no per-deployment routing table or ownership lookup.
+One Fly app proxies every `<suffix>-<mac>.deploy.built-with-hexclave.com` request to
+`https://hxc-<suffix>.fly.dev`. Marshal uses the existing Fly app identity for `<suffix>`
+and signs it: `<mac>` is the first 12 hex characters of an HMAC-SHA256 over the domain and
+suffix under `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY`, a key only Marshal and this gateway hold
+(`gateway.js` here, `platformHostnameMac` in `apps/marshal/src/platform-domain-names.ts`).
+Fly app names are global across every Fly organization, so anyone can register an
+`hxc-*` app of the right shape; without the key they cannot produce a hostname the gateway
+routes to it, which keeps our wildcard certificate and domain off content we did not
+deploy. That signature is the ownership check — there is no per-deployment routing table.
+Every other hostname, including vanity names like `login.<domain>`, returns 421. Nginx
+(with its njs module) handles HTTP, streaming uploads/downloads, and WebSockets.
 
 Source and deployment configuration live here. Hosted components remain on Vercel
 under `<project-id>.built-with-hexclave.com`; they are not in this traffic path.
@@ -29,6 +36,9 @@ export HEXCLAVE_GATEWAY_APP=hexclave-deployment-gateway
 fly apps create "$HEXCLAVE_GATEWAY_APP" --org YOUR_FLY_ORG
 fly ips allocate-v6 --app "$HEXCLAVE_GATEWAY_APP"
 fly ips allocate-v4 --shared --app "$HEXCLAVE_GATEWAY_APP"
+# The hostname signing key. Generate once, set it here, and set the SAME value as
+# HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY on the Marshal that serves this gateway's domain.
+fly secrets set --app "$HEXCLAVE_GATEWAY_APP" --stage "HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=$(openssl rand -hex 32)"
 fly deploy --app "$HEXCLAVE_GATEWAY_APP" --ha=true
 fly scale count 2 --app "$HEXCLAVE_GATEWAY_APP"
 fly certs add '*.deploy.built-with-hexclave.com' --app "$HEXCLAVE_GATEWAY_APP"
@@ -50,6 +60,13 @@ The gateway's default `.fly.dev` hostname intentionally returns 421: only deploy
 hostnames route traffic. Health checks use `Host: gateway-health.internal` and `/healthz`,
 so no customer URL path is reserved by the gateway.
 
+The gateway refuses to start without a 64-hex-character `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY`.
+A gateway and Marshal holding different keys route nothing (every hostname is 421), which
+is the failure to look for first when a fresh deployment's platform URL does not answer.
+Rotating the key renames every platform URL Marshal has handed out, so it is rotated on
+compromise, not on a schedule; to rotate, set the new value on the gateway first, then on
+Marshal, and redeploy every public service so the backend learns its new URL.
+
 For a separate preproduction gateway, create another Fly app from the same source and
 use a separate wildcard domain. Set `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN` to the bare
 suffix (for example, `deploy.example.net`) on the gateway with `fly deploy --env
@@ -58,7 +75,9 @@ certificate using that suffix. The value must be a lowercase DNS domain, without
 
 Pass the same environment variable to the local Marshal live-test command and optionally
 the Docker test command. Both use the production domain when the variable is unset.
-The override does not change Fly app names. The backend's production namespace reservation
+The override does not change Fly app names, but it does change every signature (the
+domain is bound into the mac), so a preproduction gateway needs its own Marshal
+configuration even if it shares a key. The backend's production namespace reservation
 is unchanged; this override supports testing the gateway and Marshal directly.
 
 ## Updates and operations
@@ -105,7 +124,9 @@ bun test apps/deployment-gateway/gateway.test.mjs
 
 This builds the actual gateway image and runs a pinned Bun fixture on an isolated Docker
 network. A generated test-only TLS certificate is trusted only inside that disposable
-container. Tests verify host rejection, health routing, path/method forwarding, cookies,
+container. Tests verify host rejection, signature verification (unsigned, mis-signed, wrongly
+keyed and wrongly shaped hostnames all return 421, with one signature pinned against
+Marshal's unit test), health routing, path/method forwarding, cookies,
 TLS hostname validation, incremental SSE/chunked responses, and authenticated WebSocket
 text/binary echo with clean close. Additional checks cover concurrent applications,
 redirects and upstream errors, streaming uploads, disconnected clients, unavailable
@@ -127,7 +148,8 @@ Once the gateway and wildcard DNS/TLS are ready:
 pnpm -C apps/marshal test:platform-domains:live
 ```
 
-This uses real Fly/S3 credentials in `apps/marshal/.env.local`, creates a disposable
+This uses real Fly/S3 credentials in `apps/marshal/.env.local` together with the
+gateway's `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY`, creates a disposable
 application, and checks both its direct Fly URL and gateway URL. Open the two printed
 `/compatibility` pages and click **Run browser checks** on each. It waits for both reports
 before asserting the combined result, then redeploys and checks its stable URL. Cleanup

--- a/apps/deployment-gateway/gateway.conf.template
+++ b/apps/deployment-gateway/gateway.conf.template
@@ -1,8 +1,8 @@
-# hxc- leaves at most 59 characters for the suffix of a 63-character Fly app name.
-map $host $deployment_app {
-    default "";
-    "~^(?<deployment_suffix>[a-z0-9](?:[a-z0-9-]{0,57}[a-z0-9])?)[.]${HEXCLAVE_GATEWAY_DOMAIN_PATTERN}$" hxc-$deployment_suffix;
-}
+# gateway.js verifies the hostname's signature and names the Fly app, or "" to refuse.
+# Evaluated once per request, on first use.
+js_path "/etc/nginx/njs";
+js_import gateway from gateway.js;
+js_set $deployment_app gateway.deploymentApp;
 map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;

--- a/apps/deployment-gateway/gateway.js
+++ b/apps/deployment-gateway/gateway.js
@@ -2,7 +2,7 @@
 //
 // A platform hostname is <suffix>-<mac>.<platform domain>, where hxc-<suffix> is the Fly app
 // Marshal created (apps/marshal/src/fly/naming.ts appNameForService) and <mac> is the first
-// 12 hex characters of HMAC-SHA256 over the domain and suffix under a key only Marshal and
+// 16 hex characters of HMAC-SHA256 over the domain and suffix under a key only Marshal and
 // this gateway hold (apps/marshal/src/platform-domain-names.ts platformHostnameMac — keep the
 // two byte for byte identical). Fly app names are global across every Fly org, so anyone can
 // register a shape-conforming hxc-* app; without the key they cannot produce a hostname this
@@ -11,10 +11,10 @@
 import crypto from 'crypto';
 
 const MAC_CONTEXT = 'hexclave-deployment-hostname/v1';
-const MAC_LENGTH = 12;
+const MAC_LENGTH = 16;
 // <env 1>-<ns 1-2>-<key 1-2>-<sha256 hex 18>, then the mac. Nothing else — a looser shape
 // would only widen what a leaked key could sign.
-const LABEL = /^([a-z0-9]-[a-z0-9]{1,2}-[a-z0-9]{1,2}-[0-9a-f]{18})-([0-9a-f]{12})$/;
+const LABEL = /^([a-z0-9]-[a-z0-9]{1,2}-[a-z0-9]{1,2}-[0-9a-f]{18})-([0-9a-f]{16})$/;
 
 function constantTimeEqual(expected, provided) {
   if (expected.length !== provided.length) return false;

--- a/apps/deployment-gateway/gateway.js
+++ b/apps/deployment-gateway/gateway.js
@@ -1,0 +1,43 @@
+// Decides which Fly app a request is for, or "" to refuse it with 421.
+//
+// A platform hostname is <suffix>-<mac>.<platform domain>, where hxc-<suffix> is the Fly app
+// Marshal created (apps/marshal/src/fly/naming.ts appNameForService) and <mac> is the first
+// 12 hex characters of HMAC-SHA256 over the domain and suffix under a key only Marshal and
+// this gateway hold (apps/marshal/src/platform-domain-names.ts platformHostnameMac — keep the
+// two byte for byte identical). Fly app names are global across every Fly org, so anyone can
+// register a shape-conforming hxc-* app; without the key they cannot produce a hostname this
+// gateway routes to it, which is what keeps our wildcard certificate and domain off their
+// content. The gateway therefore needs no per-deployment routing table.
+import crypto from 'crypto';
+
+const MAC_CONTEXT = 'hexclave-deployment-hostname/v1';
+const MAC_LENGTH = 12;
+// <env 1>-<ns 1-2>-<key 1-2>-<sha256 hex 18>, then the mac. Nothing else — a looser shape
+// would only widen what a leaked key could sign.
+const LABEL = /^([a-z0-9]-[a-z0-9]{1,2}-[a-z0-9]{1,2}-[0-9a-f]{18})-([0-9a-f]{12})$/;
+
+function constantTimeEqual(expected, provided) {
+  if (expected.length !== provided.length) return false;
+  let difference = 0;
+  for (let i = 0; i < expected.length; i++) difference |= expected.charCodeAt(i) ^ provided.charCodeAt(i);
+  return difference === 0;
+}
+
+function deploymentApp(r) {
+  // Both are validated at container start (15-platform-domain.envsh) and exported to the
+  // workers by nginx.conf's `env` directives.
+  const domain = process.env.HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN;
+  const key = process.env.HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY;
+  // $host is already lowercased with any port removed.
+  const host = r.variables.host;
+  if (!domain || !key || !host || !host.endsWith('.' + domain)) return '';
+  const match = LABEL.exec(host.slice(0, -(domain.length + 1)));
+  if (match === null) return '';
+  const expected = crypto.createHmac('sha256', Buffer.from(key, 'hex'))
+    .update(MAC_CONTEXT + '\0' + domain + '\0' + match[1])
+    .digest('hex')
+    .slice(0, MAC_LENGTH);
+  return constantTimeEqual(expected, match[2]) ? 'hxc-' + match[1] : '';
+}
+
+export default { deploymentApp };

--- a/apps/deployment-gateway/gateway.test.mjs
+++ b/apps/deployment-gateway/gateway.test.mjs
@@ -5,7 +5,7 @@ import { execFileSync } from 'node:child_process';
 import { mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
-import { randomUUID } from 'node:crypto';
+import { createHmac, randomUUID } from 'node:crypto';
 
 const root = import.meta.dir;
 const id = `hxc-gateway-test-${randomUUID()}`;
@@ -19,7 +19,18 @@ const port = Number(process.env.HEXCLAVE_GATEWAY_TEST_PORT ?? (Number(process.en
 if (!Number.isInteger(port) || port < 1024 || port > 65535) throw new Error('Invalid gateway test port');
 const base = `http://127.0.0.1:${port}`;
 const domain = process.env.HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN ?? 'deploy.built-with-hexclave.com';
-const host = `test.${domain}`;
+// The public development key from apps/marshal/.env.development; production uses its own.
+const key = 'a1b2c3d4e5f60718293a4b5c6d7e8f9000112233445566778899aabbccddeeff';
+// Mirrors apps/marshal/src/platform-domain-names.ts platformHostnameMac.
+function mac(appSuffix, signingKey = key, signedDomain = domain) {
+  return createHmac('sha256', Buffer.from(signingKey, 'hex')).update(`hexclave-deployment-hostname/v1\0${signedDomain}\0${appSuffix}`).digest('hex').slice(0, 12);
+}
+// Marshal-shaped app suffixes (hxc-<env 1>-<ns 1-2>-<key 1-2>-<hex 18>, minus hxc-); the
+// gateway only ever routes these. `wrong` aliases the `test` origin, whose certificate does
+// not cover it.
+const apps = { test: 't-ns-ke-0123456789abcdef01', second: 't-ns-se-0123456789abcdef02', wrong: 't-ns-wr-0123456789abcdef03' };
+const hosts = Object.fromEntries(Object.entries(apps).map(([name, suffix]) => [name, `${suffix}-${mac(suffix)}.${domain}`]));
+const host = hosts.test;
 const marker = 'gateway-test-marker';
 const created = [];
 let networkCreated = false;
@@ -31,26 +42,30 @@ async function probe(path, options = {}) {
   return await fetch(new URL(path, base), { ...options, headers: { Host: host, ...options.headers }, redirect: 'manual', signal: AbortSignal.timeout(15000) });
 }
 beforeAll(async () => {
-  command('openssl', ['req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-days', '1', '-keyout', join(temp, 'key.pem'), '-out', join(temp, 'cert.pem'), '-subj', '/CN=hxc-test.fly.dev', '-addext', 'subjectAltName=DNS:hxc-test.fly.dev,DNS:hxc-second.fly.dev']);
+  command('openssl', ['req', '-x509', '-newkey', 'rsa:2048', '-nodes', '-days', '1', '-keyout', join(temp, 'key.pem'), '-out', join(temp, 'cert.pem'), '-subj', `/CN=hxc-${apps.test}.fly.dev`, '-addext', `subjectAltName=DNS:hxc-${apps.test}.fly.dev,DNS:hxc-${apps.second}.fly.dev`]);
   command('docker', ['build', '-t', image, root]);
   imageCreated = true;
   for (const invalid of ['', '*.example.net', 'Example.net', 'example.net\n', '-bad.example.net', 'a'.repeat(64) + '.net']) {
-    expect(() => command('docker', ['run', '--rm', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${invalid}`, image, 'nginx', '-t'])).toThrow();
+    expect(() => command('docker', ['run', '--rm', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${invalid}`, '-e', `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=${key}`, image, 'nginx', '-t'])).toThrow();
   }
+  for (const invalid of ['', 'short', 'g'.repeat(64), '0'.repeat(63), `${key}\n`]) {
+    expect(() => command('docker', ['run', '--rm', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${domain}`, '-e', `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=${invalid}`, image, 'nginx', '-t'])).toThrow();
+  }
+  expect(() => command('docker', ['run', '--rm', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${domain}`, image, 'nginx', '-t'])).toThrow();
   command('docker', ['network', 'create', network]);
   networkCreated = true;
-  for (const suffix of ['test', 'second']) {
-    const container = `${origin}-${suffix}`;
-    command('docker', ['run', '-d', '--name', container, '--network', network, '--network-alias', `hxc-${suffix}.fly.dev`,
-      ...(suffix === 'test' ? ['--network-alias', 'hxc-wrong.fly.dev'] : []),
+  for (const name of ['test', 'second']) {
+    const container = `${origin}-${name}`;
+    command('docker', ['run', '-d', '--name', container, '--network', network, '--network-alias', `hxc-${apps[name]}.fly.dev`,
+      ...(name === 'test' ? ['--network-alias', `hxc-${apps.wrong}.fly.dev`] : []),
       '-v', `${resolve(root, '../marshal/src/live-proxy-fixture/server.mjs')}:/fixture.mjs:ro`, '-v', `${temp}:/tls:ro`,
-      '-e', `HEXCLAVE_LIVE_TEST_MARKER=${suffix === 'test' ? marker : 'second-marker'}`, '-e', `HEXCLAVE_LIVE_TEST_HOSTNAME=${suffix}.${domain}`, '-e', `HEXCLAVE_LIVE_TEST_FLY_HOSTNAME=hxc-${suffix}.fly.dev`,
+      '-e', `HEXCLAVE_LIVE_TEST_MARKER=${name === 'test' ? marker : 'second-marker'}`, '-e', `HEXCLAVE_LIVE_TEST_HOSTNAME=${hosts[name]}`, '-e', `HEXCLAVE_LIVE_TEST_FLY_HOSTNAME=hxc-${apps[name]}.fly.dev`,
       '-e', 'HEXCLAVE_LIVE_TEST_PORT=443', '-e', 'HEXCLAVE_LIVE_TEST_TLS_CERT=/tls/cert.pem', '-e', 'HEXCLAVE_LIVE_TEST_TLS_KEY=/tls/key.pem',
       'oven/bun:1.3.13@sha256:87416c977a612a204eb54ab9f3927023c2a3c971f4f345a01da08ea6262ae30e', 'bun', '/fixture.mjs']);
     created.push(container);
   }
   command('docker', ['run', '-d', '--name', gateway, '--network', network, '-p', `127.0.0.1:${port}:8080`,
-    '-e', 'HEXCLAVE_GATEWAY_RESOLVER=127.0.0.11', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${domain}`, '-v', `${join(temp, 'cert.pem')}:/etc/ssl/certs/ca-certificates.crt:ro`, image]);
+    '-e', 'HEXCLAVE_GATEWAY_RESOLVER=127.0.0.11', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${domain}`, '-e', `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=${key}`, '-v', `${join(temp, 'cert.pem')}:/etc/ssl/certs/ca-certificates.crt:ro`, image]);
   created.push(gateway);
   command('docker', ['exec', gateway, 'nginx', '-t']);
   for (let i = 0; i < 30; i++) {
@@ -70,11 +85,45 @@ afterAll(() => {
 });
 
 test('rejects unrelated/malformed hosts and keeps health checks off application paths', async () => {
-  for (const invalid of ['example.com', 'project.built-with-hexclave.com', domain, `a.b.${domain}`, `-a.${domain}`, `a-.${domain}`, `${'a'.repeat(60)}.${domain}`, `test.${domain.replaceAll('.', 'x')}`]) {
+  for (const invalid of ['example.com', 'project.built-with-hexclave.com', domain, `a.b.${domain}`, `-a.${domain}`, `a-.${domain}`, `${'a'.repeat(60)}.${domain}`, `test.${domain.replaceAll('.', 'x')}`, `login.${domain}`, `test.${domain}`, host.replace(`.${domain}`, `.${domain.replaceAll('.', 'x')}`), `${host}.attacker.example`]) {
     expect((await probe('/', { headers: { Host: invalid } })).status).toBe(421);
   }
   expect((await probe('/healthz', { headers: { Host: 'gateway-health.internal' } })).status).toBe(200);
   expect((await probe('/healthz')).status).toBe(404);
+});
+
+test('routes only hostnames signed with the gateway key', async () => {
+  // Pinned alongside apps/marshal/src/platform-domain-names.test.ts so the two constructions
+  // cannot drift apart unnoticed.
+  expect(mac('t-ns-ke-0123456789abcdef01', key, 'deploy.built-with-hexclave.com')).toBe('b8e6cf5af5b3');
+  expect((await probe('/')).status).toBe(200);
+  const suffix = apps.test;
+  const signed = mac(suffix);
+  const forged = [
+    // A shape-conforming app name, as anyone can register on Fly, with no signature.
+    `${suffix}.${domain}`,
+    // Off by one character, an all-zero signature, and a signature that is not hex.
+    `${suffix}-${signed.slice(0, -1)}${signed.endsWith('0') ? '1' : '0'}.${domain}`,
+    `${suffix}-${'0'.repeat(12)}.${domain}`,
+    `${suffix}-${'g'.repeat(12)}.${domain}`,
+    // Signed under a different key, over a different domain, or for a different app.
+    `${suffix}-${mac(suffix, '0'.repeat(64))}.${domain}`,
+    `${suffix}-${mac(suffix, key, `x${domain}`)}.${domain}`,
+    `${suffix}-${mac(apps.second)}.${domain}`,
+    // Correctly signed, but with a name the gateway would never have been asked to sign:
+    // a vanity label, or a suffix outside Marshal's shape.
+    `login-${mac('login')}.${domain}`,
+    `${suffix}x-${mac(`${suffix}x`)}.${domain}`,
+    `t-ns-ke-${'0'.repeat(19)}-${mac(`t-ns-ke-${'0'.repeat(19)}`)}.${domain}`,
+    // Signature bytes tucked somewhere other than the end.
+    `${signed}-${suffix}.${domain}`,
+  ];
+  for (const invalid of forged) {
+    expect([invalid, (await probe('/', { headers: { Host: invalid } })).status]).toEqual([invalid, 421]);
+  }
+  // Hostnames are case-insensitive; nginx lowercases $host before gateway.js sees it.
+  expect((await probe('/', { headers: { Host: host.toUpperCase() } })).status).toBe(200);
+  expect((await probe('/', { headers: { Host: `${host}:443` } })).status).toBe(200);
 });
 
 test('forwards methods and Set-Cookie attributes without caching', async () => {
@@ -95,12 +144,12 @@ test('preserves encoded query strings, public forwarding headers, and large uplo
   });
   expect(await response.json()).toEqual({
     method: 'POST', path: '/compatibility/request?q=a%2Fb&empty=&q=second',
-    host: 'hxc-test.fly.dev', forwardedHost: host, forwardedProto: 'https', bodyLength: 2 * 1024 * 1024,
+    host: `hxc-${apps.test}.fly.dev`, forwardedHost: host, forwardedProto: 'https', bodyLength: 2 * 1024 * 1024,
   });
 });
 
 test('verifies the TLS hostname of upstreams', async () => {
-  expect((await probe('/', { headers: { Host: `wrong.${domain}` } })).status).toBe(502);
+  expect((await probe('/', { headers: { Host: hosts.wrong } })).status).toBe(502);
 });
 
 for (const kind of ['sse', 'chunks']) {
@@ -161,7 +210,7 @@ test('proxies authenticated WebSocket text/binary messages and close', async () 
 test('keeps simultaneous application responses separate', async () => {
   const responses = await Promise.all(Array.from({ length: 20 }, async (_, index) => {
     const second = index % 2 === 1;
-    const response = await probe('/', { headers: { Host: second ? `second.${domain}` : host } });
+    const response = await probe('/', { headers: { Host: second ? hosts.second : host } });
     expect(await response.text()).toBe(second ? 'second-marker' : marker);
   }));
   expect(responses.length).toBe(20);
@@ -217,7 +266,7 @@ test('accepts new requests after a streaming client disconnects', async () => {
 
 test('a stopped upstream fails without disrupting another application', async () => {
   command('docker', ['stop', '-t', '1', `${origin}-second`]);
-  expect([502, 504]).toContain((await probe('/', { headers: { Host: `second.${domain}` } })).status);
+  expect([502, 504]).toContain((await probe('/', { headers: { Host: hosts.second } })).status);
   expect(await (await probe('/')).text()).toBe(marker);
 }, 20000);
 

--- a/apps/deployment-gateway/gateway.test.mjs
+++ b/apps/deployment-gateway/gateway.test.mjs
@@ -23,7 +23,7 @@ const domain = process.env.HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN ?? 'deploy.built-
 const key = 'a1b2c3d4e5f60718293a4b5c6d7e8f9000112233445566778899aabbccddeeff';
 // Mirrors apps/marshal/src/platform-domain-names.ts platformHostnameMac.
 function mac(appSuffix, signingKey = key, signedDomain = domain) {
-  return createHmac('sha256', Buffer.from(signingKey, 'hex')).update(`hexclave-deployment-hostname/v1\0${signedDomain}\0${appSuffix}`).digest('hex').slice(0, 12);
+  return createHmac('sha256', Buffer.from(signingKey, 'hex')).update(`hexclave-deployment-hostname/v1\0${signedDomain}\0${appSuffix}`).digest('hex').slice(0, 16);
 }
 // Marshal-shaped app suffixes (hxc-<env 1>-<ns 1-2>-<key 1-2>-<hex 18>, minus hxc-); the
 // gateway only ever routes these. `wrong` aliases the `test` origin, whose certificate does
@@ -46,12 +46,17 @@ beforeAll(async () => {
   command('docker', ['build', '-t', image, root]);
   imageCreated = true;
   for (const invalid of ['', '*.example.net', 'Example.net', 'example.net\n', '-bad.example.net', 'a'.repeat(64) + '.net']) {
-    expect(() => command('docker', ['run', '--rm', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${invalid}`, '-e', `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=${key}`, image, 'nginx', '-t'])).toThrow();
+    expect(() => command('docker', ['run', '--rm', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${invalid}`, '-e', `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=${key}`, '-e', 'HEXCLAVE_GATEWAY_ALLOW_DEVELOPMENT_KEY=1', image, 'nginx', '-t'])).toThrow();
   }
   for (const invalid of ['', 'short', 'g'.repeat(64), '0'.repeat(63), `${key}\n`]) {
-    expect(() => command('docker', ['run', '--rm', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${domain}`, '-e', `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=${invalid}`, image, 'nginx', '-t'])).toThrow();
+    expect(() => command('docker', ['run', '--rm', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${domain}`, '-e', `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=${invalid}`, '-e', 'HEXCLAVE_GATEWAY_ALLOW_DEVELOPMENT_KEY=1', image, 'nginx', '-t'])).toThrow();
   }
   expect(() => command('docker', ['run', '--rm', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${domain}`, image, 'nginx', '-t'])).toThrow();
+  // The public development key is refused unless explicitly allowed, in either case.
+  for (const dev of [key, key.toUpperCase()]) {
+    expect(() => command('docker', ['run', '--rm', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${domain}`, '-e', `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=${dev}`, image, 'nginx', '-t'])).toThrow();
+  }
+  command('docker', ['run', '--rm', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${domain}`, '-e', `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=${'0'.repeat(64)}`, image, 'nginx', '-t']);
   command('docker', ['network', 'create', network]);
   networkCreated = true;
   for (const name of ['test', 'second']) {
@@ -65,7 +70,7 @@ beforeAll(async () => {
     created.push(container);
   }
   command('docker', ['run', '-d', '--name', gateway, '--network', network, '-p', `127.0.0.1:${port}:8080`,
-    '-e', 'HEXCLAVE_GATEWAY_RESOLVER=127.0.0.11', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${domain}`, '-e', `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=${key}`, '-v', `${join(temp, 'cert.pem')}:/etc/ssl/certs/ca-certificates.crt:ro`, image]);
+    '-e', 'HEXCLAVE_GATEWAY_RESOLVER=127.0.0.11', '-e', `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=${domain}`, '-e', `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=${key}`, '-e', 'HEXCLAVE_GATEWAY_ALLOW_DEVELOPMENT_KEY=1', '-v', `${join(temp, 'cert.pem')}:/etc/ssl/certs/ca-certificates.crt:ro`, image]);
   created.push(gateway);
   command('docker', ['exec', gateway, 'nginx', '-t']);
   for (let i = 0; i < 30; i++) {
@@ -95,7 +100,7 @@ test('rejects unrelated/malformed hosts and keeps health checks off application 
 test('routes only hostnames signed with the gateway key', async () => {
   // Pinned alongside apps/marshal/src/platform-domain-names.test.ts so the two constructions
   // cannot drift apart unnoticed.
-  expect(mac('t-ns-ke-0123456789abcdef01', key, 'deploy.built-with-hexclave.com')).toBe('b8e6cf5af5b3');
+  expect(mac('t-ns-ke-0123456789abcdef01', key, 'deploy.built-with-hexclave.com')).toBe('b8e6cf5af5b36a08');
   expect((await probe('/')).status).toBe(200);
   const suffix = apps.test;
   const signed = mac(suffix);
@@ -104,8 +109,8 @@ test('routes only hostnames signed with the gateway key', async () => {
     `${suffix}.${domain}`,
     // Off by one character, an all-zero signature, and a signature that is not hex.
     `${suffix}-${signed.slice(0, -1)}${signed.endsWith('0') ? '1' : '0'}.${domain}`,
-    `${suffix}-${'0'.repeat(12)}.${domain}`,
-    `${suffix}-${'g'.repeat(12)}.${domain}`,
+    `${suffix}-${'0'.repeat(16)}.${domain}`,
+    `${suffix}-${'g'.repeat(16)}.${domain}`,
     // Signed under a different key, over a different domain, or for a different app.
     `${suffix}-${mac(suffix, '0'.repeat(64))}.${domain}`,
     `${suffix}-${mac(suffix, key, `x${domain}`)}.${domain}`,

--- a/apps/deployment-gateway/nginx.conf
+++ b/apps/deployment-gateway/nginx.conf
@@ -1,6 +1,10 @@
+load_module modules/ngx_http_js_module.so;
 user nginx;
 worker_processes auto;
 pid /var/run/nginx.pid;
+# Workers inherit no environment by default; gateway.js reads these two.
+env HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN;
+env HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY;
 error_log /dev/stderr warn;
 # Allow active sockets to drain on config reloads. Clients must still reconnect
 # during machine replacement; Fly's kill_timeout bounds shutdown during deploys.

--- a/apps/e2e/tests/backend/endpoints/api/v1/deployments/deployments.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/deployments/deployments.test.ts
@@ -1430,13 +1430,14 @@ describe("deploys against the Marshal runtime", () => {
 
     const first = await syncServiceAndUpload(serviceId, { public: true, ports: { 3000: { protocol: "http" } } });
     const publicRun = await pollDeploymentToStatus(await startDeploy({ sourceId: first.sourceId, uploadId: first.uploadId, definitionSyncId: first.definitionSyncId, levels: [[serviceId]] }), "deployed");
-    expect(serviceOutcome(publicRun, serviceId).url).toMatch(/^https:\/\/[^.]+\.deploy\.built-with-hexclave\.com$/);
+    // <app suffix>-<12 hex signature>: the gateway routes only hostnames Marshal signed.
+    expect(serviceOutcome(publicRun, serviceId).url).toMatch(/^https:\/\/[a-z0-9-]+-[0-9a-f]{12}\.deploy\.built-with-hexclave\.com$/);
     const publicService = await niceBackendFetch(`/api/v1/deployments/services/${serviceId}`, { accessType: "admin" });
     expect((publicService.body as any).public).toBe(true);
     expect((publicService.body as any).ports).toEqual({ 3000: { protocol: "http" } });
     expect((publicService.body as any).url).toBe(serviceOutcome(publicRun, serviceId).url);
     const publicApp = await findMockApp(serviceId);
-    expect(serviceOutcome(publicRun, serviceId).url).toBe(`https://${publicApp.name.slice(4)}.deploy.built-with-hexclave.com`);
+    expect(serviceOutcome(publicRun, serviceId).url).toMatch(new RegExp(`^https://${publicApp.name.slice(4)}-[0-9a-f]{12}\\.deploy\\.built-with-hexclave\\.com$`));
     expect(publicApp.certificates).toEqual([]);
     expect(publicApp.sharedIpv4).not.toBeNull();
     expect(publicApp.dedicatedIps.some((ip) => ip.type === "v6")).toBe(true);

--- a/apps/e2e/tests/backend/endpoints/api/v1/deployments/deployments.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/deployments/deployments.test.ts
@@ -1430,14 +1430,14 @@ describe("deploys against the Marshal runtime", () => {
 
     const first = await syncServiceAndUpload(serviceId, { public: true, ports: { 3000: { protocol: "http" } } });
     const publicRun = await pollDeploymentToStatus(await startDeploy({ sourceId: first.sourceId, uploadId: first.uploadId, definitionSyncId: first.definitionSyncId, levels: [[serviceId]] }), "deployed");
-    // <app suffix>-<12 hex signature>: the gateway routes only hostnames Marshal signed.
-    expect(serviceOutcome(publicRun, serviceId).url).toMatch(/^https:\/\/[a-z0-9-]+-[0-9a-f]{12}\.deploy\.built-with-hexclave\.com$/);
+    // <app suffix>-<16 hex signature>: the gateway routes only hostnames Marshal signed.
+    expect(serviceOutcome(publicRun, serviceId).url).toMatch(/^https:\/\/[a-z0-9-]+-[0-9a-f]{16}\.deploy\.built-with-hexclave\.com$/);
     const publicService = await niceBackendFetch(`/api/v1/deployments/services/${serviceId}`, { accessType: "admin" });
     expect((publicService.body as any).public).toBe(true);
     expect((publicService.body as any).ports).toEqual({ 3000: { protocol: "http" } });
     expect((publicService.body as any).url).toBe(serviceOutcome(publicRun, serviceId).url);
     const publicApp = await findMockApp(serviceId);
-    expect(serviceOutcome(publicRun, serviceId).url).toMatch(new RegExp(`^https://${publicApp.name.slice(4)}-[0-9a-f]{12}\\.deploy\\.built-with-hexclave\\.com$`));
+    expect(serviceOutcome(publicRun, serviceId).url).toMatch(new RegExp(`^https://${publicApp.name.slice(4)}-[0-9a-f]{16}\\.deploy\\.built-with-hexclave\\.com$`));
     expect(publicApp.certificates).toEqual([]);
     expect(publicApp.sharedIpv4).not.toBeNull();
     expect(publicApp.dedicatedIps.some((ip) => ip.type === "v6")).toBe(true);

--- a/apps/marshal/.env
+++ b/apps/marshal/.env
@@ -26,6 +26,8 @@ MARSHAL_FLY_GRAPHQL_API_URL=# override for the GraphQL API (certs/IPs). Defaults
 MARSHAL_FLY_LOGS_API_URL=# override for the logs API. Defaults to https://api.fly.io/api/v1 (or the fly-mock)
 MARSHAL_FLY_REGISTRY_HOST=# override for the Docker registry. Defaults to registry.fly.io
 MARSHAL_FLY_REGION=# Fly region machines are created in (runtime policy, not part of the service spec). Defaults to iad
+HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=# 64 hex chars (32 bytes) shared with the deployment gateway (apps/deployment-gateway); signs every public service's <suffix>-<mac>.deploy.built-with-hexclave.com hostname so the gateway routes only names Marshal minted. Required whenever Fly is configured; rotating it renames every platform URL
+HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=# the gateway's wildcard domain. Defaults to deploy.built-with-hexclave.com; only a separate test gateway sets it
 
 # Google Cloud — the opt-in "gcp-beta-1" runtime. Configured whenever
 # HEXCLAVE_MARSHAL_GCP_PLATFORM_PROJECT_ID is set (credentials resolve in this order: workload

--- a/apps/marshal/.env.development
+++ b/apps/marshal/.env.development
@@ -11,6 +11,8 @@ MARSHAL_BUILDER=mock
 # Fly (the default runtime) — the mock token points Marshal at the fly-mock docker service.
 MARSHAL_FLY_API_TOKEN=mock_hexclave_fly_key
 MARSHAL_FLY_ORG_SLUG=hexclave-dev
+# Public mock-only key, also used by the local gateway test. Production must use a randomly generated 32-byte key.
+HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=a1b2c3d4e5f60718293a4b5c6d7e8f9000112233445566778899aabbccddeeff
 # Google Cloud (the opt-in "gcp-beta-1" runtime) — everything below points at the gcp-mock docker service.
 HEXCLAVE_MARSHAL_GCP_BILLING_ACCOUNT=mock-billing-account
 HEXCLAVE_MARSHAL_GCP_PROJECT_PARENT=organizations/mock-organization

--- a/apps/marshal/README.md
+++ b/apps/marshal/README.md
@@ -222,7 +222,9 @@ pnpm -C apps/marshal test:platform-domains:live
 
 The runner reads real Fly and S3 credentials from `apps/marshal/.env.local`, accepting either
 the `MARSHAL_*` names or `FLY_API_TOKEN`, `FLY_ORG_SLUG`, `S3_ACCESS_KEY_ID`,
-`S3_SECRET_ACCESS_KEY`, `S3_API_ENDPOINT`, and `S3_BUCKET_NAME`. No Vercel API token is required.
+`S3_SECRET_ACCESS_KEY`, `S3_API_ENDPOINT`, and `S3_BUCKET_NAME`, plus the gateway's hostname
+signing key as `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY` (or `GATEWAY_HOSTNAME_KEY`) — the gateway
+routes only hostnames signed with its own key. No Vercel API token is required.
 Configure the dedicated gateway and wildcard DNS/TLS first, following its README.
 For an isolated test gateway on a separate domain, pass
 `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN=deploy.example.net` to the command and configure the

--- a/apps/marshal/README.md
+++ b/apps/marshal/README.md
@@ -109,8 +109,10 @@ Cloud Run has no equivalent of Fly's request-triggered VM suspend/resume for a p
 
 ## Fly deployment platform domains
 
-Public HTTP services advertise `https://<suffix>.deploy.built-with-hexclave.com`, where
-`hxc-<suffix>` is the existing Fly app name. The name remains stable across redeploys.
+Public HTTP services advertise `https://<suffix>-<mac>.deploy.built-with-hexclave.com`, where
+`hxc-<suffix>` is the existing Fly app name and `<mac>` signs it under
+`HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY`, shared with the gateway, so the gateway routes only names
+this Marshal minted. The name remains stable across redeploys.
 The dedicated Fly gateway in [apps/deployment-gateway](../deployment-gateway/README.md)
 proxies HTTP, streaming, and WebSockets to the existing `.fly.dev` origin. Provision its
 wildcard DNS/TLS before deploying this Marshal version. Hosted components remain on Vercel.

--- a/apps/marshal/src/config.ts
+++ b/apps/marshal/src/config.ts
@@ -10,6 +10,7 @@
 
 import { assertDataEncryptionKeyIsSafe, parseDataEncryptionRootKey } from "./spec-crypto.js";
 import { validateImageRef } from "./image-ref.js";
+import { DEVELOPMENT_PLATFORM_HOSTNAME_KEY, platformHostnameKey } from "./platform-domain-names.js";
 import type { ServiceKind } from "./types.js";
 
 export const MOCK_FLY_TOKEN = "mock_hexclave_fly_key";
@@ -115,6 +116,16 @@ function readFlyConfig(): FlyConfig | null {
   if (flyToken === "") return null;
   const isMockFly = flyToken === MOCK_FLY_TOKEN;
   if (isMockFly) assertMocksExplicitlyAllowed("the mock Fly token");
+  // Every public Fly service gets a gateway hostname signed with this key, so a missing or
+  // malformed one must fail here rather than on a customer's first deploy.
+  try {
+    platformHostnameKey();
+  } catch (error) {
+    throw new Error(`marshal refuses to start: ${error instanceof Error ? error.message : String(error)}`, { cause: error });
+  }
+  if ((process.env.HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY ?? "").toLowerCase() === DEVELOPMENT_PLATFORM_HOSTNAME_KEY) {
+    assertMocksExplicitlyAllowed("the public development platform-hostname key");
+  }
   // The fly-mock docker service serves all three API surfaces on one port.
   const flyMockUrl = `http://localhost:${portPrefix()}48`;
   return {

--- a/apps/marshal/src/fly/platform-address.test.ts
+++ b/apps/marshal/src/fly/platform-address.test.ts
@@ -14,7 +14,7 @@ vi.mock("./client.js", async (original) => ({
 }));
 
 import { createFlyProvider } from "./provider.js";
-import { platformHostname } from "../platform-domain-names.js";
+import { DEVELOPMENT_PLATFORM_HOSTNAME_KEY, platformHostname } from "../platform-domain-names.js";
 
 const stored: StoredSpec = {
   ns: "project", key: "web", revision: "one", created_at_millis: 1, updated_at_millis: 1, last_apply_error: null,
@@ -23,6 +23,7 @@ const stored: StoredSpec = {
 
 beforeEach(() => {
   certificates.mockClear();
+  vi.stubEnv("HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY", DEVELOPMENT_PLATFORM_HOSTNAME_KEY);
 });
 
 describe("public Fly addresses", () => {

--- a/apps/marshal/src/live-platform-domain-test.test.ts
+++ b/apps/marshal/src/live-platform-domain-test.test.ts
@@ -35,7 +35,7 @@ describe("live test setup (no provider calls)", () => {
     expect(() => parseLiveRun(run, { ...settings, MARSHAL_S3_BUCKET: "other-bucket" })).toThrow("different Fly");
     vi.stubEnv("HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY", credentials.GATEWAY_HOSTNAME_KEY);
     const identity = liveRunIdentity(run);
-    expect(identity.hostname).toMatch(/^[a-z0-9-]+-[0-9a-f]{12}\.deploy\.built-with-hexclave\.com$/);
+    expect(identity.hostname).toMatch(/^[a-z0-9-]+-[0-9a-f]{16}\.deploy\.built-with-hexclave\.com$/);
     expect(liveRunIdentity(newLiveRun(settings))).not.toEqual(identity);
   });
 

--- a/apps/marshal/src/live-platform-domain-test.test.ts
+++ b/apps/marshal/src/live-platform-domain-test.test.ts
@@ -6,6 +6,7 @@ const credentials = {
   FLY_API_TOKEN: "test-fly-token", FLY_ORG_SLUG: "test-org",
   S3_ACCESS_KEY_ID: "test-access", S3_SECRET_ACCESS_KEY: "test-secret",
   S3_API_ENDPOINT: "https://s3.example.com", S3_BUCKET_NAME: "test-bucket",
+  GATEWAY_HOSTNAME_KEY: "f".repeat(64),
 };
 
 afterEach(() => {
@@ -21,6 +22,7 @@ describe("live test setup (no provider calls)", () => {
     expect(settings.MARSHAL_S3_BUCKET).toBe(credentials.S3_BUCKET_NAME);
     expect(() => liveCredentialSettings({ ...credentials, FLY_API_TOKEN: "" })).toThrow("FLY_API_TOKEN");
     expect(() => liveCredentialSettings({ ...credentials, S3_API_ENDPOINT: "http://localhost" })).toThrow("HTTPS");
+    expect(() => liveCredentialSettings({ ...credentials, GATEWAY_HOSTNAME_KEY: "" })).toThrow("HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY");
   });
 
   it("validates recovery identity and account scope before cleanup", () => {
@@ -31,8 +33,9 @@ describe("live test setup (no provider calls)", () => {
     expect(() => parseLiveRun({ ...run, encryptionKey: "bad" }, settings)).toThrow("Recovery file");
     expect(() => parseLiveRun(run, { ...settings, MARSHAL_FLY_ORG_SLUG: "other-org" })).toThrow("different Fly");
     expect(() => parseLiveRun(run, { ...settings, MARSHAL_S3_BUCKET: "other-bucket" })).toThrow("different Fly");
+    vi.stubEnv("HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY", credentials.GATEWAY_HOSTNAME_KEY);
     const identity = liveRunIdentity(run);
-    expect(identity.hostname).toMatch(/^[a-z0-9-]+\.deploy\.built-with-hexclave\.com$/);
+    expect(identity.hostname).toMatch(/^[a-z0-9-]+-[0-9a-f]{12}\.deploy\.built-with-hexclave\.com$/);
     expect(liveRunIdentity(newLiveRun(settings))).not.toEqual(identity);
   });
 

--- a/apps/marshal/src/live-platform-domain-test.ts
+++ b/apps/marshal/src/live-platform-domain-test.ts
@@ -43,6 +43,8 @@ export function liveCredentialSettings(values: Record<string, string | undefined
     MARSHAL_S3_SECRET_ACCESS_KEY: required(values, "MARSHAL_S3_SECRET_ACCESS_KEY", "S3_SECRET_ACCESS_KEY"),
     MARSHAL_S3_ENDPOINT: required(values, "MARSHAL_S3_ENDPOINT", "S3_API_ENDPOINT"),
     MARSHAL_S3_BUCKET: required(values, "MARSHAL_S3_BUCKET", "S3_BUCKET_NAME"),
+    // The gateway under test only routes hostnames signed with its own key.
+    HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY: required(values, "HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY", "GATEWAY_HOSTNAME_KEY"),
     MARSHAL_S3_REGION: values.MARSHAL_S3_REGION ?? "auto",
     MARSHAL_S3_FORCE_PATH_STYLE: values.MARSHAL_S3_FORCE_PATH_STYLE ?? "0",
     MARSHAL_FLY_REGION: values.MARSHAL_FLY_REGION ?? "iad",

--- a/apps/marshal/src/platform-domain-names.test.ts
+++ b/apps/marshal/src/platform-domain-names.test.ts
@@ -17,7 +17,12 @@ describe("Fly proxy hostnames", () => {
     expect(isPlatformHostname("app.deploy.built-with-hexclave.com")).toBe(false);
   });
 
-  it.each(["", "*.example.net", "Example.net", "-bad.example.net", "example.net/", "example.net\n", "a".repeat(64) + ".net", "a.".repeat(96) + "net"])("rejects invalid domain %j", (domain) => {
+  it("treats an empty domain override as unset, since the .env placeholder loads as empty", () => {
+    vi.stubEnv("HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN", "");
+    expect(platformDomain()).toBe("deploy.built-with-hexclave.com");
+  });
+
+  it.each(["*.example.net", "Example.net", "-bad.example.net", "example.net/", "example.net\n", "a".repeat(64) + ".net", "a.".repeat(96) + "net"])("rejects invalid domain %j", (domain) => {
     vi.stubEnv("HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN", domain);
     expect(() => platformDomain()).toThrow("lowercase DNS domain");
   });
@@ -25,7 +30,7 @@ describe("Fly proxy hostnames", () => {
   it("reuses the complete Fly app identity without a DNS lookup or certificate", () => {
     const hostname = platformHostname("prod", "project", "web");
     const [label] = hostname.split(".");
-    const appSuffix = label.slice(0, -13);
+    const appSuffix = label.slice(0, -17);
     expect(`hxc-${appSuffix}`).toBe(appNameForService("prod", "project", "web"));
     expect(label.length).toBeLessThanOrEqual(63);
     expect(platformHostname("prod", "project", "api")).not.toBe(hostname);
@@ -36,9 +41,9 @@ describe("Fly proxy hostnames", () => {
   it("signs the hostname so only a key holder can mint one the gateway routes", () => {
     const hostname = platformHostname("prod", "project", "web");
     const [label] = hostname.split(".");
-    const appSuffix = label.slice(0, -13);
-    const mac = label.slice(-12);
-    expect(mac).toMatch(/^[0-9a-f]{12}$/);
+    const appSuffix = label.slice(0, -17);
+    const mac = label.slice(-16);
+    expect(mac).toMatch(/^[0-9a-f]{16}$/);
     expect(mac).toBe(platformHostnameMac("deploy.built-with-hexclave.com", appSuffix, platformHostnameKey()));
     // A different key, a different domain, or a different app each yield a different mac.
     expect(platformHostnameMac("deploy.built-with-hexclave.com", appSuffix, Buffer.alloc(32, 1))).not.toBe(mac);
@@ -52,7 +57,7 @@ describe("Fly proxy hostnames", () => {
   // Pinned so a change to the mac construction cannot go unnoticed: the gateway's own test
   // (apps/deployment-gateway/gateway.test.mjs) routes this exact hostname.
   it("matches the gateway's construction of the mac", () => {
-    expect(platformHostnameMac("deploy.built-with-hexclave.com", "t-ns-ke-0123456789abcdef01", Buffer.from(DEVELOPMENT_PLATFORM_HOSTNAME_KEY, "hex"))).toBe("b8e6cf5af5b3");
+    expect(platformHostnameMac("deploy.built-with-hexclave.com", "t-ns-ke-0123456789abcdef01", Buffer.from(DEVELOPMENT_PLATFORM_HOSTNAME_KEY, "hex"))).toBe("b8e6cf5af5b36a08");
   });
 
   it.each(["", "short", "g".repeat(64), "0".repeat(63), "0".repeat(65)])("rejects invalid key %j", (key) => {

--- a/apps/marshal/src/platform-domain-names.test.ts
+++ b/apps/marshal/src/platform-domain-names.test.ts
@@ -1,8 +1,11 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { appNameForService } from "./fly/naming.js";
-import { isPlatformHostname, platformDomain, platformHostname } from "./platform-domain-names.js";
+import { DEVELOPMENT_PLATFORM_HOSTNAME_KEY, isPlatformHostname, platformDomain, platformHostname, platformHostnameKey, platformHostnameMac } from "./platform-domain-names.js";
 
 describe("Fly proxy hostnames", () => {
+  beforeEach(() => {
+    vi.stubEnv("HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY", DEVELOPMENT_PLATFORM_HOSTNAME_KEY);
+  });
   afterEach(() => {
     vi.unstubAllEnvs();
   });
@@ -18,13 +21,44 @@ describe("Fly proxy hostnames", () => {
     vi.stubEnv("HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN", domain);
     expect(() => platformDomain()).toThrow("lowercase DNS domain");
   });
+
   it("reuses the complete Fly app identity without a DNS lookup or certificate", () => {
     const hostname = platformHostname("prod", "project", "web");
-    expect(`hxc-${hostname.split(".")[0]}`).toBe(appNameForService("prod", "project", "web"));
-    expect(hostname.split(".")[0].length).toBeLessThanOrEqual(63);
+    const [label] = hostname.split(".");
+    const appSuffix = label.slice(0, -13);
+    expect(`hxc-${appSuffix}`).toBe(appNameForService("prod", "project", "web"));
+    expect(label.length).toBeLessThanOrEqual(63);
     expect(platformHostname("prod", "project", "api")).not.toBe(hostname);
     expect(platformHostname("dev", "project", "web")).not.toBe(hostname);
     expect(platformHostname("prod", "another", "web")).not.toBe(hostname);
+  });
+
+  it("signs the hostname so only a key holder can mint one the gateway routes", () => {
+    const hostname = platformHostname("prod", "project", "web");
+    const [label] = hostname.split(".");
+    const appSuffix = label.slice(0, -13);
+    const mac = label.slice(-12);
+    expect(mac).toMatch(/^[0-9a-f]{12}$/);
+    expect(mac).toBe(platformHostnameMac("deploy.built-with-hexclave.com", appSuffix, platformHostnameKey()));
+    // A different key, a different domain, or a different app each yield a different mac.
+    expect(platformHostnameMac("deploy.built-with-hexclave.com", appSuffix, Buffer.alloc(32, 1))).not.toBe(mac);
+    expect(platformHostnameMac("deploy.example.net", appSuffix, platformHostnameKey())).not.toBe(mac);
+    expect(platformHostnameMac("deploy.built-with-hexclave.com", `${appSuffix.slice(0, -1)}0`, platformHostnameKey())).not.toBe(mac);
+    vi.stubEnv("HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY", "0".repeat(64));
+    expect(platformHostname("prod", "project", "web")).not.toBe(hostname);
+    expect(platformHostname("prod", "project", "web").slice(0, appSuffix.length)).toBe(appSuffix);
+  });
+
+  // Pinned so a change to the mac construction cannot go unnoticed: the gateway's own test
+  // (apps/deployment-gateway/gateway.test.mjs) routes this exact hostname.
+  it("matches the gateway's construction of the mac", () => {
+    expect(platformHostnameMac("deploy.built-with-hexclave.com", "t-ns-ke-0123456789abcdef01", Buffer.from(DEVELOPMENT_PLATFORM_HOSTNAME_KEY, "hex"))).toBe("b8e6cf5af5b3");
+  });
+
+  it.each(["", "short", "g".repeat(64), "0".repeat(63), "0".repeat(65)])("rejects invalid key %j", (key) => {
+    vi.stubEnv("HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY", key);
+    expect(() => platformHostnameKey()).toThrow("64 hexadecimal characters");
+    expect(() => platformHostname("prod", "project", "web")).toThrow("HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY");
   });
 
   it("reserves generated names without reserving hosted components", () => {

--- a/apps/marshal/src/platform-domain-names.ts
+++ b/apps/marshal/src/platform-domain-names.ts
@@ -6,13 +6,15 @@ const DEFAULT_PLATFORM_DOMAIN = "deploy.built-with-hexclave.com";
 // Public, development-only key shared with the local gateway test. Marshal refuses it
 // unless MARSHAL_ALLOW_MOCKS=1 (see config.ts), like the development data-encryption key.
 export const DEVELOPMENT_PLATFORM_HOSTNAME_KEY = "a1b2c3d4e5f60718293a4b5c6d7e8f9000112233445566778899aabbccddeeff";
-// 48 bits: a stranger's chance per guess is 2^-48, and every guess is a full HTTPS request
-// the gateway answers with 421. Keeps the label well under the 63-character DNS limit.
-export const PLATFORM_HOSTNAME_MAC_HEX_LENGTH = 12;
+// 64 bits: every guess is a full HTTPS request the gateway answers with 421, and an attacker
+// holding K registered hxc-* apps only gets a K-fold speedup. The label stays at 43
+// characters, well under the 63-character DNS limit.
+export const PLATFORM_HOSTNAME_MAC_HEX_LENGTH = 16;
 const PLATFORM_HOSTNAME_MAC_CONTEXT = "hexclave-deployment-hostname/v1";
 
 export function platformDomain(): string {
-  const domain = process.env.HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN ?? DEFAULT_PLATFORM_DOMAIN;
+  // `||`, not `??`: the documented placeholder in .env loads as an empty string.
+  const domain = process.env.HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN || DEFAULT_PLATFORM_DOMAIN;
   if (domain.length > 190 || /[^a-z0-9.-]/.test(domain) || !/^(?:[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?\.)+[a-z]{2,63}$/.test(domain)) {
     throw new Error("HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN must be a lowercase DNS domain of at most 190 characters");
   }

--- a/apps/marshal/src/platform-domain-names.ts
+++ b/apps/marshal/src/platform-domain-names.ts
@@ -1,6 +1,15 @@
+import { createHmac } from "node:crypto";
 import { appNameForService } from "./fly/naming.js";
 
 const DEFAULT_PLATFORM_DOMAIN = "deploy.built-with-hexclave.com";
+
+// Public, development-only key shared with the local gateway test. Marshal refuses it
+// unless MARSHAL_ALLOW_MOCKS=1 (see config.ts), like the development data-encryption key.
+export const DEVELOPMENT_PLATFORM_HOSTNAME_KEY = "a1b2c3d4e5f60718293a4b5c6d7e8f9000112233445566778899aabbccddeeff";
+// 48 bits: a stranger's chance per guess is 2^-48, and every guess is a full HTTPS request
+// the gateway answers with 421. Keeps the label well under the 63-character DNS limit.
+export const PLATFORM_HOSTNAME_MAC_HEX_LENGTH = 12;
+const PLATFORM_HOSTNAME_MAC_CONTEXT = "hexclave-deployment-hostname/v1";
 
 export function platformDomain(): string {
   const domain = process.env.HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN ?? DEFAULT_PLATFORM_DOMAIN;
@@ -10,13 +19,39 @@ export function platformDomain(): string {
   return domain;
 }
 
+// The key the deployment gateway also holds. Only a holder can mint a platform hostname the
+// gateway routes, which is what makes a globally claimable `hxc-*` Fly app name unreachable
+// under our domain. Rotating it renames every platform URL, so it is rotated on compromise,
+// not on a schedule.
+export function platformHostnameKey(): Buffer {
+  const value = process.env.HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY ?? "";
+  if (!/^[0-9a-fA-F]{64}$/.test(value)) {
+    throw new Error("HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY must be exactly 64 hexadecimal characters (32 bytes)");
+  }
+  return Buffer.from(value, "hex");
+}
+
+// Must match apps/deployment-gateway/gateway.js byte for byte: the gateway recomputes this
+// from the hostname alone. The domain is bound in so a name minted for one gateway (say
+// a preproduction domain sharing a key by mistake) is not valid on another.
+export function platformHostnameMac(domain: string, appSuffix: string, key: Buffer): string {
+  return createHmac("sha256", key)
+    .update(`${PLATFORM_HOSTNAME_MAC_CONTEXT}\0${domain}\0${appSuffix}`, "utf8")
+    .digest("hex")
+    .slice(0, PLATFORM_HOSTNAME_MAC_HEX_LENGTH);
+}
+
 export function platformHostname(envId: string, ns: string, key: string): string {
-  // The dedicated gateway routes <suffix>.deploy.built-with-hexclave.com to
-  // hxc-<suffix>.fly.dev. Use the
-  // existing app identity so neither redeploys nor this change rename Fly apps.
+  // The dedicated gateway routes <suffix>-<mac>.deploy.built-with-hexclave.com to
+  // hxc-<suffix>.fly.dev after checking the mac, and accepts only suffixes shaped like
+  // appNameForService's output (apps/deployment-gateway/gateway.js) — changing that shape
+  // means changing the gateway too. Use the existing app identity so neither redeploys nor
+  // this change rename Fly apps.
+  const domain = platformDomain();
   const appName = appNameForService(envId, ns, key);
   if (!appName.startsWith("hxc-")) throw new Error("Fly deployment app names must start with hxc-");
-  return `${appName.slice(4)}.${platformDomain()}`;
+  const appSuffix = appName.slice(4);
+  return `${appSuffix}-${platformHostnameMac(domain, appSuffix, platformHostnameKey())}.${domain}`;
 }
 
 export function isPlatformHostname(hostname: string): boolean {


### PR DESCRIPTION
## Problem

The deployment gateway proxied every syntactically valid `<suffix>.deploy.built-with-hexclave.com` to `hxc-<suffix>.fly.dev` with no ownership check. Fly app names are global across all Fly organizations, so anyone who registered `hxc-login` in their own org served `login.deploy.built-with-hexclave.com` under our wildcard certificate and brand domain (flagged as Critical in review).

## Fix

Platform hostnames become `<suffix>-<mac>.deploy.built-with-hexclave.com`:

- `<suffix>` is still the Fly app name minus `hxc-`; **Fly apps are not renamed**.
- `<mac>` is the first 16 hex characters (64 bits) of `HMAC-SHA256(key, "hexclave-deployment-hostname/v1\0<domain>\0<suffix>")` under a new `HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY` held only by Marshal and the gateway.
- The gateway's `map` regex is replaced by an njs handler (`apps/deployment-gateway/gateway.js`; the module already ships in the pinned `nginx:alpine`) that enforces the exact Marshal name shape, recomputes the mac, constant-time compares, and returns 421 on mismatch.

Without the key nobody can produce a hostname the gateway routes, regardless of which `hxc-*` apps they own — and the gateway stays stateless with no per-deployment routing table or Marshal dependency on the data path.

Marshal refuses to start without the key whenever Fly is configured, and refuses the public development key (in `.env.development`) outside `MARSHAL_ALLOW_MOCKS=1`. The gateway refuses to start without it, and refuses the development key unless `HEXCLAVE_GATEWAY_ALLOW_DEVELOPMENT_KEY=1`.

## Accepted gap (documented in the gateway README)

The signature proves Marshal minted a name, not that Marshal still owns the app behind it. Signatures don't expire: when a service is deleted and its Fly app removed, the name is free again, and if Fly lets a stranger re-register it the old URL serves their content. Closing that needs either never deleting apps or an ownership lookup on the request path; out of scope here. Cookie tossing between sibling tenants on the shared parent domain is likewise independent and needs a Public Suffix List submission.

## Rollout

1. `fly secrets set HEXCLAVE_DEPLOYMENT_HOSTNAME_KEY=$(openssl rand -hex 32)` on the gateway app and deploy it (README updated).
2. Set the same value on Marshal and deploy.
3. Redeploy public services so the backend learns their new URLs.

This is a hard cutover for every public service deployed under the unsigned shape — its stored URL returns 421 until redeployed. Rotating the key later is the same event, so it is rotated on compromise, not on a schedule.

## Verification

- `bun test apps/deployment-gateway/gateway.test.mjs` (builds the real image): 14/14, including a test that sends eleven forged hostnames (unsigned, off-by-one, wrong key, wrong domain, wrong app, signed vanity name, signed wrong-shape suffix, mac in the wrong position) and expects 421 for each; invalid/missing/development keys fail `nginx -t`.
- Marshal unit tests: 360 pass. One mac vector (`t-ns-ke-0123456789abcdef01` → `b8e6cf5af5b36a08` under the dev key) is pinned in both the Marshal test and the gateway test so the Node and njs constructions cannot drift apart unnoticed.
- Deployments e2e locally against the mock stack: `deployments.test.ts`, `deployments-gcp.test.ts`, `deployments-runtime.test.ts` — 137 pass. The first CI run's seven failures were the `.env` placeholder blanking `HEXCLAVE_DEPLOYMENT_PLATFORM_DOMAIN` (fixed in the second commit with `||` + a regression test).
- Backend deployments unit tests 66 pass; lint + typecheck clean for marshal, backend, e2e.
- Three independent review passes (gateway/nginx semantics with live Host-header probing, Marshal/backend consumers, adversarial security) — findings folded into the second commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deployment service URLs now include a cryptographic signature, helping ensure requests are routed only to valid applications.
  - The deployment gateway verifies signed hostnames and rejects unsigned, malformed, or incorrectly signed requests.
  - Configurable platform domains and hostname-signing keys are now supported.

- **Bug Fixes**
  - Invalid or unsafe gateway credentials are rejected during startup.
  - Empty domain overrides now correctly fall back to the default domain.

- **Documentation**
  - Added setup guidance for signing keys, key rotation, signed hostnames, and gateway behavior.

- **Tests**
  - Expanded coverage for signature validation, invalid hostnames, credential handling, and signed public-service URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->