### PR TITLE
Retry the machine start Fly rejects while a redeployed stopped machine is still replacing

### DIFF
--- a/apps/e2e/tests/backend/endpoints/api/v1/deployments/deployments.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/deployments/deployments.test.ts
@@ -170,7 +170,7 @@ type MockApp = {
   name: string,
   sharedIpv4: string | null,
   dedicatedIps: { id: string, address: string, type: string }[],
-  machines: { id: string, image: string, metadata: Record<string, string>, env: Record<string, string>, mounts: { volume: string, path: string }[], init: { exec?: string[] } | null }[],
+  machines: { id: string, state: string, image: string, metadata: Record<string, string>, env: Record<string, string>, mounts: { volume: string, path: string }[], init: { exec?: string[] } | null }[],
   volumes: { id: string, name: string, size_gb: number, attached_machine_id: string | null }[],
   certificates: { hostname: string, clientStatus: string }[],
 };
@@ -1688,6 +1688,38 @@ describe("deploys against the Marshal runtime", () => {
     const redeployedEnv = (await findMockApp(serviceId)).machines[0].env;
     expect(redeployedEnv).toMatchObject({ KEEP: "yes" });
     expect(Object.hasOwn(redeployedEnv, "DROP")).toBe(false);
+  });
+
+  it("redeploys a server that autostop has suspended", { timeout: 120_000 }, async ({ expect }) => {
+    // A `min_instances: 0` server is suspended by Fly once idle, and a deploy onto a
+    // suspended machine leaves it stopped after a transition during which a start is
+    // refused. This is how every redeploy of an idle server failed with "did not start in
+    // time" while the same image booted fine on the next request: the one start Marshal
+    // fired was rejected mid-transition and silently dropped.
+    await Project.createAndSwitch();
+    const serviceId = uniqueServiceId("idle");
+    const definition = { type: "server", min_instances: 0, ports: { 3000: { protocol: "http" } }, env: {} };
+    const { syncId: sync1, sourceId } = await syncServices({ [serviceId]: definition });
+    await pollDeploymentToStatus(await startDeploy({ sourceId, uploadId: (await createUpload()).uploadId, definitionSyncId: sync1, levels: [[serviceId]] }), "deployed");
+    const before = await findMockApp(serviceId);
+    expect(before.machines[0].state).toBe("started");
+
+    // Park it the way autostop does.
+    const suspend = await fetch(`${FLY_MOCK_URL}/v1/apps/${before.name}/machines/${before.machines[0].id}/suspend`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${FLY_MOCK_TOKEN}` },
+    });
+    expect(suspend.status).toBe(200);
+    expect((await findMockApp(serviceId)).machines[0].state).toBe("suspended");
+
+    const { syncId: sync2 } = await syncServices({ [serviceId]: { ...definition, env: { CHANGED: { value: "yes" } } } }, sourceId);
+    const deployment = await pollDeploymentToStatus(await startDeploy({ sourceId, uploadId: (await createUpload()).uploadId, definitionSyncId: sync2, levels: [[serviceId]] }), "deployed");
+    expect(serviceOutcome(deployment, serviceId).status).toBe("deployed");
+    const after = await findMockApp(serviceId);
+    // Same machine, new config, and actually running — not left stopped by the update.
+    expect(after.machines[0].id).toBe(before.machines[0].id);
+    expect(after.machines[0].env).toMatchObject({ CHANGED: "yes" });
+    expect(after.machines[0].state).toBe("started");
   });
 
   // Skipped: Marshal serializes concurrent applies with a lease built on conditional writes

--- a/apps/marshal/src/fly/machine-start.test.ts
+++ b/apps/marshal/src/fly/machine-start.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { FlyApiError, type FlyMachine } from "./client.js";
+import { startMachineWhenSettled } from "./provider.js";
+
+// A redeploy onto a machine that autostop had parked (`min_instances: 0` server, idle) is
+// the case: Fly's update leaves it stopped after a `replacing` transition, and rejects a
+// start until that transition is over. These test only whether a start gets REQUESTED —
+// the caller's started-wait is what decides whether the boot happened.
+
+const lease = { assertOwned: async () => {} } as never;
+
+function machine(state: string): FlyMachine {
+  return { id: "m-1", name: "web-0", state, region: "iad", instance_id: "inst-1", config: { image: "example/image" } };
+}
+
+function rejectedStart(state: string): FlyApiError {
+  return new FlyApiError(412, "machines POST /apps/app/machines/m-1/start", `failed to change machine state: unable to start machine from current state: '${state}'`);
+}
+
+describe("startMachineWhenSettled", () => {
+  it("starts a stopped machine once", async () => {
+    const fly = { getMachine: vi.fn(async () => machine("stopped")), startMachine: vi.fn(async () => {}) };
+    await startMachineWhenSettled(fly, "app", "m-1", lease, { pollMillis: 1 });
+    expect(fly.startMachine).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits out the post-update transition before starting, and retries a start Fly rejected", async () => {
+    // The production sequence: the update has answered but the machine is still
+    // `replacing`; a start fired now is refused; a few seconds later it is `stopped` and a
+    // start is accepted. Previously the refused start was swallowed and never retried.
+    const states = ["replacing", "replacing", "stopped", "stopped"];
+    const fly = {
+      getMachine: vi.fn(async () => machine(states.shift() ?? "stopped")),
+      startMachine: vi.fn(async () => {}),
+    };
+    fly.startMachine.mockRejectedValueOnce(rejectedStart("replacing"));
+    await startMachineWhenSettled(fly, "app", "m-1", lease, { pollMillis: 1 });
+    // Not called while `replacing` (the poll saw the state first); the rejected attempt is
+    // retried once the machine has settled.
+    expect(fly.startMachine).toHaveBeenCalledTimes(2);
+  });
+
+  it("starts a suspended machine — that is what autostop leaves behind", async () => {
+    const fly = { getMachine: vi.fn(async () => machine("suspended")), startMachine: vi.fn(async () => {}) };
+    await startMachineWhenSettled(fly, "app", "m-1", lease, { pollMillis: 1 });
+    expect(fly.startMachine).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing when Fly is already booting the machine", async () => {
+    const fly = { getMachine: vi.fn(async () => machine("starting")), startMachine: vi.fn(async () => {}) };
+    await startMachineWhenSettled(fly, "app", "m-1", lease, { pollMillis: 1 });
+    expect(fly.startMachine).not.toHaveBeenCalled();
+  });
+
+  it("gives up quietly at the budget so the started-wait can report the failure", async () => {
+    const fly = { getMachine: vi.fn(async () => machine("replacing")), startMachine: vi.fn(async () => {}) };
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await startMachineWhenSettled(fly, "app", "m-1", lease, { budgetMillis: 20, pollMillis: 1 });
+      // The one trace it leaves: previously the swallowed start left no record at all.
+      expect(error).toHaveBeenCalledTimes(1);
+    } finally {
+      error.mockRestore();
+    }
+    expect(fly.startMachine).not.toHaveBeenCalled();
+  });
+
+  it("rethrows a lost lease instead of retrying past it", async () => {
+    const { ReconciliationLeaseLostError } = await import("../reconciliation-lock.js");
+    const lost = {
+      assertOwned: async () => {
+        throw new ReconciliationLeaseLostError("lease lost");
+      },
+    } as never;
+    const fly = { getMachine: vi.fn(async () => machine("stopped")), startMachine: vi.fn(async () => {}) };
+    await expect(startMachineWhenSettled(fly, "app", "m-1", lost, { pollMillis: 1 })).rejects.toBeInstanceOf(ReconciliationLeaseLostError);
+    expect(fly.startMachine).not.toHaveBeenCalled();
+  });
+});

--- a/apps/marshal/src/fly/provider.ts
+++ b/apps/marshal/src/fly/provider.ts
@@ -265,6 +265,64 @@ export function reportedDigest(machine: FlyMachine): string | null {
 // ---------------------------------------------------------------------------
 // Machine reconciliation
 
+// Machine states in which `/start` is accepted. Anything else is a transition (`replacing`,
+// `starting`, `stopping`, `suspending`, ...) that Fly rejects a start against.
+const STARTABLE_MACHINE_STATES = new Set(["stopped", "suspended", "created"]);
+
+/**
+ * Starts a machine that is not running, tolerating the transition Fly puts it through first.
+ *
+ * `/start` is rejected while a machine is mid-transition (real Fly: `412 unable to start
+ * machine from current state: 'replacing'`), and a stopped or suspended machine that was JUST
+ * updated is exactly that for a few seconds — the update answers before Fly has finished
+ * swapping the image, and it deliberately leaves the new version stopped ("machine was in a
+ * non-started state prior to the update"). Firing `/start` once at that moment gets it
+ * rejected, nothing ever boots, and the started-wait that follows burns its whole budget on a
+ * machine nobody asked to start: that is how every redeploy onto an autosuspended
+ * `min_instances: 0` server failed with "did not start in time" while the same image booted
+ * fine seconds later on the first inbound request.
+ *
+ * So: poll until the machine is either already coming up or in a state a start is accepted
+ * from, then start it, retrying a rejected start until `budgetMillis` runs out. Gives up
+ * quietly after that — the caller's started-wait remains the arbiter of whether the boot
+ * actually happened, and this only decides whether one was requested.
+ */
+export async function startMachineWhenSettled(
+  fly: Pick<FlyClient, "getMachine" | "startMachine">,
+  appName: string,
+  machineId: string,
+  lease: ReconciliationLeaseGuard,
+  options?: { budgetMillis?: number, pollMillis?: number },
+): Promise<void> {
+  const deadline = Date.now() + (options?.budgetMillis ?? 30_000);
+  const pollMillis = options?.pollMillis ?? 1000;
+  let lastError: unknown = null;
+  for (;;) {
+    const machine = await fly.getMachine(appName, machineId);
+    // Destroyed underneath us: nothing to start; the wait will report it.
+    if (machine === null) return;
+    if (machine.state === "started" || machine.state === "starting") return;
+    if (STARTABLE_MACHINE_STATES.has(machine.state)) {
+      try {
+        await lease.assertOwned();
+        await fly.startMachine(appName, machineId);
+        return;
+      } catch (error) {
+        if (isReconciliationFencingError(error)) throw error;
+        // A rejected start is the transition race above, or Fly already booting it (the next
+        // poll sees `starting`). Anything else is worth a record, since the wait's eventual
+        // timeout is all the caller will otherwise ever see of it.
+        lastError = error;
+      }
+    }
+    if (Date.now() >= deadline) {
+      console.error(`gave up requesting a start for ${appName}/${machineId} (last state ${JSON.stringify(machine.state)})`, lastError);
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollMillis));
+  }
+}
+
 /**
  * Rolls the service's machines onto `imageRef`, and reports the image Fly says
  * slot 0 is actually running.
@@ -364,13 +422,7 @@ async function applyMachines(fly: FlyClient, stored: StoredSpec, imageRef: strin
     }
     if (existing !== undefined && existing.config.metadata?.hexclave_config_hash === desiredHash) {
       // Hash matches but a pinned machine is stopped: just start it, no config churn.
-      try {
-        await lease.assertOwned();
-        await fly.startMachine(appName, existing.id);
-      } catch (error) {
-        if (isReconciliationFencingError(error)) throw error;
-        // Already booting / raced — the wait below arbitrates.
-      }
+      await startMachineWhenSettled(fly, appName, existing.id, lease);
       await fly.waitForMachineState(appName, existing.id, "started", { instanceId: existing.instance_id, totalTimeoutSeconds: 120 });
       if (slot === 0) runningDigest = reportedDigest(existing);
       continue;
@@ -380,15 +432,11 @@ async function applyMachines(fly: FlyClient, stored: StoredSpec, imageRef: strin
       await lease.assertOwned();
       const updated = await fly.updateMachine(appName, existing.id, desired);
       if (wasStopped) {
-        // Updating a stopped machine doesn't reliably boot it; start explicitly so the
-        // started-wait below actually gates the roll (autostop re-stops it when idle).
-        try {
-          await lease.assertOwned();
-          await fly.startMachine(appName, updated.id);
-        } catch (error) {
-          if (isReconciliationFencingError(error)) throw error;
-          // Racing the update-triggered boot is fine — the wait below is the arbiter.
-        }
+        // Updating a stopped (or autosuspended) machine leaves it stopped; start explicitly so
+        // the started-wait below actually gates the roll (autostop re-stops it when idle).
+        // Not a bare `/start`: the update is still settling when it answers, and Fly rejects
+        // a start until it has — see startMachineWhenSettled.
+        await startMachineWhenSettled(fly, appName, updated.id, lease);
       }
       await fly.waitForMachineState(appName, updated.id, "started", { instanceId: updated.instance_id, totalTimeoutSeconds: 120 });
       if (slot === 0) runningDigest = reportedDigest(updated);

--- a/docker/dependencies/fly-mock/Dockerfile
+++ b/docker/dependencies/fly-mock/Dockerfile
@@ -6,8 +6,15 @@ FROM node:22-slim
 # never talks to real Fly.
 #
 # Deterministic behaviors tests rely on:
-# - Machines are "started" immediately on create/update/start; /wait returns
-#   instantly. Every machine lifecycle event appends a line to the app's logs.
+# - Machines are "started" immediately on create, on update of a running
+#   machine, and on start. Updating a machine that is NOT running mirrors real
+#   Fly instead: it goes through a short `replacing` transition and is then left
+#   `stopped` ("machine was in a non-started state prior to the update so leaving
+#   the new version stopped"), and /start is rejected with 412 while it is still
+#   `replacing` (real Fly: "unable to start machine from current state"). /wait
+#   really waits for the requested state (polling; 408 on timeout). POST /stop
+#   and /suspend exist so tests can park a machine the way autostop would.
+#   Every machine lifecycle event appends a line to the app's logs.
 # - Hostnames ending in ".verified.test" get clientStatus "Ready" immediately;
 #   all others stay "Awaiting configuration" with DNS-validation records.
 # - Adding a hostname that already exists on the SAME app errors with
@@ -148,11 +155,25 @@ function imageRefJson(image) {
   };
 }
 
+// How long an update of a non-running machine stays in `replacing` before it settles to
+// `stopped`. Long enough that a single fire-and-forget /start reliably lands inside it (that
+// is the production race being modelled), short enough not to slow the e2e suite down.
+const REPLACING_MILLIS = 1500;
+const STARTABLE_STATES = new Set(["stopped", "suspended", "created"]);
+
+function settle(machine) {
+  if (machine.state === "replacing" && Date.now() >= machine.settleAt) {
+    machine.state = "stopped";
+    appendLog(machine.app, `machine was in a non-started state prior to the update so leaving the new version stopped`, { instance: machine.id });
+  }
+  return machine.state;
+}
+
 function machineJson(machine) {
   return {
     id: machine.id,
     name: machine.name,
-    state: machine.state,
+    state: settle(machine),
     region: machine.region,
     instance_id: machine.instanceId,
     image_ref: imageRefJson(machine.config?.image),
@@ -305,6 +326,7 @@ async function handleRequest(req, res) {
         dedicatedIps: app.dedicatedIps,
         machines: [...app.machinesById.values()].map((machine) => ({
           id: machine.id,
+          state: settle(machine),
           image: machine.config.image,
           metadata: machine.config.metadata ?? {},
           env: machine.config.env ?? {},
@@ -501,6 +523,8 @@ async function handleRequest(req, res) {
       instanceId: `inst-${machineCounter}-1`,
       config: body.config ?? {},
       updates: 1,
+      settleAt: 0,
+      app,
     };
     attachVolumes(app, machine);
     app.machinesById.set(machine.id, machine);
@@ -538,9 +562,18 @@ async function handleRequest(req, res) {
       detachVolumes(app, machine.id);
       machine.config = body.config ?? machine.config;
       attachVolumes(app, machine);
-      machine.state = "started";
       machine.instanceId = `inst-${machine.id}-${++machine.updates}`;
       appendLog(app, `Machine updated to image ${machine.config.image ?? "unknown"}`, { instance: machine.id });
+      // Real Fly restarts a RUNNING machine onto the new config, but leaves a stopped or
+      // suspended one stopped — after a transition during which /start is refused. The
+      // caller has to come back and start it once that settles; a mock that booted it
+      // here would hide a caller that never does.
+      if (settle(machine) === "started") {
+        machine.state = "started";
+      } else {
+        machine.state = "replacing";
+        machine.settleAt = Date.now() + REPLACING_MILLIS;
+      }
       return sendJson(res, 200, machineJson(machine));
     }
     if (machineSub === "" && req.method === "DELETE") {
@@ -552,22 +585,36 @@ async function handleRequest(req, res) {
       return sendJson(res, 200, {});
     }
     if (machineSub === "/start" && req.method === "POST") {
+      const state = settle(machine);
+      if (state === "started") return sendJson(res, 200, {});
+      if (!STARTABLE_STATES.has(state)) {
+        // Fly's own wording (seen verbatim in production service logs), status 412.
+        return sendJson(res, 412, { error: `failed to change machine state: unable to start machine from current state: '${state}'` });
+      }
       machine.state = "started";
       appendLog(app, `Machine started`, { instance: machine.id });
       return sendJson(res, 200, {});
     }
-    if (machineSub === "/stop" && req.method === "POST") {
-      machine.state = "stopped";
-      appendLog(app, `Machine stopped`, { instance: machine.id });
+    if ((machineSub === "/stop" || machineSub === "/suspend") && req.method === "POST") {
+      machine.state = machineSub === "/stop" ? "stopped" : "suspended";
+      appendLog(app, `Machine ${machine.state}`, { instance: machine.id });
       return sendJson(res, 200, {});
     }
     if (machineSub.startsWith("/wait") && req.method === "GET") {
       // Mirror the real /wait contract enough to catch regressions: timeout caps at 60s
-      // (SMOKE-RESULTS deviation #5 — larger values 400), and a stale instance_id is a 400.
+      // (SMOKE-RESULTS deviation #5 — larger values 400), a stale instance_id is a 400, and
+      // the call really does wait for the state (408 when it does not arrive) — so a caller
+      // that forgets to start a machine sees the timeout here, not only on real Fly.
       const timeout = Number(url.searchParams.get("timeout") ?? "60");
       if (Number.isFinite(timeout) && timeout > 60) return sendJson(res, 400, { error: "timeout exceeds 60s" });
       const wantInstance = url.searchParams.get("instance_id");
       if (wantInstance !== null && wantInstance !== machine.instanceId) return sendJson(res, 400, { error: "instance_id mismatch" });
+      const wantState = url.searchParams.get("state") ?? "started";
+      const deadline = Date.now() + timeout * 1000;
+      while (settle(machine) !== wantState) {
+        if (Date.now() >= deadline) return sendJson(res, 408, { error: `timeout reached waiting for machine's state to change to ${wantState}` });
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
       return sendJson(res, 200, { ok: true });
     }
   }


### PR DESCRIPTION
## Problem

Redeploying a `min_instances: 0` server that autostop had suspended failed every time with **"the service did not start in time"**, while the same image booted fine on the next inbound request (seen on project `2ea55193…`, deployment #4; the identical config redeployed as #5 succeeded only because the machine happened to be awake).

From the service logs:

```
20:04:35  Virtual machine has been suspended
20:05:11  Pulling container image …7f6e835 (deploy #4)
20:05:15  machine was in a non-started state prior to the update so leaving the new version stopped
20:07:12  deploy #4 failed: "did not start in time"
20:07:39  Starting machine → [vinext] Production server running → reachable in 5.2s
```

## Root cause

`applyMachines` already had a `wasStopped` branch that calls `/start` after `updateMachine` — but it fired **once**, immediately, and swallowed any error. Fly's update answers before the image swap finishes; the machine sits in `replacing` for a few seconds and is then left `stopped`. A `/start` during `replacing` is rejected with `412 unable to start machine from current state` (Fly's wording is visible verbatim in the same project's logs as `[PM07] … from current state: 'created'`). The rejection was dropped with no log line, nothing ever requested a boot, and the 120s started-wait timed out.

The fly-mock hid this: it set `state: "started"` on every update and returned `/wait` instantly.

## Fix

- **`startMachineWhenSettled`** (`apps/marshal/src/fly/provider.ts`): poll `getMachine`; return if already `started`/`starting`; start once the state is `stopped`/`suspended`/`created`; retry a rejected start; 30s budget; `console.error` on give-up. The caller's started-wait remains the arbiter. Used in both start branches (pinned-but-stopped, and updated-while-stopped).
- **fly-mock** mirrors real Fly: update of a non-running machine → `replacing` (1.5s) → `stopped`; `/start` during `replacing` → 412; `/wait` actually blocks for the state (408 on timeout); `/suspend` added; `state` exposed in `/__mock/apps`.
- **Unit tests** `fly/machine-start.test.ts` — 6 cases incl. the exact `replacing → rejected start → stopped → retry` sequence.
- **e2e** "redeploys a server that autostop has suspended" — deploys a `min_instances: 0` server, suspends it via the mock, redeploys with an env change, asserts same machine + new env + `started`.

## Verification

- The e2e test fails against the previous provider (stashed the fix and re-ran: the deploy never settles) and passes with it.
- Marshal unit tests (366), typecheck, lint green; full deployments e2e (Fly + runtime + GCP, 138 tests) green against the rebuilt mock.
- **Not verified on real Fly** — the mock's `replacing`/412 semantics are inferred from production logs and Fly's documented state machine. A real redeploy onto a suspended server is the definitive check once this ships.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redeploying a `min_instances: 0` server that autostop had suspended failed with "did not start in time": Fly rejects Marshal's single `/start` while the machine is still `replacing` after an image update, the rejection was dropped without a trace, and nothing ever booted the machine. Marshal now polls until the machine settles, starts it, and retries rejected starts within a 30s budget.

- Adds `startMachineWhenSettled`, used by both start branches in `applyMachines` (pinned-but-stopped and updated-while-stopped).
- The fly-mock now mirrors real Fly: updating a non-running machine goes `replacing` → `stopped`, `/start` during the transition returns 412, and `/wait` actually waits for the state; adds `/suspend` so tests can park a machine like autostop.
- Adds unit tests for the settle-and-retry sequence and an e2e test that redeploys a suspended server, asserting the same machine ends up started with the new env.
- Not verified on real Fly — the mock's `replacing`/412 semantics are inferred from production logs.

<sup>Written for commit 4c770703061453d474c75a6cfde87cda7dae5b5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/2060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved redeployment for servers suspended by autostop, preserving the existing machine while applying updated environment settings.
  - Machines now start reliably after updates, including when transitioning through intermediate states such as replacing or suspended.
  - Added retries and safer handling for temporary start failures, preventing machines from being left stopped.
- **Tests**
  - Expanded coverage for redeployment, suspended machines, state transitions, retries, and reconciliation interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->