### PR TITLE
Document Cloudflare proxy requirements for custom deployment domains

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/deployments/panel-content.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/deployments/panel-content.tsx
@@ -16,6 +16,7 @@ import {
   ClockIcon,
   FileIcon,
   FolderIcon,
+  InfoIcon,
   LinkSimpleIcon,
   LockSimpleIcon,
   PlusIcon,
@@ -1093,6 +1094,12 @@ function DomainDetails({ project, serviceId, hostname, onVerifiedChange, onStatu
               ))}
             </tbody>
           </table>
+        </div>
+      )}
+      {!details.verified && (
+        <div className="flex items-start gap-1.5 rounded-lg bg-blue-500/[0.06] px-2.5 py-1.5 text-[11px] text-blue-700 ring-1 ring-blue-500/20 dark:text-blue-300">
+          <InfoIcon className="mt-px h-3.5 w-3.5 shrink-0" />
+          <span>Using Cloudflare? Either set these records to DNS only (proxy off) or set the zone&apos;s SSL/TLS mode to Full (strict). A proxied hostname under Flexible mode fails with Cloudflare 520 errors.</span>
         </div>
       )}
       <div className="flex items-center justify-between gap-2">

--- a/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/deployments-skill.ts
+++ b/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/deployments-skill.ts
@@ -208,7 +208,7 @@ export const deploymentsSkillSection = deindent`
      return p.getDeploymentServiceDomain('api', 'app.example.com');"
   \`\`\`
 
-  The returned \`dns_records\` are what the user must create at their DNS provider; poll \`getDeploymentServiceDomain\` to see verification flip. A hostname can only be attached to one service across all of Hexclave. Humans can also add domains in the dashboard (service → Domains). Agents should not do that in a browser.
+  The returned \`dns_records\` are what the user must create at their DNS provider; poll \`getDeploymentServiceDomain\` to see verification flip. Cloudflare users must either create the records as DNS-only (proxy off) or set the zone's SSL/TLS mode to Full (strict): a proxied hostname under Flexible mode fails with Cloudflare 520 errors. A hostname can only be attached to one service across all of Hexclave. Humans can also add domains in the dashboard (service → Domains). Agents should not do that in a browser.
 
   ## Removing a service
 

--- a/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/deployments-skill.ts
+++ b/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/deployments-skill.ts
@@ -11,7 +11,7 @@ export const deploymentsSkillSection = deindent`
 
   Every service is either a \`"server"\` or a \`"serverless"\`. A \`server\` is a single instance that SUSPENDS when idle and resumes with its memory intact, and it is the only type that may have a persistent disk. A \`serverless\` scales out between \`minInstances\` and \`maxInstances\` and STOPS on scale-down, so each start is a cold start and it can have no disk. Use \`server\` for anything stateful (a database, a queue, anything writing to a volume) and \`serverless\` for stateless web apps and APIs.
 
-  Enable the app by adding \`"deploy"\` under \`apps.installed\` in your config (quote it — it contains a hyphen). Services themselves are NOT part of the \`config\` export and cannot be declared in \`hexclave.config.ts\`: they live in their own file, \`hexclave.deploy.ts\`, next to it.
+  Enable the app by adding \`deploy: { enabled: true }\` under \`apps.installed\` in your config, then run \`config push\`. The \`enabled: true\` is required: every app defaults to disabled, and an empty \`deploy: {}\` entry leaves it disabled. Services themselves are NOT part of the \`config\` export and cannot be declared in \`hexclave.config.ts\`: they live in their own file, \`hexclave.deploy.ts\`, next to it.
 
   ## The deploy export
 


### PR DESCRIPTION
## Problem

Attaching a custom domain to a deployed service on a Cloudflare-managed zone: DNS records are created, the certificate issues and the dashboard reports the domain verified — but the site answers with Cloudflare **520** errors (blank page, then Cloudflare's "Web server is returning an unknown error").

Root cause, confirmed on a real domain: the hostname was Cloudflare-proxied and the zone's SSL/TLS mode was **Flexible**, so Cloudflare reached the Fly app over plain HTTP. Turning the proxy off fixed it immediately; turning it back on reproduced it; switching the zone to **Full (strict)** fixed it with the proxy on. Nothing on the Marshal side is wrong — Fly holds a valid certificate for the hostname and the ownership TXT lets issuance succeed even when proxied.

## Change

Tell users up front, in the two places they set up a domain:

- **Deployment skill** (`deployments-skill.ts`, Domains section): one sentence — Cloudflare users must either create the records DNS-only or set the zone to Full (strict); Flexible mode fails with 520s.
- **Dashboard** (service → Domains → expanded DNS panel): a small info box with the same guidance under the records table, shown only while the domain is unverified.

No behaviour changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the Cloudflare proxy requirements for custom deployment domains and fixes the deploy app enable instructions in the deployment skill.

- Cloudflare users must create DNS records as DNS-only or set the zone's SSL/TLS mode to Full (strict); proxied hostnames under Flexible mode fail with Cloudflare 520 errors.
- Adds this guidance to the dashboard's DNS panel for unverified domains and to the skill prompt.
- The skill now tells agents to enable the deploy app with `deploy: { enabled: true }` followed by `config push`, since apps default to disabled and an empty `deploy: {}` leaves them disabled.
- No runtime behavior changes.

<sup>Written for commit 4f5b02c0277cd32b115abf8f349bcb7a33996820. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare-specific guidance when configuring custom domains.
  * Users are advised to use DNS-only mode or Full (strict) SSL/TLS to help prevent 520 errors.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->